### PR TITLE
fix: add missing TKey template parameter to pagination stubs

### DIFF
--- a/stubs/common/Contracts/Pagination.stubphp
+++ b/stubs/common/Contracts/Pagination.stubphp
@@ -3,6 +3,7 @@
 namespace Illuminate\Contracts\Pagination;
 
 /**
+ * @template TKey of array-key
  * @template TItem
  */
 interface Paginator
@@ -14,14 +15,16 @@ interface Paginator
 }
 
 /**
+ * @template TKey of array-key
  * @template TItem
  *
- * @extends Paginator<TItem>
+ * @extends Paginator<TKey, TItem>
  */
 interface LengthAwarePaginator extends Paginator
 {}
 
 /**
+ * @template TKey of array-key
  * @template TItem
  */
 interface CursorPaginator

--- a/stubs/common/Database/Eloquent/Builder.stubphp
+++ b/stubs/common/Database/Eloquent/Builder.stubphp
@@ -466,7 +466,7 @@ class Builder implements BuilderContract
      * @param  list<non-empty-string>  $columns
      * @param  string  $pageName
      * @param  int|null  $page
-     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
+     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator<int, TModel>
      *
      * @throws \InvalidArgumentException
      */
@@ -477,7 +477,7 @@ class Builder implements BuilderContract
      * @param  list<non-empty-string>  $columns
      * @param  string  $pageName
      * @param  int|null  $page
-     * @return \Illuminate\Contracts\Pagination\Paginator
+     * @return \Illuminate\Contracts\Pagination\Paginator<int, TModel>
      */
     public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null) {}
 
@@ -488,7 +488,7 @@ class Builder implements BuilderContract
      * @param  array<array-key, mixed>  $columns
      * @param  string  $cursorName
      * @param  \Illuminate\Pagination\Cursor|string|null  $cursor
-     * @return \Illuminate\Pagination\CursorPaginator<TModel>
+     * @return \Illuminate\Pagination\CursorPaginator<int, TModel>
      */
     public function cursorPaginate($perPage = null, $columns = ['*'], $cursorName = 'cursor', $cursor = null) {}
 

--- a/stubs/common/Database/Eloquent/Relations/BelongsToMany.stubphp
+++ b/stubs/common/Database/Eloquent/Relations/BelongsToMany.stubphp
@@ -118,7 +118,7 @@ class BelongsToMany extends Relation
      * @param  array<int, mixed>  $columns
      * @param  string  $pageName
      * @param  int|null  $page
-     * @return \Illuminate\Pagination\LengthAwarePaginator<TRelatedModel>
+     * @return \Illuminate\Pagination\LengthAwarePaginator<int, TRelatedModel>
      */
     public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null) {}
 
@@ -129,7 +129,7 @@ class BelongsToMany extends Relation
      * @param  array<int, mixed>  $columns
      * @param  string  $pageName
      * @param  int|null  $page
-     * @return \Illuminate\Pagination\Paginator<TRelatedModel>
+     * @return \Illuminate\Pagination\Paginator<int, TRelatedModel>
      */
     public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null) {}
 
@@ -140,7 +140,7 @@ class BelongsToMany extends Relation
      * @param  array<int, mixed>  $columns
      * @param  string  $cursorName
      * @param  string|null  $cursor
-     * @return \Illuminate\Pagination\CursorPaginator<TRelatedModel>
+     * @return \Illuminate\Pagination\CursorPaginator<int, TRelatedModel>
      */
     public function cursorPaginate($perPage = null, $columns = ['*'], $cursorName = 'cursor', $cursor = null) {}
 }

--- a/stubs/common/Database/Eloquent/Relations/HasManyThrough.stubphp
+++ b/stubs/common/Database/Eloquent/Relations/HasManyThrough.stubphp
@@ -48,7 +48,7 @@ class HasManyThrough extends Relation
      * @param  array<int, mixed>  $columns
      * @param  string  $pageName
      * @param  int|null  $page
-     * @return \Illuminate\Pagination\LengthAwarePaginator<TRelatedModel>
+     * @return \Illuminate\Pagination\LengthAwarePaginator<int, TRelatedModel>
      */
     public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null) {}
 
@@ -59,7 +59,7 @@ class HasManyThrough extends Relation
      * @param  array<int, mixed>  $columns
      * @param  string  $pageName
      * @param  int|null  $page
-     * @return \Illuminate\Pagination\Paginator<TRelatedModel>
+     * @return \Illuminate\Pagination\Paginator<int, TRelatedModel>
      */
     public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null) {}
 
@@ -70,7 +70,7 @@ class HasManyThrough extends Relation
      * @param  array<int, mixed>  $columns
      * @param  string  $cursorName
      * @param  string|null  $cursor
-     * @return \Illuminate\Pagination\CursorPaginator<TRelatedModel>
+     * @return \Illuminate\Pagination\CursorPaginator<int, TRelatedModel>
      */
     public function cursorPaginate($perPage = null, $columns = ['*'], $cursorName = 'cursor', $cursor = null) {}
 

--- a/stubs/common/Pagination/Pagination.stubphp
+++ b/stubs/common/Pagination/Pagination.stubphp
@@ -3,9 +3,10 @@
 namespace Illuminate\Pagination;
 
 /**
+ * @template TKey of array-key
  * @template TValue
  *
- * @mixin \Illuminate\Support\Collection<array-key, TValue>
+ * @mixin \Illuminate\Support\Collection<TKey, TValue>
  */
 abstract class AbstractPaginator implements \Illuminate\Contracts\Support\Htmlable
 {
@@ -15,12 +16,12 @@ abstract class AbstractPaginator implements \Illuminate\Contracts\Support\Htmlab
     public function items(): array {}
 
     /**
-     * @return \Illuminate\Support\Collection<array-key, TValue>
+     * @return \Illuminate\Support\Collection<TKey, TValue>
      */
     public function getCollection(): \Illuminate\Support\Collection {}
 
     /**
-     * @return \ArrayIterator<array-key, TValue>
+     * @return \ArrayIterator<TKey, TValue>
      */
     public function getIterator(): \Traversable {}
 
@@ -40,35 +41,38 @@ abstract class AbstractPaginator implements \Illuminate\Contracts\Support\Htmlab
 }
 
 /**
+ * @template TKey of array-key
  * @template TValue
  *
- * @implements \ArrayAccess<array-key, TValue>
- * @implements \IteratorAggregate<array-key, TValue>
- * @implements \Illuminate\Contracts\Support\Arrayable<array-key, TValue>
- * @implements \Illuminate\Contracts\Pagination\Paginator<TValue>
+ * @implements \ArrayAccess<TKey, TValue>
+ * @implements \IteratorAggregate<TKey, TValue>
+ * @implements \Illuminate\Contracts\Support\Arrayable<TKey, TValue>
+ * @implements \Illuminate\Contracts\Pagination\Paginator<TKey, TValue>
  *
- * @extends AbstractPaginator<TValue>
+ * @extends AbstractPaginator<TKey, TValue>
  */
 class Paginator extends AbstractPaginator implements \Illuminate\Contracts\Support\Arrayable, \ArrayAccess, \Countable, \IteratorAggregate, \Illuminate\Contracts\Support\Jsonable, \JsonSerializable, \Illuminate\Contracts\Pagination\Paginator
 {}
 
 /**
+ * @template TKey of array-key
  * @template TValue
  *
- * @implements \ArrayAccess<array-key, TValue>
- * @implements \IteratorAggregate<array-key, TValue>
- * @implements \Illuminate\Contracts\Support\Arrayable<array-key, TValue>
- * @implements \Illuminate\Contracts\Pagination\LengthAwarePaginator<TValue>
+ * @implements \ArrayAccess<TKey, TValue>
+ * @implements \IteratorAggregate<TKey, TValue>
+ * @implements \Illuminate\Contracts\Support\Arrayable<TKey, TValue>
+ * @implements \Illuminate\Contracts\Pagination\LengthAwarePaginator<TKey, TValue>
  *
- * @extends AbstractPaginator<TValue>
+ * @extends AbstractPaginator<TKey, TValue>
  */
 class LengthAwarePaginator extends AbstractPaginator implements \Illuminate\Contracts\Support\Arrayable, \ArrayAccess, \Countable, \IteratorAggregate, \Illuminate\Contracts\Support\Jsonable, \JsonSerializable, \Illuminate\Contracts\Pagination\LengthAwarePaginator
 {}
 
 /**
+ * @template TKey of array-key
  * @template TValue
  *
- * @mixin \Illuminate\Support\Collection<mixed, TValue>
+ * @mixin \Illuminate\Support\Collection<TKey, TValue>
  */
 abstract class AbstractCursorPaginator implements \Illuminate\Contracts\Support\Htmlable
 {
@@ -78,12 +82,12 @@ abstract class AbstractCursorPaginator implements \Illuminate\Contracts\Support\
     public function items(): array {}
 
     /**
-     * @return \Illuminate\Support\Collection<array-key, TValue>
+     * @return \Illuminate\Support\Collection<TKey, TValue>
      */
     public function getCollection(): \Illuminate\Support\Collection {}
 
     /**
-     * @return \ArrayIterator<array-key, TValue>
+     * @return \ArrayIterator<TKey, TValue>
      */
     public function getIterator(): \Traversable {}
 
@@ -103,14 +107,15 @@ abstract class AbstractCursorPaginator implements \Illuminate\Contracts\Support\
 }
 
 /**
+ * @template TKey of array-key
  * @template TValue
  *
- * @implements \ArrayAccess<array-key, TValue>
- * @implements \IteratorAggregate<array-key, TValue>
- * @implements \Illuminate\Contracts\Support\Arrayable<array-key, TValue>
- * @implements \Illuminate\Contracts\Pagination\CursorPaginator<TValue>
+ * @implements \ArrayAccess<TKey, TValue>
+ * @implements \IteratorAggregate<TKey, TValue>
+ * @implements \Illuminate\Contracts\Support\Arrayable<TKey, TValue>
+ * @implements \Illuminate\Contracts\Pagination\CursorPaginator<TKey, TValue>
  *
- * @extends AbstractCursorPaginator<TValue>
+ * @extends AbstractCursorPaginator<TKey, TValue>
  */
 class CursorPaginator extends AbstractCursorPaginator implements \Illuminate\Contracts\Support\Arrayable, \ArrayAccess, \Countable, \IteratorAggregate, \Illuminate\Contracts\Support\Jsonable, \JsonSerializable, \Illuminate\Contracts\Pagination\CursorPaginator
 {}

--- a/tests/Type/tests/EloquentBuilderTypesTest.phpt
+++ b/tests/Type/tests/EloquentBuilderTypesTest.phpt
@@ -61,7 +61,19 @@ final class UserRepository
             });
     }
 
-    /** @return \Illuminate\Pagination\CursorPaginator<User> */
+    /** @return \Illuminate\Contracts\Pagination\LengthAwarePaginator<int, User> */
+    public function testPaginate(): \Illuminate\Contracts\Pagination\LengthAwarePaginator
+    {
+        return User::query()->paginate();
+    }
+
+    /** @return \Illuminate\Contracts\Pagination\Paginator<int, User> */
+    public function testSimplePaginate(): \Illuminate\Contracts\Pagination\Paginator
+    {
+        return User::query()->simplePaginate();
+    }
+
+    /** @return \Illuminate\Pagination\CursorPaginator<int, User> */
     public function testCursorPaginate(Builder $builder): \Illuminate\Pagination\CursorPaginator
     {
         return User::query()->cursorPaginate();

--- a/tests/Type/tests/PaginationTest.phpt
+++ b/tests/Type/tests/PaginationTest.phpt
@@ -1,0 +1,54 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
+use Illuminate\Pagination\CursorPaginator;
+use Illuminate\Support\Collection;
+
+/**
+ * @param Collection<int, string> $items
+ */
+function length_aware_paginator_accepts_collection(Collection $items): LengthAwarePaginator
+{
+    return new LengthAwarePaginator($items, 100, 15);
+}
+
+/**
+ * @param Collection<int, string> $items
+ */
+function paginator_accepts_collection(Collection $items): Paginator
+{
+    return new Paginator($items, 15);
+}
+
+/** @param LengthAwarePaginator<int, string> $paginator */
+function length_aware_paginator_items(LengthAwarePaginator $paginator): void
+{
+    $_items = $paginator->items();
+    /** @psalm-check-type-exact $_items = array<string> */
+
+    $_collection = $paginator->getCollection();
+    /** @psalm-check-type-exact $_collection = Collection<int, string> */
+}
+
+/** @param Paginator<int, string> $paginator */
+function paginator_items(Paginator $paginator): void
+{
+    $_items = $paginator->items();
+    /** @psalm-check-type-exact $_items = array<string> */
+
+    $_collection = $paginator->getCollection();
+    /** @psalm-check-type-exact $_collection = Collection<int, string> */
+}
+
+/** @param CursorPaginator<int, string> $paginator */
+function cursor_paginator_items(CursorPaginator $paginator): void
+{
+    $_items = $paginator->items();
+    /** @psalm-check-type-exact $_items = array<string> */
+
+    $_collection = $paginator->getCollection();
+    /** @psalm-check-type-exact $_collection = Collection<int, string> */
+}
+--EXPECT--


### PR DESCRIPTION
## Summary

Closes #439 

- Add `TKey of array-key` template parameter to all pagination stubs (`AbstractPaginator`, `Paginator`, `LengthAwarePaginator`, `AbstractCursorPaginator`, `CursorPaginator`) and their contract interfaces to match Laravel's actual generic signatures
- Update Builder and Relations stubs (`paginate()`, `simplePaginate()`, `cursorPaginate()`) to pass `<int, TModel>` template args
- Add type tests for pagination constructor acceptance and return type inference

Fixes #439

## Test plan

- [x] New `PaginationTest.phpt` — verifies constructor accepts typed `Collection`, and `items()`/`getCollection()` return correct types for all 3 paginator types
- [x] Updated `EloquentBuilderTypesTest.phpt` — verifies `paginate()`, `simplePaginate()`, and `cursorPaginate()` on Builder return correctly typed paginators
- [x] Full test suite passes (`composer test`)