### PR TITLE
Drop Psalm 7 support on 3.x, require ^6.16.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Maintained versions:
 | Laravel Psalm Plugin | PHP   | Laravel   | Psalm |
 |----------------------|-------|-----------|-------|
 | 4.x (upcoming)       | ^8.3  | 12, 13    | 7     |
-| 3.x                  | ^8.2  | 11, 12    | 6, 7  |
+| 3.x                  | ^8.2  | 11, 12    | 6     |
 | 2.12+                | ^8.0  | 9, 10, 11 | 5, 6  |
 
 _(Older versions of Laravel, PHP, and Psalm were supported by version 1.x of the plugin, but they are no longer maintained)_

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "orchestra/testbench-core": "^9.11 || ^10.0",
         "symfony/console": "^7.1",
         "symfony/finder": "^7.1",
-        "vimeo/psalm": "^6.15 || ^7.0.0-beta16 || dev-master"
+        "vimeo/psalm": "^6.16.1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.94",


### PR DESCRIPTION
## Summary

Psalm 7 is not compatible with v3.x stubs and type tests. Restrict to Psalm 6 only.
Use plugin v4.x for Psalm 7 support.

## Test plan

- [x] CI should pass with Psalm 6.16.1