### PR TITLE
Replace include_once with autoloader-based model discovery

### DIFF
--- a/src/Providers/ModelDiscoveryProvider.php
+++ b/src/Providers/ModelDiscoveryProvider.php
@@ -10,17 +10,22 @@ use ReflectionClass;
 
 use function array_values;
 use function class_exists;
+use function count;
 use function file_get_contents;
 use function get_declared_classes;
 use function is_a;
 use function is_array;
 use function is_dir;
 use function is_string;
-use function array_diff;
-use function in_array;
-use function preg_match;
 use function realpath;
 use function str_starts_with;
+use function token_get_all;
+
+use const T_CLASS;
+use const T_NAME_QUALIFIED;
+use const T_NAMESPACE;
+use const T_STRING;
+use const T_WHITESPACE;
 
 /**
  * Discovers Eloquent model classes from the project.
@@ -39,7 +44,7 @@ final class ModelDiscoveryProvider
     {
         $directories = self::resolveModelDirectories($app);
 
-        /** @var list<class-string<Model>> $models */
+        /** @var array<class-string<Model>, class-string<Model>> $models */
         $models = [];
 
         foreach ($directories as $directory) {
@@ -58,53 +63,31 @@ final class ModelDiscoveryProvider
                     continue;
                 }
 
-                // Use Composer's autoloader to load the class safely
-                // class_exists() triggers autoloading without fatal errors
+                // Trigger Composer's autoloader to load the class; the try/catch
+                // guards against files that fail to compile or have missing dependencies
                 try {
                     if (!class_exists($className, true)) {
                         continue;
                     }
-                } catch (\Throwable) {
+                } catch (\Error) {
                     continue;
                 }
 
-                if (!is_a($className, Model::class, true)) {
-                    continue;
-                }
-
-                try {
-                    $reflection = new ReflectionClass($className);
-                } catch (\ReflectionException) {
-                    continue;
-                }
-
-                if ($reflection->isAbstract()) {
-                    continue;
-                }
-
-                if (!in_array($className, $models, true)) {
-                    $models[] = $className;
+                if (self::isConcreteModel($className)) {
+                    /** @var class-string<Model> $className */
+                    $models[$className] = $className;
                 }
             }
         }
 
         // Also check already-loaded classes (from Composer's classmap)
         foreach (get_declared_classes() as $class) {
-            if (!is_a($class, Model::class, true)) {
-                continue;
-            }
-
-            try {
-                $reflection = new ReflectionClass($class);
-            } catch (\ReflectionException) {
-                continue;
-            }
-
-            if ($reflection->isAbstract()) {
+            if (!self::isConcreteModel($class)) {
                 continue;
             }
 
             // Only include classes from the configured directories
+            $reflection = new ReflectionClass($class);
             $fileName = $reflection->getFileName();
             if (!is_string($fileName)) {
                 continue;
@@ -117,15 +100,14 @@ final class ModelDiscoveryProvider
 
                 $realDir = realpath($directory);
                 if ($realDir !== false && str_starts_with($fileName, $realDir)) {
-                    if (!in_array($class, $models, true)) {
-                        $models[] = $class;
-                    }
+                    /** @var class-string<Model> $class */
+                    $models[$class] = $class;
                     break;
                 }
             }
         }
 
-        self::$modelClasses = $models;
+        self::$modelClasses = array_values($models);
     }
 
     /**
@@ -181,26 +163,114 @@ final class ModelDiscoveryProvider
     }
 
     /**
-     * Extract the fully qualified class name from a PHP file by parsing
-     * the namespace and class declarations.
+     * Check whether a class is a concrete (non-abstract) Eloquent Model subclass.
      *
-     * @return class-string|null
+     * @param class-string $className
+     * @psalm-suppress MissingPureAnnotation uses reflection which has side effects
+     */
+    private static function isConcreteModel(string $className): bool
+    {
+        if (!is_a($className, Model::class, true)) {
+            return false;
+        }
+
+        try {
+            $reflection = new ReflectionClass($className);
+        } catch (\ReflectionException) {
+            return false;
+        }
+
+        return !$reflection->isAbstract();
+    }
+
+    /**
+     * Extract the fully qualified class name from a PHP file using token_get_all().
+     *
+     * This correctly handles comments, strings, and all class modifier keywords
+     * (abstract, final, readonly).
      */
     private static function extractClassName(string $filePath): ?string
     {
-        $contents = file_get_contents($filePath);
+        $contents = @file_get_contents($filePath);
         if ($contents === false) {
             return null;
         }
 
+        $tokens = token_get_all($contents);
+        $count = count($tokens);
         $namespace = '';
-        if (preg_match('/^\s*namespace\s+([^\s;{]+)/m', $contents, $matches)) {
-            $namespace = $matches[1] . '\\';
+
+        for ($i = 0; $i < $count; $i++) {
+            if (!is_array($tokens[$i])) {
+                continue;
+            }
+
+            if ($tokens[$i][0] === T_NAMESPACE) {
+                $namespace = self::parseNamespace($tokens, $i, $count);
+                continue;
+            }
+
+            if ($tokens[$i][0] === T_CLASS) {
+                $name = self::parseClassName($tokens, $i, $count);
+                if ($name !== null) {
+                    return $namespace !== '' ? $namespace . '\\' . $name : $name;
+                }
+            }
         }
 
-        if (preg_match('/^\s*(?:abstract\s+|final\s+)?class\s+(\w+)/m', $contents, $matches)) {
-            /** @var class-string */
-            return $namespace . $matches[1];
+        return null;
+    }
+
+    /**
+     * @param array<array{0: int, 1: string, 2: int}|string> $tokens
+     */
+    private static function parseNamespace(array $tokens, int &$i, int $count): string
+    {
+        $namespace = '';
+        $i++;
+
+        for (; $i < $count; $i++) {
+            if (!is_array($tokens[$i])) {
+                break;
+            }
+
+            if ($tokens[$i][0] === T_WHITESPACE) {
+                continue;
+            }
+
+            if ($tokens[$i][0] === T_STRING || $tokens[$i][0] === T_NAME_QUALIFIED) {
+                $namespace .= $tokens[$i][1];
+            } else {
+                break;
+            }
+        }
+
+        return $namespace;
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @param array<array{0: int, 1: string, 2: int}|string> $tokens
+     */
+    private static function parseClassName(array $tokens, int $i, int $count): ?string
+    {
+        // Skip whitespace after 'class' keyword to find the class name
+        $i++;
+        for (; $i < $count; $i++) {
+            if (!is_array($tokens[$i])) {
+                return null;
+            }
+
+            if ($tokens[$i][0] === T_WHITESPACE) {
+                continue;
+            }
+
+            if ($tokens[$i][0] === T_STRING) {
+                return $tokens[$i][1];
+            }
+
+            return null;
         }
 
         return null;

--- a/tests/Unit/Providers/ModelDiscoveryProviderTest.php
+++ b/tests/Unit/Providers/ModelDiscoveryProviderTest.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Providers;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Providers\ModelDiscoveryProvider;
+use ReflectionMethod;
+
+use function file_exists;
+use function file_put_contents;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+#[CoversClass(ModelDiscoveryProvider::class)]
+final class ModelDiscoveryProviderTest extends TestCase
+{
+    private static ?ReflectionMethod $extractClassName = null;
+
+    private ?string $tempFile = null;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$extractClassName = new ReflectionMethod(ModelDiscoveryProvider::class, 'extractClassName');
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->tempFile !== null && file_exists($this->tempFile)) {
+            unlink($this->tempFile);
+        }
+    }
+
+    /**
+     * @return iterable<string, array{string, ?string}>
+     */
+    public static function extract_class_name_cases(): iterable
+    {
+        yield 'simple class' => [
+            '<?php namespace App\Models; class User {}',
+            'App\Models\User',
+        ];
+
+        yield 'final class' => [
+            '<?php namespace App\Models; final class User {}',
+            'App\Models\User',
+        ];
+
+        yield 'abstract class' => [
+            '<?php namespace App\Models; abstract class BaseModel {}',
+            'App\Models\BaseModel',
+        ];
+
+        yield 'readonly class' => [
+            '<?php namespace App\Models; readonly class User {}',
+            'App\Models\User',
+        ];
+
+        yield 'final readonly class' => [
+            '<?php namespace App\Models; final readonly class User {}',
+            'App\Models\User',
+        ];
+
+        yield 'abstract readonly class' => [
+            '<?php namespace App\Models; abstract readonly class BaseModel {}',
+            'App\Models\BaseModel',
+        ];
+
+        yield 'no namespace' => [
+            '<?php class LegacyModel {}',
+            'LegacyModel',
+        ];
+
+        yield 'class inside block comment is ignored' => [
+            <<<'PHP'
+            <?php
+            namespace App\Models;
+            /*
+            class OldModelName
+            */
+            class ActualModel {}
+            PHP,
+            'App\Models\ActualModel',
+        ];
+
+        yield 'class in single-line comment is ignored' => [
+            <<<'PHP'
+            <?php
+            namespace App\Models;
+            // class FakeModel
+            class RealModel {}
+            PHP,
+            'App\Models\RealModel',
+        ];
+
+        yield 'class in string is ignored' => [
+            <<<'PHP'
+            <?php
+            namespace App\Models;
+            $x = 'class NotAClass {}';
+            class RealModel {}
+            PHP,
+            'App\Models\RealModel',
+        ];
+
+        yield 'trait returns null' => [
+            '<?php namespace App\Traits; trait HasSlug {}',
+            null,
+        ];
+
+        yield 'interface returns null' => [
+            '<?php namespace App\Contracts; interface Searchable {}',
+            null,
+        ];
+
+        yield 'enum returns null' => [
+            '<?php namespace App\Enums; enum Status: string { case Active = "active"; }',
+            null,
+        ];
+
+        yield 'empty file returns null' => [
+            '<?php',
+            null,
+        ];
+
+        yield 'class with extends' => [
+            '<?php namespace App\Models; class Post extends Model {}',
+            'App\Models\Post',
+        ];
+
+        yield 'multiline namespace and class' => [
+            <<<'PHP'
+            <?php
+
+            namespace App\Models;
+
+            use Illuminate\Database\Eloquent\Model;
+
+            class Post extends Model
+            {
+            }
+            PHP,
+            'App\Models\Post',
+        ];
+
+        yield '::class constant before real class' => [
+            <<<'PHP'
+            <?php
+            namespace App\Models;
+            $x = SomeOther::class;
+            class User {}
+            PHP,
+            'App\Models\User',
+        ];
+
+        yield 'anonymous class before real class' => [
+            <<<'PHP'
+            <?php
+            namespace App\Models;
+            $x = new class extends Model {};
+            class User {}
+            PHP,
+            'App\Models\User',
+        ];
+
+        yield 'PHP attributes on class' => [
+            <<<'PHP'
+            <?php
+            namespace App\Models;
+            #[SomeAttribute]
+            class User {}
+            PHP,
+            'App\Models\User',
+        ];
+
+        yield 'multiple classes returns first' => [
+            '<?php namespace App\Models; class First {} class Second {}',
+            'App\Models\First',
+        ];
+
+        yield 'bracketed namespace' => [
+            '<?php namespace App\Models { class User {} }',
+            'App\Models\User',
+        ];
+    }
+
+    #[DataProvider('extract_class_name_cases')]
+    public function test_extract_class_name(string $contents, ?string $expected): void
+    {
+        $this->tempFile = tempnam(sys_get_temp_dir(), 'psalm_test_');
+        self::assertNotFalse($this->tempFile);
+        file_put_contents($this->tempFile, $contents);
+
+        $result = self::$extractClassName->invoke(null, $this->tempFile);
+
+        self::assertSame($expected, $result);
+    }
+
+    public function test_extract_class_name_returns_null_for_nonexistent_file(): void
+    {
+        $result = self::$extractClassName->invoke(null, '/nonexistent/path/file.php');
+
+        self::assertNull($result);
+    }
+}


### PR DESCRIPTION
## Summary

Model discovery was finding **0 models** on projects with complex directory structures, silently disabling all model-aware type inference.

### Root cause

`ModelDiscoveryProvider` used `include_once` to load PHP files during model scanning. On **case-insensitive filesystems** (macOS HFS+/APFS), this causes uncatchable `Fatal error: Cannot redeclare class/trait` when the same file is encountered via different resolved paths.

This happens when:
- Multiple scan directories overlap or contain symlinks
- Composer's classmap has already autoloaded a file under a different path casing
- Relative vs absolute path resolution produces different strings for the same file

The fatal error is **not catchable** with `try/catch` — PHP kills the process. Since the plugin catches `\Throwable` around the entire discovery loop, the fatal error causes discovery to silently return an empty model list.

### Impact

On big projects (tested on 53 Eloquent models across 39 `app/Modules/*/Models/` directories), the plugin discovered 0 models. All handlers that depend on `ModelDiscoveryProvider::getModelClasses()` — property resolution, accessor detection, scope handling, factory types — were effectively disabled.

### Fix

Replace `include_once` with a two-step approach:

1. **Parse** the namespace and class name from file contents using regex (no PHP execution)
2. **Load** via `class_exists($className, true)` which triggers Composer's autoloader

This is safe because:
- Composer's autoloader handles duplicate loading gracefully (returns the cached class)
- `class_exists()` returns `false` (not fatal) if autoloading fails
- Any `\Throwable` from autoloading is caught and skipped
- The regex parser handles `namespace`, `class`, `abstract class`, and `final class` declarations

Also adds deduplication (`in_array` check) since the same class can appear in both the file-scanning and `get_declared_classes()` loops.

### New method: `extractClassName()`

```php
private static function extractClassName(string $filePath): ?string
```

Reads a PHP file and extracts the FQCN by matching:
- `namespace Foo\Bar;` → namespace prefix
- `class Baz` / `abstract class Baz` / `final class Baz` → class name

Returns `null` for files without a class declaration (traits, interfaces, enums, config files).

## Test plan

- [ ] `composer test` passes (54 tests)
- [ ] Plugin discovers models on macOS (case-insensitive filesystem)
- [ ] Plugin discovers models when scan directories overlap
- [ ] Files without classes (traits, interfaces, enums) are skipped gracefully
- [ ] Autoloader failures are caught and skipped