### PR TITLE
Fix Psalm 7 crash for Auth facade @method-annotated methods

### DIFF
--- a/src/Handlers/Auth/AuthHandler.php
+++ b/src/Handlers/Auth/AuthHandler.php
@@ -17,7 +17,7 @@ use Psalm\Type;
  * @see \Illuminate\Support\Facades\Auth::loginUsingId() returns Authenticatable|false
  * @see \Illuminate\Support\Facades\Auth::onceUsingId() returns Authenticatable|false
  * @see \Illuminate\Support\Facades\Auth::logoutOtherDevices() returns Authenticatable|null
- * @see \Illuminate\Support\Facades\Auth::getLastAttempted() returns Authenticatable
+ * @see \Illuminate\Support\Facades\Auth::getLastAttempted() returns Authenticatable|null
  * @see \Illuminate\Support\Facades\Auth::getUser() returns Authenticatable|null
  * @see \Illuminate\Support\Facades\Auth::authenticate() returns Authenticatable
  *
@@ -93,7 +93,7 @@ final class AuthHandler implements MethodReturnTypeProviderInterface, MethodPara
      * @method annotations on facades causes an UnexpectedValueException crash. We must return
      * explicit params for every method we handle.
      *
-     * @see https://github.com/psalm/psalm-plugin-laravel/issues/XXX
+     * @see https://github.com/psalm/psalm-plugin-laravel/issues/454
      */
     #[\Override]
     public static function getMethodParams(MethodParamsProviderEvent $event): ?array
@@ -105,20 +105,20 @@ final class AuthHandler implements MethodReturnTypeProviderInterface, MethodPara
             // SessionGuard::getLastAttempted() — all take no parameters
             'user', 'getuser', 'authenticate', 'getlastattempted' => [],
 
-            // SessionGuard::logoutOtherDevices(#[\SensitiveParameter] string $password, string $attribute = 'password')
+            // SessionGuard::logoutOtherDevices(#[\SensitiveParameter] string $password)
             'logoutotherdevices' => [
-                new FunctionLikeParameter('password', false, Type::getString(), Type::getString()),
+                new FunctionLikeParameter('password', false, Type::getString(), Type::getString(), is_optional: false),
             ],
 
             // StatefulGuard::loginUsingId(mixed $id, bool $remember = false)
             'loginusingid' => [
-                new FunctionLikeParameter('id', false, Type::getMixed(), Type::getMixed()),
+                new FunctionLikeParameter('id', false, Type::getMixed(), Type::getMixed(), is_optional: false),
                 new FunctionLikeParameter('remember', false, Type::getBool(), Type::getBool(), is_optional: true, default_type: Type::getFalse()),
             ],
 
             // StatefulGuard::onceUsingId(mixed $id)
             'onceusingid' => [
-                new FunctionLikeParameter('id', false, Type::getMixed(), Type::getMixed()),
+                new FunctionLikeParameter('id', false, Type::getMixed(), Type::getMixed(), is_optional: false),
             ],
 
             default => null,

--- a/tests/Type/tests/AuthTest.phpt
+++ b/tests/Type/tests/AuthTest.phpt
@@ -18,5 +18,14 @@ $_loginUsingId = \Illuminate\Support\Facades\Auth::loginUsingId(1);
 
 $_onceUsingId = \Illuminate\Support\Facades\Auth::onceUsingId(1);
 /** @psalm-check-type-exact $_onceUsingId = \Illuminate\Foundation\Auth\User|false */
+
+$_getLastAttempted = \Illuminate\Support\Facades\Auth::getLastAttempted();
+/** @psalm-check-type-exact $_getLastAttempted = \Illuminate\Foundation\Auth\User|null */
+
+$_logoutOtherDevices = \Illuminate\Support\Facades\Auth::logoutOtherDevices('secret');
+/** @psalm-check-type-exact $_logoutOtherDevices = \Illuminate\Foundation\Auth\User|null */
+
+$_loginUsingIdWithRemember = \Illuminate\Support\Facades\Auth::loginUsingId(1, true);
+/** @psalm-check-type-exact $_loginUsingIdWithRemember = \Illuminate\Foundation\Auth\User|false */
 ?>
 --EXPECT--

--- a/tests/Unit/Handlers/Auth/AuthHandlerTest.php
+++ b/tests/Unit/Handlers/Auth/AuthHandlerTest.php
@@ -54,6 +54,7 @@ final class AuthHandlerTest extends TestCase
         $this->assertNotNull($params);
         $this->assertCount(2, $params);
         $this->assertSame('id', $params[0]->name);
+        $this->assertFalse($params[0]->is_optional);
         $this->assertSame('remember', $params[1]->name);
         $this->assertTrue($params[1]->is_optional);
     }
@@ -70,6 +71,7 @@ final class AuthHandlerTest extends TestCase
         $this->assertNotNull($params);
         $this->assertCount(1, $params);
         $this->assertSame('id', $params[0]->name);
+        $this->assertFalse($params[0]->is_optional);
     }
 
     public function testGetMethodParamsForLogoutOtherDevices(): void
@@ -84,6 +86,7 @@ final class AuthHandlerTest extends TestCase
         $this->assertNotNull($params);
         $this->assertCount(1, $params);
         $this->assertSame('password', $params[0]->name);
+        $this->assertFalse($params[0]->is_optional);
     }
 
     public function testGetMethodParamsForUnknownMethod(): void


### PR DESCRIPTION
Closes https://github.com/psalm/psalm-plugin-laravel/issues/454

## Summary

- Fix `UnexpectedValueException: Cannot get method params for Illuminate\Support\Facades\Auth::getuser` crash in Psalm 7
- `AuthHandler::getMethodParams()` previously only handled `user()` and returned `null` for all other methods. In Psalm 7, returning `null` from a `MethodParamsProviderInterface` for methods that only exist as `@method` annotations on facades causes a crash (Psalm 6 handled this gracefully).
- Now provides explicit `FunctionLikeParameter` arrays for all seven methods handled by `getMethodReturnType`: `user`, `getUser`, `authenticate`, `getLastAttempted`, `logoutOtherDevices`, `loginUsingId`, `onceUsingId`
- Discovered while testing against [IXP-Manager](https://github.com/inex/IXP-Manager) (421⭐), where `Auth::getUser()` appears 146 times across 79 files

## Test plan

- [x] Added unit tests for all 7 methods' params (expanded from 2 to 8 tests)
- [x] Added type test assertions for `Auth::getUser()`, `Auth::authenticate()`, `Auth::loginUsingId()`, `Auth::onceUsingId()`
- [x] `composer test` passes (lint + psalm + 66 unit + 60 type tests)