### PR TITLE
fix: support `Model::select()` and other Query\Builder forward calls

### DIFF
--- a/stubs/common/Database/Eloquent/Builder.stubphp
+++ b/stubs/common/Database/Eloquent/Builder.stubphp
@@ -703,7 +703,7 @@ class Builder implements BuilderContract
      * Add a right join to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $table
-     * @param  \Closure|string  $first
+     * @param  \Closure|\Illuminate\Contracts\Database\Query\Expression|string  $first
      * @param  string|null  $operator
      * @param  \Illuminate\Contracts\Database\Query\Expression|string|null  $second
      * @return self<TModel>

--- a/tests/Type/tests/EloquentBuilderQueryMethodsTest.phpt
+++ b/tests/Type/tests/EloquentBuilderQueryMethodsTest.phpt
@@ -182,6 +182,62 @@ function test_whereExists_instance(): Builder
     });
 }
 
+/** @return Builder<User> */
+function test_rightJoin_instance(): Builder
+{
+    return User::query()->rightJoin('posts', 'users.id', '=', 'posts.user_id');
+}
+
+/** @return Builder<User> */
+function test_crossJoin_instance(): Builder
+{
+    return User::query()->crossJoin('colors');
+}
+
+/** @return Builder<User> */
+function test_orWhereIn_instance(): Builder
+{
+    return User::query()->orWhereIn('id', [1, 2, 3]);
+}
+
+/** @return Builder<User> */
+function test_orWhereNotIn_instance(): Builder
+{
+    return User::query()->orWhereNotIn('id', [4, 5]);
+}
+
+/** @return Builder<User> */
+function test_whereNotBetween_instance(): Builder
+{
+    return User::query()->whereNotBetween('id', [1, 100]);
+}
+
+/** @return Builder<User> */
+function test_whereNotExists_instance(): Builder
+{
+    return User::query()->whereNotExists(function (\Illuminate\Database\Query\Builder $query) {
+        $query->select('id');
+    });
+}
+
+/** @return Builder<User> */
+function test_whereFullText_instance(): Builder
+{
+    return User::query()->whereFullText('name', 'search term');
+}
+
+/** @return Builder<User> */
+function test_lock_instance(): Builder
+{
+    return User::query()->lock();
+}
+
+/** @return Builder<User> */
+function test_sharedLock_instance(): Builder
+{
+    return User::query()->sharedLock();
+}
+
 // --- Chaining: static call + forwarded methods + terminal ---
 
 function test_select_chain_to_first(): ?User


### PR DESCRIPTION
Re-declares 29 commonly-used `Query\Builder` methods on the `Eloquent\Builder` stub with `self<TModel>` return types, so the generic context is preserved through `__call()` forwarding.

Fixes #216

## Problem

`User::select('name', 'email')` loses the `Builder<User>` generic type because `select()` resolves through `@mixin Query\Builder` where `$this` resolves to `Query\Builder`, not `Eloquent\Builder<TModel>`.

## Why stubs (not a handler)

The initial idea was to use a `MethodReturnTypeProvider` handler to dynamically fix the return type. This doesn't work because of how Psalm resolves `@mixin` chains:

1. `Model` has `@mixin Builder`, `Builder` has `@mixin Query\Builder`
2. When Psalm sees `Model::select()`, it checks `Model`'s mixins → finds `Builder`
3. It calls `Methods::methodExists()` on `Builder` to check if `select()` exists
4. **This check only looks at `Builder`'s own/inherited methods — it never checks `Builder`'s own `@mixin Query\Builder`**
5. Method not found → `UndefinedMagicMethod` → handler never fires

The bottleneck is `Methods::methodExists()` ([Methods.php:88-167](https://github.com/vimeo/psalm/blob/master/src/Psalm/Internal/Codebase/Methods.php#L88-L167)): it checks `MethodExistenceProvider`, `declaring_method_ids`, `pseudo_methods`, and `__call`, but never the target class's own `namedMixins`. Psalm's `@mixin` is single-level only — transitive resolution (mixin-of-mixin) is not supported.

(Interestingly, the IDE completion code in `Codebase::getCompletionItemsForClassishThing()` *is* recursive with cycle protection, so autocomplete would show the method — but analysis rejects it.)

A `MethodExistenceProvider` could theoretically make Psalm *believe* the method exists, but it would need to manually replicate the mixin chain resolution for every call — essentially reimplementing what Psalm should do natively.

Re-declaring the methods on the stub is the same pattern already used for `where()`, `orWhere()`, `latest()`, etc.

## Changes

- Re-declares 29 commonly-used `Query\Builder` methods on `Eloquent\Builder` stub with `self<TModel>` return types
- Adds `@psalm-taint-sink sql` annotations on SQL-injectable parameters
- Adds taint sinks to existing `latest()`, `oldest()`, `fromQuery()` methods
- Comprehensive type tests covering static calls, instance calls, and chaining

**Methods added:** `select`, `addSelect`, `distinct`, `join`, `leftJoin`, `rightJoin`, `crossJoin`, `orderBy`, `orderByDesc`, `groupBy`, `limit`, `take`, `offset`, `skip`, `whereIn`, `whereNotIn`, `orWhereIn`, `orWhereNotIn`, `whereBetween`, `whereNotBetween`, `whereNull`, `whereNotNull`, `whereColumn`, `whereExists`, `whereNotExists`, `whereFullText`, `lock`, `lockForUpdate`, `sharedLock`