### PR TITLE
Upgrade to PHPUnit 11.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,12 @@
         }
     ],
     "homepage": "https://github.com/psalm/psalm-plugin-laravel",
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/alies-dev/psalm-tester"
+        }
+    ],
     "require": {
         "php": "^8.2",
         "ext-simplexml": "*",
@@ -36,8 +42,8 @@
     },
     "require-dev": {
         "laravel/framework": "^11.35 || ^12.0",
-        "phpunit/phpunit": "^10.5 || ^11.5",
-        "phpyh/psalm-tester": "^0.1.0",
+        "phpunit/phpunit": "^11.5",
+        "phpyh/psalm-tester": "dev-batch",
         "ramsey/collection": "^1.3",
         "rector/rector": "^2.3",
         "slevomat/coding-standard": "^8.15",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          cacheDirectory=".phpunit.cache"
          executionOrder="depends,defects"
@@ -17,7 +17,7 @@
         </testsuite>
     </testsuites>
 
-    <source restrictDeprecations="true" restrictNotices="true" restrictWarnings="true">
+    <source restrictNotices="true" restrictWarnings="true" ignoreIndirectDeprecations="true">
         <include>
             <directory>src</directory>
         </include>

--- a/tests/Unit/Handlers/Eloquent/Schema/AbstractSchemaAggregatorTestCase.php
+++ b/tests/Unit/Handlers/Eloquent/Schema/AbstractSchemaAggregatorTestCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Eloquent\Schema;
 
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Psalm\Internal\Provider\StatementsProvider;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaAggregator;
@@ -21,7 +22,7 @@ use function realpath;
 use const DIRECTORY_SEPARATOR;
 use const PHP_VERSION_ID;
 
-/** @covers \Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaAggregator */
+#[CoversClass(SchemaAggregator::class)]
 abstract class AbstractSchemaAggregatorTestCase extends TestCase
 {
     final protected function instantiateSchemaAggregator(string $filepath): SchemaAggregator

--- a/tests/Unit/Handlers/Eloquent/Schema/DefaultUserTableTest.php
+++ b/tests/Unit/Handlers/Eloquent/Schema/DefaultUserTableTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Eloquent\Schema;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaAggregator;
 
-/** @covers \Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaAggregator */
+#[CoversClass(SchemaAggregator::class)]
 final class DefaultUserTableTest extends AbstractSchemaAggregatorTestCase
 {
-    /** @test */
+    #[Test]
     public function it_detects_all_columns_from_anonymous_class_migration(): void
     {
         $schemaAggregator = $this->instantiateSchemaAggregator(__DIR__ . '/migrations/default_users_table_anon');
@@ -17,7 +19,7 @@ final class DefaultUserTableTest extends AbstractSchemaAggregatorTestCase
         $this->assertAllDefaultUsersTableColumnsDetectedProperly($schemaAggregator);
     }
 
-    /** @test */
+    #[Test]
     public function it_detects_all_columns_from_named_class_migration(): void
     {
         $schemaAggregator = $this->instantiateSchemaAggregator(__DIR__ . '/migrations/default_users_table_named');
@@ -25,7 +27,7 @@ final class DefaultUserTableTest extends AbstractSchemaAggregatorTestCase
         $this->assertAllDefaultUsersTableColumnsDetectedProperly($schemaAggregator);
     }
 
-    /** @test */
+    #[Test]
     public function it_detects_all_columns_from_migration_that_uses_root_namespace_facades(): void
     {
         $schemaAggregator = $this->instantiateSchemaAggregator(__DIR__ . '/migrations/default_users_table_root_ns_facade');


### PR DESCRIPTION
## Summary
- Drop PHPUnit 10.5 support, require `^11.5`
- Switch `psalm-tester` to `alies-dev/psalm-tester` `dev-batch` branch (adds PHPUnit 11 compatibility)
- Migrate `phpunit.xml.dist` to PHPUnit 11 schema
- Convert remaining docblock annotations (`@covers`, `@test`) to PHP attributes (`#[CoversClass]`, `#[Test]`)