### PR TITLE
Add `@psalm-taint-escape system_secret` for `Hash::make()` and `bcrypt()`

### DIFF
--- a/docs/contribute/taint-analysis.md
+++ b/docs/contribute/taint-analysis.md
@@ -100,7 +100,7 @@ All taint kind names are defined in [`Psalm\Type\TaintKind::TAINT_NAMES`](https:
 | `ssrf`          | Server-side request forgery               | `Http::get($url)`                             | --                                            |
 | `file`          | Path traversal                            | `Filesystem::get()`, `response()->download()` | --                                            |
 | `user_secret`   | Password/token exposure in logs or output | `echo`, log sinks                             | `Hash::make()`, `Encrypter::encrypt()`        |
-| `system_secret` | Internal secret exposure                  | `echo`, log sinks                             | `Encrypter::encrypt()`                        |
+| `system_secret` | Internal secret exposure                  | `echo`, log sinks                             | `Hash::make()`, `Encrypter::encrypt()`        |
 
 ### All available kinds
 

--- a/stubs/common/Foundation/helpers.stubphp
+++ b/stubs/common/Foundation/helpers.stubphp
@@ -85,6 +85,7 @@ function back($status = 302, $headers = [], $fallback = false) {}
  * @return non-empty-string
  *
  * @psalm-taint-escape user_secret
+ * @psalm-taint-escape system_secret
  */
 function bcrypt($value, $options = []) {}
 

--- a/stubs/common/Hashing/HashManager.stubphp
+++ b/stubs/common/Hashing/HashManager.stubphp
@@ -12,6 +12,7 @@ class HashManager
      * @return string
      *
      * @psalm-taint-escape user_secret
+     * @psalm-taint-escape system_secret
      */
     public function make($value, array $options = []) {}
 }

--- a/tests/Type/tests/TaintAnalysis/SafeBcryptEscapesSystemSecret.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeBcryptEscapesSystemSecret.phpt
@@ -1,0 +1,19 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * bcrypt() delegates to HashManager::make() — the original system secret
+ * cannot be recovered from the hash. Should not trigger TaintedSystemSecret.
+ */
+function storeHashedToken(): void {
+    /** @psalm-taint-source system_secret */
+    $token = getenv('SECRET_TOKEN');
+
+    $hashed = bcrypt((string) $token);
+
+    file_put_contents('/tmp/safe.txt', $hashed);
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeBcryptEscapesUserSecret.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeBcryptEscapesUserSecret.phpt
@@ -1,0 +1,18 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * bcrypt() is a one-way hash — the original plaintext password
+ * cannot be recovered. Writing the hash should not trigger TaintedUserSecret.
+ */
+function storeBcryptedPassword(\Illuminate\Foundation\Auth\User $user): void {
+    $password = $user->getAuthPassword();
+
+    $hashed = bcrypt($password);
+
+    file_put_contents('/tmp/safe.txt', $hashed);
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeHashMakeEscapesSystemSecret.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeHashMakeEscapesSystemSecret.phpt
@@ -1,0 +1,19 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * HashManager::make() is a one-way hash — the original system secret
+ * cannot be recovered. Writing the hash should not trigger TaintedSystemSecret.
+ */
+function storeHashedApiKey(\Illuminate\Hashing\HashManager $hash): void {
+    /** @psalm-taint-source system_secret */
+    $apiKey = getenv('API_KEY');
+
+    $hashed = $hash->make((string) $apiKey);
+
+    file_put_contents('/tmp/safe.txt', $hashed);
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeHashMakeEscapesUserSecret.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeHashMakeEscapesUserSecret.phpt
@@ -1,0 +1,18 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * HashManager::make() is a one-way hash — the original plaintext password
+ * cannot be recovered. Writing the hash should not trigger TaintedUserSecret.
+ */
+function storeHashedPassword(\Illuminate\Foundation\Auth\User $user, \Illuminate\Hashing\HashManager $hash): void {
+    $password = $user->getAuthPassword();
+
+    $hashed = $hash->make($password);
+
+    file_put_contents('/tmp/safe.txt', $hashed);
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## What does this PR do?

`HashManager::make()` had `@psalm-taint-escape user_secret` but was missing `system_secret`. An API key passed through `Hash::make()` retained `system_secret` taint. Same gap existed on `bcrypt()`.

Fixes #564

## How was it tested?

- 4 new taint analysis type tests covering both `user_secret` and `system_secret` escapes for `HashManager::make()` and `bcrypt()`
- Full test suite passes (515 tests)

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
- [x] Documentation is updated (taint-analysis.md escape table)
