### PR TITLE
Handle `Blueprint::datetimes()` and fix `ulid()` default column name

### DIFF
--- a/src/Handlers/Eloquent/Schema/SchemaAggregator.php
+++ b/src/Handlers/Eloquent/Schema/SchemaAggregator.php
@@ -17,6 +17,7 @@ final class SchemaAggregator
      * @see \Illuminate\Database\Schema\Blueprint
      */
     private const METHODS_USE_HARDCODED_COLUMN_NAME = [
+        'datetimes',
         'timestamps',
         'timestampstz',
         'nullabletimestamps',
@@ -40,7 +41,7 @@ final class SchemaAggregator
         'softdeletesdatetime' => 'deleted_at',
         'softdeletestz' => 'deleted_at',
         'uuid' => 'uuid',
-        'ulid' => 'uuid',
+        'ulid' => 'ulid',
         'ipaddress' => 'ip_address',
         'macaddress' => 'mac_address',
     ];
@@ -411,35 +412,38 @@ final class SchemaAggregator
 
             $first_method_name_lc = \strtolower($first_method_call->name->name);
 
-            if ($first_method_call->args === []) {
-                if (\in_array($first_method_name_lc, self::METHODS_USE_HARDCODED_COLUMN_NAME, true)) {
-                    switch ($first_method_name_lc) {
-                        case 'droptimestamps':
-                        case 'droptimestampstz':
-                            $table->dropColumn('created_at');
-                            $table->dropColumn('updated_at');
-                            break;
+            // Handle methods that always produce the same hardcoded column names,
+            // regardless of arguments (args are precision values, not column names).
+            if (\in_array($first_method_name_lc, self::METHODS_USE_HARDCODED_COLUMN_NAME, true)) {
+                switch ($first_method_name_lc) {
+                    case 'droptimestamps':
+                    case 'droptimestampstz':
+                        $table->dropColumn('created_at');
+                        $table->dropColumn('updated_at');
+                        break;
 
-                        case 'remembertoken':
-                            $table->setColumn(new SchemaColumn('remember_token', 'string', $nullable));
-                            break;
+                    case 'remembertoken':
+                        $table->setColumn(new SchemaColumn('remember_token', 'string', $nullable));
+                        break;
 
-                        case 'dropremembertoken':
-                            $table->dropColumn('remember_token');
-                            break;
+                    case 'dropremembertoken':
+                        $table->dropColumn('remember_token');
+                        break;
 
-                        case 'timestamps':
-                        case 'timestampstz':
-                        case 'nullabletimestamps':
-                        case 'nullabletimestampstz':
-                            $table->setColumn(new SchemaColumn('created_at', 'string', true));
-                            $table->setColumn(new SchemaColumn('updated_at', 'string', true));
-                            break;
-                    }
-
-                    continue; // foreach
+                    case 'datetimes':
+                    case 'timestamps':
+                    case 'timestampstz':
+                    case 'nullabletimestamps':
+                    case 'nullabletimestampstz':
+                        $table->setColumn(new SchemaColumn('created_at', 'string', true));
+                        $table->setColumn(new SchemaColumn('updated_at', 'string', true));
+                        break;
                 }
 
+                continue; // foreach
+            }
+
+            if ($first_method_call->args === []) {
                 if (\array_key_exists($first_method_name_lc, self::METHODS_HAVE_DEFAULT_COLUMN_NAME)) {
                     $column_name = self::METHODS_HAVE_DEFAULT_COLUMN_NAME[$first_method_name_lc];
                 } else {

--- a/tests/Unit/Handlers/Eloquent/Schema/DatetimesTest.php
+++ b/tests/Unit/Handlers/Eloquent/Schema/DatetimesTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Eloquent\Schema;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaAggregator;
+
+#[CoversClass(SchemaAggregator::class)]
+final class DatetimesTest extends AbstractSchemaAggregatorTestCase
+{
+    #[Test]
+    public function datetimes_creates_nullable_created_at_and_updated_at(): void
+    {
+        $schema = $this->schemaFromMigration(<<<'PHP'
+            <?php
+            use Illuminate\Database\Migrations\Migration;
+            use Illuminate\Database\Schema\Blueprint;
+            use Illuminate\Support\Facades\Schema;
+
+            return new class extends Migration {
+                public function up(): void
+                {
+                    Schema::create('posts', static function (Blueprint $table) {
+                        $table->id();
+                        $table->datetimes();
+                    });
+                }
+            };
+            PHP);
+
+        $this->assertTableHasNullableColumnOfType('created_at', 'string', $schema->tables['posts']);
+        $this->assertTableHasNullableColumnOfType('updated_at', 'string', $schema->tables['posts']);
+    }
+
+    #[Test]
+    public function datetimes_with_precision_creates_nullable_columns(): void
+    {
+        $schema = $this->schemaFromMigration(<<<'PHP'
+            <?php
+            use Illuminate\Database\Migrations\Migration;
+            use Illuminate\Database\Schema\Blueprint;
+            use Illuminate\Support\Facades\Schema;
+
+            return new class extends Migration {
+                public function up(): void
+                {
+                    Schema::create('posts', static function (Blueprint $table) {
+                        $table->id();
+                        $table->datetimes(0);
+                    });
+                }
+            };
+            PHP);
+
+        $this->assertTableHasNullableColumnOfType('created_at', 'string', $schema->tables['posts']);
+        $this->assertTableHasNullableColumnOfType('updated_at', 'string', $schema->tables['posts']);
+    }
+
+    #[Test]
+    public function datetimes_behaves_like_timestamps(): void
+    {
+        $schema = $this->schemaFromMigration(<<<'PHP'
+            <?php
+            use Illuminate\Database\Migrations\Migration;
+            use Illuminate\Database\Schema\Blueprint;
+            use Illuminate\Support\Facades\Schema;
+
+            return new class extends Migration {
+                public function up(): void
+                {
+                    Schema::create('posts_a', static function (Blueprint $table) {
+                        $table->id();
+                        $table->datetimes();
+                    });
+
+                    Schema::create('posts_b', static function (Blueprint $table) {
+                        $table->id();
+                        $table->timestamps();
+                    });
+                }
+            };
+            PHP);
+
+        // Both methods should produce identical schema columns
+        $this->assertEquals(
+            $schema->tables['posts_a']->columns['created_at'],
+            $schema->tables['posts_b']->columns['created_at'],
+        );
+        $this->assertEquals(
+            $schema->tables['posts_a']->columns['updated_at'],
+            $schema->tables['posts_b']->columns['updated_at'],
+        );
+    }
+}

--- a/tests/Unit/Handlers/Eloquent/Schema/UlidDefaultColumnNameTest.php
+++ b/tests/Unit/Handlers/Eloquent/Schema/UlidDefaultColumnNameTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Eloquent\Schema;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaAggregator;
+
+#[CoversClass(SchemaAggregator::class)]
+final class UlidDefaultColumnNameTest extends AbstractSchemaAggregatorTestCase
+{
+    #[Test]
+    public function ulid_without_args_defaults_to_ulid_column(): void
+    {
+        $schema = $this->schemaFromMigration(<<<'PHP'
+            <?php
+            use Illuminate\Database\Migrations\Migration;
+            use Illuminate\Database\Schema\Blueprint;
+            use Illuminate\Support\Facades\Schema;
+
+            return new class extends Migration {
+                public function up(): void
+                {
+                    Schema::create('posts', static function (Blueprint $table) {
+                        $table->ulid();
+                    });
+                }
+            };
+            PHP);
+
+        $this->assertTableHasNotNullableColumnOfType('ulid', 'string', $schema->tables['posts']);
+    }
+
+    #[Test]
+    public function ulid_with_custom_name(): void
+    {
+        $schema = $this->schemaFromMigration(<<<'PHP'
+            <?php
+            use Illuminate\Database\Migrations\Migration;
+            use Illuminate\Database\Schema\Blueprint;
+            use Illuminate\Support\Facades\Schema;
+
+            return new class extends Migration {
+                public function up(): void
+                {
+                    Schema::create('posts', static function (Blueprint $table) {
+                        $table->ulid('custom_ulid');
+                    });
+                }
+            };
+            PHP);
+
+        $this->assertTableHasNotNullableColumnOfType('custom_ulid', 'string', $schema->tables['posts']);
+    }
+
+    #[Test]
+    public function uuid_default_column_name_unchanged(): void
+    {
+        $schema = $this->schemaFromMigration(<<<'PHP'
+            <?php
+            use Illuminate\Database\Migrations\Migration;
+            use Illuminate\Database\Schema\Blueprint;
+            use Illuminate\Support\Facades\Schema;
+
+            return new class extends Migration {
+                public function up(): void
+                {
+                    Schema::create('posts', static function (Blueprint $table) {
+                        $table->uuid();
+                    });
+                }
+            };
+            PHP);
+
+        $this->assertTableHasNotNullableColumnOfType('uuid', 'string', $schema->tables['posts']);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes two schema aggregator bugs:

- **#529** — `$table->datetimes()` was silently ignored because `datetimes` was missing from `METHODS_USE_HARDCODED_COLUMN_NAME`. Now registers nullable `created_at`/`updated_at` columns, matching `timestamps()` behavior.
- **#530** — `$table->ulid()` without arguments registered a column named `uuid` instead of `ulid` due to a copy-paste error in `METHODS_HAVE_DEFAULT_COLUMN_NAME`.

**Bonus fix**: Moved the hardcoded-column-name dispatch before the `args === []` gate, so `timestamps($precision)`, `datetimes($precision)`, and similar calls with precision arguments are no longer silently ignored. This was a pre-existing bug affecting all timestamp-family methods.

## Test plan

- [x] New `DatetimesTest` — verifies `datetimes()` creates nullable columns, works with precision arg, behaves like `timestamps()`
- [x] New `UlidDefaultColumnNameTest` — verifies `ulid()` defaults to column name `ulid`, custom names work, `uuid()` default unchanged
- [x] Full test suite passes (lint + Psalm + 205 unit tests + 74 type tests)

Closes #529, closes #530