### PR TITLE
Add taint stubs for `UploadedFile` and `encrypt`/`decrypt` helpers

### DIFF
--- a/stubs/common/Foundation/helpers.stubphp
+++ b/stubs/common/Foundation/helpers.stubphp
@@ -130,7 +130,19 @@ function cookie($name = null, $value = null, $minutes = 0, $path = null, $domain
 // csrf_field: nothing to stub
 // csrf_token: nothing to stub
 // database_path: processed by Psalm handlers
-// decrypt: nothing to stub
+
+/**
+ * Decrypt the given value.
+ *
+ * @param  string  $value
+ * @param  bool  $unserialize
+ * @return mixed
+ *
+ * @psalm-taint-unescape user_secret
+ * @psalm-taint-unescape system_secret
+ * @psalm-flow ($value) -> return
+ */
+function decrypt($value, $unserialize = true) {}
 
 /**
  * Dispatch a job to its appropriate handler.
@@ -151,7 +163,18 @@ function dispatch($job) {}
  */
 function dispatch_sync($job, $handler = null) {}
 
-// encrypt: nothing to stub
+/**
+ * Encrypt the given value.
+ *
+ * @param  mixed  $value
+ * @param  bool  $serialize
+ * @return string
+ *
+ * @psalm-taint-escape user_secret
+ * @psalm-taint-escape system_secret
+ * @psalm-flow ($value) -> return
+ */
+function encrypt($value, $serialize = true): string {}
 
 /**
  * Dispatch an event and call the listeners.

--- a/stubs/taintAnalysis/Http/UploadedFile.stubphp
+++ b/stubs/taintAnalysis/Http/UploadedFile.stubphp
@@ -1,0 +1,70 @@
+<?php
+
+namespace Illuminate\Http;
+
+/**
+ * Taint annotations for UploadedFile methods that return user-controlled data.
+ *
+ * These methods extract metadata from the multipart upload request, which is
+ * entirely attacker-controlled: the filename, extension, and MIME type are sent
+ * by the client and can contain path-traversal sequences, XSS payloads, or
+ * spoofed values. The file contents are likewise user-supplied.
+ *
+ * @see \Symfony\Component\HttpFoundation\File\UploadedFile (parent)
+ */
+class UploadedFile
+{
+    /**
+     * Returns the original file name supplied by the client.
+     *
+     * @return string
+     *
+     * @psalm-taint-source input
+     */
+    public function getClientOriginalName(): string {}
+
+    /**
+     * Returns the original file full path supplied by the client (webkitdirectory uploads).
+     *
+     * @return string
+     *
+     * @psalm-taint-source input
+     */
+    public function getClientOriginalPath(): string {}
+
+    /**
+     * Returns the original file extension supplied by the client.
+     *
+     * @return string
+     *
+     * @psalm-taint-source input
+     */
+    public function getClientOriginalExtension(): string {}
+
+    /**
+     * Returns the MIME type supplied by the client (Content-Type header, spoofable).
+     *
+     * @return string
+     *
+     * @psalm-taint-source input
+     */
+    public function getClientMimeType(): string {}
+
+    /**
+     * Returns the file extension guessed from the client-supplied MIME type.
+     *
+     * @psalm-taint-source input
+     */
+    public function clientExtension() {}
+
+    /**
+     * Returns the raw contents of the uploaded file.
+     *
+     * @return false|string
+     *
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     *
+     * @psalm-taint-source input
+     */
+    public function get() {}
+}


### PR DESCRIPTION
## Summary

- Add `@psalm-taint-source input` for `UploadedFile` methods that return user-controlled data: `getClientOriginalName()`, `getClientOriginalPath()`, `getClientOriginalExtension()`, `getClientMimeType()`, `clientExtension()`, `get()` — new stub at `stubs/taintAnalysis/Http/UploadedFile.stubphp`
- Add `@psalm-taint-escape`/`@psalm-taint-unescape` for `encrypt()`/`decrypt()` helper functions to match existing `Encrypter` class annotations in `stubs/common/Foundation/helpers.stubphp`

Closes #535
Closes #536

## Test plan

- [x] `composer psalm` passes (no new errors)
- [x] `composer test:unit` passes
- [x] `composer test:type` passes
- [x] Stub signatures verified against Laravel/Symfony source
- [x] Taint annotations reviewed by security-taint agent for correctness