### PR TITLE
stub `Conditionable::when()`/`unless()` and `Tappable::tap()` to fix `mixed` return on fluent chains

### DIFF
--- a/stubs/common/Support/Traits/Conditionable.stubphp
+++ b/stubs/common/Support/Traits/Conditionable.stubphp
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Support\Traits;
+
+trait Conditionable
+{
+    /**
+     * Apply the callback if the given "value" is (or resolves to) truthy.
+     *
+     * Psalm can't narrow `$this|TWhenReturnType` when the callback return type
+     * is a template — inference collapses to `mixed`. Returning `$this` unconditionally
+     * keeps fluent chains type-safe for the common case where the callback returns void
+     * or the same builder/collection instance.
+     *
+     * @return $this
+     */
+    public function when($value = null, ?callable $callback = null, ?callable $default = null) {}
+
+    /**
+     * Apply the callback if the given "value" is (or resolves to) falsy.
+     *
+     * Same rationale as `when()` — `$this` keeps fluent chains type-safe.
+     *
+     * @return $this
+     */
+    public function unless($value = null, ?callable $callback = null, ?callable $default = null) {}
+}

--- a/stubs/common/Support/Traits/Tappable.stubphp
+++ b/stubs/common/Support/Traits/Tappable.stubphp
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Support\Traits;
+
+trait Tappable
+{
+    /**
+     * Call the given Closure with this instance then return the instance.
+     *
+     * Laravel's real return type is `($callback is null ? HigherOrderTapProxy : $this)`,
+     * but Psalm collapses conditional returns on trait methods to `mixed`. Returning
+     * `$this` unconditionally keeps fluent chains type-safe for the common case.
+     *
+     * @param  callable|null  $callback
+     * @return $this
+     */
+    public function tap($callback = null) {}
+}

--- a/tests/Type/tests/ConditionableTappableTest.phpt
+++ b/tests/Type/tests/ConditionableTappableTest.phpt
@@ -1,0 +1,119 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Stringable;
+
+/**
+ * Regression tests for Conditionable::when()/unless() and Tappable::tap().
+ *
+ * Without stubs these methods return mixed, breaking all fluent chains.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/704
+ */
+
+/**
+ * when() on an Eloquent Builder must preserve the builder type, not return mixed.
+ * Before the stub, ->where() after ->when() would produce MixedMethodCall.
+ */
+function test_eloquent_builder_when_fluent_chain(): void
+{
+    Customer::query()
+        ->when(true, null, null)
+        ->where('active', true)
+        ->paginate();
+}
+
+/** unless() on an Eloquent Builder must preserve the builder type, not return mixed. */
+function test_eloquent_builder_unless_fluent_chain(): void
+{
+    Customer::query()
+        ->unless(false, null, null)
+        ->where('active', true)
+        ->paginate();
+}
+
+/**
+ * when() on a typed Builder variable returns the same builder type ($this).
+ *
+ * @param Builder<Customer> $builder
+ */
+function test_eloquent_builder_when_return_type(Builder $builder): void
+{
+    $_result = $builder->when(true, null, null);
+    /** @psalm-check-type-exact $_result = Builder<Customer>&static */
+}
+
+/**
+ * unless() on a typed Builder variable returns the same builder type ($this).
+ *
+ * @param Builder<Customer> $builder
+ */
+function test_eloquent_builder_unless_return_type(Builder $builder): void
+{
+    $_result = $builder->unless(false, null, null);
+    /** @psalm-check-type-exact $_result = Builder<Customer>&static */
+}
+
+/**
+ * Query\Builder uses Conditionable via BuildsQueries — fluent chain must not break.
+ */
+function test_query_builder_when_fluent_chain(QueryBuilder $builder): void
+{
+    $builder
+        ->when(true, null, null)
+        ->where('active', true)
+        ->get();
+}
+
+/** when() on Query\Builder returns the same builder type ($this). */
+function test_query_builder_when_return_type(QueryBuilder $builder): void
+{
+    $_result = $builder->when(true, null, null);
+    /** @psalm-check-type-exact $_result = Illuminate\Database\Query\Builder&static */
+}
+
+/** when() on Collection must preserve the collection type, not return mixed. */
+function test_collection_when_fluent_chain(): void
+{
+    /** @var Collection<int, string> $collection */
+    $collection = new Collection(['a', 'b', 'c']);
+    $_result = $collection->when(true, null, null);
+    /** @psalm-check-type-exact $_result = Collection<int, string>&static */
+    $_result->values();
+}
+
+/** when() on Stringable must preserve Stringable, not return mixed. */
+function test_stringable_when_fluent_chain(): void
+{
+    (new Stringable('hello'))
+        ->when(true, null, null)
+        ->value();
+}
+
+/** tap() with a callback returns $this — preserves the calling type in the chain. */
+function test_stringable_tap_with_callback(): void
+{
+    $_result = (new Stringable('hello'))->tap(static function (Stringable $s): void {
+        echo (string) $s;
+    });
+    /** @psalm-check-type-exact $_result = Stringable&static */
+}
+
+/**
+ * tap() without a callback also types as $this (stub simplification).
+ *
+ * At runtime Laravel returns HigherOrderTapProxy for the null case.
+ * The stub approximates this as $this to avoid mixed collapse — acceptable
+ * because HigherOrderTapProxy proxies all calls back to the original object.
+ */
+function test_tap_without_callback(): void
+{
+    $_result = (new Stringable('hello'))->tap();
+    /** @psalm-check-type-exact $_result = Stringable&static */
+}
+?>
+--EXPECT--


### PR DESCRIPTION
## Issue to Solve

`when()`, `unless()`, and `tap()` return `mixed` in static analysis, breaking fluent chains on builders, collections, `Stringable`, and paginators.

## Related

Fixes #704

## Solution Description

Add trait stubs for `Conditionable` and `Tappable` that override the return type to `$this`.

Psalm can't narrow `$this|TWhenReturnType` when the callback return type is a template — inference collapses to `mixed`. Returning `$this` unconditionally keeps fluent chains type-safe for the common case (callbacks returning void or the same instance).

Verified with type tests covering all major trait consumers: `Eloquent\Builder`, `Query\Builder`, `Collection`, and `Stringable`.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/tests/ConditionableTappableTest.phpt`)
