### PR TITLE
Add regression guard for Eloquent fetch ssrf/header taint false positive

### DIFF
--- a/tests/Type/tests/TaintAnalysis/SafeSsrfEloquentFetch.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeSsrfEloquentFetch.phpt
@@ -1,0 +1,71 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Eloquent model-fetch methods (findOrFail, find, first, etc.) must NOT propagate
+ * ssrf/header taint from the lookup key ($id) to the returned model.
+ *
+ * The lookup key controls WHICH row is retrieved from the DB, not the content of
+ * the row. DB-fetched model attributes come from the database, not from the key.
+ *
+ * Common false-positive pattern (observed in pixelfed):
+ *   $id = $request->input('id');       // tainted
+ *   $status = Status::findOrFail($id); // DB fetch — result is trusted
+ *   redirect($status->url());          // must NOT fire TaintedSSRF + TaintedHeader
+ *
+ * Current behavior: Psalm does not propagate taint through stub functions without
+ * @psalm-flow, so the fetch methods already do not propagate ssrf/header taint.
+ * This test is a regression guard to catch if that behavior changes.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/686
+ */
+
+class StatusModel extends \Illuminate\Database\Eloquent\Model
+{
+    public function getRedirectUrl(): string
+    {
+        return (string) $this->getAttribute('url');
+    }
+}
+
+// find/findOrFail pass mixed $id into a typed template parameter → MixedArgument needed
+/** @psalm-suppress MixedAssignment, MixedArgument */
+function noSsrfViaFindOrFail(\Illuminate\Http\Request $request): void
+{
+    $id = $request->input('id');
+    $status = StatusModel::query()->findOrFail($id);
+    redirect($status->getRedirectUrl());
+}
+
+/** @psalm-suppress MixedAssignment, MixedArgument */
+function noSsrfViaFind(\Illuminate\Http\Request $request): void
+{
+    $id = $request->input('id');
+    $status = StatusModel::query()->find($id);
+    if ($status !== null) {
+        redirect($status->getRedirectUrl());
+    }
+}
+
+// where() accepts mixed as its value argument → only MixedAssignment needed
+/** @psalm-suppress MixedAssignment */
+function noSsrfViaFirst(\Illuminate\Http\Request $request): void
+{
+    $id = $request->input('id');
+    $status = StatusModel::query()->where('id', $id)->first();
+    if ($status !== null) {
+        redirect($status->getRedirectUrl());
+    }
+}
+
+/** @psalm-suppress MixedAssignment */
+function noSsrfViaFirstOrFail(\Illuminate\Http\Request $request): void
+{
+    $id = $request->input('id');
+    $status = StatusModel::query()->where('id', $id)->firstOrFail();
+    redirect($status->getRedirectUrl());
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

`redirect()` to a DB-fetched model URL (e.g. `redirect($status->url())` after `Status::findOrFail($id)`) was reported to fire false-positive `TaintedSSRF` + `TaintedHeader` in real-world projects. The lookup key `$id` controls which row is fetched, not the content of the returned model's attributes.

## Related

Closes #686

## Solution Description

Investigation revealed that Psalm does not propagate taint through stub functions without `@psalm-flow` — so the false positive from the stubs alone is not currently triggered. The project's own taint-analysis guide explicitly prohibits `@psalm-taint-escape` without a paired `@psalm-flow` (to avoid silently dropping all taint kinds).

Instead of adding stub annotations that would violate this rule and be no-ops anyway, this PR adds a regression-guard type test that:

- Documents the expected behavior (no `TaintedSSRF`/`TaintedHeader` when redirecting to a DB-fetched model URL)
- Covers `findOrFail`, `find`, `first`, and `firstOrFail` patterns
- Includes an honest comment explaining the current mechanism and that it guards against future regressions if Psalm's taint propagation behavior changes

## Checklist
- [x] Tests cover the change (type test in `tests/Type/TaintAnalysis/`)
