### PR TITLE
Resolve static Query\Builder methods and scopes on Model classes

### DIFF
--- a/src/Handlers/Eloquent/BuilderScopeHandler.php
+++ b/src/Handlers/Eloquent/BuilderScopeHandler.php
@@ -7,6 +7,7 @@ namespace Psalm\LaravelPlugin\Handlers\Eloquent;
 use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Psalm\Codebase;
 use Psalm\Internal\MethodIdentifier;
 use Psalm\LaravelPlugin\Util\ModelPropertyResolver;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
@@ -66,9 +67,13 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface
 
     /**
      * Check if the model has a scope for the given method name.
+     *
+     * Public so ModelMethodHandler can reuse this for method existence checks
+     * on static Model calls (e.g., User::active() → scopeActive).
+     *
      * @param class-string<\Illuminate\Database\Eloquent\Model> $modelClass
      */
-    private static function hasScopeMethod(\Psalm\Codebase $codebase, string $modelClass, string $methodName): bool
+    public static function hasScopeMethod(Codebase $codebase, string $modelClass, string $methodName): bool
     {
         $key = $modelClass . '::' . $methodName;
 
@@ -102,7 +107,7 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface
      * @param class-string<Model> $modelClass
      * @psalm-mutation-free
      */
-    private static function hasScopeAttribute(\Psalm\Codebase $codebase, string $modelClass, string $methodName): bool
+    private static function hasScopeAttribute(Codebase $codebase, string $modelClass, string $methodName): bool
     {
         try {
             $methodStorage = $codebase->methods->getStorage(

--- a/src/Handlers/Eloquent/ModelMethodHandler.php
+++ b/src/Handlers/Eloquent/ModelMethodHandler.php
@@ -6,29 +6,268 @@ namespace Psalm\LaravelPlugin\Handlers\Eloquent;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Class_;
+use Psalm\Codebase;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Internal\MethodIdentifier;
 use Psalm\LaravelPlugin\Util\ProxyMethodReturnTypeProvider;
 use Psalm\Plugin\EventHandler\AfterClassLikeVisitInterface;
 use Psalm\Plugin\EventHandler\Event\AfterClassLikeVisitEvent;
+use Psalm\Plugin\EventHandler\Event\MethodExistenceProviderEvent;
+use Psalm\Plugin\EventHandler\Event\MethodParamsProviderEvent;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\Event\MethodVisibilityProviderEvent;
 use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\StatementsSource;
+use Psalm\Storage\FunctionLikeParameter;
 use Psalm\Type;
 use Psalm\Type\Union;
 
+/**
+ * Handles static method calls on Eloquent Models that are forwarded to Builder via __callStatic.
+ *
+ * Responsibilities:
+ * 1. Method existence — confirms magic methods exist (suppresses UndefinedMagicMethod)
+ * 2. Method visibility — confirms magic methods are public
+ * 3. Method params — provides parameter definitions for argument checking
+ * 4. Return types — proxies calls to Builder<TModel> for type inference
+ * 5. afterClassLikeVisit — removes pseudo static methods so the plugin can handle them
+ *
+ * Existence, visibility, params, and return type providers for concrete Model subclasses are
+ * registered dynamically per-model by {@see ModelRegistrationHandler} because Psalm's
+ * provider lookup requires exact class name matching — a handler registered for Model::class
+ * is not consulted for concrete subclasses like App\Models\User.
+ *
+ * The getClassLikeNames() registration for Model::class still handles Model::query()
+ * and the __callStatic proxy for methods resolvable through the single-hop mixin chain.
+ */
 final class ModelMethodHandler implements MethodReturnTypeProviderInterface, AfterClassLikeVisitInterface
 {
     /**
-     * @inheritDoc
+     * Cache for isUnresolvedBuilderMethod results.
+     *
+     * This method is called up to 4 times per static method call (existence, visibility,
+     * params, return type), so caching avoids redundant methodExists lookups.
+     *
+     * @var array<string, bool>
+     */
+    private static array $unresolvedCache = [];
+
+    /**
+     * @return list<string>
      * @psalm-pure
      */
     #[\Override]
     public static function getClassLikeNames(): array
     {
         return [Model::class];
+    }
+
+    /**
+     * Confirm that a static magic method exists on a Model subclass.
+     *
+     * Only confirms methods NOT already resolvable through Psalm's @mixin chain.
+     * Methods on Eloquent\Builder (like where(), get()) are found by Psalm via
+     * Model's @mixin Builder<static> automatically. Confirming them here would
+     * set $fake_method_exists=true in the analyzer, bypassing mixin resolution
+     * for instance calls and losing type information.
+     *
+     * We only handle:
+     * 1. Query\Builder methods not explicitly on Eloquent\Builder (e.g., whereIn, orderBy)
+     *    These can't be reached through the double mixin: Model → Builder → Query\Builder.
+     * 2. Scope methods (legacy scopeX or #[Scope] attribute)
+     *
+     * Registered as a closure per concrete Model class by {@see ModelRegistrationHandler}.
+     */
+    public static function doesMethodExist(MethodExistenceProviderEvent $event): ?bool
+    {
+        $source = $event->getSource();
+
+        if ($source === null) {
+            return null;
+        }
+
+        return self::isUnresolvedBuilderMethod(
+            $source->getCodebase(),
+            $event->getFqClasslikeName(),
+            $event->getMethodNameLowercase(),
+        ) ? true : null;
+    }
+
+    /**
+     * Magic methods forwarded via __callStatic are effectively public.
+     *
+     * Registered defensively per concrete Model class by {@see ModelRegistrationHandler}
+     * in case Psalm's visibility check is reached for fake-method-exists paths.
+     */
+    public static function isMethodVisible(MethodVisibilityProviderEvent $event): ?bool
+    {
+        return self::isUnresolvedBuilderMethod(
+            $event->getSource()->getCodebase(),
+            $event->getFqClasslikeName(),
+            $event->getMethodNameLowercase(),
+        ) ? true : null;
+    }
+
+    /**
+     * Provide method parameter definitions for methods confirmed by doesMethodExist.
+     *
+     * Psalm needs to know the parameter types for argument checking (checkMethodArgs).
+     * For Query\Builder methods, we delegate to the actual Query\Builder params.
+     * For scope methods, we use the scope's params minus the first $query parameter.
+     *
+     * Registered as a closure per concrete Model class by {@see ModelRegistrationHandler}.
+     *
+     * @return list<FunctionLikeParameter>|null
+     */
+    public static function getMethodParams(MethodParamsProviderEvent $event): ?array
+    {
+        $source = $event->getStatementsSource();
+
+        if (!$source instanceof StatementsSource) {
+            return null;
+        }
+
+        $codebase = $source->getCodebase();
+        $modelClass = $event->getFqClasslikeName();
+        $methodName = $event->getMethodNameLowercase();
+
+        if (!self::isUnresolvedBuilderMethod($codebase, $modelClass, $methodName)) {
+            return null;
+        }
+
+        // Query\Builder method — use its actual params
+        /** @var lowercase-string $methodName */
+        $queryBuilderMethodId = new MethodIdentifier(QueryBuilder::class, $methodName);
+        if ($codebase->methodExists($queryBuilderMethodId)) {
+            return $codebase->methods->getMethodParams($queryBuilderMethodId);
+        }
+
+        // Scope method — params from the scope definition minus the first $query param.
+        // Use string-based methodExists (like BuilderScopeHandler) so Psalm handles
+        // case normalization. Then create MethodIdentifier with lowercase for getMethodParams.
+
+        // Legacy: scopeActive(Builder $query, ...) → active(...)
+        $legacyScopeMethod = $modelClass . '::scope' . \ucfirst($methodName);
+        if ($codebase->methodExists($legacyScopeMethod)) {
+            /** @var lowercase-string $legacyScopeLower */
+            $legacyScopeLower = 'scope' . $methodName;
+            return \array_slice(
+                $codebase->methods->getMethodParams(new MethodIdentifier($modelClass, $legacyScopeLower)),
+                1,
+            );
+        }
+
+        // Modern #[Scope]: active(Builder $query, ...) → active(...)
+        $directMethod = $modelClass . '::' . $methodName;
+        if ($codebase->methodExists($directMethod)) {
+            return \array_slice(
+                $codebase->methods->getMethodParams(new MethodIdentifier($modelClass, $methodName)),
+                1,
+            );
+        }
+
+        return null;
+    }
+
+    /**
+     * Provide return types for methods confirmed by doesMethodExist.
+     *
+     * When the existence provider confirms a method (e.g., whereIn, active), Psalm calls
+     * the return type provider with the method name directly (not __callstatic). This handler
+     * proxies the call to Builder<ModelClass> to resolve the return type.
+     *
+     * Registered as a closure per concrete Model class by {@see ModelRegistrationHandler}.
+     */
+    public static function getReturnTypeForForwardedMethod(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        $source = $event->getSource();
+
+        if (!$source instanceof StatementsAnalyzer) {
+            return null;
+        }
+
+        $codebase = $source->getCodebase();
+        $modelClass = $event->getFqClasslikeName();
+        $methodName = $event->getMethodNameLowercase();
+
+        // Only handle methods confirmed by doesMethodExist — don't interfere with
+        // methods already resolved through the @mixin chain (where, get, first, etc.)
+        if (!self::isUnresolvedBuilderMethod($codebase, $modelClass, $methodName)) {
+            return null;
+        }
+
+        $calledClass = $event->getCalledFqClasslikeName() ?? $modelClass;
+
+        // Scope methods: return Builder<Model> directly.
+        // Using executeFakeCall for scopes doesn't work reliably because the scope
+        // is resolved via Builder's __call magic which may fail in a fake call context.
+        /** @var class-string<Model> $modelClass */
+        if (BuilderScopeHandler::hasScopeMethod($codebase, $modelClass, $methodName)) {
+            return new Union([
+                new Type\Atomic\TGenericObject(Builder::class, [
+                    new Union([new Type\Atomic\TNamedObject($calledClass)]),
+                ]),
+            ]);
+        }
+
+        // Query\Builder methods: proxy the call through Builder<Model> to resolve
+        // the return type with proper template type preservation.
+        $fake_method_call = new MethodCall(
+            // Variable name must match what executeFakeCall sets in context: $fakeProxyObject
+            new Variable('fakeProxyObject'),
+            $methodName,
+            $event->getCallArgs(),
+        );
+
+        $fakeProxy = new Type\Atomic\TGenericObject(Builder::class, [
+            new Union([
+                new Type\Atomic\TNamedObject($calledClass),
+            ]),
+        ]);
+
+        return ProxyMethodReturnTypeProvider::executeFakeCall($source, $fake_method_call, $event->getContext(), $fakeProxy);
+    }
+
+    /**
+     * Check if a method on a Model needs explicit existence confirmation.
+     *
+     * Returns true only for methods that Psalm can't resolve via its normal
+     * @mixin chain — either Query\Builder methods unreachable through the double
+     * mixin hop, or scope methods defined on the model.
+     */
+    private static function isUnresolvedBuilderMethod(Codebase $codebase, string $modelClass, string $methodName): bool
+    {
+        $key = $modelClass . '::' . $methodName;
+
+        if (\array_key_exists($key, self::$unresolvedCache)) {
+            return self::$unresolvedCache[$key];
+        }
+
+        /** @var lowercase-string $methodName */
+
+        // Methods on Eloquent\Builder (e.g., where, get, first) are resolved by Psalm
+        // via Model's @mixin Builder<static>. Don't interfere — let the mixin handle it.
+        if ($codebase->methodExists(new MethodIdentifier(Builder::class, $methodName))) {
+            return self::$unresolvedCache[$key] = false;
+        }
+
+        // Methods on Query\Builder that are NOT on Eloquent\Builder (e.g., whereIn,
+        // orderBy). At runtime these are forwarded via Builder::__call → forwardCallTo.
+        // Psalm's single-level mixin resolution can't reach them through the double hop:
+        // Model → Builder → Query\Builder. Confirm existence so Psalm doesn't emit
+        // UndefinedMagicMethod.
+        if ($codebase->methodExists(new MethodIdentifier(QueryBuilder::class, $methodName))) {
+            return self::$unresolvedCache[$key] = true;
+        }
+
+        // Scope methods (e.g., scopeActive → active, #[Scope] verified → verified).
+        // These are defined on the model and forwarded via __callStatic → Builder.
+        /** @var class-string<Model> $modelClass */
+        return self::$unresolvedCache[$key] = BuilderScopeHandler::hasScopeMethod($codebase, $modelClass, $methodName);
     }
 
     /** @inheritDoc */

--- a/src/Handlers/Eloquent/ModelRegistrationHandler.php
+++ b/src/Handlers/Eloquent/ModelRegistrationHandler.php
@@ -20,11 +20,15 @@ use Psalm\Type\Union;
 
 /**
  * Discovers Eloquent model classes from Psalm's scanned codebase and registers
- * property handlers for each discovered model.
+ * property and method handlers for each discovered model.
  *
  * This replaces directory-based model scanning: instead of pre-scanning directories
  * for model files, we wait until Psalm has populated its codebase with all project
- * classes, then register property handlers for every concrete Model subclass found.
+ * classes, then register handlers for every concrete Model subclass found.
+ *
+ * Registers per-model:
+ * - Method existence, visibility, params, and return types ({@see ModelMethodHandler})
+ * - Property existence, visibility, and types (relationships, accessors, columns)
  *
  * @internal
  */
@@ -73,6 +77,27 @@ final class ModelRegistrationHandler implements AfterCodebasePopulatedInterface
     {
         $className = $storage->name;
         $properties = $codebase->properties;
+        $methods = $codebase->methods;
+
+        // Method existence, visibility, and return types for static __callStatic forwarding.
+        // Registered per-model because Psalm's provider lookup uses exact class names —
+        // a handler for Model::class is not consulted for App\Models\User.
+        $methods->existence_provider->registerClosure(
+            $className,
+            ModelMethodHandler::doesMethodExist(...),
+        );
+        $methods->visibility_provider->registerClosure(
+            $className,
+            ModelMethodHandler::isMethodVisible(...),
+        );
+        $methods->params_provider->registerClosure(
+            $className,
+            ModelMethodHandler::getMethodParams(...),
+        );
+        $methods->return_type_provider->registerClosure(
+            $className,
+            ModelMethodHandler::getReturnTypeForForwardedMethod(...),
+        );
 
         // Registration order matters — the first non-null result wins.
 

--- a/tests/Type/tests/ModelStaticBuilderMethodsTest.phpt
+++ b/tests/Type/tests/ModelStaticBuilderMethodsTest.phpt
@@ -1,0 +1,92 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+
+/**
+ * Static calls to Query\Builder methods via Model::__callStatic should resolve
+ * without UndefinedMagicMethod. These methods live on Query\Builder and are
+ * forwarded through Eloquent\Builder at runtime via __call → forwardCallTo.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/498
+ */
+
+/** Query\Builder method forwarded through double mixin: Model → Builder → Query\Builder. */
+function test_static_whereIn(): void
+{
+    $_result = User::whereIn('id', [1, 2, 3]);
+    /** @psalm-check-type-exact $_result = Builder<User>&static */
+}
+
+function test_static_orderBy(): void
+{
+    $_result = User::orderBy('name');
+    /** @psalm-check-type-exact $_result = Builder<User>&static */
+}
+
+/** Chaining: forwarded method → Eloquent\Builder method → terminal. */
+function test_static_whereIn_chain_to_get(): void
+{
+    $_result = User::whereIn('id', [1, 2, 3])->get();
+    /** @psalm-check-type-exact $_result = Collection<int, User> */
+}
+
+/** Chaining two forwarded Query\Builder methods. */
+function test_static_chain_forwarded_methods(): void
+{
+    $_result = User::whereIn('id', [1, 2, 3])->orderBy('name')->get();
+    /** @psalm-check-type-exact $_result = Collection<int, User> */
+}
+
+/** Regression: User::where() must still work (declared on Eloquent\Builder stub). */
+/** @return Builder<User> */
+function test_static_where(): Builder
+{
+    return User::where('active', true);
+}
+
+/** Regression: User::query() must still work. */
+function test_static_query(): void
+{
+    $_result = User::query();
+    /** @psalm-check-type-exact $_result = Builder<User> */
+}
+
+/** Legacy scope called statically: scopeActive → User::active(). */
+function test_static_legacy_scope(): void
+{
+    $_result = User::active();
+    /** @psalm-check-type-exact $_result = Builder<User> */
+}
+
+/**
+ * Modern #[Scope] attribute: the idiomatic call is through the Builder.
+ * This exercises BuilderScopeHandler::hasScopeAttribute via the Builder path.
+ *
+ * Calling User::verified() statically triggers InvalidStaticInvocation because
+ * it's a real instance method — see test_scope_attribute_static_is_invalid below.
+ */
+/** @return Builder<User> */
+function test_scope_attribute_via_builder(): Builder
+{
+    return User::query()->verified();
+}
+
+/** #[Scope] methods are real instance methods — static calls are correctly rejected. */
+function test_scope_attribute_static_is_invalid(): void
+{
+    $_result = User::verified();
+}
+
+/** Negative test: non-existent methods must still be reported. */
+function test_nonexistent_method(): void
+{
+    $_result = User::completelyFakeMethod();
+}
+?>
+--EXPECTF--
+MixedReturnStatement on line %d: Could not infer a return type
+InvalidStaticInvocation on line %d: Method App\Models\User::verified is not static, but is called statically
+UndefinedMagicMethod on line %d: Magic method App\Models\User::completelyfakemethod does not exist


### PR DESCRIPTION
## What does this PR do?

Fixes #498

Static calls like `User::whereIn(...)`, `User::orderBy(...)`, and `User::active()` (scope) triggered `UndefinedMagicMethod` because Psalm's single-level `@mixin` resolution couldn't reach Query\Builder methods through the double hop: `Model → Builder → Query\Builder`.

This PR registers per-model method providers (existence, visibility, params, return type) that confirm and type-resolve:

1. **Query\Builder methods** not explicitly on Eloquent\Builder (e.g., `whereIn`, `orderBy`) — these are forwarded at runtime via `Builder::__call → forwardCallTo`
2. **Legacy scope methods** (`scopeX → x`) called statically on Model

Methods already resolvable through Model's `@mixin Builder<static>` (`where`, `get`, `first`, etc.) are intentionally skipped to avoid interfering with Psalm's mixin resolution for instance calls.

### Why per-model registration?

Psalm's provider lookup uses exact class name matching — a handler registered for `Model::class` is not consulted for concrete subclasses like `App\Models\User`. The providers are registered dynamically in `ModelRegistrationHandler::afterCodebasePopulated()`, following the same pattern used for property providers.

### Files changed

- **`ModelMethodHandler`** — added `doesMethodExist`, `isMethodVisible`, `getMethodParams`, `getReturnTypeForForwardedMethod` with `isUnresolvedBuilderMethod` gate + cache
- **`ModelRegistrationHandler`** — registers 4 new closures per model (existence, visibility, params, return type)
- **`BuilderScopeHandler`** — made `hasScopeMethod()` public for reuse

## How was it tested?

- New type test `ModelStaticBuilderMethodsTest.phpt` covering:
  - `User::whereIn()` / `User::orderBy()` with exact type checks (`Builder<User>&static`)
  - Chained calls: `User::whereIn(...)->get()`, `User::whereIn(...)->orderBy(...)->get()`
  - Legacy scope: `User::active()` with exact type check (`Builder<User>`)
  - `#[Scope]` attribute: `User::verified()` correctly emits `InvalidStaticInvocation`
  - `#[Scope]` via Builder: `User::query()->verified()` (documents pre-existing `MixedReturnStatement`)
  - Negative test: `User::completelyFakeMethod()` still emits `UndefinedMagicMethod`
  - Regression tests: `User::where()`, `User::query()` unchanged
- Verified against [monicahq/monica](https://github.com/monicahq/monica): all `Model::whereIn` false positives from the issue are eliminated
- All 208 tests pass, Psalm self-analysis clean

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
- [x] Documentation is updated (if needed, otherwise remove this item)
