### PR TITLE
Add taint annotations for Auth credential exposure

### DIFF
--- a/stubs/common/Auth/Authenticatable.stubphp
+++ b/stubs/common/Auth/Authenticatable.stubphp
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Auth;
+
+trait Authenticatable
+{
+    /**
+     * Get the password for the user.
+     *
+     * Returns the password hash from the database. Leaking it enables
+     * offline brute-force attacks.
+     *
+     * @return string
+     *
+     * @psalm-taint-source user_secret
+     */
+    public function getAuthPassword() {}
+
+    /**
+     * Get the token value for the "remember me" session.
+     *
+     * Leaking this token allows session hijacking.
+     *
+     * @return string|null
+     *
+     * @psalm-taint-source user_secret
+     */
+    public function getRememberToken() {}
+}

--- a/stubs/common/Auth/SessionGuard.stubphp
+++ b/stubs/common/Auth/SessionGuard.stubphp
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Auth;
+
+class SessionGuard
+{
+    /**
+     * Create a HMAC of the password hash for storage in cookies.
+     *
+     * The HMAC digest is not the original hash, so user_secret taint is
+     * removed. Other taint kinds are preserved via @psalm-flow.
+     *
+     * @param  string  $passwordHash
+     * @return string
+     *
+     * @psalm-taint-escape user_secret
+     * @psalm-flow ($passwordHash) -> return
+     */
+    public function hashPasswordForCookie($passwordHash) {}
+}

--- a/stubs/common/Auth/TokenGuard.stubphp
+++ b/stubs/common/Auth/TokenGuard.stubphp
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Auth;
+
+class TokenGuard
+{
+    /**
+     * Get the token for the current request.
+     *
+     * Reads from query string, request body, Bearer header, and HTTP basic
+     * password — all user-controlled input.
+     *
+     * @return string|null
+     *
+     * @psalm-taint-source input
+     */
+    public function getTokenForRequest() {}
+}

--- a/tests/Type/tests/TaintAnalysis/SafeAuthHashPasswordForCookie.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeAuthHashPasswordForCookie.phpt
@@ -1,0 +1,18 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * hashPasswordForCookie() HMACs the password hash, removing user_secret taint.
+ * Writing the HMAC digest to a file should not trigger TaintedUserSecret.
+ */
+function storeHashedPasswordCookie(\Illuminate\Foundation\Auth\User $user, \Illuminate\Auth\SessionGuard $guard): void {
+    $hash = $user->getAuthPassword();
+
+    $hmac = $guard->hashPasswordForCookie($hash);
+
+    file_put_contents('/tmp/cookie.txt', $hmac);
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlHashPasswordForCookie.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlHashPasswordForCookie.phpt
@@ -1,0 +1,20 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * hashPasswordForCookie() escapes user_secret but preserves other taint kinds
+ * via @psalm-flow. Input taint (which includes html) must survive.
+ */
+function hashPreservesHtmlTaint(\Illuminate\Http\Request $request, \Illuminate\Auth\SessionGuard $guard): void {
+    /** @var string $input */
+    $input = $request->input('data');
+
+    $hashed = $guard->hashPasswordForCookie($input);
+
+    echo $hashed;
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML%A

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlTokenGuardToken.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlTokenGuardToken.phpt
@@ -1,0 +1,13 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+function leakApiToken(\Illuminate\Auth\TokenGuard $guard): void {
+    $token = $guard->getTokenForRequest();
+
+    echo $token;
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML%A

--- a/tests/Type/tests/TaintAnalysis/TaintedUserSecretAuthPassword.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedUserSecretAuthPassword.phpt
@@ -1,0 +1,13 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+function leakPasswordHash(\Illuminate\Foundation\Auth\User $user): void {
+    $hash = $user->getAuthPassword();
+
+    echo $hash;
+}
+?>
+--EXPECTF--
+%ATaintedUserSecret on line %d: Detected tainted user secret%A

--- a/tests/Type/tests/TaintAnalysis/TaintedUserSecretRememberToken.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedUserSecretRememberToken.phpt
@@ -1,0 +1,13 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+function leakRememberToken(\Illuminate\Foundation\Auth\User $user): void {
+    $token = $user->getRememberToken();
+
+    echo $token;
+}
+?>
+--EXPECTF--
+%ATaintedUserSecret on line %d: Detected tainted user secret%A


### PR DESCRIPTION
## What does this PR do?

Adds taint analysis coverage for the Auth namespace. Closes #560.

**Sources** (credential/token exposure):
- `TokenGuard::getTokenForRequest()` — `@psalm-taint-source input` (raw API token from HTTP request)
- `Authenticatable::getAuthPassword()` — `@psalm-taint-source user_secret` (password hash)
- `Authenticatable::getRememberToken()` — `@psalm-taint-source user_secret` (session hijacking token)

**Escapes:**
- `SessionGuard::hashPasswordForCookie()` — `@psalm-taint-escape user_secret` + `@psalm-flow` (HMAC removes secret taint, preserves others)

Note: `loginUsingId()`/`onceUsingId()` were intentionally excluded — their `$id` goes through PDO parameterized bindings, not raw SQL, so marking them as SQL sinks would cause false positives.

## How was it tested?

5 taint type tests covering all annotations:
- 3 source detection tests (`TaintedHtml`, `TaintedUserSecret` x2)
- 1 escape test (`SafeAuthHashPasswordForCookie`)
- 1 flow-preservation test (`TaintedHtmlHashPasswordForCookie`)

Full suite green (262 unit + 178 type tests).

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
- [x] Documentation is updated (if needed, otherwise remove this item)
