### PR TITLE
Fix false-positive ArgumentTypeCoercion for retry() helper

### DIFF
--- a/stubs/common/Support/helpers.stubphp
+++ b/stubs/common/Support/helpers.stubphp
@@ -104,9 +104,9 @@ function optional($value = null, callable $callback = null) {}
  * Retry an operation a given number of times.
  *
  * @template TValue
- * @param positive-int|list<int> $times
+ * @param int|list<int> $times
  * @param callable(int): TValue $callback
- * @param int<0, max> $sleep
+ * @param int $sleep
  * @param null|callable(\Exception): bool $when
  * @psalm-return TValue
  *


### PR DESCRIPTION
## Summary
- Relaxed overly strict parameter types in the `retry()` helper stub to match Laravel's actual signatures
- Changed `$times` from `positive-int|list<int>` to `int|list<int>`
- Changed `$sleep` from `int<0, max>` to `int`

Fixes #412

## Details
The stub used `positive-int` for `$times` and `int<0, max>` for `$sleep`, which caused `ArgumentTypeCoercion` errors when passing plain `int` variables. Laravel itself declares these as `int` and handles edge cases gracefully:
- `$times < 1` still executes the callback once
- Negative `$sleep` results in 0ms sleep

## Test plan
- [x] All 37 existing type tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>