### PR TITLE
Resolving an issue in the plugin where it isn't always bootstrapped.

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -3,7 +3,7 @@
     totallyTyped="false"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
-    xsi:schemaLocation="https://getpsalm.org/schema/config file:///Users/matthewbrown/Desktop/vimeo/git/laravel-psalm-plugin/vendor/vimeo/psalm/config.xsd"
+    xsi:schemaLocation="https://getpsalm.org/schema/config"
 >
     <projectFiles>
         <directory name="src" />


### PR DESCRIPTION
On a fresh install in a repository that has Laravel installed, I was getting the following error:

```
$ ./vendor/bin/psalm
Scanning files...

In Config.php line 892:
                                                    
  Failed to load plugin Psalm\LaravelPlugin\Plugin  
                                                    

In Generator.php line 53:
                                              
  array_merge(): Argument #2 is not an array  
                                              
```

Upon further debugging, I was getting this because the `LaravelIdeHelper` service provider wasn't being properly booted up, resulting in that library attempting to use configuration data that did not exist within my `config/` directory.