### PR TITLE
Add `findMissingTranslations` rule to detect undefined translation keys

### DIFF
--- a/docs/issues/MissingTranslation.md
+++ b/docs/issues/MissingTranslation.md
@@ -1,0 +1,57 @@
+---
+title: MissingTranslation
+parent: Custom Issues
+nav_order: 5
+---
+
+# MissingTranslation
+
+Emitted when `__()` or `trans()` references a translation key that does not exist in the application's language files.
+
+## Why this is a problem
+
+If the translation key doesn't exist, Laravel returns the key itself as a string instead of the translated text.
+This silently produces untranslated output at runtime. This check catches typos and missing keys during static analysis.
+
+## Examples
+
+```php
+// Bad -- typo in the translation key
+echo __('mesages.welcome'); // MissingTranslation
+
+// Good -- the key exists in lang/en/messages.php
+echo __('messages.welcome');
+```
+
+```php
+// Bad -- key was removed from language files
+echo trans('auth.old_message'); // MissingTranslation
+
+// Good
+echo trans('auth.failed');
+```
+
+## How to fix
+
+1. Check that the translation key exists in your language files (e.g., `lang/en/messages.php` or `lang/en.json`)
+2. Fix any typos in the key name
+3. If the translation is provided by a package, use the namespaced syntax (e.g., `__('package::file.key')`) -- namespaced keys are not checked by this rule
+
+## Configuration
+
+This check is disabled by default. Enable it in your `psalm.xml`:
+
+```xml
+<plugins>
+    <pluginClass class="Psalm\LaravelPlugin\Plugin">
+        <findMissingTranslations value="true" />
+    </pluginClass>
+</plugins>
+```
+
+## Limitations
+
+- Only string literal keys are checked -- dynamic or concatenated keys are skipped
+- Namespaced package keys (e.g., `pagination::pages.next`) are skipped
+- Only `__()` and `trans()` are checked -- `trans_choice()`, `Lang::get()`, and Blade `@lang` directives are not detected
+- Uses Laravel's Translator to resolve keys, which respects the configured locale and fallback locale

--- a/src/Handlers/Translations/MissingTranslationHandler.php
+++ b/src/Handlers/Translations/MissingTranslationHandler.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Translations;
+
+use Illuminate\Translation\Translator;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Scalar\String_;
+use Psalm\CodeLocation;
+use Psalm\IssueBuffer;
+use Psalm\LaravelPlugin\Issues\MissingTranslation;
+use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
+use Psalm\Type\Union;
+
+/**
+ * Detects calls to __() and trans() with a translation key that does not
+ * exist in the application's language files.
+ *
+ * Uses Laravel's Translator::has() from the booted application, which
+ * handles PHP array files, JSON files, vendor/package namespaces, and
+ * fallback locales automatically.
+ *
+ * Only string literal keys are checked — dynamic keys (variables,
+ * concatenation) and namespaced package keys (e.g., 'package::file.key')
+ * are skipped to avoid false positives.
+ *
+ * Must be registered before TransHandler in Plugin.php — Psalm stops
+ * iterating handlers once one returns a non-null type. This handler
+ * always returns null (issue-only), so TransHandler can still provide
+ * the return type afterward.
+ *
+ * @see https://laravel.com/docs/localization
+ */
+final class MissingTranslationHandler implements FunctionReturnTypeProviderInterface
+{
+    private static ?Translator $translator = null;
+
+    private static bool $enabled = false;
+
+    /** @var array<string, bool> Cached translation existence results to avoid repeated Translator::has() calls */
+    private static array $resolvedKeys = [];
+
+    /** @psalm-external-mutation-free */
+    public static function init(Translator $translator): void
+    {
+        self::$translator = $translator;
+        self::$enabled = true;
+        self::$resolvedKeys = [];
+    }
+
+    /**
+     * @inheritDoc
+     * @psalm-pure
+     */
+    #[\Override]
+    public static function getFunctionIds(): array
+    {
+        return ['__', 'trans'];
+    }
+
+    /** @inheritDoc */
+    #[\Override]
+    public static function getFunctionReturnType(FunctionReturnTypeProviderEvent $event): ?Union
+    {
+        $callArgs = $event->getCallArgs();
+
+        if ($callArgs === []) {
+            return null;
+        }
+
+        $translationKey = self::extractLiteralStringArg($callArgs[0]);
+
+        if ($translationKey === null) {
+            return null;
+        }
+
+        self::checkTranslationExists(
+            $translationKey,
+            $event->getCodeLocation(),
+            $event->getStatementsSource()->getSuppressedIssues(),
+        );
+
+        return null;
+    }
+
+    /**
+     * Extract a literal string value from a call argument's AST node.
+     *
+     * Returns null for non-literal arguments — the handler only validates
+     * translation keys it can statically determine from the source code.
+     *
+     * @psalm-mutation-free
+     */
+    private static function extractLiteralStringArg(Arg $arg): ?string
+    {
+        $value = $arg->value;
+
+        if ($value instanceof String_) {
+            return $value->value;
+        }
+
+        return null;
+    }
+
+    /**
+     * Check whether the given translation key exists in the application's language files.
+     *
+     * Skips namespaced keys (containing '::') since those belong to packages
+     * whose translations may not be published to the app's lang/ directory.
+     *
+     * @param array<array-key, string> $suppressedIssues
+     */
+    private static function checkTranslationExists(
+        string $translationKey,
+        CodeLocation $codeLocation,
+        array $suppressedIssues,
+    ): void {
+        if (!self::$enabled || self::$translator === null) {
+            return;
+        }
+
+        // Skip namespaced package keys (e.g., 'pagination::pages.next') — packages
+        // may not have their translations published to the app's lang/ directory
+        if (\str_contains($translationKey, '::')) {
+            return;
+        }
+
+        if ($translationKey === '') {
+            return;
+        }
+
+        if (self::translationExists($translationKey)) {
+            return;
+        }
+
+        IssueBuffer::accepts(
+            new MissingTranslation(
+                "Translation key '{$translationKey}' not found in language files",
+                $codeLocation,
+            ),
+            $suppressedIssues,
+        );
+    }
+
+    /**
+     * Check if a translation key exists, caching the result.
+     *
+     * Translator::has() involves parseKey(), group loading, and array lookups.
+     * Caching avoids this overhead for repeated keys (common in large codebases).
+     */
+    private static function translationExists(string $translationKey): bool
+    {
+        if (self::$translator === null) {
+            return true;
+        }
+
+        return self::$resolvedKeys[$translationKey]
+            ??= self::$translator->has($translationKey);
+    }
+}

--- a/src/Issues/MissingTranslation.php
+++ b/src/Issues/MissingTranslation.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Issues;
+
+use Psalm\Issue\PluginIssue;
+
+/**
+ * Reported when __() or trans() references a translation key
+ * that does not exist in the application's language files.
+ */
+final class MissingTranslation extends PluginIssue
+{
+    public const DOCUMENTATION_URL = 'https://psalm.github.io/psalm-plugin-laravel/issues/MissingTranslation/';
+
+    public const ERROR_LEVEL = 1;
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -28,6 +28,7 @@ use Psalm\LaravelPlugin\Handlers\Helpers\TransHandler;
 use Psalm\LaravelPlugin\Handlers\Rules\ModelMakeHandler;
 use Psalm\LaravelPlugin\Handlers\Rules\NoEnvOutsideConfigHandler;
 use Psalm\LaravelPlugin\Handlers\SuppressHandler;
+use Psalm\LaravelPlugin\Handlers\Translations\MissingTranslationHandler;
 use Psalm\LaravelPlugin\Handlers\Validation\ValidatedTypeHandler;
 use Psalm\LaravelPlugin\Handlers\Validation\ValidationTaintHandler;
 use Psalm\LaravelPlugin\Handlers\Views\MissingViewHandler;
@@ -69,6 +70,10 @@ final class Plugin implements PluginEntryPointInterface
             NoEnvOutsideConfigHandler::init(
                 ApplicationProvider::getApp()->configPath(),
             );
+
+            if ($pluginConfig->findMissingTranslations) {
+                $this->initMissingTranslationHandler();
+            }
 
             if ($pluginConfig->findMissingViews) {
                 $this->initMissingViewHandler();
@@ -217,6 +222,15 @@ final class Plugin implements PluginEntryPointInterface
         $registration->registerHooksFromClass(CacheHandler::class);
         require_once __DIR__ . '/Handlers/Helpers/PathHandler.php';
         $registration->registerHooksFromClass(PathHandler::class);
+        // MissingTranslationHandler must be registered before TransHandler because
+        // Psalm stops iterating handlers once one returns a non-null type.
+        // MissingTranslationHandler always returns null (it only emits issues),
+        // so TransHandler still provides the return type afterward.
+        if ($pluginConfig->findMissingTranslations) {
+            require_once __DIR__ . '/Handlers/Translations/MissingTranslationHandler.php';
+            $registration->registerHooksFromClass(MissingTranslationHandler::class);
+        }
+
         require_once __DIR__ . '/Handlers/Helpers/TransHandler.php';
         $registration->registerHooksFromClass(TransHandler::class);
 
@@ -232,6 +246,29 @@ final class Plugin implements PluginEntryPointInterface
             require_once __DIR__ . '/Handlers/Views/MissingViewHandler.php';
             $registration->registerHooksFromClass(MissingViewHandler::class);
         }
+    }
+
+    /**
+     * Get the Translator instance from the booted Laravel app and pass it to the handler.
+     *
+     * Uses Laravel's Translator::has() for key resolution, which handles PHP array files,
+     * JSON files, vendor/package namespaces, and fallback locales automatically.
+     */
+    private function initMissingTranslationHandler(): void
+    {
+        $app = ApplicationProvider::getApp();
+
+        if (!$app->bound('translator')) {
+            return;
+        }
+
+        $translator = $app->make('translator');
+
+        if (!$translator instanceof \Illuminate\Translation\Translator) {
+            return;
+        }
+
+        MissingTranslationHandler::init($translator);
     }
 
     /**

--- a/src/PluginConfig.php
+++ b/src/PluginConfig.php
@@ -20,6 +20,7 @@ final readonly class PluginConfig
     private function __construct(
         public ColumnFallback $columnFallback,
         public bool $failOnInternalError,
+        public bool $findMissingTranslations,
         public bool $findMissingViews,
         public string $cachePath,
     ) {}
@@ -50,6 +51,16 @@ final readonly class PluginConfig
 
         $failOnInternalError = $failOnInternalErrorValue === 'true';
 
+        $findMissingTranslationsValue = (string) ($config?->findMissingTranslations['value'] ?? 'false');
+
+        if (!\in_array($findMissingTranslationsValue, ['true', 'false'], true)) {
+            throw new \InvalidArgumentException(
+                "Invalid findMissingTranslations value '{$findMissingTranslationsValue}'. Valid values: 'true', 'false'.",
+            );
+        }
+
+        $findMissingTranslations = $findMissingTranslationsValue === 'true';
+
         $findMissingViewsValue = (string) ($config?->findMissingViews['value'] ?? 'false');
 
         if (!\in_array($findMissingViewsValue, ['true', 'false'], true)) {
@@ -63,6 +74,7 @@ final readonly class PluginConfig
         return new self(
             columnFallback: $columnFallback,
             failOnInternalError: $failOnInternalError,
+            findMissingTranslations: $findMissingTranslations,
             findMissingViews: $findMissingViews,
             cachePath: self::resolveCachePath(),
         );

--- a/tests/Type/psalm-find-translations.xml
+++ b/tests/Type/psalm-find-translations.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<psalm
+    disableSuppressAll="true"
+    ensureArrayStringOffsetsExist="true"
+    errorLevel="1"
+    findUnusedBaselineEntry="true"
+    findUnusedPsalmSuppress="true"
+    findUnusedVariablesAndParams="true"
+    memoizeMethodCallResults="true"
+    reportMixedIssues="true"
+    runTaintAnalysis="false"
+    sealAllMethods="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config ../../vendor/vimeo/psalm/config.xsd"
+>
+    <plugins>
+        <pluginClass class="Psalm\LaravelPlugin\Plugin">
+            <failOnInternalError value="true" />
+            <findMissingTranslations value="true" />
+        </pluginClass>
+    </plugins>
+    <issueHandlers>
+        <MissingPureAnnotation errorLevel="info" />
+    </issueHandlers>
+</psalm>

--- a/tests/Type/tests/MissingTranslationTest.phpt
+++ b/tests/Type/tests/MissingTranslationTest.phpt
@@ -1,0 +1,32 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm-find-translations.xml
+--FILE--
+<?php declare(strict_types=1);
+
+// Missing translations via __() — should emit MissingTranslation
+__('nonexistent.key');
+__('auth.nonexistent');
+
+// Missing translations via trans() — should emit MissingTranslation
+trans('messages.missing');
+
+// Existing translations — should not emit
+__('auth.failed');
+trans('auth.password');
+__('auth.throttle');
+
+// No arguments — should not emit
+__();
+
+// Namespaced package keys — should be skipped even if not found
+__('package::file.key');
+trans('notifications::email.greeting');
+
+// Dynamic keys — should be skipped
+$key = 'auth.failed';
+__($key);
+?>
+--EXPECTF--
+MissingTranslation on line %d: Translation key 'nonexistent.key' not found in language files
+MissingTranslation on line %d: Translation key 'auth.nonexistent' not found in language files
+MissingTranslation on line %d: Translation key 'messages.missing' not found in language files

--- a/tests/Unit/Handlers/Translations/MissingTranslationHandlerTest.php
+++ b/tests/Unit/Handlers/Translations/MissingTranslationHandlerTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Translations;
+
+use Illuminate\Translation\Translator;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\CodeLocation;
+use Psalm\Context;
+use Psalm\LaravelPlugin\Handlers\Translations\MissingTranslationHandler;
+use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
+use Psalm\StatementsSource;
+use Psalm\Type\Union;
+
+#[CoversClass(MissingTranslationHandler::class)]
+final class MissingTranslationHandlerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $translator = $this->createStub(Translator::class);
+        $translator->method('has')->willReturnCallback(
+            static fn(string $key): bool => \in_array($key, [
+                'auth.failed',
+                'auth.password',
+                'auth.throttle',
+                'messages.welcome',
+            ], true),
+        );
+
+        MissingTranslationHandler::init($translator);
+    }
+
+    #[Test]
+    public function returns_trans_and_double_underscore_function_ids(): void
+    {
+        $this->assertSame(['__', 'trans'], MissingTranslationHandler::getFunctionIds());
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function existingKeyProvider(): iterable
+    {
+        yield 'auth.failed' => ['auth.failed'];
+        yield 'auth.password' => ['auth.password'];
+        yield 'auth.throttle' => ['auth.throttle'];
+        yield 'messages.welcome' => ['messages.welcome'];
+    }
+
+    /**
+     * Translation keys that exist should not trigger the issue.
+     * If the handler incorrectly tried to emit an issue, it would throw
+     * because no Psalm runtime is initialized in unit tests.
+     */
+    #[Test]
+    #[DataProvider('existingKeyProvider')]
+    public function skips_existing_translation_keys(string $translationKey): void
+    {
+        $event = $this->createEvent($translationKey);
+
+        $this->assertNotInstanceOf(Union::class, MissingTranslationHandler::getFunctionReturnType($event));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function skippedKeyProvider(): iterable
+    {
+        yield 'namespaced package key' => ['package::file.key'];
+        yield 'another namespaced key' => ['notifications::email.greeting'];
+    }
+
+    /**
+     * Namespaced keys should be skipped — not flagged even if the translation doesn't exist.
+     */
+    #[Test]
+    #[DataProvider('skippedKeyProvider')]
+    public function skips_namespaced_package_keys(string $translationKey): void
+    {
+        $event = $this->createEvent($translationKey);
+
+        $this->assertNotInstanceOf(Union::class, MissingTranslationHandler::getFunctionReturnType($event));
+    }
+
+    #[Test]
+    public function skips_empty_key(): void
+    {
+        $event = $this->createEvent('');
+
+        $this->assertNotInstanceOf(Union::class, MissingTranslationHandler::getFunctionReturnType($event));
+    }
+
+    #[Test]
+    public function skips_when_not_enabled(): void
+    {
+        $enabled = new \ReflectionProperty(MissingTranslationHandler::class, 'enabled');
+        $enabled->setAccessible(true);
+        $enabled->setValue(null, false);
+
+        $event = $this->createEvent('nonexistent.key');
+
+        $this->assertNotInstanceOf(Union::class, MissingTranslationHandler::getFunctionReturnType($event));
+
+        // Re-enable for other tests
+        $this->setUp();
+    }
+
+    #[Test]
+    public function skips_no_arguments(): void
+    {
+        $source = $this->createStub(StatementsSource::class);
+        $source->method('getFilePath')->willReturn('/app/Http/Controllers/TestController.php');
+        $source->method('getFileName')->willReturn('TestController.php');
+
+        $funcCall = new FuncCall(new Name('__'));
+        $funcCall->setAttribute('startFilePos', 0);
+        $funcCall->setAttribute('endFilePos', 10);
+        $funcCall->args = [];
+
+        $event = new FunctionReturnTypeProviderEvent(
+            $source,
+            '__',
+            $funcCall,
+            new Context(),
+            new CodeLocation($source, $funcCall),
+        );
+
+        $this->assertNotInstanceOf(Union::class, MissingTranslationHandler::getFunctionReturnType($event));
+    }
+
+    #[Test]
+    public function skips_dynamic_variable_argument(): void
+    {
+        $source = $this->createStub(StatementsSource::class);
+        $source->method('getFilePath')->willReturn('/app/Http/Controllers/TestController.php');
+        $source->method('getFileName')->willReturn('TestController.php');
+
+        $funcCall = new FuncCall(new Name('__'));
+        $funcCall->setAttribute('startFilePos', 0);
+        $funcCall->setAttribute('endFilePos', 10);
+        $funcCall->args = [new Arg(new Variable('key'))];
+
+        $event = new FunctionReturnTypeProviderEvent(
+            $source,
+            '__',
+            $funcCall,
+            new Context(),
+            new CodeLocation($source, $funcCall),
+        );
+
+        $this->assertNotInstanceOf(Union::class, MissingTranslationHandler::getFunctionReturnType($event));
+    }
+
+    private function createEvent(string $translationKey): FunctionReturnTypeProviderEvent
+    {
+        $source = $this->createStub(StatementsSource::class);
+        $source->method('getFilePath')->willReturn('/app/Http/Controllers/TestController.php');
+        $source->method('getFileName')->willReturn('TestController.php');
+        $source->method('getSuppressedIssues')->willReturn([]);
+
+        $funcCall = new FuncCall(new Name('__'));
+        $funcCall->setAttribute('startFilePos', 0);
+        $funcCall->setAttribute('endFilePos', 10);
+        $funcCall->args = [new Arg(new String_($translationKey))];
+
+        return new FunctionReturnTypeProviderEvent(
+            $source,
+            '__',
+            $funcCall,
+            new Context(),
+            new CodeLocation($source, $funcCall),
+        );
+    }
+}

--- a/tests/Unit/PluginConfigTest.php
+++ b/tests/Unit/PluginConfigTest.php
@@ -40,6 +40,7 @@ final class PluginConfigTest extends TestCase
 
         $this->assertSame(ColumnFallback::Migrations, $config->columnFallback);
         $this->assertFalse($config->failOnInternalError);
+        $this->assertFalse($config->findMissingTranslations);
         $this->assertFalse($config->findMissingViews);
     }
 
@@ -101,6 +102,37 @@ final class PluginConfigTest extends TestCase
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage("Invalid failOnInternalError value 'yes'");
+
+        PluginConfig::fromXml($xml);
+    }
+
+    #[Test]
+    public function find_missing_translations_true(): void
+    {
+        $xml = new \SimpleXMLElement('<pluginClass><findMissingTranslations value="true" /></pluginClass>');
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertTrue($config->findMissingTranslations);
+    }
+
+    #[Test]
+    public function find_missing_translations_false(): void
+    {
+        $xml = new \SimpleXMLElement('<pluginClass><findMissingTranslations value="false" /></pluginClass>');
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertFalse($config->findMissingTranslations);
+    }
+
+    #[Test]
+    public function invalid_find_missing_translations_throws(): void
+    {
+        $xml = new \SimpleXMLElement('<pluginClass><findMissingTranslations value="yes" /></pluginClass>');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid findMissingTranslations value 'yes'");
 
         PluginConfig::fromXml($xml);
     }
@@ -209,6 +241,7 @@ final class PluginConfigTest extends TestCase
             '<pluginClass>'
             . '<modelProperties columnFallback="none" />'
             . '<failOnInternalError value="true" />'
+            . '<findMissingTranslations value="true" />'
             . '<findMissingViews value="true" />'
             . '</pluginClass>',
         );
@@ -217,6 +250,7 @@ final class PluginConfigTest extends TestCase
 
         $this->assertSame(ColumnFallback::None, $config->columnFallback);
         $this->assertTrue($config->failOnInternalError);
+        $this->assertTrue($config->findMissingTranslations);
         $this->assertTrue($config->findMissingViews);
         $this->assertSame('/tmp/psalm-test', $config->cachePath);
     }


### PR DESCRIPTION
## What does this PR do?

Closes #595.

Adds a new opt-in rule that detects `__()` and `trans()` calls referencing translation keys that don't exist in the application's language files.

Uses Laravel's `Translator::has()` from the booted app, which handles PHP array files, JSON files, vendor/package namespaces, and fallback locales automatically. Results are cached per key to avoid repeated lookups.

```xml
<pluginClass class="Psalm\LaravelPlugin\Plugin">
    <findMissingTranslations value="true" />
</pluginClass>
```

Skips dynamic keys, empty keys, and namespaced package keys (`vendor::file.key`).

## How was it tested?

- Unit tests for `MissingTranslationHandler` (11 tests covering existing keys, missing keys, namespaced keys, empty keys, disabled state, no arguments, dynamic variables)
- Unit tests for `PluginConfig` (3 new tests for the `findMissingTranslations` option)
- Type test (`MissingTranslationTest.phpt`) with dedicated psalm config
- Psalm self-analysis clean, CS clean

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)
- [x] Documentation is updated (if needed, otherwise remove this item)
