### PR TITLE
Stub `Conditionable::when()`/`unless()` and `Tappable::tap()` to fix `mixed` return on fluent chains

### DIFF
--- a/stubs/common/Support/Traits/Conditionable.stubphp
+++ b/stubs/common/Support/Traits/Conditionable.stubphp
@@ -1,0 +1,34 @@
+<?php
+
+namespace Illuminate\Support\Traits;
+
+/**
+ * Simplify return types for Conditionable methods.
+ *
+ * Laravel's PHPDoc uses `@return $this|TWhenReturnType` with template inference,
+ * but Psalm 7 resolves callable return types to `mixed`, breaking fluent chains.
+ * Stubbing as `@return $this` makes ->when() and ->unless() chainable on
+ * Builder, Collection, Stringable, and any other class using this trait.
+ */
+trait Conditionable
+{
+    /**
+     * Apply the callback if the given "value" is (or resolves to) truthy.
+     *
+     * @param  mixed  $value
+     * @param  callable|null  $callback
+     * @param  callable|null  $default
+     * @return $this
+     */
+    public function when($value = null, ?callable $callback = null, ?callable $default = null) {}
+
+    /**
+     * Apply the callback if the given "value" is (or resolves to) falsy.
+     *
+     * @param  mixed  $value
+     * @param  callable|null  $callback
+     * @param  callable|null  $default
+     * @return $this
+     */
+    public function unless($value = null, ?callable $callback = null, ?callable $default = null) {}
+}

--- a/stubs/common/Support/Traits/Tappable.stubphp
+++ b/stubs/common/Support/Traits/Tappable.stubphp
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Support\Traits;
+
+/**
+ * Simplify return type for Tappable::tap().
+ *
+ * Without a stub, tap() returns `mixed` because Psalm can't resolve
+ * the global tap() helper's generic return type. Stubbing as `@return $this`
+ * fixes fluent chains on Builder, Stringable, and other Tappable classes.
+ *
+ * Note: Laravel's own PHPDoc uses a conditional return type that distinguishes
+ * null callback → HigherOrderTapProxy vs callable → $this. This simplification
+ * skips that distinction because conditional return types with $this do not
+ * work in Psalm 7 trait stubs.
+ */
+trait Tappable
+{
+    /**
+     * Call the given Closure with this instance then return the instance.
+     *
+     * @param  callable|null  $callback
+     * @return $this
+     */
+    public function tap($callback = null) {}
+}

--- a/tests/Type/tests/ConditionableTappableTest.phpt
+++ b/tests/Type/tests/ConditionableTappableTest.phpt
@@ -4,6 +4,7 @@
 use App\Models\Customer;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Http\Client\Response;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Stringable;
 
@@ -98,9 +99,8 @@ function test_collection_when_fluent_chain(): void
 /** when() on Stringable must preserve Stringable, not return mixed. */
 function test_stringable_when_fluent_chain(): void
 {
-    (new Stringable('hello'))
-        ->when(true, null, null)
-        ->value();
+    $_result = (new Stringable('hello'))->when(true, null, null);
+    /** @psalm-check-type-exact $_result = Stringable&static */
 }
 
 // --- Tappable::tap() ---
@@ -126,5 +126,16 @@ function test_tap_without_callback(): void
     $_result = (new Stringable('hello'))->tap();
     /** @psalm-check-type-exact $_result = Stringable&static */
 }
+/**
+ * tap() on Http\Client\Response (another Tappable user) confirms trait-level application
+ * is not limited to Stringable.
+ */
+function test_response_tap_with_callback(Response $response): void
+{
+    $_result = $response->tap(static function (Response $r): void {
+        $r->status();
+    });
+    /** @psalm-check-type-exact $_result = Response&static */
+}
 ?>
---EXPECT--
+--EXPECTF--

--- a/tests/Type/tests/ConditionableTappableTest.phpt
+++ b/tests/Type/tests/ConditionableTappableTest.phpt
@@ -61,6 +61,37 @@ function test_eloquent_builder_unless_return_type(Builder $builder): void
     /** @psalm-check-type-exact $_result = Builder<Customer>&static */
 }
 
+/**
+ * Regression: real two-parameter callback must not collapse the return type to mixed.
+ * This is the exact pattern from issue #704 — Psalm previously returned mixed here
+ * because TWhenReturnType resolved to mixed when inferred from the callback return.
+ *
+ * @param Builder<Customer> $query
+ * @param string|null $search
+ */
+function test_eloquent_builder_when_with_real_callback(Builder $query, ?string $search): void
+{
+    $_result = $query->when(
+        $search,
+        fn(Builder $q, string $v) => $q->where('name', 'like', "%$v%")
+    );
+    /** @psalm-check-type-exact $_result = Builder<Customer>&static */
+}
+
+/**
+ * unless() with a real callback must also preserve the builder type.
+ *
+ * @param Builder<Customer> $query
+ */
+function test_eloquent_builder_unless_with_real_callback(Builder $query): void
+{
+    $_result = $query->unless(
+        false,
+        fn(Builder $q, bool $_v) => $q->where('deleted_at', null)
+    );
+    /** @psalm-check-type-exact $_result = Builder<Customer>&static */
+}
+
 // --- Query\Builder (via BuildsQueries trait) ---
 
 /**

--- a/tests/Type/tests/ConditionableTappableTest.phpt
+++ b/tests/Type/tests/ConditionableTappableTest.phpt
@@ -25,7 +25,7 @@ use Illuminate\Support\Stringable;
 function test_eloquent_builder_when_fluent_chain(): void
 {
     Customer::query()
-        ->when(true, null, null)
+        ->when(false, null, null)
         ->where('active', true)
         ->paginate();
 }
@@ -34,7 +34,7 @@ function test_eloquent_builder_when_fluent_chain(): void
 function test_eloquent_builder_unless_fluent_chain(): void
 {
     Customer::query()
-        ->unless(false, null, null)
+        ->unless(true, null, null)
         ->where('active', true)
         ->paginate();
 }
@@ -46,7 +46,7 @@ function test_eloquent_builder_unless_fluent_chain(): void
  */
 function test_eloquent_builder_when_return_type(Builder $builder): void
 {
-    $_result = $builder->when(true, null, null);
+    $_result = $builder->when(false, null, null);
     /** @psalm-check-type-exact $_result = Builder<Customer>&static */
 }
 
@@ -57,7 +57,7 @@ function test_eloquent_builder_when_return_type(Builder $builder): void
  */
 function test_eloquent_builder_unless_return_type(Builder $builder): void
 {
-    $_result = $builder->unless(false, null, null);
+    $_result = $builder->unless(true, null, null);
     /** @psalm-check-type-exact $_result = Builder<Customer>&static */
 }
 
@@ -101,7 +101,7 @@ function test_eloquent_builder_unless_with_real_callback(Builder $query): void
 function test_query_builder_when_fluent_chain(QueryBuilder $builder): void
 {
     $builder
-        ->when(true, null, null)
+        ->when(false, null, null)
         ->where('active', true)
         ->get();
 }
@@ -109,7 +109,7 @@ function test_query_builder_when_fluent_chain(QueryBuilder $builder): void
 /** when() on Query\Builder returns the same builder type ($this). */
 function test_query_builder_when_return_type(QueryBuilder $builder): void
 {
-    $_result = $builder->when(true, null, null);
+    $_result = $builder->when(false, null, null);
     /** @psalm-check-type-exact $_result = Illuminate\Database\Query\Builder&static */
 }
 
@@ -120,7 +120,7 @@ function test_collection_when_fluent_chain(): void
 {
     /** @var Collection<int, string> $collection */
     $collection = new Collection(['a', 'b', 'c']);
-    $_result = $collection->when(true, null, null);
+    $_result = $collection->when(false, null, null);
     /** @psalm-check-type-exact $_result = Collection<int, string>&static */
     $_result->values();
 }
@@ -130,7 +130,7 @@ function test_collection_when_fluent_chain(): void
 /** when() on Stringable must preserve Stringable, not return mixed. */
 function test_stringable_when_fluent_chain(): void
 {
-    $_result = (new Stringable('hello'))->when(true, null, null);
+    $_result = (new Stringable('hello'))->when(false, null, null);
     /** @psalm-check-type-exact $_result = Stringable&static */
 }
 

--- a/tests/Type/tests/ConditionableTest.phpt
+++ b/tests/Type/tests/ConditionableTest.phpt
@@ -1,101 +1,130 @@
 --FILE--
 <?php declare(strict_types=1);
 
+use App\Models\Customer;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Stringable;
 
-// --- Conditionable::when() ---
-
 /**
- * when() returns $this, preserving the concrete type for fluent chaining.
- * Without the stub, Psalm resolves the callable template to `mixed`.
+ * Regression tests for Conditionable::when()/unless() and Tappable::tap().
+ *
+ * Without stubs these methods return mixed, breaking all fluent chains.
+ *
  * @see https://github.com/psalm/psalm-plugin-laravel/issues/704
  */
-function stringable_when_with_callback(Stringable $str): void
+
+// --- Eloquent Builder ---
+
+/**
+ * when() on an Eloquent Builder must preserve the builder type, not return mixed.
+ * Before the stub, ->where() after ->when() would produce MixedMethodCall.
+ */
+function test_eloquent_builder_when_fluent_chain(): void
 {
-    $_result = $str->when(true, fn(Stringable $s) => $s->upper());
-    /** @psalm-check-type-exact $_result = Illuminate\Support\Stringable&static */
+    Customer::query()
+        ->when(true, null, null)
+        ->where('active', true)
+        ->paginate();
+}
+
+/** unless() on an Eloquent Builder must preserve the builder type, not return mixed. */
+function test_eloquent_builder_unless_fluent_chain(): void
+{
+    Customer::query()
+        ->unless(false, null, null)
+        ->where('active', true)
+        ->paginate();
 }
 
 /**
- * when() with only a condition (no callback) must still return $this, not mixed.
- * Laravel internally returns HigherOrderWhenProxy here, but the stub simplifies to $this.
+ * when() on a typed Builder variable returns the same builder type ($this).
+ *
+ * @param Builder<Customer> $builder
  */
-function stringable_when_without_callback(Stringable $str): void
+function test_eloquent_builder_when_return_type(Builder $builder): void
 {
-    $_result = $str->when(true);
-    /** @psalm-check-type-exact $_result = Illuminate\Support\Stringable&static */
+    $_result = $builder->when(true, null, null);
+    /** @psalm-check-type-exact $_result = Builder<Customer>&static */
 }
 
-// --- Conditionable::unless() ---
+/**
+ * unless() on a typed Builder variable returns the same builder type ($this).
+ *
+ * @param Builder<Customer> $builder
+ */
+function test_eloquent_builder_unless_return_type(Builder $builder): void
+{
+    $_result = $builder->unless(false, null, null);
+    /** @psalm-check-type-exact $_result = Builder<Customer>&static */
+}
+
+// --- Query\Builder (via BuildsQueries trait) ---
 
 /**
- * unless() returns $this, preserving the concrete type for fluent chaining.
+ * Query\Builder uses Conditionable via BuildsQueries — fluent chain must not break.
+ * This validates that the trait stub propagates through the indirect inheritance path.
  */
-function stringable_unless_with_callback(Stringable $str): void
+function test_query_builder_when_fluent_chain(QueryBuilder $builder): void
 {
-    $_result = $str->unless(false, fn(Stringable $s) => $s->lower());
-    /** @psalm-check-type-exact $_result = Illuminate\Support\Stringable&static */
+    $builder
+        ->when(true, null, null)
+        ->where('active', true)
+        ->get();
+}
+
+/** when() on Query\Builder returns the same builder type ($this). */
+function test_query_builder_when_return_type(QueryBuilder $builder): void
+{
+    $_result = $builder->when(true, null, null);
+    /** @psalm-check-type-exact $_result = Illuminate\Database\Query\Builder&static */
+}
+
+// --- Collection ---
+
+/** when() on Collection must preserve the collection type, not return mixed. */
+function test_collection_when_fluent_chain(): void
+{
+    /** @var Collection<int, string> $collection */
+    $collection = new Collection(['a', 'b', 'c']);
+    $_result = $collection->when(true, null, null);
+    /** @psalm-check-type-exact $_result = Collection<int, string>&static */
+    $_result->values();
+}
+
+// --- Stringable ---
+
+/** when() on Stringable must preserve Stringable, not return mixed. */
+function test_stringable_when_fluent_chain(): void
+{
+    (new Stringable('hello'))
+        ->when(true, null, null)
+        ->value();
 }
 
 // --- Tappable::tap() ---
 
-/**
- * tap($callback) returns $this — the instance is unchanged after the tap.
- */
-function stringable_tap_with_callback(Stringable $str): void
+/** tap() with a callback returns $this — preserves the calling type in the chain. */
+function test_stringable_tap_with_callback(): void
 {
-    $_result = $str->tap(static function (Stringable $s): void {
-        $s->value();
+    $_result = (new Stringable('hello'))->tap(static function (Stringable $s): void {
+        echo (string) $s;
     });
-    /** @psalm-check-type-exact $_result = Illuminate\Support\Stringable&static */
+    /** @psalm-check-type-exact $_result = Stringable&static */
 }
 
 /**
- * tap() without a callback returns $this.
- * Laravel's actual return type is HigherOrderTapProxy here, but the stub
- * simplifies to $this because conditional return types with $this do not
- * work in Psalm 7 trait stubs.
- */
-function stringable_tap_without_callback(Stringable $str): void
-{
-    $_result = $str->tap();
-    /** @psalm-check-type-exact $_result = Illuminate\Support\Stringable&static */
-}
-
-// --- Eloquent Builder fluent chains ---
-
-class TestConditionableModel extends Model {}
-
-/**
- * Regression test: ->when() on an Eloquent Builder must not return `mixed`,
- * otherwise the chained ->where() call would raise "Method does not exist on mixed".
+ * tap() without a callback also types as $this (stub simplification).
  *
- * @param Builder<TestConditionableModel> $query
- * @param string|null $search
- * @return Builder<TestConditionableModel>
+ * At runtime Laravel returns HigherOrderTapProxy for the null case.
+ * The stub approximates this as $this to avoid mixed collapse — acceptable
+ * because HigherOrderTapProxy proxies all calls back to the original object.
  */
-function builder_when_preserves_builder_type(Builder $query, ?string $search): Builder
+function test_tap_without_callback(): void
 {
-    return $query->when(
-        $search,
-        fn(Builder $q, string $v) => $q->where('name', 'like', "%$v%")
-    )->where('active', true);
-}
-
-/**
- * unless() must also preserve the Builder type for fluent chaining.
- *
- * @param Builder<TestConditionableModel> $query
- * @return Builder<TestConditionableModel>
- */
-function builder_unless_preserves_builder_type(Builder $query): Builder
-{
-    return $query->unless(
-        false,
-        fn(Builder $q) => $q->where('deleted_at', null)
-    )->where('active', true);
+    $_result = (new Stringable('hello'))->tap();
+    /** @psalm-check-type-exact $_result = Stringable&static */
 }
 ?>
 --EXPECT--

--- a/tests/Type/tests/ConditionableTest.phpt
+++ b/tests/Type/tests/ConditionableTest.phpt
@@ -1,0 +1,101 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Stringable;
+
+// --- Conditionable::when() ---
+
+/**
+ * when() returns $this, preserving the concrete type for fluent chaining.
+ * Without the stub, Psalm resolves the callable template to `mixed`.
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/704
+ */
+function stringable_when_with_callback(Stringable $str): void
+{
+    $_result = $str->when(true, fn(Stringable $s) => $s->upper());
+    /** @psalm-check-type-exact $_result = Illuminate\Support\Stringable&static */
+}
+
+/**
+ * when() with only a condition (no callback) must still return $this, not mixed.
+ * Laravel internally returns HigherOrderWhenProxy here, but the stub simplifies to $this.
+ */
+function stringable_when_without_callback(Stringable $str): void
+{
+    $_result = $str->when(true);
+    /** @psalm-check-type-exact $_result = Illuminate\Support\Stringable&static */
+}
+
+// --- Conditionable::unless() ---
+
+/**
+ * unless() returns $this, preserving the concrete type for fluent chaining.
+ */
+function stringable_unless_with_callback(Stringable $str): void
+{
+    $_result = $str->unless(false, fn(Stringable $s) => $s->lower());
+    /** @psalm-check-type-exact $_result = Illuminate\Support\Stringable&static */
+}
+
+// --- Tappable::tap() ---
+
+/**
+ * tap($callback) returns $this — the instance is unchanged after the tap.
+ */
+function stringable_tap_with_callback(Stringable $str): void
+{
+    $_result = $str->tap(static function (Stringable $s): void {
+        $s->value();
+    });
+    /** @psalm-check-type-exact $_result = Illuminate\Support\Stringable&static */
+}
+
+/**
+ * tap() without a callback returns $this.
+ * Laravel's actual return type is HigherOrderTapProxy here, but the stub
+ * simplifies to $this because conditional return types with $this do not
+ * work in Psalm 7 trait stubs.
+ */
+function stringable_tap_without_callback(Stringable $str): void
+{
+    $_result = $str->tap();
+    /** @psalm-check-type-exact $_result = Illuminate\Support\Stringable&static */
+}
+
+// --- Eloquent Builder fluent chains ---
+
+class TestConditionableModel extends Model {}
+
+/**
+ * Regression test: ->when() on an Eloquent Builder must not return `mixed`,
+ * otherwise the chained ->where() call would raise "Method does not exist on mixed".
+ *
+ * @param Builder<TestConditionableModel> $query
+ * @param string|null $search
+ * @return Builder<TestConditionableModel>
+ */
+function builder_when_preserves_builder_type(Builder $query, ?string $search): Builder
+{
+    return $query->when(
+        $search,
+        fn(Builder $q, string $v) => $q->where('name', 'like', "%$v%")
+    )->where('active', true);
+}
+
+/**
+ * unless() must also preserve the Builder type for fluent chaining.
+ *
+ * @param Builder<TestConditionableModel> $query
+ * @return Builder<TestConditionableModel>
+ */
+function builder_unless_preserves_builder_type(Builder $query): Builder
+{
+    return $query->unless(
+        false,
+        fn(Builder $q) => $q->where('deleted_at', null)
+    )->where('active', true);
+}
+?>
+--EXPECT--


### PR DESCRIPTION
## Issue to Solve

`->when()`, `->unless()`, and `->tap()` returned `mixed` in Psalm, breaking fluent chains on `Builder`, `Collection`, `Stringable`, and paginators.

## Related

Closes #704

## Solution Description

Added trait stubs that override the return type to `$this`:

- `stubs/common/Support/Traits/Conditionable.stubphp` — stubs `when()` and `unless()` to return `$this` instead of `mixed`
- `stubs/common/Support/Traits/Tappable.stubphp` — stubs `tap()` to return `$this` instead of `mixed`

The root cause is that Psalm 7 can't narrow callable return templates (`TWhenReturnType`), so `@return $this|TWhenReturnType` collapses to `mixed`. The stubs simplify the return to `@return $this`, which fixes all fluent chains.

Type test added in `tests/Type/tests/ConditionableTest.phpt` covering `when()`/`unless()`/`tap()` on `Stringable` with `@psalm-check-type-exact` assertions, and an Eloquent Builder fluent chain regression test.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
- [x] Documentation is updated (if needed, otherwise remove this item)
