### PR TITLE
stubs: Add `@psalm-this-out` to paginator `setCollection()`

### DIFF
--- a/stubs/common/Pagination/Pagination.stubphp
+++ b/stubs/common/Pagination/Pagination.stubphp
@@ -21,6 +21,16 @@ abstract class AbstractPaginator implements \Illuminate\Contracts\Support\Htmlab
     public function getCollection(): \Illuminate\Support\Collection {}
 
     /**
+     * @template TSetKey of array-key
+     * @template TSetValue
+     *
+     * @param  \Illuminate\Support\Collection<TSetKey, TSetValue>  $collection
+     * @psalm-this-out static<TSetKey, TSetValue>
+     * @return $this
+     */
+    public function setCollection(\Illuminate\Support\Collection $collection) {}
+
+    /**
      * @return \ArrayIterator<TKey, TValue>
      */
     public function getIterator(): \Traversable {}
@@ -85,6 +95,16 @@ abstract class AbstractCursorPaginator implements \Illuminate\Contracts\Support\
      * @return \Illuminate\Support\Collection<TKey, TValue>
      */
     public function getCollection(): \Illuminate\Support\Collection {}
+
+    /**
+     * @template TSetKey of array-key
+     * @template TSetValue
+     *
+     * @param  \Illuminate\Support\Collection<TSetKey, TSetValue>  $collection
+     * @psalm-this-out static<TSetKey, TSetValue>
+     * @return $this
+     */
+    public function setCollection(\Illuminate\Support\Collection $collection) {}
 
     /**
      * @return \ArrayIterator<TKey, TValue>

--- a/tests/Type/tests/CursorPaginatorSetCollectionTest.phpt
+++ b/tests/Type/tests/CursorPaginatorSetCollectionTest.phpt
@@ -1,0 +1,38 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Pagination\CursorPaginator;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
+
+final class CursorPaginatorSetCollectionTest
+{
+    /**
+     * @param CursorPaginator<int, string> $paginator
+     * @param Collection<int, int> $newCollection
+     */
+    public function setCollectionNarrowsType(CursorPaginator $paginator, Collection $newCollection): void
+    {
+        $paginator->setCollection($newCollection);
+
+        $_collection = $paginator->getCollection();
+        /** @psalm-check-type-exact $_collection = Collection<int, int> */
+    }
+
+    /**
+     * @param LengthAwarePaginator<int, string> $paginator
+     * @param Collection<int, int> $newCollection
+     */
+    public function setCollectionNarrowsLengthAwarePaginatorType(
+        LengthAwarePaginator $paginator,
+        Collection $newCollection,
+    ): void {
+        $paginator->setCollection($newCollection);
+
+        $_collection = $paginator->getCollection();
+        /** @psalm-check-type-exact $_collection = Collection<int, int> */
+    }
+}
+
+?>
+--EXPECT--


### PR DESCRIPTION
`AbstractCursorPaginator::setCollection()` already carries `@phpstan-this-out static<TSetKey, TSetValue>` in Laravel's source. `AbstractPaginator::setCollection()` has the same implementation (replaces `$this->items`) but the annotation is missing upstream.

This adds `@psalm-this-out static<TSetKey, TSetValue>` to both, so calling `setCollection(Collection<int, Foo>)` on any paginator narrows its type to `Paginator<int, Foo>` rather than keeping the original item type.
