### PR TITLE
fix: resolve 50+ GB memory explosion in RelationsMethodHandler

### DIFF
--- a/src/Handlers/Eloquent/RelationsMethodHandler.php
+++ b/src/Handlers/Eloquent/RelationsMethodHandler.php
@@ -131,10 +131,11 @@ final class RelationsMethodHandler implements MethodReturnTypeProviderInterface
             foreach ($returnType->getAtomicTypes() as $atomicType) {
                 if ($atomicType instanceof Type\Atomic\TNamedObject) {
                     $fqcn = \strtolower($atomicType->value);
-                    // Match: Builder<TModel>, self<TModel>, Query\Builder, or static/$this
+                    // Match Eloquent\Builder or static/$this return types.
+                    // Do NOT match Query\Builder — methods like toBase()/getQuery()
+                    // return Query\Builder intentionally, not a fluent chain.
                     if (
                         $fqcn === \strtolower(Builder::class)
-                        || $fqcn === \strtolower(QueryBuilder::class)
                         || $fqcn === 'static'
                     ) {
                         return true;


### PR DESCRIPTION
## Summary

- Replaces `ProxyMethodReturnTypeProvider::executeFakeCall()` with lightweight type lookup via `classlike_storage_provider` and `methods->getStorage()`
- `executeFakeCall()` cloned Psalm's `node_data` (full statement analysis context) for every relation method call — on large codebases this caused 50+ GB memory explosion
- Uses `declaring_method_ids` instead of `methodExists()` to avoid `__call` magic resolution
- Catches specific exception types (`InvalidArgumentException`, `UnexpectedValueException`) matching what Psalm actually throws

**Tested on IxDF-web** (~5,900 analyzed files, ~53 Eloquent models):
- Before: 57+ GB memory, OOM killed
- After: 4.7 GB memory, 187s runtime (baseline without plugin: 4.6 GB, 180s)

## Test plan
- [x] `composer test` passes (cs-fixer + psalm + unit tests + type tests)
- [x] Architectural guard test from PR #433 now passes
- [x] Verified on IxDF-web production codebase: memory stays under 5 GB