### PR TITLE
Use Laravel's standard source code folder

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -6,7 +6,7 @@
     xsi:schemaLocation="https://getpsalm.org/schema/config"
 >
     <projectFiles>
-        <directory name="src" />
+        <directory name="app" />
         <ignoreFiles>
             <directory name="vendor" />
         </ignoreFiles>


### PR DESCRIPTION
Laravel skeleton always defines `app` as the folder to store the source code. It makes sense for the plugin that targets Laravel users to provide a configuration that matches the standard Laravel configuration.