### PR TITLE
Remove false-positive taint source from `Request::integer()` and `Request::float()`

### DIFF
--- a/stubs/common/Http/Concerns/InteractsWithInput.stubphp
+++ b/stubs/common/Http/Concerns/InteractsWithInput.stubphp
@@ -156,22 +156,24 @@ trait InteractsWithInput
     /**
      * Retrieve input as an integer value.
      *
+     * Not a taint source: (int) cast cannot produce an injection payload.
+     * e.g. (int) "1; DROP TABLE users" → 1
+     *
      * @param  string  $key
      * @param  int  $default
      * @return int
-     *
-     * @psalm-taint-source input
      */
     public function integer($key, $default = 0) {}
 
     /**
      * Retrieve input as a float value.
      *
+     * Not a taint source: (float) cast cannot produce an injection payload.
+     * e.g. (float) "<script>alert(1)</script>" → 0.0
+     *
      * @param  string  $key
      * @param  float  $default
      * @return float
-     *
-     * @psalm-taint-source input
      */
     public function float($key, $default = 0.0) {}
 

--- a/tests/Type/tests/TaintAnalysis/SafeRequestFloatNoTaint.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeRequestFloatNoTaint.phpt
@@ -1,0 +1,11 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/** float() returns (float) cast of input — cannot carry injection payload. */
+function useFloatInput(\Illuminate\Http\Request $request): void {
+    echo $request->float('price');
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeRequestIntegerNoTaint.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeRequestIntegerNoTaint.phpt
@@ -1,0 +1,11 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/** integer() returns (int) cast of input — cannot carry injection payload. */
+function useIntegerInput(\Illuminate\Http\Request $request): void {
+    echo $request->integer('page');
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## What does this PR do?

Removes `@psalm-taint-source input` from `Request::integer()` and `Request::float()` in `InteractsWithInput.stubphp`. These methods use `(int)` and `(float)` casts respectively, which destroy any injection payload — matching the existing treatment of `boolean()`, `date()`, and `enum()`.

Fixes #574

## How was it tested?

Two new taint regression tests (`SafeRequestIntegerNoTaint.phpt`, `SafeRequestFloatNoTaint.phpt`) confirm these methods don't trigger false-positive taint warnings.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
