### PR TITLE
Narrow `Collection::flatten()` and `collapse()` return types to preserve `TValue`

### DIFF
--- a/src/Handlers/Collections/CollectionFlattenHandler.php
+++ b/src/Handlers/Collections/CollectionFlattenHandler.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Collections;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Enumerable;
+use Illuminate\Support\LazyCollection;
+use PhpParser\Node\Scalar\LNumber;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\Type;
+use Psalm\Type\Atomic\TArray;
+use Psalm\Type\Atomic\TGenericObject;
+use Psalm\Type\Atomic\TKeyedArray;
+use Psalm\Type\Union;
+
+/**
+ * Narrows Collection::flatten() return type when the depth argument is a known literal.
+ *
+ * Laravel's flatten() docblock returns `static<int, mixed>`, which erases generic info.
+ * This handler recovers TValue for the most common cases:
+ *
+ * - flatten(1) on Collection<K, Collection<K2, V>> or Collection<K, array<K2, V>> → Collection<int, V>
+ * - collapse() on Collection<K, Collection<K2, V>> or Collection<K, array<K2, V>> → Collection<int, V>
+ *
+ * collapse() is semantically equivalent to flatten(1) — both unwrap one level of nesting.
+ * For flatten() with unknown/infinite depth, defers to Psalm's default.
+ * Note: flatten(0) is equivalent to flatten(INF) in Laravel, not a no-op.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/617
+ * @internal
+ */
+final class CollectionFlattenHandler implements MethodReturnTypeProviderInterface
+{
+    /**
+     * @return list<string>
+     * @psalm-pure
+     */
+    #[\Override]
+    public static function getClassLikeNames(): array
+    {
+        // EloquentCollection is excluded: its TValue is constrained to Model, so nested
+        // collections (Collection<K, Collection<K2, V>>) can't occur. The handler would
+        // always bail out via extractInnerValue() returning null.
+        return [Collection::class, LazyCollection::class];
+    }
+
+    /** @psalm-mutation-free */
+    #[\Override]
+    public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        $method = $event->getMethodNameLowercase();
+
+        // collapse() is always single-level — no depth argument needed
+        $isSingleLevelFlatten = $method === 'collapse'
+            || ($method === 'flatten' && self::extractLiteralDepth($event) === 1);
+
+        if (!$isSingleLevelFlatten) {
+            return null;
+        }
+
+        $templateTypeParameters = $event->getTemplateTypeParameters();
+        if ($templateTypeParameters === null || \count($templateTypeParameters) < 2) {
+            return null;
+        }
+
+        $tValue = $templateTypeParameters[1];
+        $innerValue = self::extractInnerValue($tValue);
+        if ($innerValue === null) {
+            return null;
+        }
+
+        $className = $event->getCalledFqClasslikeName() ?? $event->getFqClasslikeName();
+
+        return new Union([
+            new TGenericObject($className, [Type::getInt(), $innerValue], is_static: true),
+        ]);
+    }
+
+    /**
+     * Extract the literal integer depth from the first argument, if present.
+     *
+     * Returns null for: no arguments (= INF depth), non-literal expressions, non-int values.
+     * @psalm-mutation-free
+     */
+    private static function extractLiteralDepth(MethodReturnTypeProviderEvent $event): ?int
+    {
+        $args = $event->getCallArgs();
+        if ($args === []) {
+            return null; // no argument = INF depth, can't narrow
+        }
+
+        $depthArg = $args[0]->value;
+
+        // Direct literal: flatten(1)
+        if ($depthArg instanceof LNumber) {
+            return $depthArg->value;
+        }
+
+        return null;
+    }
+
+    /**
+     * Extract the value type from a collection-like or array-like TValue.
+     *
+     * Handles: Collection<K, V>, array<K, V>, array{...} (via getGenericValueType).
+     * @psalm-mutation-free
+     */
+    private static function extractInnerValue(Union $tValue): ?Union
+    {
+        if (!$tValue->isSingle()) {
+            return null; // union TValue like Collection|array — too complex, bail
+        }
+
+        $atomic = $tValue->getSingleAtomic();
+
+        // Collection<K, V>, LazyCollection<K, V>, or any Enumerable — extract V (index 1)
+        if ($atomic instanceof TGenericObject && \count($atomic->type_params) >= 2) {
+            if (\is_a($atomic->value, Enumerable::class, allow_string: true)) {
+                return $atomic->type_params[1];
+            }
+        }
+
+        // array<K, V> — extract V (index 1)
+        if ($atomic instanceof TArray && \count($atomic->type_params) >= 2) {
+            return $atomic->type_params[1];
+        }
+
+        // array{key: type, ...} — get the generic value type
+        if ($atomic instanceof TKeyedArray) {
+            return $atomic->getGenericValueType();
+        }
+
+        return null;
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -12,6 +12,7 @@ use Psalm\LaravelPlugin\Handlers\Auth\AuthHandler;
 use Psalm\LaravelPlugin\Handlers\Auth\GuardHandler;
 use Psalm\LaravelPlugin\Handlers\Auth\RequestHandler;
 use Psalm\LaravelPlugin\Handlers\Collections\CollectionFilterHandler;
+use Psalm\LaravelPlugin\Handlers\Collections\CollectionFlattenHandler;
 use Psalm\LaravelPlugin\Handlers\Collections\CollectionPluckHandler;
 use Psalm\LaravelPlugin\Handlers\Console\CommandArgumentHandler;
 use Psalm\LaravelPlugin\Handlers\Eloquent\BuilderScopeHandler;
@@ -206,6 +207,8 @@ final class Plugin implements PluginEntryPointInterface
 
         require_once __DIR__ . '/Handlers/Collections/CollectionFilterHandler.php';
         $registration->registerHooksFromClass(CollectionFilterHandler::class);
+        require_once __DIR__ . '/Handlers/Collections/CollectionFlattenHandler.php';
+        $registration->registerHooksFromClass(CollectionFlattenHandler::class);
         require_once __DIR__ . '/Handlers/Collections/CollectionPluckHandler.php';
         $registration->registerHooksFromClass(CollectionPluckHandler::class);
 

--- a/tests/Type/tests/CollectionFlattenTest.phpt
+++ b/tests/Type/tests/CollectionFlattenTest.phpt
@@ -1,0 +1,116 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
+
+/**
+ * flatten(1) preserves inner collection/array value types.
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/617
+ */
+final class CollectionFlattenTest
+{
+    /** @param Collection<int, Collection<int, string>> $collection */
+    public function flattenOneNestedCollection(Collection $collection): void
+    {
+        $_result = $collection->flatten(1);
+        /** @psalm-check-type-exact $_result = Collection<int, string>&static */
+    }
+
+    /** @param Collection<int, array<string, int>> $collection */
+    public function flattenOneNestedArray(Collection $collection): void
+    {
+        $_result = $collection->flatten(1);
+        /** @psalm-check-type-exact $_result = Collection<int, int>&static */
+    }
+
+    /** @param Collection<string, list<string>> $collection */
+    public function flattenOneNestedList(Collection $collection): void
+    {
+        $_result = $collection->flatten(1);
+        /** @psalm-check-type-exact $_result = Collection<int, string>&static */
+    }
+
+    /**
+     * flatten(0) is equivalent to flatten(INF) in Laravel — defers to default.
+     * @param Collection<string, int> $collection
+     */
+    public function flattenZeroDefersToDefault(Collection $collection): void
+    {
+        $_result = $collection->flatten(0);
+        /** @psalm-check-type-exact $_result = Collection<int, mixed>&static */
+    }
+
+    /**
+     * flatten() with no argument (INF depth) falls through to default (mixed).
+     * @param Collection<int, Collection<int, string>> $collection
+     */
+    public function flattenInfDepthReturnsMixed(Collection $collection): void
+    {
+        $_result = $collection->flatten();
+        /** @psalm-check-type-exact $_result = Collection<int, mixed>&static */
+    }
+
+    /** @param LazyCollection<int, Collection<int, string>> $collection */
+    public function lazyCollectionFlattenOne(LazyCollection $collection): void
+    {
+        $_result = $collection->flatten(1);
+        /** @psalm-check-type-exact $_result = LazyCollection<int, string>&static */
+    }
+
+    /**
+     * flatten(1) on a non-nested collection defers to Psalm's default (mixed).
+     * @param Collection<int, string> $collection
+     */
+    public function flattenOneOnFlatCollection(Collection $collection): void
+    {
+        $_result = $collection->flatten(1);
+        /** @psalm-check-type-exact $_result = Collection<int, mixed>&static */
+    }
+
+    /**
+     * flatten(2) is not handled — defers to Psalm's default.
+     * @param Collection<int, Collection<int, Collection<int, string>>> $collection
+     */
+    public function flattenTwoDefersToDefault(Collection $collection): void
+    {
+        $_result = $collection->flatten(2);
+        /** @psalm-check-type-exact $_result = Collection<int, mixed>&static */
+    }
+
+    /**
+     * collapse() is semantically equivalent to flatten(1).
+     * @param Collection<int, Collection<int, string>> $collection
+     */
+    public function collapsePreservesInnerType(Collection $collection): void
+    {
+        $_result = $collection->collapse();
+        /** @psalm-check-type-exact $_result = Collection<int, string>&static */
+    }
+
+    /** @param Collection<int, array<string, int>> $collection */
+    public function collapseNestedArray(Collection $collection): void
+    {
+        $_result = $collection->collapse();
+        /** @psalm-check-type-exact $_result = Collection<int, int>&static */
+    }
+
+    /**
+     * The issue's original use case: map-then-flatten(1).
+     * @param Collection<int, array{category: string, items: list<string>}> $groups
+     */
+    public function mapThenFlatten(Collection $groups): void
+    {
+        $_result = $groups
+            ->map(function (array $group): Collection {
+                /** @var Collection<int, array{name: string, category: string}> */
+                return collect($group['items'])->map(
+                    fn(string $item): array => ['name' => $item, 'category' => $group['category']]
+                );
+            })
+            ->flatten(1);
+        /** @psalm-check-type-exact $_result = Collection<int, array{name: string, category: string}>&static */
+    }
+}
+?>
+--EXPECT--


### PR DESCRIPTION
## What does this PR do?

Adds a `MethodReturnTypeProvider` for `Collection::flatten(1)` and `Collection::collapse()` that preserves the inner value type instead of returning `Collection<int, mixed>`.

When `flatten(1)` or `collapse()` is called on `Collection<K, Collection<K2, V>>` or `Collection<K, array<K2, V>>`, the handler returns `Collection<int, V>` — eliminating `MixedReturnTypeCoercion` errors on the common map-then-flatten pattern.

Closes #617

**Scope:** Only `flatten(1)` and `collapse()` are narrowed. All other `flatten()` cases (no args, non-literal depth, depth > 1) defer to Psalm's default `Collection<int, mixed>`.

**EloquentCollection** is excluded — its `TModel` is constrained to `Model`, so nested collections can't occur, making the handler a no-op.

## How was it tested?

- Type test (`tests/Type/tests/CollectionFlattenTest.phpt`) covering: nested collections, nested arrays, nested lists, non-nested fallback, `flatten(0)`/`flatten(2)` deferral, `LazyCollection`, `collapse()`, and the original issue's map-then-flatten pattern.
- Psalm self-analysis passes clean.
- Unit tests unaffected.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
- [x] Documentation is updated (if needed, otherwise remove this item)
