### PR TITLE
fix: Collection empty()/sum() types, Http\Client\Response taint sources, php-parser LNumber deprecation

### DIFF
--- a/src/Handlers/Collections/CollectionFlattenHandler.php
+++ b/src/Handlers/Collections/CollectionFlattenHandler.php
@@ -7,7 +7,7 @@ namespace Psalm\LaravelPlugin\Handlers\Collections;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Enumerable;
 use Illuminate\Support\LazyCollection;
-use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Scalar\Int_;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
 use Psalm\Type;
@@ -92,7 +92,7 @@ final class CollectionFlattenHandler implements MethodReturnTypeProviderInterfac
 
         $depthArg = $args[0]->value;
 
-        if ($depthArg instanceof LNumber) {
+        if ($depthArg instanceof Int_) {
             return $depthArg->value;
         }
 

--- a/stubs/common/Support/Collection.stubphp
+++ b/stubs/common/Support/Collection.stubphp
@@ -20,6 +20,35 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     use EnumeratesValues;
 
     /**
+     * Create a new instance with no items.
+     *
+     * @psalm-mutation-free
+     * @return static<never, never>
+     */
+    public static function empty() {}
+
+    /**
+     * Get the sum of the given values.
+     *
+     * At runtime, the accumulator starts at 0 and uses the + operator,
+     * so the result is always int|float (non-numeric values throw TypeError).
+     *
+     * When called without arguments, the return type narrows based on TValue:
+     * - Collection<_, int>::sum() → int (matches array_sum behavior for int arrays)
+     * - Collection<_, float>::sum() → float
+     * - Otherwise → int|float
+     *
+     * @template TCallbackReturn of int|float
+     *
+     * @param  (callable(TValue, TKey): TCallbackReturn)|string|null  $callback
+     * @return ($callback is null
+     *  ? (TValue is int ? int : (TValue is float ? float : int|float))
+     *  : ($callback is string ? int|float : TCallbackReturn)
+     * )
+     */
+    public function sum($callback = null) {}
+
+    /**
      * Get the first item from the collection passing the given truth test.
      *
      * @psalm-mutation-free

--- a/stubs/common/Support/Enumerable.stubphp
+++ b/stubs/common/Support/Enumerable.stubphp
@@ -9,4 +9,26 @@ namespace Illuminate\Support;
  * @extends \IteratorAggregate<TKey, TValue>
  * @extends \Illuminate\Contracts\Support\Arrayable<TKey, TValue>
  */
-interface Enumerable extends \Illuminate\Contracts\Support\Arrayable, \Countable, \IteratorAggregate, \JsonSerializable {}
+interface Enumerable extends \Illuminate\Contracts\Support\Arrayable, \Countable, \IteratorAggregate, \JsonSerializable
+{
+    /**
+     * Get the sum of the given values.
+     *
+     * At runtime, the accumulator starts at 0 and uses the + operator,
+     * so the result is always int|float (non-numeric values throw TypeError).
+     *
+     * When called without arguments, the return type narrows based on TValue:
+     * - Collection<_, int>::sum() → int (matches array_sum behavior for int arrays)
+     * - Collection<_, float>::sum() → float
+     * - Otherwise → int|float
+     *
+     * @template TCallbackReturn of int|float
+     *
+     * @param  (callable(TValue, TKey): TCallbackReturn)|string|null  $callback
+     * @return ($callback is null
+     *  ? (TValue is int ? int : (TValue is float ? float : int|float))
+     *  : ($callback is string ? int|float : TCallbackReturn)
+     * )
+     */
+    public function sum($callback = null);
+}

--- a/stubs/taintAnalysis/Http/Client/Response.stubphp
+++ b/stubs/taintAnalysis/Http/Client/Response.stubphp
@@ -1,0 +1,83 @@
+<?php
+
+namespace Illuminate\Http\Client;
+
+class Response implements \ArrayAccess, \Stringable
+{
+    /**
+     * Get the body of the response.
+     *
+     * @return string
+     *
+     * @psalm-taint-source input
+     */
+    public function body() {}
+
+    /**
+     * Get the decoded JSON body of the response as an array or scalar value.
+     *
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @return mixed
+     *
+     * @psalm-taint-source input
+     */
+    public function json($key = null, $default = null) {}
+
+    /**
+     * Get the decoded JSON body of the response as an object.
+     *
+     * @return object|null
+     *
+     * @psalm-taint-source input
+     */
+    public function object() {}
+
+    /**
+     * Get the decoded JSON body of the response as a collection.
+     *
+     * @param  string|null  $key
+     * @return \Illuminate\Support\Collection
+     *
+     * @psalm-taint-source input
+     */
+    public function collect($key = null) {}
+
+    /**
+     * Get the decoded JSON body of the response as a fluent object.
+     *
+     * @param  string|null  $key
+     * @return \Illuminate\Support\Fluent
+     *
+     * @psalm-taint-source input
+     */
+    public function fluent($key = null) {}
+
+    /**
+     * Get a header from the response.
+     *
+     * @param  string  $header
+     * @return string
+     *
+     * @psalm-taint-source input
+     */
+    public function header(string $header) {}
+
+    /**
+     * Get the headers from the response.
+     *
+     * @return array
+     *
+     * @psalm-taint-source input
+     */
+    public function headers() {}
+
+    /**
+     * Get the body of the response.
+     *
+     * @return string
+     *
+     * @psalm-taint-source input
+     */
+    public function __toString() {}
+}

--- a/tests/Type/tests/CollectionFlattenTest.phpt
+++ b/tests/Type/tests/CollectionFlattenTest.phpt
@@ -1,0 +1,140 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
+
+/**
+ * flatten(1) preserves inner collection/array value types.
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/617
+ */
+final class CollectionFlattenTest
+{
+    /** @param Collection<int, Collection<int, string>> $collection */
+    public function flattenOneNestedCollection(Collection $collection): void
+    {
+        $_result = $collection->flatten(1);
+        /** @psalm-check-type-exact $_result = Collection<int, string>&static */
+    }
+
+    /** @param Collection<int, array<string, int>> $collection */
+    public function flattenOneNestedArray(Collection $collection): void
+    {
+        $_result = $collection->flatten(1);
+        /** @psalm-check-type-exact $_result = Collection<int, int>&static */
+    }
+
+    /** @param Collection<string, list<string>> $collection */
+    public function flattenOneNestedList(Collection $collection): void
+    {
+        $_result = $collection->flatten(1);
+        /** @psalm-check-type-exact $_result = Collection<int, string>&static */
+    }
+
+    /**
+     * flatten(0) is equivalent to flatten(INF) in Laravel — defers to default.
+     * @param Collection<string, int> $collection
+     */
+    public function flattenZeroDefersToDefault(Collection $collection): void
+    {
+        $_result = $collection->flatten(0);
+        /** @psalm-check-type-exact $_result = Collection<int, mixed>&static */
+    }
+
+    /**
+     * flatten() with no argument (INF depth) falls through to default (mixed).
+     * @param Collection<int, Collection<int, string>> $collection
+     */
+    public function flattenInfDepthReturnsMixed(Collection $collection): void
+    {
+        $_result = $collection->flatten();
+        /** @psalm-check-type-exact $_result = Collection<int, mixed>&static */
+    }
+
+    /** @param LazyCollection<int, Collection<int, string>> $collection */
+    public function lazyCollectionFlattenOne(LazyCollection $collection): void
+    {
+        $_result = $collection->flatten(1);
+        /** @psalm-check-type-exact $_result = LazyCollection<int, string>&static */
+    }
+
+    /**
+     * flatten(1) on a non-nested collection defers to Psalm's default (mixed).
+     * @param Collection<int, string> $collection
+     */
+    public function flattenOneOnFlatCollection(Collection $collection): void
+    {
+        $_result = $collection->flatten(1);
+        /** @psalm-check-type-exact $_result = Collection<int, mixed>&static */
+    }
+
+    /**
+     * flatten(2) is not handled — defers to Psalm's default.
+     * @param Collection<int, Collection<int, Collection<int, string>>> $collection
+     */
+    public function flattenTwoDefersToDefault(Collection $collection): void
+    {
+        $_result = $collection->flatten(2);
+        /** @psalm-check-type-exact $_result = Collection<int, mixed>&static */
+    }
+
+    /**
+     * collapse() is semantically equivalent to flatten(1).
+     * @param Collection<int, Collection<int, string>> $collection
+     */
+    public function collapsePreservesInnerType(Collection $collection): void
+    {
+        $_result = $collection->collapse();
+        /** @psalm-check-type-exact $_result = Collection<int, string>&static */
+    }
+
+    /** @param Collection<int, array<string, int>> $collection */
+    public function collapseNestedArray(Collection $collection): void
+    {
+        $_result = $collection->collapse();
+        /** @psalm-check-type-exact $_result = Collection<int, int>&static */
+    }
+
+    /** @param LazyCollection<int, Collection<int, string>> $collection */
+    public function lazyCollectionCollapse(LazyCollection $collection): void
+    {
+        $_result = $collection->collapse();
+        /** @psalm-check-type-exact $_result = LazyCollection<int, string>&static */
+    }
+
+    /** @param Collection<int, array{name: string, age: int}> $collection */
+    public function flattenOneKeyedArray(Collection $collection): void
+    {
+        $_result = $collection->flatten(1);
+        /** @psalm-check-type-exact $_result = Collection<int, int|string>&static */
+    }
+
+    /**
+     * Union TValue defers to default — too complex to narrow.
+     * @param Collection<int, Collection<int, string>|array<int, string>> $collection
+     */
+    public function flattenOneUnionTValueDefersToDefault(Collection $collection): void
+    {
+        $_result = $collection->flatten(1);
+        /** @psalm-check-type-exact $_result = Collection<int, mixed>&static */
+    }
+
+    /**
+     * The issue's original use case: map-then-flatten(1).
+     * @param Collection<int, array{category: string, items: list<string>}> $groups
+     */
+    public function mapThenFlatten(Collection $groups): void
+    {
+        $_result = $groups
+            ->map(function (array $group): Collection {
+                /** @var Collection<int, array{name: string, category: string}> */
+                return collect($group['items'])->map(
+                    fn(string $item): array => ['name' => $item, 'category' => $group['category']]
+                );
+            })
+            ->flatten(1);
+        /** @psalm-check-type-exact $_result = Collection<int, array{name: string, category: string}>&static */
+    }
+}
+?>
+--EXPECT--

--- a/tests/Type/tests/CollectionMethodsTest.phpt
+++ b/tests/Type/tests/CollectionMethodsTest.phpt
@@ -140,6 +140,101 @@ final class CollectionTypes
 
         return $collection->isNotEmpty() ? null : $collection->first();
     }
+
+    /**
+     * empty() returns static<never, never>, assignable to any Collection type.
+     * @psalm-check-type-exact $empty = Collection<never, never>
+     */
+    public function emptyReturnsNeverNever(): Collection
+    {
+        $empty = Collection::empty();
+
+        return $empty;
+    }
+
+    /**
+     * Collection<never, never> is assignable to any concrete Collection type
+     * because never is the bottom type (subtype of everything).
+     * @return Collection<int, string>
+     */
+    public function emptyIsAssignableToConcreteCollection(): Collection
+    {
+        return Collection::empty();
+    }
+
+    /**
+     * String key falls through to the string branch: int|float.
+     * Distinguishes from callable branches where result type narrows,
+     * while callable callbacks narrow the return type.
+     * @see https://github.com/psalm/psalm-plugin-laravel/issues/678
+     */
+    public function sumWithStringKey(): int|float
+    {
+        /** @psalm-check-type-exact $sum = float|int */
+        $sum = $this->getCollection()->sum('length');
+
+        return $sum;
+    }
+
+    /**
+     * When the callback returns int, sum() narrows to int (not int|float).
+     * Return type `: int` verifies narrowing — Psalm rejects int|float here.
+     * @see https://github.com/psalm/psalm-plugin-laravel/issues/678
+     */
+    public function sumWithCallableReturningInt(): int
+    {
+        return $this->getCollection()->sum(function (string $item): int {
+            return strlen($item);
+        });
+    }
+
+    /**
+     * When the callback returns float, sum() narrows to float.
+     * Return type `: float` verifies narrowing — Psalm rejects int|float here.
+     * @see https://github.com/psalm/psalm-plugin-laravel/issues/678
+     */
+    public function sumWithCallableReturningFloat(): float
+    {
+        return $this->getCollection()->sum(function (string $item): float {
+            return (float) strlen($item);
+        });
+    }
+
+    /** @see https://github.com/psalm/psalm-plugin-laravel/issues/678 */
+    public function sumWithoutArguments(): int
+    {
+        /** @var Collection<int, int> */
+        $numbers = new Collection();
+
+        /** @psalm-check-type-exact $sum = int */
+        $sum = $numbers->sum();
+
+        return $sum;
+    }
+
+    /** @see https://github.com/psalm/psalm-plugin-laravel/issues/678 */
+    public function sumWithoutArgumentsFloat(): float
+    {
+        /** @var Collection<int, float> */
+        $numbers = new Collection();
+
+        /** @psalm-check-type-exact $sum = float */
+        $sum = $numbers->sum();
+
+        return $sum;
+    }
+
+    /** @see https://github.com/psalm/psalm-plugin-laravel/issues/678 */
+    public function sumWithoutArgumentsMixed(): int|float
+    {
+        /** @var Collection<int, int|float> */
+        $numbers = new Collection();
+
+        /** @psalm-check-type-exact $sum = float|int */
+        $sum = $numbers->sum();
+
+        return $sum;
+    }
 }
 
 /** @var Collection<string, string> */

--- a/tests/Type/tests/EloquentCollectionTypesTest.phpt
+++ b/tests/Type/tests/EloquentCollectionTypesTest.phpt
@@ -29,6 +29,17 @@ final class UserRepository
     {
       return User::query()->where($attributes)->get();
     }
+
+    /**
+     * Eloquent\Collection::empty() resolves static<never, never> through inheritance.
+     * @psalm-check-type-exact $empty = \Illuminate\Database\Eloquent\Collection<never, never>
+     */
+    public function emptyEloquentCollection(): \Illuminate\Database\Eloquent\Collection
+    {
+      $empty = \Illuminate\Database\Eloquent\Collection::empty();
+
+      return $empty;
+    }
 }
 ?>
 --EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlClientResponseBody.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlClientResponseBody.phpt
@@ -1,0 +1,16 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Http\Client\Response::body() returns the raw response body from an external
+ * HTTP request — it must be treated as a taint source.
+ */
+function renderApiBody(\Illuminate\Http\Client\Response $response): void {
+    echo $response->body();
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlClientResponseHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlClientResponseHeader.phpt
@@ -1,0 +1,16 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Http\Client\Response::header() returns a header value from an external HTTP
+ * response — it must be treated as a taint source.
+ */
+function renderApiHeader(\Illuminate\Http\Client\Response $response): void {
+    echo $response->header('X-Custom');
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlClientResponseJson.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlClientResponseJson.phpt
@@ -1,0 +1,16 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Http\Client\Response::json() returns decoded JSON from an external HTTP
+ * request — it must be treated as a taint source.
+ */
+function renderApiJson(\Illuminate\Http\Client\Response $response): void {
+    echo $response->json('name');
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlClientResponseToString.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlClientResponseToString.phpt
@@ -1,0 +1,16 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Http\Client\Response::__toString() returns the response body via string
+ * casting — it must be treated as a taint source.
+ */
+function renderApiResponse(\Illuminate\Http\Client\Response $response): void {
+    echo (string) $response;
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes


### PR DESCRIPTION
Backports four fixes from `master` to `3.x`.

**`LNumber` → `Int_` in `CollectionFlattenHandler`** — `PhpParser\Node\Scalar\LNumber` is deprecated in php-parser v5; replace with `Int_`.

**`Collection::empty()` stub** — adds `static<never, never>` return type so the empty factory is assignable to any typed Collection.

**`Collection::sum()` / `Enumerable::sum()` narrowing** — conditional return type based on `TValue` and callback: `Collection<_, int>::sum()` → `int`, `Collection<_, float>::sum()` → `float`, callable narrows to `TCallbackReturn`.

**`Http\Client\Response` taint sources** — marks `body()`, `json()`, `object()`, `collect()`, `fluent()`, `header()`, `headers()`, and `__toString()` as `@psalm-taint-source input`. External HTTP responses are untrusted data. Signatures use the Laravel 11 form (without the `$flags` parameter added in Laravel 12).
