### PR TITLE
feat: auto-discover migration directories via Migrator

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -181,7 +181,7 @@ final class Plugin implements PluginEntryPointInterface
 
         $migrationFilePathnames = [];
         foreach ($this->getMigrationDirectories($app) as $directory) {
-            $migrationFilePathnames = \array_merge($migrationFilePathnames, $this->findPhpFilesRecursive($directory));
+            \array_push($migrationFilePathnames, ...$this->findPhpFilesRecursive($directory));
         }
 
         if ($migrationFilePathnames === []) {


### PR DESCRIPTION
Issue #342

- Reads extra migration paths from Laravel's `Migrator::paths()` (populated by `loadMigrationsFrom()` in service providers)
- Merges them with the default `database/migrations` directory — matching Laravel's own `BaseCommand::getMigrationPaths()` behavior
- Zero config required — works automatically for packages like Laravel Modules, Spatie, and domain-driven setups
