### PR TITLE
Redeclare `Model::increment()`/`decrement()` as public in stub

### DIFF
--- a/stubs/common/Database/Eloquent/Model.stubphp
+++ b/stubs/common/Database/Eloquent/Model.stubphp
@@ -188,4 +188,47 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @psalm-variadic
      */
     public function makeHidden($attributes) {}
+
+    /**
+     * Increment a column's value by a given amount.
+     *
+     * These methods are protected in Laravel's source but explicitly forwarded as public
+     * via Model::__call(). Redeclared here to match the runtime public API.
+     *
+     * @param  string  $column
+     * @param  float|int  $amount
+     * @param  array<string, mixed>  $extra
+     * @return int
+     */
+    public function increment($column, $amount = 1, array $extra = []) {}
+
+    /**
+     * Decrement a column's value by a given amount.
+     *
+     * @param  string  $column
+     * @param  float|int  $amount
+     * @param  array<string, mixed>  $extra
+     * @return int
+     */
+    public function decrement($column, $amount = 1, array $extra = []) {}
+
+    /**
+     * Increment a column's value by a given amount without raising any events.
+     *
+     * @param  string  $column
+     * @param  float|int  $amount
+     * @param  array<string, mixed>  $extra
+     * @return int
+     */
+    public function incrementQuietly($column, $amount = 1, array $extra = []) {}
+
+    /**
+     * Decrement a column's value by a given amount without raising any events.
+     *
+     * @param  string  $column
+     * @param  float|int  $amount
+     * @param  array<string, mixed>  $extra
+     * @return int
+     */
+    public function decrementQuietly($column, $amount = 1, array $extra = []) {}
 }

--- a/tests/Type/tests/ModelIncrementDecrementTest.phpt
+++ b/tests/Type/tests/ModelIncrementDecrementTest.phpt
@@ -1,0 +1,50 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\User;
+
+/**
+ * Model::increment() and decrement() are protected in Laravel's source but
+ * explicitly forwarded as public via Model::__call(). The plugin redeclares
+ * them as public in the Model stub so external callers don't get errors.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/512
+ */
+
+function test_increment(User $user): void
+{
+    $_result = $user->increment('login_count');
+    /** @psalm-check-type-exact $_result = int */
+}
+
+function test_decrement(User $user): void
+{
+    $_result = $user->decrement('login_count');
+    /** @psalm-check-type-exact $_result = int */
+}
+
+function test_increment_with_amount(User $user): void
+{
+    $_result = $user->increment('login_count', 5);
+    /** @psalm-check-type-exact $_result = int */
+}
+
+function test_increment_with_extra(User $user): void
+{
+    $_result = $user->increment('login_count', 1, ['last_login' => now()]);
+    /** @psalm-check-type-exact $_result = int */
+}
+
+function test_increment_quietly(User $user): void
+{
+    $_result = $user->incrementQuietly('login_count');
+    /** @psalm-check-type-exact $_result = int */
+}
+
+function test_decrement_quietly(User $user): void
+{
+    $_result = $user->decrementQuietly('login_count');
+    /** @psalm-check-type-exact $_result = int */
+}
+?>
+--EXPECT--


### PR DESCRIPTION
## What does this PR do?

`Model::increment()`, `decrement()`, `incrementQuietly()`, and `decrementQuietly()` are `protected` in Laravel's source but explicitly forwarded as public via `Model::__call()`. Psalm sees the `protected` visibility and reports `UndefinedMagicMethod` for external calls like `$post->increment('view_count')`.

Redeclares all four methods as `public` in the Model stub to match the runtime API.

Fixes #512

## How was it tested?

- New type test `ModelIncrementDecrementTest.phpt` covering all 4 methods with parameter variants
- Full test suite passes (`composer test`)

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
- [x] Documentation is updated (if needed, otherwise remove this item)
