### PR TITLE
Add taint analysis tests for undertested stub sinks

### DIFF
--- a/tests/Type/tests/TaintAnalysis/TaintedFileFilesystemAdapter.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedFileFilesystemAdapter.phpt
@@ -1,0 +1,106 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * FilesystemAdapter methods that accept a user-controlled path
+ * are file-taint sinks — an attacker could read, overwrite, or
+ * delete arbitrary files via path traversal.
+ */
+
+function storageGet(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
+    $fs->get($request->input('path'));
+}
+
+function storagePut(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
+    $fs->put($request->input('path'), 'contents');
+}
+
+function storageDownload(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
+    $fs->download($request->input('path'));
+}
+
+function storageDelete(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
+    $fs->delete($request->input('path'));
+}
+
+function storageCopy(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
+    $fs->copy($request->input('from'), $request->input('to'));
+}
+
+function storageMove(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
+    $fs->move($request->input('from'), $request->input('to'));
+}
+
+function storageMakeDirectory(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
+    $fs->makeDirectory($request->input('dir'));
+}
+
+function storageDeleteDirectory(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
+    $fs->deleteDirectory($request->input('dir'));
+}
+
+function storageJson(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
+    $fs->json($request->input('path'));
+}
+
+function storageResponse(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
+    $fs->response($request->input('path'));
+}
+
+function storageServe(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
+    $fs->serve($request, $request->input('path'));
+}
+
+function storagePutFile(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
+    $fs->putFile($request->input('path'), 'file');
+}
+
+function storagePutFileAs(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
+    $fs->putFileAs($request->input('path'), 'file', $request->input('name'));
+}
+
+function storagePrepend(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
+    $fs->prepend($request->input('path'), 'data');
+}
+
+function storageAppend(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
+    $fs->append($request->input('path'), 'data');
+}
+
+function storageReadStream(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
+    $fs->readStream($request->input('path'));
+}
+
+function storageWriteStream(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
+    /** @var resource $stream */
+    $stream = null;
+    $fs->writeStream($request->input('path'), $stream);
+}
+
+function storageTemporaryUploadUrl(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
+    $fs->temporaryUploadUrl($request->input('path'), new \DateTimeImmutable('+1 hour'));
+}
+?>
+--EXPECTF--
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling

--- a/tests/Type/tests/TaintAnalysis/TaintedFileFilesystemAdapter.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedFileFilesystemAdapter.phpt
@@ -74,8 +74,8 @@ function storageReadStream(\Illuminate\Http\Request $request, \Illuminate\Filesy
 }
 
 function storageWriteStream(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
-    /** @var resource $stream */
-    $stream = null;
+    $stream = tmpfile();
+    assert($stream !== false);
     $fs->writeStream($request->input('path'), $stream);
 }
 

--- a/tests/Type/tests/TaintAnalysis/TaintedFileResponseFactory.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedFileResponseFactory.phpt
@@ -1,0 +1,21 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * ResponseFactory::download() and ::file() accept a file path —
+ * user-controlled paths enable arbitrary file read/download.
+ */
+
+function responseDownload(\Illuminate\Http\Request $request, \Illuminate\Routing\ResponseFactory $response): void {
+    $response->download($request->input('file'));
+}
+
+function responseFile(\Illuminate\Http\Request $request, \Illuminate\Routing\ResponseFactory $response): void {
+    $response->file($request->input('file'));
+}
+?>
+--EXPECTF--
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderMailableRecipients.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderMailableRecipients.phpt
@@ -1,0 +1,42 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Mailable cc/bcc/replyTo/from methods are header sinks —
+ * user-controlled addresses or names can inject CRLF sequences
+ * into email headers.
+ */
+
+function mailableFrom(\Illuminate\Http\Request $request): void {
+    $mailable = new \Illuminate\Mail\Mailable();
+    $mailable->from($request->input('email'));
+}
+
+function mailableCc(\Illuminate\Http\Request $request): void {
+    $mailable = new \Illuminate\Mail\Mailable();
+    $mailable->cc($request->input('email'));
+}
+
+function mailableBcc(\Illuminate\Http\Request $request): void {
+    $mailable = new \Illuminate\Mail\Mailable();
+    $mailable->bcc($request->input('email'));
+}
+
+function mailableReplyTo(\Illuminate\Http\Request $request): void {
+    $mailable = new \Illuminate\Mail\Mailable();
+    $mailable->replyTo($request->input('email'));
+}
+
+function mailableFromName(\Illuminate\Http\Request $request): void {
+    $mailable = new \Illuminate\Mail\Mailable();
+    $mailable->from('safe@example.com', $request->input('name'));
+}
+?>
+--EXPECTF--
+%ATaintedHeader on line %d: Detected tainted header
+%ATaintedHeader on line %d: Detected tainted header
+%ATaintedHeader on line %d: Detected tainted header
+%ATaintedHeader on line %d: Detected tainted header
+%ATaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderMailableRecipients.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderMailableRecipients.phpt
@@ -33,8 +33,26 @@ function mailableFromName(\Illuminate\Http\Request $request): void {
     $mailable = new \Illuminate\Mail\Mailable();
     $mailable->from('safe@example.com', $request->input('name'));
 }
+
+function mailableCcName(\Illuminate\Http\Request $request): void {
+    $mailable = new \Illuminate\Mail\Mailable();
+    $mailable->cc('safe@example.com', $request->input('name'));
+}
+
+function mailableBccName(\Illuminate\Http\Request $request): void {
+    $mailable = new \Illuminate\Mail\Mailable();
+    $mailable->bcc('safe@example.com', $request->input('name'));
+}
+
+function mailableReplyToName(\Illuminate\Http\Request $request): void {
+    $mailable = new \Illuminate\Mail\Mailable();
+    $mailable->replyTo('safe@example.com', $request->input('name'));
+}
 ?>
 --EXPECTF--
+%ATaintedHeader on line %d: Detected tainted header
+%ATaintedHeader on line %d: Detected tainted header
+%ATaintedHeader on line %d: Detected tainted header
 %ATaintedHeader on line %d: Detected tainted header
 %ATaintedHeader on line %d: Detected tainted header
 %ATaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactory.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactory.phpt
@@ -1,0 +1,33 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * ResponseFactory methods that render user-controlled content
+ * are html-taint sinks — an attacker could inject scripts or
+ * markup into the response body.
+ */
+
+function responseMake(\Illuminate\Http\Request $request, \Illuminate\Routing\ResponseFactory $response): void {
+    $response->make($request->input('body'));
+}
+
+function responseJson(\Illuminate\Http\Request $request, \Illuminate\Routing\ResponseFactory $response): void {
+    $response->json($request->input('data'));
+}
+
+function responseJsonp(\Illuminate\Http\Request $request, \Illuminate\Routing\ResponseFactory $response): void {
+    $response->jsonp($request->input('callback'), $request->input('data'));
+}
+
+function responseView(\Illuminate\Http\Request $request, \Illuminate\Routing\ResponseFactory $response): void {
+    $response->view('welcome', $request->input('data'));
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedShellProcessCommandStart.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedShellProcessCommandStart.phpt
@@ -1,0 +1,24 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * PendingProcess::command() and ::start() are shell sinks —
+ * user-controlled input passed as a command enables arbitrary
+ * command execution.
+ */
+
+function processCommand(\Illuminate\Http\Request $request): void {
+    $process = new \Illuminate\Process\PendingProcess();
+    $process->command($request->input('cmd'));
+}
+
+function processStart(\Illuminate\Http\Request $request): void {
+    $process = new \Illuminate\Process\PendingProcess();
+    $process->start($request->input('cmd'));
+}
+?>
+--EXPECTF--
+%ATaintedShell on line %d: Detected tainted shell code
+%ATaintedShell on line %d: Detected tainted shell code


### PR DESCRIPTION
## Issue to Solve

Several taint analysis stubs had correct annotations but no positive tests exercising them, leaving regression risk.

## Related

N/A — test coverage improvement, no functional changes.

## Solution Description

Added 5 PHPT taint analysis tests covering previously untested sinks:

- **`FilesystemAdapter`** — all 17 `@psalm-taint-sink file` methods (`get`, `put`, `download`, `delete`, `copy`, `move`, `json`, `response`, `serve`, `putFile`, `putFileAs`, `prepend`, `append`, `readStream`, `writeStream`, `temporaryUploadUrl`, `makeDirectory`, `deleteDirectory`)
- **`ResponseFactory`** — `make()`, `json()`, `jsonp()`, `view()` (html sinks) and `download()`, `file()` (file sinks)
- **`Mailable`** — `from()`, `cc()`, `bcc()`, `replyTo()` with both `$address` and `$name` parameters
- **`PendingProcess`** — `command()` and `start()` (complements existing `run()` test)

All tests pass locally (5/5).

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
- [x] Documentation is updated (if needed, otherwise remove this item)
