### PR TITLE
Preserve Relation type when calling fluent builder methods like `where()`

### DIFF
--- a/stubs/common/Database/Eloquent/Relations/Relation.stubphp
+++ b/stubs/common/Database/Eloquent/Relations/Relation.stubphp
@@ -77,25 +77,138 @@ abstract class Relation
         return $this->query->get($columns);
     }
 
+    // Fluent builder methods are declared here explicitly so Psalm resolves them
+    // on the Relation class (triggering our MethodReturnTypeProvider) instead of
+    // falling through to the @mixin Builder, which would return Builder and lose
+    // the Relation type in fluent chains like $this->posts()->where(...).
+
     /**
-     * Add an "order by" clause for a timestamp to the query.
-     *
-     * Psalm note: ideally the type should be inferred from $this->query
-     *
-     * @param  string|\Illuminate\Database\Query\Expression  $column
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function where($column, $operator = null, $value = null, $boolean = 'and') {}
+
+    /**
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNot($column, $operator = null, $value = null, $boolean = 'and') {}
+
+    /**
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  mixed  $values
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereIn($column, $values, $boolean = 'and', $not = false) {}
+
+    /**
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  mixed  $values
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNotIn($column, $values, $boolean = 'and') {}
+
+    /**
+     * @param  string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereNull($column, $boolean = 'and', $not = false) {}
+
+    /**
+     * @param  string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  string  $boolean
+     * @return $this
+     */
+    public function whereNotNull($column, $boolean = 'and') {}
+
+    /**
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  iterable  $values
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereBetween($column, iterable $values, $boolean = 'and', $not = false) {}
+
+    /**
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  string  $direction
+     * @return $this
+     */
+    public function orderBy($column, $direction = 'asc') {}
+
+    /**
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @return $this
+     */
+    public function orderByDesc($column) {}
+
+    /**
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @return $this
      */
     public function latest($column = null) {}
 
     /**
-     * Add an "order by" clause for a timestamp to the query.
-     *
-     * Psalm note: ideally the type should be inferred from $this->query
-     *
-     * @param  string|\Illuminate\Database\Query\Expression  $column
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @return $this
      */
     public function oldest($column = null) {}
+
+    /**
+     * @param  int  $value
+     * @return $this
+     */
+    public function limit($value) {}
+
+    /**
+     * @param  int  $value
+     * @return $this
+     */
+    public function take($value) {}
+
+    /**
+     * @param  int  $value
+     * @return $this
+     */
+    public function offset($value) {}
+
+    /**
+     * @param  int  $value
+     * @return $this
+     */
+    public function skip($value) {}
+
+    /**
+     * @param  string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @return $this
+     */
+    public function select($column = ['*']) {}
+
+    /**
+     * @param  array|mixed  $relations
+     * @param  \Closure|string|null  $callback
+     * @return $this
+     */
+    public function with($relations, $callback = null) {}
+
+    /**
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression|null  $column
+     * @param  string  $direction
+     * @return $this
+     */
+    public function reorder($column = null, $direction = 'asc') {}
 
     /**
      * Get the underlying query for the relation.

--- a/tests/Type/tests/EloquentRelationFluentWhereTest.phpt
+++ b/tests/Type/tests/EloquentRelationFluentWhereTest.phpt
@@ -1,0 +1,82 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Phone;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+/**
+ * Verify that calling Builder methods (where, orderBy, etc.) on a Relation
+ * returns the Relation type, not Builder.
+ *
+ * Before the fix, @mixin Builder on Relation caused Psalm to resolve these
+ * methods on Builder, bypassing RelationsMethodHandler entirely.
+ */
+
+// HasOne: basic fluent methods
+function test_hasOne_where(HasOne $rel): HasOne {
+    return $rel->where('active', true);
+}
+
+function test_hasOne_orderBy(HasOne $rel): HasOne {
+    return $rel->orderBy('name');
+}
+
+function test_hasOne_limit(HasOne $rel): HasOne {
+    return $rel->limit(10);
+}
+
+function test_hasOne_chain(HasOne $rel): HasOne {
+    return $rel->where('active', true)->orderBy('name')->limit(10);
+}
+
+// HasMany: common pattern
+function test_hasMany_where(HasMany $rel): HasMany {
+    return $rel->where('role', 'student');
+}
+
+function test_hasMany_whereIn(HasMany $rel): HasMany {
+    return $rel->whereIn('status', ['active', 'pending']);
+}
+
+function test_hasMany_whereNull(HasMany $rel): HasMany {
+    return $rel->whereNull('deleted_at');
+}
+
+// BelongsToMany: multi-template-param relation
+function test_belongsToMany_where(BelongsToMany $rel): BelongsToMany {
+    return $rel->where('active', true);
+}
+
+// Real-world pattern: calling where() on a relation returned by a model method
+function test_model_relation_where(): HasOne {
+    return (new User())->phone()->where('active', true);
+}
+
+function test_model_relation_belongsToMany(): BelongsToMany {
+    return (new User())->roles()->where('name', 'admin');
+}
+
+function test_model_relation_fluent_chain(): HasOne {
+    return (new User())->phone()->where('active', true)->orderBy('created_at')->latest();
+}
+
+// Exact type check with explicitly typed relation variable
+function test_exact_type_preserved(): HasOne {
+    /** @var HasOne<Phone, User> $rel */
+    $rel = (new User())->phone();
+    $filtered = $rel->where('active', true);
+    /** @psalm-check-type-exact $filtered = HasOne<Phone, User> */
+    return $filtered;
+}
+
+// Non-fluent methods must NOT return the relation type.
+// first() should return TRelatedModel|null, not HasOne.
+function test_first_returns_model_not_relation(HasOne $rel): ?\Illuminate\Database\Eloquent\Model {
+    return $rel->where('active', true)->first();
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

Calling fluent builder methods like `where()`, `orderBy()`, `limit()` on a Relation (e.g., `$this->enrollments()->where('role', 'student')`) incorrectly returned `Builder` instead of the Relation type, causing false `InvalidReturnStatement` / `InvalidReturnType` errors.

## Solution Description

The `@mixin Builder<TRelatedModel>` on `Relation` caused Psalm to resolve fluent methods directly on `Builder`, bypassing our `RelationsMethodHandler`. The handler never fired, so the return type was `Builder` instead of `HasMany`/`HasOne`/etc.

Fix: add explicit fluent builder method declarations (`where`, `whereNot`, `whereIn`, `whereNotIn`, `whereNull`, `whereNotNull`, `whereBetween`, `orderBy`, `orderByDesc`, `latest`, `oldest`, `limit`, `take`, `offset`, `skip`, `select`, `with`, `reorder`) directly to the `Relation` stub with `@return $this`. Psalm finds them before the mixin, allowing `RelationsMethodHandler` to fire and return the correct Relation subtype.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
- [x] Documentation is updated (if needed, otherwise remove this item)
