### PR TITLE
Narrow `__()` and `trans()` return type to `string` when translation key resolves to a string

### DIFF
--- a/src/Handlers/Translations/MissingTranslationHandler.php
+++ b/src/Handlers/Translations/MissingTranslationHandler.php
@@ -182,29 +182,38 @@ final class MissingTranslationHandler implements FunctionReturnTypeProviderInter
         }
 
         try {
-            if (!self::$translator->has($translationKey)) {
-                self::$resolvedKeys[$translationKey] = null;
-
-                return null;
-            }
-
-            $value = self::$translator->get($translationKey);
-
-            $type = \is_array($value)
-                ? Type::getArray()
-                : Type::getString();
-
-            self::$resolvedKeys[$translationKey] = $type;
-
-            return $type;
-        } catch (\Throwable) {
+            $exists = self::$translator->has($translationKey);
+        } catch (\Exception) {
             // Malformed language files (PHP syntax errors, invalid JSON) can cause
-            // Translator to throw. Return string|array to avoid false positives,
-            // matching the fallback behavior of TransHandler.
+            // Translator::has() to throw. Return string|array to avoid emitting
+            // a false MissingTranslation for a key that may actually exist.
             $fallback = Type::combineUnionTypes(Type::getString(), Type::getArray());
-            self::$resolvedKeys[$translationKey] = $fallback;
 
-            return $fallback;
+            return self::$resolvedKeys[$translationKey] = $fallback;
         }
+
+        if (!$exists) {
+            self::$resolvedKeys[$translationKey] = null;
+
+            return null;
+        }
+
+        try {
+            $value = self::$translator->get($translationKey);
+        } catch (\Exception) {
+            // Key exists but value cannot be retrieved — return string|array
+            // to avoid false positives, matching TransHandler's fallback.
+            $fallback = Type::combineUnionTypes(Type::getString(), Type::getArray());
+
+            return self::$resolvedKeys[$translationKey] = $fallback;
+        }
+
+        $type = \is_array($value)
+            ? Type::getArray()
+            : Type::getString();
+
+        self::$resolvedKeys[$translationKey] = $type;
+
+        return $type;
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -224,8 +224,10 @@ final class Plugin implements PluginEntryPointInterface
         $registration->registerHooksFromClass(PathHandler::class);
         // MissingTranslationHandler must be registered before TransHandler because
         // Psalm stops iterating handlers once one returns a non-null type.
-        // MissingTranslationHandler always returns null (it only emits issues),
-        // so TransHandler still provides the return type afterward.
+        // For existing keys, MissingTranslationHandler returns a precise type
+        // (string or array), preempting TransHandler's less precise string|array.
+        // For missing, dynamic, or namespaced keys, it returns null so
+        // TransHandler can still provide a fallback type.
         if ($pluginConfig->findMissingTranslations) {
             require_once __DIR__ . '/Handlers/Translations/MissingTranslationHandler.php';
             $registration->registerHooksFromClass(MissingTranslationHandler::class);

--- a/tests/Type/tests/MissingTranslationTest.phpt
+++ b/tests/Type/tests/MissingTranslationTest.phpt
@@ -23,6 +23,11 @@ $throttle = __('auth.throttle');
 /** @psalm-check-type-exact $throttle = string */
 echo $throttle;
 
+// Existing translations — array type (validation.between is an array in Laravel)
+$between = __('validation.between');
+/** @psalm-check-type-exact $between = array<array-key, mixed> */
+print_r($between);
+
 // No arguments — should not emit
 __();
 

--- a/tests/Unit/Handlers/Translations/MissingTranslationHandlerTest.php
+++ b/tests/Unit/Handlers/Translations/MissingTranslationHandlerTest.php
@@ -122,10 +122,11 @@ final class MissingTranslationHandlerTest extends TestCase
 
     /**
      * When Translator::has() throws (e.g. malformed language file), the handler
-     * should return string|array to avoid false positives and crashes.
+     * should return string|array to avoid emitting a false MissingTranslation
+     * for a key that may actually exist.
      */
     #[Test]
-    public function returns_string_or_array_when_translator_throws(): void
+    public function returns_string_or_array_when_has_throws(): void
     {
         $translator = $this->createStub(Translator::class);
         $translator->method('has')->willThrowException(new \RuntimeException('Invalid language file'));
@@ -133,6 +134,30 @@ final class MissingTranslationHandlerTest extends TestCase
         MissingTranslationHandler::init($translator);
 
         $event = $this->createEvent('broken.key');
+        $result = MissingTranslationHandler::getFunctionReturnType($event);
+
+        $this->assertInstanceOf(Union::class, $result);
+        $this->assertTrue($result->hasString(), 'Expected string in union type');
+        $this->assertTrue($result->hasArray(), 'Expected array in union type');
+
+        // Re-init with working translator for other tests
+        $this->setUp();
+    }
+
+    /**
+     * When Translator::has() succeeds but get() throws, the handler should
+     * return string|array as a safe fallback since we know the key exists.
+     */
+    #[Test]
+    public function returns_string_or_array_when_get_throws(): void
+    {
+        $translator = $this->createStub(Translator::class);
+        $translator->method('has')->willReturn(true);
+        $translator->method('get')->willThrowException(new \RuntimeException('Cannot read value'));
+
+        MissingTranslationHandler::init($translator);
+
+        $event = $this->createEvent('broken.value');
         $result = MissingTranslationHandler::getFunctionReturnType($event);
 
         $this->assertInstanceOf(Union::class, $result);


### PR DESCRIPTION
## What does this PR do?

When `findMissingTranslations` is enabled, `MissingTranslationHandler` now resolves the actual translation value via `Translator::get()` and returns a precise type (`string` or `array`) instead of always returning `null` and deferring to `TransHandler`.

This eliminates `PossiblyInvalidArgument` false positives for code passing `__('key')` to parameters expecting `string` — common with Nova fields and similar APIs.

Closes #0

## How was it tested?

- Unit tests verify `string`, `array`, and `string|array` (exception fallback) return types
- Type test asserts `@psalm-check-type-exact` for resolved keys

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)
- [x] Documentation is updated (if needed, otherwise remove this item)
