### PR TITLE
Add taint sources for session data retrieval (`Session\Store::get()` and other)

### DIFF
--- a/stubs/common/Foundation/helpers.stubphp
+++ b/stubs/common/Foundation/helpers.stubphp
@@ -295,6 +295,8 @@ function response($content = '', $status = 200, array $headers = []) {}
  * @param  mixed[]|string|null  $key
  * @param  mixed  $default
  * @return ($key is null ? \Illuminate\Session\SessionManager : ($key is array ? null : mixed))
+ *
+ * @psalm-taint-source input
  */
 function session($key = null, $default = null) {}
 

--- a/stubs/common/Session/Store.stubphp
+++ b/stubs/common/Session/Store.stubphp
@@ -1,0 +1,98 @@
+<?php
+
+namespace Illuminate\Session;
+
+class Store
+{
+    /**
+     * Get an item from the session.
+     *
+     * @param  \UnitEnum|string  $key
+     * @param  mixed  $default
+     * @return mixed
+     *
+     * @psalm-taint-source input
+     */
+    public function get($key, $default = null) {}
+
+    /**
+     * Get the value of a given key and then forget it.
+     *
+     * @param  \UnitEnum|string  $key
+     * @param  mixed  $default
+     * @return mixed
+     *
+     * @psalm-taint-source input
+     */
+    public function pull($key, $default = null) {}
+
+    /**
+     * Get all of the session data.
+     *
+     * @return array
+     *
+     * @psalm-taint-source input
+     */
+    public function all() {}
+
+    /**
+     * Get a subset of the session data.
+     *
+     * @param  array  $keys
+     * @return array
+     *
+     * @psalm-taint-source input
+     */
+    public function only(array $keys) {}
+
+    /**
+     * Get all the session data except for a specified array of items.
+     *
+     * @param  array  $keys
+     * @return array
+     *
+     * @psalm-taint-source input
+     */
+    public function except(array $keys) {}
+
+    /**
+     * Remove an item from the session, returning its value.
+     *
+     * @param  \UnitEnum|string  $key
+     * @return mixed
+     *
+     * @psalm-taint-source input
+     */
+    public function remove($key) {}
+
+    /**
+     * Get the requested item from the flashed input array.
+     *
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @return mixed
+     *
+     * @psalm-taint-source input
+     */
+    public function getOldInput($key = null, $default = null) {}
+
+    /**
+     * Get an item from the session, or store the default value.
+     *
+     * @param  \UnitEnum|string  $key
+     * @param  \Closure  $callback
+     * @return mixed
+     *
+     * @psalm-taint-source input
+     */
+    public function remember($key, \Closure $callback) {}
+
+    /**
+     * Get the previous URL from the session.
+     *
+     * @return string|null
+     *
+     * @psalm-taint-source input
+     */
+    public function previousUrl() {}
+}

--- a/tests/Type/tests/SessionTest.phpt
+++ b/tests/Type/tests/SessionTest.phpt
@@ -1,0 +1,39 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Session\Store;
+
+function test_session_store_types(Store $session): void
+{
+    $_get = $session->get('key');
+    /** @psalm-check-type-exact $_get = mixed */
+
+    $_getDefault = $session->get('key', 'default');
+    /** @psalm-check-type-exact $_getDefault = mixed */
+
+    $_pull = $session->pull('key');
+    /** @psalm-check-type-exact $_pull = mixed */
+
+    $_remove = $session->remove('key');
+    /** @psalm-check-type-exact $_remove = mixed */
+
+    $_all = $session->all();
+    /** @psalm-check-type-exact $_all = array */
+
+    $_only = $session->only(['key1', 'key2']);
+    /** @psalm-check-type-exact $_only = array */
+
+    $_except = $session->except(['key1']);
+    /** @psalm-check-type-exact $_except = array */
+
+    $_oldInput = $session->getOldInput('email');
+    /** @psalm-check-type-exact $_oldInput = mixed */
+
+    $_remember = $session->remember('key', fn () => 'value');
+    /** @psalm-check-type-exact $_remember = mixed */
+
+    $_previousUrl = $session->previousUrl();
+    /** @psalm-check-type-exact $_previousUrl = null|string */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeSessionManagerNoTaint.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeSessionManagerNoTaint.phpt
@@ -1,0 +1,10 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+function useSessionManager(): void {
+    echo session()->getName();
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionHelper.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionHelper.phpt
@@ -1,0 +1,12 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+function renderSessionData() {
+    echo session('last_query');
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStore.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStore.phpt
@@ -1,0 +1,12 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+function renderSessionData(\Illuminate\Session\Store $session) {
+    echo $session->get('user_input');
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreAll.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreAll.phpt
@@ -1,0 +1,14 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+function renderAllSessionData(\Illuminate\Session\Store $session) {
+    $data = $session->all();
+
+    echo $data['name'];
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreExcept.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreExcept.phpt
@@ -1,0 +1,14 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+function renderExceptSessionData(\Illuminate\Session\Store $session) {
+    $data = $session->except(['password']);
+
+    echo $data['name'];
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreOldInput.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreOldInput.phpt
@@ -1,0 +1,12 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+function renderOldInput(\Illuminate\Session\Store $session) {
+    echo $session->getOldInput('email');
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreOnly.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreOnly.phpt
@@ -1,0 +1,14 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+function renderOnlySessionData(\Illuminate\Session\Store $session) {
+    $data = $session->only(['name']);
+
+    echo $data['name'];
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStorePreviousUrl.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStorePreviousUrl.phpt
@@ -1,0 +1,12 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+function renderPreviousUrl(\Illuminate\Session\Store $session) {
+    echo $session->previousUrl();
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStorePull.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStorePull.phpt
@@ -1,0 +1,12 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+function renderPulledSessionData(\Illuminate\Session\Store $session) {
+    echo $session->pull('user_input');
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreRemember.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreRemember.phpt
@@ -1,0 +1,12 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+function renderRememberedSessionData(\Illuminate\Session\Store $session) {
+    echo $session->remember('user_input', fn () => 'default');
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreRemove.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreRemove.phpt
@@ -1,0 +1,12 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+function renderRemovedSessionData(\Illuminate\Session\Store $session) {
+    echo $session->remove('user_input');
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlSessionHelper.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlSessionHelper.phpt
@@ -1,0 +1,14 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+function unsafeSessionHelperQuery() {
+    $builder = new \Illuminate\Database\Query\Builder();
+    $searchTerm = session('search');
+
+    $builder->raw($searchTerm);
+}
+?>
+--EXPECTF--
+%ATaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlSessionStore.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlSessionStore.phpt
@@ -1,0 +1,14 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+function unsafeSessionQuery(\Illuminate\Session\Store $session) {
+    $builder = new \Illuminate\Database\Query\Builder();
+    $searchTerm = $session->get('search');
+
+    $builder->raw($searchTerm);
+}
+?>
+--EXPECTF--
+%ATaintedSql on line %d: Detected tainted SQL


### PR DESCRIPTION
## What does this PR do?

Adds `@psalm-taint-source input` annotations for session data retrieval methods to detect stored XSS and stored SQL injection vulnerabilities. Session data is a stored taint vector — user input enters in one request, gets persisted, and is retrieved unsafely in a later request.

**Changes:**
- `session()` helper: mark return as taint source
- New taint stub for `Illuminate\Session\Store`: `get()`, `pull()`, `all()`, `only()`, `except()`, `remove()`, `getOldInput()`, `remember()`, `previousUrl()`
- Type tests with `@psalm-check-type-exact` for all Store methods
- Taint tests for HTML and SQL sinks, plus a negative test for `session()` with no args

Closes #479. Supersedes #490.

## How was it tested?

- `composer test` passes (lint + psalm + unit + type)
- 13 taint analysis tests (HTML sink for each method, SQL sink for `get()` and `session()` helper)
- 1 negative taint test (`session()->getName()` does not trigger false positive)
- 1 type test with `@psalm-check-type-exact` for all 9 Store methods

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)
- [x] Documentation is updated (if needed, otherwise remove this item)
