### PR TITLE
Add @psalm-taint-sink header for Response header methods

### DIFF
--- a/stubs/common/Http/ResponseTrait.stubphp
+++ b/stubs/common/Http/ResponseTrait.stubphp
@@ -5,6 +5,29 @@ namespace Illuminate\Http;
 trait ResponseTrait
 {
     /**
+     * Set a header on the Response.
+     *
+     * @param  string  $key
+     * @param  array|string  $values
+     * @param  bool  $replace
+     * @return $this
+     *
+     * @psalm-taint-sink header $key
+     * @psalm-taint-sink header $values
+     */
+    public function header($key, $values, $replace = true) {}
+
+    /**
+     * Add an array of headers to the response.
+     *
+     * @param  \Symfony\Component\HttpFoundation\HeaderBag|array  $headers
+     * @return $this
+     *
+     * @psalm-taint-sink header $headers
+     */
+    public function withHeaders($headers) {}
+
+    /**
      * Add a cookie to the response.
      *
      * Accepts a Cookie object directly, or variadic string arguments forwarded to the cookie()

--- a/tests/Type/tests/TaintAnalysis/SafeHeaderResponseStatic.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeHeaderResponseStatic.phpt
@@ -1,0 +1,12 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+function staticHeaders(): \Illuminate\Http\Response {
+    return response('OK')
+        ->header('X-Custom', 'static-value')
+        ->withHeaders(['Content-Type' => 'application/json']);
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderResponseHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderResponseHeader.phpt
@@ -1,0 +1,12 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+function setHeader(\Illuminate\Http\Request $request) {
+    $value = $request->input('x_custom');
+    return response('OK')->header('X-Custom', $value);
+}
+?>
+--EXPECTF--
+%ATaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderResponseHeaderKey.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderResponseHeaderKey.phpt
@@ -1,0 +1,12 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+function setHeaderKey(\Illuminate\Http\Request $request) {
+    $key = $request->input('header_name');
+    return response('OK')->header($key, 'static-value');
+}
+?>
+--EXPECTF--
+%ATaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderResponseWithHeaders.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderResponseWithHeaders.phpt
@@ -1,0 +1,12 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+function setHeaders(\Illuminate\Http\Request $request) {
+    $headers = ['X-Custom' => $request->input('x_custom')];
+    return response('OK')->withHeaders($headers);
+}
+?>
+--EXPECTF--
+%ATaintedHeader on line %d: Detected tainted header


### PR DESCRIPTION
## What does this PR do?

Annotate `ResponseTrait::header()` and `withHeaders()` with `@psalm-taint-sink header` to detect HTTP header injection when user input flows into response headers.

Both `$key` and `$values` on `header()` are sinks — attacker-controlled header names are dangerous too (e.g. injecting `Set-Cookie` or `Location`).

Closes #543

## How was it tested?

4 taint analysis type tests:
- `TaintedHeaderResponseHeader` — tainted header value
- `TaintedHeaderResponseHeaderKey` — tainted header key
- `TaintedHeaderResponseWithHeaders` — tainted headers array
- `SafeHeaderResponseStatic` — static values produce no false positives

Full test suite passes (`composer test`).

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
- [x] Documentation is updated (if needed, otherwise remove this item)
