### PR TITLE
Support patch-version stub directories

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -105,13 +105,13 @@ final class Plugin implements PluginEntryPointInterface
             }
         }
 
-        $stubs = [];
+        $stubGroups = [];
 
         foreach (self::filterVersionDirectories($candidates, $version) as $dir) {
-            $stubs = \array_merge($stubs, $this->findStubFiles($stubsRoot . '/' . $dir));
+            $stubGroups[] = $this->findStubFiles($stubsRoot . '/' . $dir);
         }
 
-        return $stubs;
+        return $stubGroups === [] ? [] : \array_merge(...$stubGroups);
     }
 
     /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -74,12 +74,67 @@ final class Plugin implements PluginEntryPointInterface
         return $this->findStubFiles(\dirname(__DIR__) . '/stubs/common');
     }
 
-    /** @return list<string> */
+    /**
+     * Collect stubs from all version directories that are <= the installed Laravel version.
+     *
+     * Supports both major-only directories (e.g. "12/", "13/") and patch-level directories
+     * (e.g. "12.20.0/", "12.41.0/"). Directories are sorted in ascending version order so
+     * that later versions override earlier ones for same-named stubs.
+     *
+     * @see https://www.php.net/version_compare — treats "12" as "12.0.0"
+     *
+     * @return list<string>
+     */
     private function getStubsForLaravelVersion(string $version): array
     {
-        [$majorVersion] = \explode('.', $version);
+        $stubsRoot = \dirname(__DIR__) . '/stubs';
 
-        return $this->findStubFiles(\dirname(__DIR__) . '/stubs/' . $majorVersion);
+        // Collect version directories (names starting with a digit, e.g. "12", "12.20.0", "13")
+        $candidates = [];
+
+        foreach (new \DirectoryIterator($stubsRoot) as $entry) {
+            if (! $entry->isDir() || $entry->isDot()) {
+                continue;
+            }
+
+            $dirName = $entry->getFilename();
+
+            // Skip non-version directories (e.g. "common")
+            if (\ctype_digit($dirName[0])) {
+                $candidates[] = $dirName;
+            }
+        }
+
+        $stubs = [];
+
+        foreach (self::filterVersionDirectories($candidates, $version) as $dir) {
+            $stubs = \array_merge($stubs, $this->findStubFiles($stubsRoot . '/' . $dir));
+        }
+
+        return $stubs;
+    }
+
+    /**
+     * Filter and sort version directory names, keeping only those <= the target version.
+     *
+     * @param list<string> $candidates directory names (e.g. ["13", "12", "12.20.0"])
+     *
+     * @return list<string> sorted ascending by version (e.g. ["12", "12.20.0"])
+     *
+     * @psalm-pure
+     *
+     * @internal used by tests
+     */
+    public static function filterVersionDirectories(array $candidates, string $targetVersion): array
+    {
+        $matched = \array_filter(
+            $candidates,
+            static fn(string $dir): bool => \version_compare($dir, $targetVersion, '<='),
+        );
+
+        \usort($matched, static fn(string $a, string $b): int => \version_compare($a, $b));
+
+        return $matched;
     }
 
     /**

--- a/stubs/12.41.0/Http/Client/PendingRequest.stubphp
+++ b/stubs/12.41.0/Http/Client/PendingRequest.stubphp
@@ -1,0 +1,105 @@
+<?php
+
+namespace Illuminate\Http\Client;
+
+/**
+ * Async-aware PendingRequest — available since Laravel 12.41.0.
+ *
+ * Before 12.41.0, async requests returned GuzzleHttp\Promise\PromiseInterface.
+ * From 12.41.0+, Laravel introduced LazyPromise and the $async property became
+ * a template parameter, enabling conditional return types on HTTP methods.
+ *
+ * @template TAsync of bool = false
+ */
+class PendingRequest
+{
+    /**
+     * Toggle asynchronicity in requests.
+     *
+     * @template T of bool = true
+     *
+     * @param  T  $async
+     * @return self<T>
+     *
+     * @psalm-self-out self<T>
+     */
+    public function async(bool $async = true) {}
+
+    /**
+     * Issue a GET request to the given URL.
+     *
+     * @param  string  $url
+     * @param  array<string, mixed>|string|null  $query
+     * @return (TAsync is true ? \Illuminate\Http\Client\Promises\LazyPromise : \Illuminate\Http\Client\Response)
+     *
+     * @psalm-taint-sink ssrf $url
+     */
+    public function get(string $url, $query = null) {}
+
+    /**
+     * Issue a HEAD request to the given URL.
+     *
+     * @param  string  $url
+     * @param  array<string, mixed>|string|null  $query
+     * @return (TAsync is true ? \Illuminate\Http\Client\Promises\LazyPromise : \Illuminate\Http\Client\Response)
+     *
+     * @psalm-taint-sink ssrf $url
+     */
+    public function head(string $url, $query = null) {}
+
+    /**
+     * Issue a POST request to the given URL.
+     *
+     * @param  string  $url
+     * @param  array<string, mixed>|\JsonSerializable|\Illuminate\Contracts\Support\Arrayable<string, mixed>  $data
+     * @return (TAsync is true ? \Illuminate\Http\Client\Promises\LazyPromise : \Illuminate\Http\Client\Response)
+     *
+     * @psalm-taint-sink ssrf $url
+     */
+    public function post(string $url, $data = []) {}
+
+    /**
+     * Issue a PATCH request to the given URL.
+     *
+     * @param  string  $url
+     * @param  array<string, mixed>|\JsonSerializable|\Illuminate\Contracts\Support\Arrayable<string, mixed>  $data
+     * @return (TAsync is true ? \Illuminate\Http\Client\Promises\LazyPromise : \Illuminate\Http\Client\Response)
+     *
+     * @psalm-taint-sink ssrf $url
+     */
+    public function patch(string $url, $data = []) {}
+
+    /**
+     * Issue a PUT request to the given URL.
+     *
+     * @param  string  $url
+     * @param  array<string, mixed>|\JsonSerializable|\Illuminate\Contracts\Support\Arrayable<string, mixed>  $data
+     * @return (TAsync is true ? \Illuminate\Http\Client\Promises\LazyPromise : \Illuminate\Http\Client\Response)
+     *
+     * @psalm-taint-sink ssrf $url
+     */
+    public function put(string $url, $data = []) {}
+
+    /**
+     * Issue a DELETE request to the given URL.
+     *
+     * @param  string  $url
+     * @param  array<string, mixed>|\JsonSerializable|\Illuminate\Contracts\Support\Arrayable<string, mixed>  $data
+     * @return (TAsync is true ? \Illuminate\Http\Client\Promises\LazyPromise : \Illuminate\Http\Client\Response)
+     *
+     * @psalm-taint-sink ssrf $url
+     */
+    public function delete(string $url, $data = []) {}
+
+    /**
+     * Send the request to the given URL.
+     *
+     * @param  string  $method
+     * @param  string  $url
+     * @param  array<string, mixed>  $options
+     * @return (TAsync is true ? \Illuminate\Http\Client\Promises\LazyPromise : \Illuminate\Http\Client\Response)
+     *
+     * @psalm-taint-sink ssrf $url
+     */
+    public function send(string $method, string $url, array $options = []) {}
+}

--- a/tests/Type/tests/Http/PendingRequestTest.phpt
+++ b/tests/Type/tests/Http/PendingRequestTest.phpt
@@ -1,0 +1,33 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
+use Illuminate\Http\Client\Promises\LazyPromise;
+
+/**
+ * After calling async(), Psalm narrows TAsync to true via @psalm-self-out,
+ * so HTTP methods return LazyPromise.
+ */
+function async_get_returns_promise(PendingRequest $request): LazyPromise {
+    return $request->async()->get('https://example.com');
+};
+
+function async_post_returns_promise(PendingRequest $request): LazyPromise {
+    return $request->async()->post('https://example.com');
+};
+
+function async_send_returns_promise(PendingRequest $request): LazyPromise {
+    return $request->async()->send('GET', 'https://example.com');
+};
+
+/**
+ * When TAsync is unresolved (Psalm doesn't narrow class template defaults),
+ * sync methods return the union. This is correct — callers receiving a
+ * PendingRequest don't know whether async() was called.
+ */
+function sync_get_returns_union(PendingRequest $request): LazyPromise|Response {
+    return $request->get('https://example.com');
+};
+?>
+--EXPECTF--

--- a/tests/Unit/PluginVersionStubsTest.php
+++ b/tests/Unit/PluginVersionStubsTest.php
@@ -24,7 +24,7 @@ final class PluginVersionStubsTest extends TestCase
         string $targetVersion,
         array $expected,
     ): void {
-        self::assertSame($expected, Plugin::filterVersionDirectories($candidates, $targetVersion));
+        $this->assertSame($expected, Plugin::filterVersionDirectories($candidates, $targetVersion));
     }
 
     /** @return iterable<string, array{list<string>, string, list<string>}> */

--- a/tests/Unit/PluginVersionStubsTest.php
+++ b/tests/Unit/PluginVersionStubsTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Plugin;
+
+#[CoversClass(Plugin::class)]
+final class PluginVersionStubsTest extends TestCase
+{
+    /**
+     * @param list<string> $candidates
+     * @param list<string> $expected
+     */
+    #[Test]
+    #[DataProvider('versionFilteringProvider')]
+    public function it_filters_and_sorts_version_directories(
+        array $candidates,
+        string $targetVersion,
+        array $expected,
+    ): void {
+        self::assertSame($expected, Plugin::filterVersionDirectories($candidates, $targetVersion));
+    }
+
+    /** @return iterable<string, array{list<string>, string, list<string>}> */
+    public static function versionFilteringProvider(): iterable
+    {
+        yield 'major-only dirs — includes matching major' => [
+            ['12', '13'],
+            '12.5.0',
+            ['12'],
+        ];
+
+        yield 'major-only dirs — includes both when on higher major' => [
+            ['12', '13'],
+            '13.1.0',
+            ['12', '13'],
+        ];
+
+        yield 'patch dirs — includes only versions <= target' => [
+            ['12', '12.20.0', '12.41.0', '13'],
+            '12.30.0',
+            ['12', '12.20.0'],
+        ];
+
+        yield 'patch dirs — includes all matching versions' => [
+            ['12', '12.20.0', '12.41.0'],
+            '12.50.0',
+            ['12', '12.20.0', '12.41.0'],
+        ];
+
+        yield 'exact version match is included' => [
+            ['12.20.0'],
+            '12.20.0',
+            ['12.20.0'],
+        ];
+
+        yield 'empty candidates returns empty' => [
+            [],
+            '12.0.0',
+            [],
+        ];
+
+        yield 'no matching versions returns empty' => [
+            ['13', '13.5.0'],
+            '12.99.0',
+            [],
+        ];
+
+        yield 'sorts ascending by version, not lexicographically' => [
+            ['12.9.0', '12.20.0', '12'],
+            '12.20.0',
+            ['12', '12.9.0', '12.20.0'],
+        ];
+
+        yield 'mixed major and patch versions' => [
+            ['11', '12', '12.20.0', '12.41.0', '13', '13.5.0'],
+            '13.2.0',
+            ['11', '12', '12.20.0', '12.41.0', '13'],
+        ];
+    }
+}


### PR DESCRIPTION
## Issue to Solve

Stub loading only supported major-version directories (`stubs/12/`, `stubs/13/`). When Laravel introduces type changes in minor/patch releases, there was no way to provide version-specific stub overrides at a finer granularity.

## Solution Description

Refactored `getStubsForLaravelVersion()` in `Plugin` to scan `stubs/` for all version-named directories (starting with a digit) and load those where version `<=` the installed Laravel version, sorted ascending via `version_compare()`.

This supports both major-only (`stubs/12/`) and patch-level (`stubs/12.20.0/`) directories. `version_compare()` treats `"12"` as `"12.0.0"`, so existing major dirs continue to work.

Extracted `Plugin::filterVersionDirectories()` as a pure static method for testability.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)
