### PR TITLE
Add `@psalm-taint-escape sql` for `Connection::escape()`

### DIFF
--- a/stubs/common/Support/Facades/DB.stubphp
+++ b/stubs/common/Support/Facades/DB.stubphp
@@ -164,4 +164,15 @@ class DB extends Facade
      * @psalm-taint-sink sql $query
      */
     public static function selectResultSets($query, $bindings = [], $useReadPdo = true, array $fetchUsing = []) {}
+
+    /**
+     * Escape a value for safe SQL embedding.
+     *
+     * @param  string|float|int|bool|null  $value
+     * @param  bool  $binary
+     * @return string
+     *
+     * @psalm-taint-escape sql
+     */
+    public static function escape($value, $binary = false) {}
 }

--- a/stubs/taintAnalysis/Database/Connection.stubphp
+++ b/stubs/taintAnalysis/Database/Connection.stubphp
@@ -151,4 +151,15 @@ class Connection
      * @psalm-taint-sink sql $query
      */
     public function selectResultSets($query, $bindings = [], $useReadPdo = true, array $fetchUsing = []) {}
+
+    /**
+     * Escape a value for safe SQL embedding.
+     *
+     * @param  string|float|int|bool|null  $value
+     * @param  bool  $binary
+     * @return string
+     *
+     * @psalm-taint-escape sql
+     */
+    public function escape($value, $binary = false) {}
 }

--- a/tests/Type/tests/TaintAnalysis/SafeSqlConnectionEscape.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeSqlConnectionEscape.phpt
@@ -1,0 +1,21 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Connection::escape() uses PDO::quote() internally and is safe for SQL embedding.
+ *
+ * @psalm-suppress MixedAssignment, MixedArgument
+ */
+function safeSqlEscape(\Illuminate\Http\Request $request): void {
+    $connection = new \Illuminate\Database\Connection(new PDO('sqlite::memory:'));
+    $userInput = $request->input('name');
+
+    $escaped = $connection->escape($userInput);
+
+    // Using the escaped value in a raw query should not trigger TaintedSql
+    $connection->unprepared("SELECT * FROM users WHERE name = {$escaped}");
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeSqlDbEscape.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeSqlDbEscape.phpt
@@ -1,0 +1,20 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * DB::escape() uses PDO::quote() internally and is safe for SQL embedding.
+ *
+ * @psalm-suppress MixedAssignment, MixedArgument
+ */
+function safeSqlDbEscape(\Illuminate\Http\Request $request): void {
+    $userInput = $request->input('name');
+
+    $escaped = \Illuminate\Support\Facades\DB::escape($userInput);
+
+    // Using the escaped value in a raw query should not trigger TaintedSql
+    \Illuminate\Support\Facades\DB::unprepared("SELECT * FROM users WHERE name = {$escaped}");
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Summary

Closes #534

- Add `@psalm-taint-escape sql` for `Connection::escape()` in the taint analysis stub — prevents false positives when developers properly escape values before embedding in raw queries
- Add matching annotation on the `DB` facade stub for consistency with existing sink annotations
- Add type tests for both `Connection::escape()` and `DB::escape()` taint escape paths

## Test plan

- [x] Psalm self-analysis passes
- [x] Unit tests pass (213 tests)
- [x] All 29 taint analysis type tests pass (27 existing + 2 new)
- [x] Stub signature verified against Laravel 13.1.1 source (`Connection::escape()` at line 1131)