### PR TITLE
Add first-party Laravel packages to application test

### DIFF
--- a/tests/Application/laravel-test.sh
+++ b/tests/Application/laravel-test.sh
@@ -118,6 +118,11 @@ info "Creating a new Laravel project using installer v${LARAVEL_INSTALLER_VERSIO
 composer create-project --quiet --prefer-dist laravel/laravel "$APP_INSTALLATION_PATH" "$LARAVEL_INSTALLER_VERSION"
 cd "$APP_INSTALLATION_PATH"
 
+info "Installing first-party Laravel packages for realistic analysis coverage"
+composer require --quiet laravel/sanctum laravel/scout laravel/pennant laravel/socialite laravel/jetstream laravel/cashier
+./artisan jetstream:install livewire --teams
+./artisan pennant:feature ExampleFeature
+
 info "Making different types of classes for Laravel to analyze them using Psalm"
 ./artisan make:cast ExampleCast
 ./artisan make:channel ExampleChannel


### PR DESCRIPTION
## What does this PR do?

Install first-party Laravel packages (Sanctum, Scout, Pennant, Socialite, Jetstream, Cashier) in the application test for more realistic analysis coverage.

## How was it tested?

`composer test:app`

## Checklist
- [ ] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)
