### PR TITLE
Fix CastsMethodParser crash on Psalm 7

### DIFF
--- a/src/Handlers/Eloquent/Schema/CastsMethodParser.php
+++ b/src/Handlers/Eloquent/Schema/CastsMethodParser.php
@@ -43,7 +43,7 @@ final class CastsMethodParser
             $methodStorage = $codebase->methods->getStorage(
                 MethodIdentifier::wrap($methodId),
             );
-        } catch (\InvalidArgumentException) {
+        } catch (\InvalidArgumentException|\UnexpectedValueException) {
             return [];
         }
 


### PR DESCRIPTION
## Summary

`CastsMethodParser::parse()` crashes with an uncaught `UnexpectedValueException` on Psalm 7 when parsing models with a `casts()` method.

### Root cause

`$codebase->methods->getStorage()` throws different exception types depending on the Psalm version:
- **Psalm 6**: `InvalidArgumentException` when method storage is not found
- **Psalm 7**: `UnexpectedValueException` when method storage is null

The catch clause only handled `InvalidArgumentException`, so on Psalm 7 the exception propagated uncaught.

### Fix

Add `UnexpectedValueException` to the catch clause:

```php
// Before
} catch (\InvalidArgumentException) {

// After  
} catch (\InvalidArgumentException|\UnexpectedValueException) {
```

This is backwards-compatible — works on both Psalm 6 and 7.

## Test plan

- [x] `composer test` passes (54 tests)
- [x] Models with `casts()` method are parsed without crash on Psalm 7
- [x] Models with `casts()` method still work on Psalm 6