### PR TITLE
Narrow `Collection::filter()` return type when called without callback

### DIFF
--- a/src/Handlers/Collections/CollectionFilterHandler.php
+++ b/src/Handlers/Collections/CollectionFilterHandler.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Collections;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\Type\Atomic;
+use Psalm\Type\Atomic\TArray;
+use Psalm\Type\Atomic\TFalse;
+use Psalm\Type\Atomic\TGenericObject;
+use Psalm\Type\Atomic\TNonEmptyArray;
+use Psalm\Type\Atomic\TNonFalsyString;
+use Psalm\Type\Atomic\TNull;
+use Psalm\Type\Atomic\TString;
+use Psalm\Type\Union;
+
+/**
+ * Narrows Collection::filter() return type when called without a callback.
+ *
+ * Laravel's filter() with no arguments calls array_filter(), which removes all
+ * falsy values. The most impactful narrowing is removing `null` and `false` from
+ * TValue, covering the vast majority of real-world usage (e.g., ->map()->filter()).
+ *
+ * Not covered (intentionally, 80/20):
+ * - Numeric falsy types (0, 0.0) are not narrowed — Psalm has no `non-zero-int` atomic
+ *   type, so the complexity of constructing `int<min, -1>|int<1, max>` isn't worth it.
+ * - `Enumerable` type-hints — the handler only fires for Collection and LazyCollection
+ *   concrete types, not the Enumerable interface.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/441
+ */
+final class CollectionFilterHandler implements MethodReturnTypeProviderInterface
+{
+    /**
+     * @return list<string>
+     * @psalm-pure
+     */
+    #[\Override]
+    public static function getClassLikeNames(): array
+    {
+        return [Collection::class, LazyCollection::class];
+    }
+
+    /** @psalm-mutation-free */
+    #[\Override]
+    public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        if ($event->getMethodNameLowercase() !== 'filter') {
+            return null;
+        }
+
+        // Only narrow when called with no arguments (or explicit null).
+        // With a callback, we can't know what it filters — let Psalm use the default.
+        if (! self::isCalledWithoutCallback($event)) {
+            return null;
+        }
+
+        $templateTypeParameters = $event->getTemplateTypeParameters();
+        if ($templateTypeParameters === null || \count($templateTypeParameters) < 2) {
+            return null;
+        }
+
+        $tKey = $templateTypeParameters[0];
+        $tValue = $templateTypeParameters[1];
+
+        $narrowed = self::removeFalsyTypes($tValue);
+        if ($narrowed === null) {
+            return null; // nothing to narrow, or would become empty
+        }
+
+        // Return the same Collection subclass with narrowed TValue.
+        // is_static: true preserves the `&static` intersection, matching filter()'s `return static`.
+        $className = $event->getCalledFqClasslikeName() ?? $event->getFqClasslikeName();
+
+        return new Union([
+            new TGenericObject($className, [$tKey, $narrowed], is_static: true),
+        ]);
+    }
+
+    /**
+     * Check if filter() was called with no arguments or with an explicit null literal.
+     * @psalm-mutation-free
+     */
+    private static function isCalledWithoutCallback(MethodReturnTypeProviderEvent $event): bool
+    {
+        $args = $event->getCallArgs();
+
+        if ($args === []) {
+            return true;
+        }
+
+        // filter(null) — explicit null is equivalent to no callback
+        if (\count($args) === 1) {
+            $argValue = $args[0]->value;
+            if ($argValue instanceof \PhpParser\Node\Expr\ConstFetch
+                && \strtolower($argValue->name->toString()) === 'null') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Remove falsy types and narrow remaining types to their non-empty variants.
+     *
+     * - Removes `null` and `false` entirely
+     * - Narrows `string` → `non-empty-string`, `array` → `non-empty-array`
+     *
+     * Returns null if nothing changed or narrowing would leave the union empty.
+     * @psalm-mutation-free
+     */
+    private static function removeFalsyTypes(Union $type): ?Union
+    {
+        $atomics = $type->getAtomicTypes();
+        $filtered = [];
+        $changed = false;
+
+        foreach ($atomics as $atomic) {
+            if ($atomic instanceof TNull || $atomic instanceof TFalse) {
+                $changed = true;
+                continue;
+            }
+
+            $narrowed = self::narrowAtomic($atomic);
+            if ($narrowed !== $atomic) {
+                $changed = true;
+            }
+
+            $filtered[] = $narrowed;
+        }
+
+        if (! $changed || $filtered === []) {
+            return null;
+        }
+
+        return new Union($filtered);
+    }
+
+    /**
+     * Narrow an atomic type to its non-empty variant where possible.
+     *
+     * array_filter() removes "", "0", and [] — so `string` becomes `non-falsy-string`
+     * (excludes both "" and "0") and `array` becomes `non-empty-array`.
+     * Already-narrow subtypes are left as-is.
+     *
+     * Not narrowed: int/float — Psalm has no `non-zero-int` atomic type, and constructing
+     * `int<min, -1>|int<1, max>` adds complexity for a rare use case.
+     *
+     * @psalm-pure
+     */
+    private static function narrowAtomic(Atomic $atomic): Atomic
+    {
+        // Narrow TString but not its subclasses (TNonFalsyString, TNonEmptyString, TLiteralString, etc.)
+        if ($atomic::class === TString::class) {
+            return new TNonFalsyString();
+        }
+
+        // Narrow TArray but not TNonEmptyArray or other subclasses
+        if ($atomic::class === TArray::class) {
+            return new TNonEmptyArray($atomic->type_params);
+        }
+
+        return $atomic;
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -11,6 +11,7 @@ use Psalm\LaravelPlugin\Handlers\Application\OffsetHandler;
 use Psalm\LaravelPlugin\Handlers\Auth\AuthHandler;
 use Psalm\LaravelPlugin\Handlers\Auth\GuardHandler;
 use Psalm\LaravelPlugin\Handlers\Auth\RequestHandler;
+use Psalm\LaravelPlugin\Handlers\Collections\CollectionFilterHandler;
 use Psalm\LaravelPlugin\Handlers\Console\CommandArgumentHandler;
 use Psalm\LaravelPlugin\Handlers\Eloquent\BuilderScopeHandler;
 use Psalm\LaravelPlugin\Handlers\Eloquent\ModelMethodHandler;
@@ -160,6 +161,9 @@ final class Plugin implements PluginEntryPointInterface
         $registration->registerHooksFromClass(ModelMethodHandler::class);
         require_once __DIR__ . '/Handlers/Eloquent/BuilderScopeHandler.php';
         $registration->registerHooksFromClass(BuilderScopeHandler::class);
+
+        require_once __DIR__ . '/Handlers/Collections/CollectionFilterHandler.php';
+        $registration->registerHooksFromClass(CollectionFilterHandler::class);
 
         require_once __DIR__ . '/Handlers/Console/CommandArgumentHandler.php';
         $registration->registerHooksFromClass(CommandArgumentHandler::class);

--- a/tests/Type/tests/CollectionFilterTest.phpt
+++ b/tests/Type/tests/CollectionFilterTest.phpt
@@ -1,0 +1,146 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
+
+/**
+ * filter() without callback removes null/false and narrows string/array.
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/441
+ */
+final class CollectionFilterTest
+{
+    /** @param Collection<int, string|null> $collection */
+    public function filterRemovesNull(Collection $collection): void
+    {
+        $_filtered = $collection->filter();
+        /** @psalm-check-type-exact $_filtered = Collection<int, non-falsy-string>&static */
+    }
+
+    /** @param Collection<int, string|false> $collection */
+    public function filterRemovesFalse(Collection $collection): void
+    {
+        $_filtered = $collection->filter();
+        /** @psalm-check-type-exact $_filtered = Collection<int, non-falsy-string>&static */
+    }
+
+    /** @param Collection<int, string|null|false> $collection */
+    public function filterRemovesNullAndFalse(Collection $collection): void
+    {
+        $_filtered = $collection->filter();
+        /** @psalm-check-type-exact $_filtered = Collection<int, non-falsy-string>&static */
+    }
+
+    /**
+     * filter() with a callback should NOT narrow — we don't know what the callback filters.
+     * @param Collection<int, string|null> $collection
+     */
+    public function filterWithCallbackDoesNotNarrow(Collection $collection): void
+    {
+        $_result = $collection->filter(fn (string|null $item) => $item !== null);
+        /** @psalm-check-type-exact $_result = Collection<int, null|string>&static */
+    }
+
+    /**
+     * The original issue's use case: map() producing nullable, then filter().
+     * @param Collection<int, string> $collection
+     */
+    public function mapThenFilter(Collection $collection): void
+    {
+        $_filtered = $collection
+            ->map(fn (string $item): ?string => strlen($item) > 3 ? $item : null)
+            ->filter();
+        /** @psalm-check-type-exact $_filtered = Collection<int, non-falsy-string>&static */
+    }
+
+    /** @param LazyCollection<int, string|null> $collection */
+    public function lazyCollectionFilterRemovesNull(LazyCollection $collection): void
+    {
+        $_filtered = $collection->filter();
+        /** @psalm-check-type-exact $_filtered = LazyCollection<int, non-falsy-string>&static */
+    }
+
+    /**
+     * string narrows to non-falsy-string (array_filter removes "" and "0").
+     * @param Collection<int, string> $collection
+     */
+    public function filterNarrowsStringToNonEmpty(Collection $collection): void
+    {
+        $_filtered = $collection->filter();
+        /** @psalm-check-type-exact $_filtered = Collection<int, non-falsy-string>&static */
+    }
+
+    /**
+     * array narrows to non-empty-array (array_filter removes []).
+     * @param Collection<int, array<string, int>> $collection
+     */
+    public function filterNarrowsArrayToNonEmpty(Collection $collection): void
+    {
+        $_filtered = $collection->filter();
+        /** @psalm-check-type-exact $_filtered = Collection<int, non-empty-array<string, int>>&static */
+    }
+
+    /**
+     * non-empty-string stays non-empty-string (already a TString subclass, not narrowed further).
+     * @param Collection<int, non-empty-string|null> $collection
+     */
+    public function filterPreservesNonEmptyString(Collection $collection): void
+    {
+        $_filtered = $collection->filter();
+        /** @psalm-check-type-exact $_filtered = Collection<int, non-empty-string>&static */
+    }
+
+    /**
+     * int is NOT narrowed (no non-zero-int atomic type in Psalm).
+     * @param Collection<int, int|null> $collection
+     */
+    public function filterDoesNotNarrowInt(Collection $collection): void
+    {
+        $_filtered = $collection->filter();
+        /** @psalm-check-type-exact $_filtered = Collection<int, int>&static */
+    }
+
+    /**
+     * Eloquent Collection extends Support Collection, so the handler fires for it too.
+     * TModel is constrained to Model, so null isn't valid here — but the handler still
+     * works for narrowing other falsy types or leaving the type unchanged.
+     * @param \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model> $collection
+     */
+    public function eloquentCollectionFilterPassesThrough(\Illuminate\Database\Eloquent\Collection $collection): void
+    {
+        $_filtered = $collection->filter();
+        /** @psalm-check-type-exact $_filtered = \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model>&static */
+    }
+
+    /**
+     * filter(null) behaves identically to filter() in Laravel.
+     * @param Collection<int, string|null> $collection
+     */
+    public function filterWithExplicitNullNarrows(Collection $collection): void
+    {
+        $_filtered = $collection->filter(null);
+        /** @psalm-check-type-exact $_filtered = Collection<int, non-falsy-string>&static */
+    }
+
+    /**
+     * float is NOT narrowed (same reasoning as int — no non-zero-float type).
+     * @param Collection<int, float|null> $collection
+     */
+    public function filterDoesNotNarrowFloat(Collection $collection): void
+    {
+        $_filtered = $collection->filter();
+        /** @psalm-check-type-exact $_filtered = Collection<int, float>&static */
+    }
+
+    /**
+     * When TValue has nothing to narrow, handler defers to Psalm's default.
+     * @param Collection<int, int> $collection
+     */
+    public function filterWithNothingToNarrow(Collection $collection): void
+    {
+        $_filtered = $collection->filter();
+        /** @psalm-check-type-exact $_filtered = Collection<int, int>&static */
+    }
+}
+?>
+--EXPECT--


### PR DESCRIPTION
## Summary

- Add `CollectionFilterHandler` that narrows `TValue` when `Collection::filter()` or `LazyCollection::filter()` is called without a callback
- Removes `null` and `false` from the union type
- Narrows `string` to `non-empty-string` and `array` to `non-empty-array`
- Preserves `&static` intersection type so fluent chaining on subclasses works correctly
- Closes #441

## How it works

Laravel's `filter()` with no arguments calls `array_filter()`, which removes all falsy values. This handler intercepts no-argument `filter()` calls and narrows the generic `TValue`:

| Original type | After `->filter()` |
|---|---|
| `string\|null` | `non-empty-string` |
| `string\|false` | `non-empty-string` |
| `string` | `non-empty-string` |
| `array<K, V>` | `non-empty-array<K, V>` |
| `int\|null` | `int` |
| `Foo\|null` | `Foo` |

**Intentionally not covered** (documented in code):
- Numeric falsy types (`0`, `0.0`) — Psalm has no `non-zero-int` atomic type, and constructing `int<min, -1>|int<1, max>` adds complexity for a rare use case
- `Enumerable` interface type-hints — handler only fires for concrete `Collection`/`LazyCollection`

## Test plan

- [x] Type test `CollectionFilterTest.phpt` covers: null removal, false removal, combined, callback passthrough, map-then-filter chain, LazyCollection, string→non-empty-string, array→non-empty-array, non-empty-string preserved, int not narrowed
- [x] `composer test` passes (lint + Psalm self-analysis + unit tests + type tests)
