### PR TITLE
Narrow `Auth::guard()` return type to concrete guard class

### DIFF
--- a/src/Handlers/Auth/AuthConfigAnalyzer.php
+++ b/src/Handlers/Auth/AuthConfigAnalyzer.php
@@ -60,6 +60,31 @@ final class AuthConfigAnalyzer
         return \is_string($guard) ? $guard : null;
     }
 
+    /**
+     * Maps a guard name to its concrete guard class based on the configured driver.
+     * Returns null for unknown guards or non-standard (custom) drivers.
+     *
+     * Standard driver → class mappings (built into Laravel's AuthManager):
+     * - 'session' → SessionGuard
+     * - 'token'   → TokenGuard
+     *
+     * @return class-string<\Illuminate\Contracts\Auth\Guard>|null
+     */
+    public function getGuardFQCN(string $guard): ?string
+    {
+        $driver = $this->config->get("auth.guards.{$guard}.driver");
+
+        if (! \is_string($driver)) {
+            return null;
+        }
+
+        return match ($driver) {
+            'session' => \Illuminate\Auth\SessionGuard::class,
+            'token' => \Illuminate\Auth\TokenGuard::class,
+            default => null, // custom drivers cannot be statically resolved
+        };
+    }
+
     /** @return list<class-string<\Illuminate\Contracts\Auth\Authenticatable>> */
     public function getAllAuthenticatables(): array
     {

--- a/src/Handlers/Auth/AuthHandler.php
+++ b/src/Handlers/Auth/AuthHandler.php
@@ -26,7 +26,7 @@ use Psalm\Type;
  * name is a known string literal and its driver is a standard Laravel driver (session/token):
  * @see \Illuminate\Support\Facades\Auth::guard() returns Guard|StatefulGuard (narrowed when possible)
  *
- * There are also Methods that return Guard instance (handed in {@see \Psalm\LaravelPlugin\Handlers\Auth\GuardHandler}):
+ * There are also Methods that return Guard instance (handled in {@see \Psalm\LaravelPlugin\Handlers\Auth\GuardHandler}):
  * @see \Illuminate\Support\Facades\Auth::createSessionDriver()
  * @see \Illuminate\Support\Facades\Auth::createTokenDriver()
  * @see \Illuminate\Support\Facades\Auth::setRememberDuration()

--- a/src/Handlers/Auth/AuthHandler.php
+++ b/src/Handlers/Auth/AuthHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Handlers\Auth;
 
+use Psalm\LaravelPlugin\Handlers\Auth\Concerns\ExtractsGuardNameFromCallLike;
 use Psalm\Plugin\EventHandler\Event\MethodParamsProviderEvent;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\MethodParamsProviderInterface;
@@ -21,6 +22,10 @@ use Psalm\Type;
  * @see \Illuminate\Support\Facades\Auth::getUser() returns Authenticatable|null
  * @see \Illuminate\Support\Facades\Auth::authenticate() returns Authenticatable
  *
+ * Also narrows the return type of Auth::guard($name) to the concrete guard class when the guard
+ * name is a known string literal and its driver is a standard Laravel driver (session/token):
+ * @see \Illuminate\Support\Facades\Auth::guard() returns Guard|StatefulGuard (narrowed when possible)
+ *
  * There are also Methods that return Guard instance (handed in {@see \Psalm\LaravelPlugin\Handlers\Auth\GuardHandler}):
  * @see \Illuminate\Support\Facades\Auth::createSessionDriver()
  * @see \Illuminate\Support\Facades\Auth::createTokenDriver()
@@ -30,6 +35,7 @@ use Psalm\Type;
  */
 final class AuthHandler implements MethodReturnTypeProviderInterface, MethodParamsProviderInterface
 {
+    use ExtractsGuardNameFromCallLike;
     /**
      * @return list<string>
      * @psalm-pure
@@ -45,6 +51,10 @@ final class AuthHandler implements MethodReturnTypeProviderInterface, MethodPara
     public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Type\Union
     {
         $method_name_lowercase = $event->getMethodNameLowercase();
+
+        if ($method_name_lowercase === 'guard') {
+            return self::resolveGuardReturnType($event);
+        }
 
         if (
             ! \in_array($method_name_lowercase, [
@@ -87,6 +97,32 @@ final class AuthHandler implements MethodReturnTypeProviderInterface, MethodPara
     }
 
     /**
+     * Narrows Auth::guard($name) to the concrete guard class when the guard name is a known
+     * string literal and its driver maps to a standard Laravel guard class.
+     * Returns null to fall back to the stub's declared type when narrowing is not possible
+     * (dynamic guard name, unknown guard, or custom driver).
+     */
+    private static function resolveGuardReturnType(MethodReturnTypeProviderEvent $event): ?Type\Union
+    {
+        $default_guard = AuthConfigAnalyzer::instance()->getDefaultGuard();
+        if ($default_guard === null) {
+            return null; // normally should not happen (e.g. empty or invalid auth.php)
+        }
+
+        $guard_name = self::getGuardNameFromFirstArgument($event->getStmt(), $default_guard);
+        if ($guard_name === null) {
+            return null; // dynamic guard name — cannot narrow statically
+        }
+
+        $fqcn = AuthConfigAnalyzer::instance()->getGuardFQCN($guard_name);
+        if ($fqcn === null) {
+            return null; // unknown guard or custom driver
+        }
+
+        return new Type\Union([new Type\Atomic\TNamedObject($fqcn)]);
+    }
+
+    /**
      * Provide explicit parameter definitions for all methods handled by {@see getMethodReturnType}.
      *
      * In Psalm 7, returning null from a MethodParamsProvider for methods that only exist as
@@ -104,6 +140,18 @@ final class AuthHandler implements MethodReturnTypeProviderInterface, MethodPara
             // Guard::user(), GuardHelpers::authenticate(), SessionGuard::getUser(),
             // SessionGuard::getLastAttempted() — all take no parameters
             'user', 'getuser', 'authenticate', 'getlastattempted' => [],
+
+            // AuthManager::guard(?string $name = null)
+            'guard' => [
+                new FunctionLikeParameter(
+                    'name',
+                    false,
+                    new Type\Union([new Type\Atomic\TString(), new Type\Atomic\TNull()]),
+                    new Type\Union([new Type\Atomic\TString(), new Type\Atomic\TNull()]),
+                    is_optional: true,
+                    default_type: Type::getNull(),
+                ),
+            ],
 
             // SessionGuard::logoutOtherDevices(#[\SensitiveParameter] string $password)
             'logoutotherdevices' => [

--- a/src/Handlers/Auth/AuthHandler.php
+++ b/src/Handlers/Auth/AuthHandler.php
@@ -36,6 +36,7 @@ use Psalm\Type;
 final class AuthHandler implements MethodReturnTypeProviderInterface, MethodParamsProviderInterface
 {
     use ExtractsGuardNameFromCallLike;
+
     /**
      * @return list<string>
      * @psalm-pure

--- a/src/Handlers/Auth/Concerns/ExtractsGuardNameFromCallLike.php
+++ b/src/Handlers/Auth/Concerns/ExtractsGuardNameFromCallLike.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Psalm\LaravelPlugin\Handlers\Auth\Concerns;
 
 use PhpParser\Node\Expr\CallLike;
+use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Scalar\String_;
 
 trait ExtractsGuardNameFromCallLike
@@ -20,6 +21,13 @@ trait ExtractsGuardNameFromCallLike
 
         if ($first_arg_type_expr instanceof String_) {
             return $first_arg_type_expr->value;
+        }
+
+        // A literal null argument is equivalent to no argument — both resolve the default guard.
+        // e.g. guard(null) behaves identically to guard() at runtime.
+        if ($first_arg_type_expr instanceof ConstFetch
+            && \strtolower($first_arg_type_expr->name->toString()) === 'null') {
+            return $default_guard;
         }
 
         return null; // guard unknown

--- a/tests/Type/tests/Auth/AuthTest.phpt
+++ b/tests/Type/tests/Auth/AuthTest.phpt
@@ -46,7 +46,7 @@ $_guardUnknown = \Illuminate\Support\Facades\Auth::guard('nonexistent-guard');
 /** @psalm-check-type-exact $_guardUnknown = \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard */
 
 $_guardNull = \Illuminate\Support\Facades\Auth::guard(null);
-// null arg is treated like a dynamic value (not String_ AST node) — falls back to stub's declared union type
-/** @psalm-check-type-exact $_guardNull = \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard */
+// null is equivalent to no argument — narrows to the default guard's concrete class
+/** @psalm-check-type-exact $_guardNull = \Illuminate\Auth\SessionGuard */
 ?>
 --EXPECT--

--- a/tests/Type/tests/Auth/AuthTest.phpt
+++ b/tests/Type/tests/Auth/AuthTest.phpt
@@ -27,5 +27,26 @@ $_logoutOtherDevices = \Illuminate\Support\Facades\Auth::logoutOtherDevices('sec
 
 $_loginUsingIdWithRemember = \Illuminate\Support\Facades\Auth::loginUsingId(1, true);
 /** @psalm-check-type-exact $_loginUsingIdWithRemember = \Illuminate\Foundation\Auth\User|false */
+
+// Auth::guard() return type narrowing
+$_guardWeb = \Illuminate\Support\Facades\Auth::guard('web');
+/** @psalm-check-type-exact $_guardWeb = \Illuminate\Auth\SessionGuard */
+
+$_guardNoArg = \Illuminate\Support\Facades\Auth::guard();
+/** @psalm-check-type-exact $_guardNoArg = \Illuminate\Auth\SessionGuard */
+
+/** @var string $guardName */
+$guardName = 'web';
+$_guardDynamic = \Illuminate\Support\Facades\Auth::guard($guardName);
+// dynamic guard name — falls back to stub's declared union type
+/** @psalm-check-type-exact $_guardDynamic = \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard */
+
+$_guardUnknown = \Illuminate\Support\Facades\Auth::guard('nonexistent-guard');
+// unknown guard name — falls back to stub's declared union type
+/** @psalm-check-type-exact $_guardUnknown = \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard */
+
+$_guardNull = \Illuminate\Support\Facades\Auth::guard(null);
+// null arg is treated like a dynamic value (not String_ AST node) — falls back to stub's declared union type
+/** @psalm-check-type-exact $_guardNull = \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard */
 ?>
 --EXPECT--

--- a/tests/Unit/Handlers/Auth/AuthHandlerTest.php
+++ b/tests/Unit/Handlers/Auth/AuthHandlerTest.php
@@ -87,6 +87,21 @@ final class AuthHandlerTest extends TestCase
         $this->assertFalse($params[0]->is_optional);
     }
 
+    public function testGetMethodParamsForGuard(): void
+    {
+        $event = new MethodParamsProviderEvent(
+            \Illuminate\Support\Facades\Auth::class,
+            'guard',
+        );
+
+        $params = AuthHandler::getMethodParams($event);
+
+        $this->assertNotNull($params, "getMethodParams() must not return null for 'guard' — Psalm 7 crashes on null for @method-annotated facade methods");
+        $this->assertCount(1, $params);
+        $this->assertSame('name', $params[0]->name);
+        $this->assertTrue($params[0]->is_optional);
+    }
+
     public function testGetMethodParamsForUnknownMethod(): void
     {
         $event = new MethodParamsProviderEvent(


### PR DESCRIPTION
## Issue to Solve

`Auth::guard('web')` returns `\Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard` even when the guard name is a known string literal. The concrete class (`SessionGuard`, `TokenGuard`) can be determined statically from `config/auth.php`.

## Related

Closes #705

## Solution Description

Added `MethodReturnTypeProviderInterface` handling for `Auth::guard()` in `AuthHandler`:

- Reads the guard name from the first argument (string literal) or falls back to the default guard (no argument)
- Looks up the driver via `auth.guards.{name}.driver` in config
- Maps standard drivers to their concrete classes: `session` → `SessionGuard`, `token` → `TokenGuard`
- Falls back to `null` (stub's declared type) for dynamic names, unknown guards, and custom drivers

Also added `MethodParamsProviderInterface` entry for `guard()` to prevent the Psalm 7 crash that occurs when `null` is returned for `@method`-annotated facade methods (#454).

Verified with type tests covering: literal guard name, no-arg (default guard), dynamic string variable, unknown guard name, and `null` argument.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and unit test in `tests/Unit/`)
- [ ] Documentation is updated (if needed, otherwise remove this item)
