### PR TITLE
feat: improve stub types for better static analysis

### DIFF
--- a/stubs/common/Database/Eloquent/Builder.stubphp
+++ b/stubs/common/Database/Eloquent/Builder.stubphp
@@ -337,16 +337,16 @@ class Builder implements BuilderContract
     /**
      * @param  array<string, mixed>  $attributes
      * @param  array  $values
-     * @return TModel|self<TModel>
+     * @return TModel
      */
     public function firstOrNew(array $attributes = [], array $values = []) {}
 
     /**
      * @param  array<string, mixed>  $attributes
-     * @param  array  $values
-     * @return TModel|self<TModel>
+     * @param  \Closure|array  $values
+     * @return TModel
      */
-    public function firstOrCreate(array $attributes = [], array $values = []) {}
+    public function firstOrCreate(array $attributes = [], \Closure|array $values = []) {}
 
     /**
      * @param  (\Closure(static): void)|(\Closure(static): static)|non-empty-string|list<non-empty-string>|int, mixed>|\Illuminate\Database\Query\Expression  $column
@@ -436,7 +436,7 @@ class Builder implements BuilderContract
     /**
      * Get a lazy collection for the given query.
      *
-     * @return \Illuminate\Support\LazyCollection
+     * @return \Illuminate\Support\LazyCollection<int, TModel>
      */
     public function cursor() {}
 

--- a/stubs/common/Database/Eloquent/Collection.stubphp
+++ b/stubs/common/Database/Eloquent/Collection.stubphp
@@ -23,4 +23,12 @@ class Collection extends BaseCollection implements QueueableCollection
      * @psalm-return (TKey is \Illuminate\Database\Eloquent\Model ? TModel|TFindDefault : (TKey is (\Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<mixed>) ? static<TKey, TModel> : TModel|TFindDefault))
      */
     public function find($key, $default = null) {}
+
+    /**
+     * Load a set of relationships onto the collection if they are not already eager loaded.
+     *
+     * @param  array<array-key, (callable(\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Eloquent\Relations\Relation): mixed)|string>|string  $relations
+     * @return $this
+     */
+    public function loadMissing($relations) {}
 }

--- a/stubs/common/Database/Eloquent/Concerns/QueriesRelationships.stubphp
+++ b/stubs/common/Database/Eloquent/Concerns/QueriesRelationships.stubphp
@@ -1,0 +1,106 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Concerns;
+
+use Closure;
+use Illuminate\Database\Eloquent\Builder;
+
+trait QueriesRelationships
+{
+    /**
+     * Add a relationship count / exists condition to the query with where clauses.
+     * Also load the relationship with same condition.
+     *
+     * @param  string  $relation
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder): mixed)|null  $callback
+     * @param  string  $operator
+     * @param  \Illuminate\Contracts\Database\Query\Expression|int  $count
+     * @return $this
+     */
+    public function withWhereHas($relation, ?Closure $callback = null, $operator = '>=', $count = 1) {}
+
+    /**
+     * Add a "belongs to" relationship where clause to the query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model>  $related
+     * @param  string|null  $relationshipName
+     * @param  string  $boolean
+     * @return $this
+     *
+     * @throws \Illuminate\Database\Eloquent\RelationNotFoundException
+     */
+    public function whereBelongsTo($related, $relationshipName = null, $boolean = 'and') {}
+
+    /**
+     * Add a "belongs to" relationship with an "or where" clause to the query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $related
+     * @param  string|null  $relationshipName
+     * @return $this
+     *
+     * @throws \RuntimeException
+     */
+    public function orWhereBelongsTo($related, $relationshipName = null) {}
+
+    /**
+     * Add subselect queries to include an aggregate value for a relationship.
+     *
+     * @param  mixed  $relations
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  string|null  $function
+     * @return $this
+     */
+    public function withAggregate($relations, $column, $function = null) {}
+
+    /**
+     * Add subselect queries to count the relations.
+     *
+     * @param  mixed  $relations
+     * @return $this
+     */
+    public function withCount($relations) {}
+
+    /**
+     * Add subselect queries to include the max of the relation's column.
+     *
+     * @param  string|array  $relation
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @return $this
+     */
+    public function withMax($relation, $column) {}
+
+    /**
+     * Add subselect queries to include the min of the relation's column.
+     *
+     * @param  string|array  $relation
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @return $this
+     */
+    public function withMin($relation, $column) {}
+
+    /**
+     * Add subselect queries to include the sum of the relation's column.
+     *
+     * @param  string|array  $relation
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @return $this
+     */
+    public function withSum($relation, $column) {}
+
+    /**
+     * Add subselect queries to include the average of the relation's column.
+     *
+     * @param  string|array  $relation
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @return $this
+     */
+    public function withAvg($relation, $column) {}
+
+    /**
+     * Add subselect queries to include the existence of related models.
+     *
+     * @param  string|array  $relation
+     * @return $this
+     */
+    public function withExists($relation) {}
+}

--- a/stubs/common/Database/Eloquent/Model.stubphp
+++ b/stubs/common/Database/Eloquent/Model.stubphp
@@ -101,4 +101,39 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @return \Illuminate\Database\Eloquent\Builder<$this>
      */
     public function newEloquentBuilder($query) {}
+
+    /**
+     * Get the value of the model's primary key.
+     *
+     * @return int|string|null
+     */
+    public function getKey() {}
+
+    /**
+     * Get the attributes that have been changed since the last sync.
+     *
+     * @return array<string, mixed>
+     */
+    public function getDirty() {}
+
+    /**
+     * Get the attributes that were changed when the model was last saved.
+     *
+     * @return array<string, mixed>
+     */
+    public function getChanges() {}
+
+    /**
+     * Convert the model instance to an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray() {}
+
+    /**
+     * Get all of the current attributes on the model.
+     *
+     * @return array<string, mixed>
+     */
+    public function getAttributes() {}
 }

--- a/stubs/common/Database/Query/Builder.stubphp
+++ b/stubs/common/Database/Query/Builder.stubphp
@@ -145,4 +145,12 @@ class Builder
      * @psalm-taint-sink sql $expression
      */
     public function rawValue(string $expression, array $bindings = []) {}
+
+    /**
+     * Retrieve the sum of the values of a given column.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @return int|float
+     */
+    public function sum($column) {}
 }

--- a/stubs/common/Routing/Route.stubphp
+++ b/stubs/common/Routing/Route.stubphp
@@ -11,4 +11,12 @@ class Route
      * @return ($middleware is null ? string[] : $this)
      */
     public function middleware($middleware = null) {}
+
+    /**
+     * Get the action array or one of its properties for the route.
+     *
+     * @param  string|null  $key
+     * @return ($key is null ? array : mixed)
+     */
+    public function getAction($key = null) {}
 }

--- a/stubs/common/Support/Facades/Cache.stubphp
+++ b/stubs/common/Support/Facades/Cache.stubphp
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Support\Facades;
+
+class Cache extends Facade
+{
+    /**
+     * Get an item from the cache, or execute the given Closure and store the result.
+     *
+     * @template TCacheValue
+     *
+     * @param  \UnitEnum|string  $key
+     * @param  \Closure|\DateTimeInterface|\DateInterval|int|null  $ttl
+     * @param  \Closure(): TCacheValue  $callback
+     * @return TCacheValue
+     */
+    public static function remember($key, $ttl, \Closure $callback) {}
+
+    /**
+     * Get an item from the cache, or execute the given Closure and store the result forever.
+     *
+     * @template TCacheValue
+     *
+     * @param  \UnitEnum|string  $key
+     * @param  \Closure(): TCacheValue  $callback
+     * @return TCacheValue
+     */
+    public static function rememberForever($key, \Closure $callback) {}
+}

--- a/stubs/common/Support/Facades/DB.stubphp
+++ b/stubs/common/Support/Facades/DB.stubphp
@@ -5,6 +5,19 @@ namespace Illuminate\Support\Facades;
 class DB extends Facade
 {
     /**
+     * Execute a Closure within a transaction.
+     *
+     * @template TReturnValue
+     *
+     * @param  \Closure(\Illuminate\Database\Connection): TReturnValue  $callback
+     * @param  int  $attempts
+     * @return TReturnValue
+     *
+     * @throws \Throwable
+     */
+    public static function transaction(\Closure $callback, $attempts = 1) {}
+
+    /**
      * Create a raw database expression.
      *
      * @param  mixed  $value
@@ -20,7 +33,7 @@ class DB extends Facade
      * @param  string  $query
      * @param  array  $bindings
      * @param  bool  $useReadPdo
-     * @return array
+     * @return list<\stdClass>
      *
      * @psalm-taint-sink sql $query
      */
@@ -64,7 +77,7 @@ class DB extends Facade
      * @param  string  $query
      * @param  array  $bindings
      * @param  bool  $useReadPdo
-     * @return mixed
+     * @return \stdClass|null
      *
      * @psalm-taint-sink sql $query
      */

--- a/stubs/common/Support/Testing/Fakes/EventFake.stubphp
+++ b/stubs/common/Support/Testing/Fakes/EventFake.stubphp
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Support\Testing\Fakes;
+
+class EventFake
+{
+    /**
+     * Assert if an event has a listener attached to it.
+     *
+     * @param  string  $expectedEvent
+     * @param  string|array{class-string, string}  $expectedListener
+     * @return void
+     */
+    public function assertListening($expectedEvent, $expectedListener) {}
+}

--- a/stubs/common/Support/helpers.stubphp
+++ b/stubs/common/Support/helpers.stubphp
@@ -106,13 +106,13 @@ function optional($value = null, callable $callback = null) {}
  * @template TValue
  * @param int|list<int> $times
  * @param callable(int): TValue $callback
- * @param int $sleep
- * @param null|callable(\Exception): bool $when
+ * @param int|\Closure(int, \Throwable): int $sleepMilliseconds
+ * @param null|callable(\Throwable): bool $when
  * @psalm-return TValue
  *
- * @throws \Exception
+ * @throws \Throwable
  */
-function retry($times, callable $callback, $sleep = 0, $when = null) {}
+function retry($times, callable $callback, $sleepMilliseconds = 0, $when = null) {}
 
 /**
  * Get a new stringable object from the given string.


### PR DESCRIPTION
## Summary

- **Eloquent Builder**: fix `cursor()` generic return (`LazyCollection<int, TModel>`), `firstOrNew`/`firstOrCreate` return `TModel` (not `TModel|self<TModel>`), `firstOrCreate` accepts `Closure|array` for deferred values (Laravel 12)
- **Model**: add `getKey()` → `int|string|null`, `getDirty()`/`getChanges()`/`toArray()`/`getAttributes()` → `array<string, mixed>`
- **Eloquent Collection**: add `loadMissing()` with typed `$relations` param
- **Query Builder**: add `sum()` → `int|float`
- **Route**: add `getAction()` with conditional return type
- **DB facade**: add `transaction()` with template return type and `Connection` callback param, improve `select()` → `list<stdClass>`, `selectOne()` → `stdClass|null` (preserving taint-sink annotations)
- **Cache facade** (new): `remember()`/`rememberForever()` with template return types
- **QueriesRelationships** (new): `withWhereHas`, `whereBelongsTo`, `orWhereBelongsTo`, `withCount`/`withMax`/`withMin`/`withSum`/`withAvg`/`withExists`
- **EventFake** (new): `assertListening()` with typed params
- **Support helpers**: fix `retry()` param name to `$sleepMilliseconds`, add `Closure` sleep variant, fix `@throws` to `\Throwable`

All types verified against Laravel 12.53.0 source. Zero new test failures.

## Test plan

- [x] `composer psalm` — no errors
- [x] `phpunit tests/Type/` — same 28 pre-existing failures, zero new
- [x] `phpunit tests/Unit/` — all pass (48 tests, 198 assertions)