### PR TITLE
Speed up type tests 16x using batch mode

### DIFF
--- a/tests/Type/PsalmTest.php
+++ b/tests/Type/PsalmTest.php
@@ -4,39 +4,71 @@ declare(strict_types=1);
 
 namespace Tests\Psalm\LaravelPlugin\Type;
 
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use PHPyh\PsalmTester\PsalmTester;
 
-use function str_replace;
-
 final class PsalmTest extends TestCase
 {
-    private ?PsalmTester $psalmTester = null;
+    /** @var array<string, string> */
+    private static array $batchResults = [];
+
+    /** @var array<string, \PHPyh\PsalmTester\PsalmTest> */
+    private static array $testData = [];
+
+    #[\Override]
+    public static function setUpBeforeClass(): void
+    {
+        $tester = PsalmTester::create(
+            defaultArguments: '--no-progress --no-diff --config=' . __DIR__ . '/psalm.xml',
+        );
+
+        $baseDir = self::baseDir();
+
+        foreach (self::discoverPhptFiles($baseDir) as $absPath => $relPath) {
+            self::$testData[$relPath] = \PHPyh\PsalmTester\PsalmTest::fromPhptFile($absPath);
+        }
+
+        self::$batchResults = $tester->runBatch(self::$testData);
+    }
 
     /** @return \Generator<string, array{0: string}> */
     public static function providePhptFiles(): \Generator
     {
-        $baseDir = __DIR__ . \DIRECTORY_SEPARATOR . 'tests' . \DIRECTORY_SEPARATOR;
-        $testExtension = 'phpt';
+        $baseDir = self::baseDir();
 
-        $dirItr = new \RecursiveDirectoryIterator($baseDir);
-        $itr = new \RecursiveIteratorIterator($dirItr);
-        $regItr = new \RegexIterator($itr, "/^.+.{$testExtension}\$/", \RegexIterator::GET_MATCH);
-
-        foreach ($regItr as $file) {
-            $filepath = $file[0];
-            $relativeFilepath = str_replace($baseDir, '', $filepath);
-            yield $relativeFilepath => [$filepath];
+        foreach (self::discoverPhptFiles($baseDir) as $relPath) {
+            yield $relPath => [$relPath];
         }
     }
 
     #[DataProvider('providePhptFiles')]
-    public function testPhptFiles(string $phptFilepath): void
+    public function testPhptFiles(string $relPath): void
     {
-        $this->psalmTester ??= PsalmTester::create(
-            defaultArguments: '--no-progress --no-diff --config=' . __DIR__ . '/psalm.xml',
+        Assert::assertThat(
+            self::$batchResults[$relPath],
+            self::$testData[$relPath]->constraint,
         );
-        $this->psalmTester->test(\PHPyh\PsalmTester\PsalmTest::fromPhptFile($phptFilepath));
+    }
+
+    /** @psalm-pure */
+    private static function baseDir(): string
+    {
+        return __DIR__ . \DIRECTORY_SEPARATOR . 'tests' . \DIRECTORY_SEPARATOR;
+    }
+
+    /** @return \Generator<string, string> absPath => relPath */
+    private static function discoverPhptFiles(string $baseDir): \Generator
+    {
+        $dirItr = new \RecursiveDirectoryIterator($baseDir);
+        $itr = new \RecursiveIteratorIterator($dirItr);
+        $regItr = new \RegexIterator($itr, '/^.+\.phpt$/', \RegexIterator::GET_MATCH);
+
+        foreach ($regItr as $file) {
+            $filepath = $file[0];
+            $relPath = \str_replace($baseDir, '', $filepath);
+            yield $filepath => $relPath;
+        }
     }
 }

--- a/tests/Type/tests/DatabaseBuilderTypesTest.phpt
+++ b/tests/Type/tests/DatabaseBuilderTypesTest.phpt
@@ -3,7 +3,7 @@
 
 use App\Models\User;
 
-final class UserRepository
+final class DatabaseBuilderUserRepository
 {
     /** @param \Illuminate\Database\Eloquent\Builder<\App\Models\User> $builder */
     public function firstFromDatabaseBuilderInstance(\Illuminate\Database\Eloquent\Builder $builder): ?User {

--- a/tests/Type/tests/EloquentBuilderTypesTest.phpt
+++ b/tests/Type/tests/EloquentBuilderTypesTest.phpt
@@ -5,7 +5,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use App\Models\User;
 
-final class UserRepository
+final class EloquentBuilderUserRepository
 {
     /** @return Builder<User> */
     public function getNewQuery(): Builder

--- a/tests/Type/tests/Support/helpers/cookie.phpt
+++ b/tests/Type/tests/Support/helpers/cookie.phpt
@@ -11,7 +11,7 @@ function single_arg_to_get_cookie(): \Symfony\Component\HttpFoundation\Cookie
     return cookie('some.key');
 }
 
-function no_args(): \Illuminate\Cookie\CookieJar
+function cookie_no_args(): \Illuminate\Cookie\CookieJar
 {
     return cookie();
 }

--- a/tests/Type/tests/Support/helpers/logger.phpt
+++ b/tests/Type/tests/Support/helpers/logger.phpt
@@ -1,12 +1,12 @@
 --FILE--
 <?php declare(strict_types=1);
 
-function args(): null
+function logger_args(): null
 {
     return logger('this should return void');
 }
 
-function no_args(): \Illuminate\Log\LogManager
+function logger_no_args(): \Illuminate\Log\LogManager
 {
     return logger();
 }

--- a/tests/Type/tests/Support/helpers/session.phpt
+++ b/tests/Type/tests/Support/helpers/session.phpt
@@ -11,7 +11,7 @@ function array_arg_to_set_session(): null
     return session(['some-key' => 42]);
 }
 
-function no_args(): \Illuminate\Session\SessionManager
+function session_no_args(): \Illuminate\Session\SessionManager
 {
     return session();
 }

--- a/tests/Type/tests/TaintAnalysis/TaintEscapeHtml.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintEscapeHtml.phpt
@@ -3,7 +3,7 @@
 --FILE--
 <?php declare(strict_types=1);
 
-function renderComment(\Illuminate\Http\Request $request) {
+function renderEscapedComment(\Illuminate\Http\Request $request) {
     $comment = $request->input('comment');
     echo e($comment);
 }


### PR DESCRIPTION
## Summary

- Run all `.phpt` type tests in a single Psalm invocation via `runBatch()` instead of spawning Psalm per test
- Rename duplicate class/function names across test files to avoid collisions in batch mode
- Type tests go from **2:26 → 9 seconds** (~16x faster)

## Test plan

- [x] `composer test:type` passes with same 28 pre-existing failures (no regressions)
