### PR TITLE
Add taint sink for `HtmlString` to detect XSS bypass

### DIFF
--- a/stubs/taintAnalysis/Support/HtmlString.stubphp
+++ b/stubs/taintAnalysis/Support/HtmlString.stubphp
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Support;
+
+class HtmlString
+{
+    /**
+     * Create a new HTML string instance.
+     *
+     * HtmlString marks content as "safe HTML" that bypasses Blade's {{ }} escaping.
+     * If user input is wrapped in HtmlString, it creates an XSS vulnerability
+     * that is invisible in Blade templates.
+     *
+     * @param  string  $html
+     *
+     * @psalm-taint-sink html $html
+     */
+    public function __construct($html = '') {}
+}

--- a/tests/Type/tests/TaintAnalysis/SafeHtmlString.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeHtmlString.phpt
@@ -1,0 +1,13 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+function renderSafeBio(\Illuminate\Http\Request $request): \Illuminate\Support\HtmlString {
+    /** @var string $bio */
+    $bio = $request->input('bio');
+
+    return new \Illuminate\Support\HtmlString(e($bio));
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlString.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlString.phpt
@@ -1,0 +1,13 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+function renderBio(\Illuminate\Http\Request $request) {
+    $bio = $request->input('bio');
+
+    return new \Illuminate\Support\HtmlString($bio);
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML


### PR DESCRIPTION
## Summary

- Add `@psalm-taint-sink html` to `HtmlString::__construct()` to detect XSS where user input bypasses Blade's `{{ }}` escaping
- `HtmlString` marks content as "safe HTML" — if tainted input flows into it, the resulting output bypasses `htmlspecialchars()`, creating an invisible XSS vulnerability
- The constructor is the single convergence point for all ~25 HtmlString creation sites in Laravel

## Changes

- **`stubs/taintAnalysis/Support/HtmlString.stubphp`** — new taint sink stub
- **`tests/Type/tests/TaintAnalysis/TaintedHtmlString.phpt`** — verifies tainted input to HtmlString is detected
- **`tests/Type/tests/TaintAnalysis/SafeHtmlString.phpt`** — verifies `e()` escaping clears taint before HtmlString

Closes #473

## Test plan

- [x] `composer test` passes (lint, psalm, unit, type tests)
- [x] New taint test detects `TaintedHtml` when user input flows to `HtmlString`
- [x] Safe test confirms no error when input is escaped with `e()` first