### PR TITLE
feat(stubs): support generic Scope interface

### DIFF
--- a/src/Handlers/SuppressHandler.php
+++ b/src/Handlers/SuppressHandler.php
@@ -38,6 +38,21 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
     ];
 
     /**
+     * Suppress class-level issues by implemented interface.
+     *
+     * MissingTemplateParam is suppressed for Scope implementors because our stub
+     * promotes @template from method-level to class-level (see issue #207).
+     * Users who don't add @implements Scope<Model> shouldn't be penalised.
+     *
+     * @var array<string, list<string>>
+     */
+    private const CLASS_LEVEL_BY_INTERFACE = [
+        'MissingTemplateParam' => [
+            'Illuminate\Database\Eloquent\Scope',
+        ],
+    ];
+
+    /**
      * Suppress class-level issues by FQCN.
      * Less flexible — use parent class or trait based checks when possible.
      *
@@ -148,6 +163,7 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
 
             self::suppressByParentClass($classStorage);
             self::suppressByUsedTraits($classStorage);
+            self::suppressByInterface($classStorage);
         }
     }
 
@@ -191,6 +207,22 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
                     if ($method_storage instanceof MethodStorage) {
                         self::suppress($issue, $method_storage);
                     }
+                }
+            }
+        }
+    }
+
+    private static function suppressByInterface(ClassLikeStorage $classStorage): void
+    {
+        if ($classStorage->class_implements === []) {
+            return;
+        }
+
+        foreach (self::CLASS_LEVEL_BY_INTERFACE as $issue => $interfaces) {
+            foreach ($interfaces as $interface) {
+                if (isset($classStorage->class_implements[\strtolower($interface)])) {
+                    self::suppress($issue, $classStorage);
+                    break;
                 }
             }
         }

--- a/stubs/common/Database/Eloquent/Scope.stubphp
+++ b/stubs/common/Database/Eloquent/Scope.stubphp
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+/**
+ * Moving the @template from method-level to class-level allows implementations
+ * to bind the model type via @implements Scope<ConcreteModel>, which prevents
+ * MoreSpecificImplementedParamType errors when narrowing $builder and $model.
+ *
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ *
+ * @link https://github.com/psalm/psalm-plugin-laravel/issues/207
+ */
+interface Scope
+{
+    /**
+     * Apply the scope to a given Eloquent query builder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<TModel>  $builder
+     * @param  TModel  $model
+     * @return void
+     */
+    public function apply(Builder $builder, Model $model);
+}

--- a/tests/Type/tests/ScopeClassTest.phpt
+++ b/tests/Type/tests/ScopeClassTest.phpt
@@ -1,0 +1,61 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+/**
+ * Plain Scope implementation without @implements — the most common real-world
+ * pattern. Must continue to work without errors after promoting the template
+ * from method-level to class-level.
+ */
+final class PlainScope implements Scope
+{
+    #[\Override]
+    public function apply(Builder $builder, Model $model): void
+    {
+        $builder->where('active', true);
+    }
+}
+
+/**
+ * Implementing Scope with narrowed @param types should not trigger
+ * MoreSpecificImplementedParamType when @implements binds the template.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/207
+ *
+ * @implements Scope<User>
+ */
+final class ActiveScope implements Scope
+{
+    /**
+     * @param Builder<User> $builder
+     * @param User $model
+     */
+    #[\Override]
+    public function apply(Builder $builder, Model $model): void
+    {
+        $builder->where('active', true);
+    }
+}
+
+/**
+ * Invalid template bound — \stdClass is not a Model subclass.
+ * Psalm should reject this with InvalidTemplateParam.
+ *
+ * @implements Scope<\stdClass>
+ */
+final class InvalidScope implements Scope
+{
+    #[\Override]
+    public function apply(Builder $builder, Model $model): void
+    {
+        $builder->where('invalid', true);
+    }
+}
+?>
+--EXPECTF--
+InvalidTemplateParam on line %d: Extended template param TModel expects type Illuminate\Database\Eloquent\Model, type stdClass given
+ImplementedParamTypeMismatch on line %d: Argument 2 of InvalidScope::apply has wrong type 'Illuminate\Database\Eloquent\Model', expecting 'stdClass' as defined by Illuminate\Database\Eloquent\Scope::apply


### PR DESCRIPTION
## Summary

Closes #207.

- Adds a stub for `Illuminate\Database\Eloquent\Scope` that promotes `@template TModel` from method-level to class-level, enabling `@implements Scope<ConcreteModel>` to bind the template parameter
- Suppresses `MissingTemplateParam` for Scope implementors that don't use `@implements` (the most common real-world pattern) via `SuppressHandler`
- Adds type tests covering plain implementation, bound implementation (`@implements Scope<User>`), and invalid bound (`@implements Scope<\stdClass>`)

## Test plan

- [x] `composer test` passes (CS fixer, Psalm self-analysis, unit tests, type tests)
- [x] Type test verifies plain `implements Scope` produces no errors (regression guard)
- [x] Type test verifies `@implements Scope<User>` with narrowed `@param` types produces no `MoreSpecificImplementedParamType`
- [x] Type test verifies `@implements Scope<\stdClass>` correctly emits `InvalidTemplateParam`