### PR TITLE
Suppress `MissingTemplateParam` for `HasFactory` trait

### DIFF
--- a/src/Handlers/SuppressHandler.php
+++ b/src/Handlers/SuppressHandler.php
@@ -35,6 +35,13 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
         'PropertyNotSetInConstructor' => [
             'Illuminate\Queue\InteractsWithQueue',
         ],
+        // HasFactory has @template TFactory, but many Laravel models omit the
+        // annotation — the framework resolves the factory class via naming
+        // convention at runtime. Suppress the noise. Users who want type-safe
+        // factory() calls can add @use HasFactory<ConcreteFactory>.
+        'MissingTemplateParam' => [
+            'Illuminate\Database\Eloquent\Factories\HasFactory',
+        ],
     ];
 
     /**

--- a/tests/Type/tests/HasFactoryTemplateParamTest.phpt
+++ b/tests/Type/tests/HasFactoryTemplateParamTest.phpt
@@ -1,0 +1,44 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Standard Laravel pattern: use HasFactory without specifying the template.
+ * Laravel resolves the factory class via naming convention at runtime.
+ * The plugin should suppress MissingTemplateParam for this common case.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/517
+ */
+class Article extends Model
+{
+    use HasFactory;
+}
+
+/**
+ * Explicit template binding still works — users who want type-safe
+ * factory() calls can opt in with @use HasFactory<ConcreteFactory>.
+ *
+ * @extends Factory<ExplicitArticle>
+ */
+class ExplicitArticleFactory extends Factory
+{
+    protected $model = ExplicitArticle::class;
+
+    /** @return array<string, mixed> */
+    #[\Override]
+    public function definition(): array
+    {
+        return [];
+    }
+}
+
+/** @use HasFactory<ExplicitArticleFactory> */
+class ExplicitArticle extends Model
+{
+    use HasFactory;
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## What does this PR do?

Suppress `MissingTemplateParam` for models using `HasFactory` without an explicit `@use HasFactory<ConcreteFactory>` annotation. Many Laravel models omit the template parameter since the framework resolves the factory class via naming convention at runtime.

Users who want type-safe `factory()` calls can still opt in with `@use HasFactory<ConcreteFactory>`.

Fixes #517

## How was it tested?

Type test (`HasFactoryTemplateParamTest.phpt`) covering:
- Model with plain `use HasFactory` — no `MissingTemplateParam` emitted
- Model with explicit `@use HasFactory<ConcreteFactory>` — still works correctly

Full test suite passes (`composer test`).

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
- [x] ~Documentation is updated~ (not needed)
