### PR TITLE
fix: revert overly specific return types that cause regressions

### DIFF
--- a/stubs/common/Database/Eloquent/Model.stubphp
+++ b/stubs/common/Database/Eloquent/Model.stubphp
@@ -105,7 +105,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Get the value of the model's primary key.
      *
-     * @return int|string|null
+     * @return int|string
      */
     public function getKey() {}
 

--- a/stubs/common/Support/Facades/DB.stubphp
+++ b/stubs/common/Support/Facades/DB.stubphp
@@ -33,7 +33,7 @@ class DB extends Facade
      * @param  string  $query
      * @param  array  $bindings
      * @param  bool  $useReadPdo
-     * @return list<\stdClass>
+     * @return array
      *
      * @psalm-taint-sink sql $query
      */
@@ -77,7 +77,7 @@ class DB extends Facade
      * @param  string  $query
      * @param  array  $bindings
      * @param  bool  $useReadPdo
-     * @return \stdClass|null
+     * @return mixed
      *
      * @psalm-taint-sink sql $query
      */


### PR DESCRIPTION
## Summary

- `Model::getKey()`: revert to `int|string` — null causes cascading mixed inference in array/concatenation contexts (14+ false positives)
- `DB::select()`: revert to `array` — `list<\stdClass>` causes MixedPropertyFetch on dynamic property access (8+ false positives)
- `DB::selectOne()`: revert to `mixed` — `\stdClass|null` causes MixedPropertyFetch (4+ false positives)

All taint-sink annotations are preserved. Only return types reverted to match Laravel's own declared signatures.

Follow-up to #436.

## Test plan

- [ ] Verify no new Psalm errors on projects using DB::select/selectOne
- [ ] Verify getKey() doesn't cause mixed inference in array contexts
- [ ] Run `composer test` passes