### PR TITLE
Add `Collection::empty()` stub with `static<never, never>` return type

### DIFF
--- a/stubs/common/Support/Collection.stubphp
+++ b/stubs/common/Support/Collection.stubphp
@@ -20,6 +20,14 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     use EnumeratesValues;
 
     /**
+     * Create a new instance with no items.
+     *
+     * @psalm-mutation-free
+     * @return static<never, never>
+     */
+    public static function empty() {}
+
+    /**
      * Get the first item from the collection passing the given truth test.
      *
      * @psalm-mutation-free

--- a/tests/Type/tests/Collection/CollectionTypesTest.phpt
+++ b/tests/Type/tests/Collection/CollectionTypesTest.phpt
@@ -29,6 +29,17 @@ final class CustomerRepository
     {
       return Customer::query()->where($attributes)->get();
     }
+
+    /**
+     * Eloquent\Collection::empty() resolves static<never, never> through inheritance.
+     * @psalm-check-type-exact $empty = \Illuminate\Database\Eloquent\Collection<never, never>
+     */
+    public function emptyEloquentCollection(): \Illuminate\Database\Eloquent\Collection
+    {
+      $empty = \Illuminate\Database\Eloquent\Collection::empty();
+
+      return $empty;
+    }
 }
 ?>
 --EXPECTF--

--- a/tests/Type/tests/CollectionMethodsTest.phpt
+++ b/tests/Type/tests/CollectionMethodsTest.phpt
@@ -154,6 +154,27 @@ final class CollectionTypes
 
         return $collection->isNotEmpty() ? null : $collection->first();
     }
+
+    /**
+     * empty() returns static<never, never>, assignable to any Collection type.
+     * @psalm-check-type-exact $empty = Collection<never, never>
+     */
+    public function emptyReturnsNeverNever(): Collection
+    {
+        $empty = Collection::empty();
+
+        return $empty;
+    }
+
+    /**
+     * Collection<never, never> is assignable to any concrete Collection type
+     * because never is the bottom type (subtype of everything).
+     * @return Collection<int, string>
+     */
+    public function emptyIsAssignableToConcreteCollection(): Collection
+    {
+        return Collection::empty();
+    }
 }
 
 /** @var Collection<string, string> */


### PR DESCRIPTION
## Issue to Solve

`Collection::empty()` returns `static` which Psalm resolves without template narrowing. Since the collection is guaranteed empty, the return type should be `static<never, never>` — matching how Psalm types empty arrays as `array<never, never>`.

## Solution Description

Added a stub for `Collection::empty()` with `@return static<never, never>`. The `never` bottom type makes the empty collection assignable to any `Collection<TKey, TValue>`.

Three type tests cover the change:
- Exact type assertion (`Collection<never, never>`)
- Assignability to concrete `Collection<int, string>`
- Inheritance through `Eloquent\Collection`

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)
