### PR TITLE
Narrow `env()` return type based on default value argument

### DIFF
--- a/src/Handlers/Helpers/EnvHandler.php
+++ b/src/Handlers/Helpers/EnvHandler.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Helpers;
+
+use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
+use Psalm\Type;
+use Psalm\Type\Atomic\TNull;
+use Psalm\Type\Atomic\TString;
+
+/**
+ * Narrows the return type of env() based on the default value argument.
+ *
+ * Laravel's env() returns the env var value when set, or the default when not set.
+ * We model the "env var is set" case as string — a deliberate simplification matching
+ * Larastan's approach. The runtime can also return bool for "true"/"false"/"null" string
+ * values (via Env::getOption() magic parsing), but static analysis of that requires
+ * knowing the env var's value at analysis time, which is not possible. Using string keeps
+ * the type useful in practice without a cascade of string|bool|null everywhere.
+ *
+ * Narrowing rules:
+ * - No default:                  string|null
+ * - Default type includes null:  string|null
+ * - Default type is mixed:       string|null  (mixed implicitly includes null)
+ * - Default excludes null:       string|typeof(default)
+ *   → Default is any string subtype: collapses to string (TString covers all subtypes)
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/707
+ */
+final class EnvHandler implements FunctionReturnTypeProviderInterface
+{
+    /**
+     * @inheritDoc
+     * @psalm-pure
+     */
+    #[\Override]
+    public static function getFunctionIds(): array
+    {
+        return ['env'];
+    }
+
+    /** @inheritDoc */
+    #[\Override]
+    public static function getFunctionReturnType(FunctionReturnTypeProviderEvent $event): Type\Union
+    {
+        $call_args = $event->getCallArgs();
+
+        // No default argument — env var may not be set → null
+        if (\count($call_args) < 2) {
+            return new Type\Union([new TString(), new TNull()]);
+        }
+
+        $second_arg_type = $event->getStatementsSource()
+            ->getNodeTypeProvider()
+            ->getType($call_args[1]->value);
+
+        // Unknown type, default includes null, or default is mixed (implicitly includes null):
+        // fall back to string|null
+        if ($second_arg_type === null
+            || $second_arg_type->isNullable()
+            || $second_arg_type->hasMixed()
+        ) {
+            return new Type\Union([new TString(), new TNull()]);
+        }
+
+        // Default excludes null: return string|typeof(default).
+        // All string subtypes (TLiteralString, TNonEmptyString, etc.) extend TString and are
+        // already covered by the TString we include, so we skip them to avoid redundant
+        // string|'bar' unions — the result is just string.
+        $result_types = [new TString()];
+
+        foreach ($second_arg_type->getAtomicTypes() as $atomic) {
+            if (!$atomic instanceof TString) {
+                $result_types[] = $atomic;
+            }
+        }
+
+        return new Type\Union($result_types);
+    }
+}

--- a/src/Handlers/Helpers/EnvHandler.php
+++ b/src/Handlers/Helpers/EnvHandler.php
@@ -58,7 +58,7 @@ final class EnvHandler implements FunctionReturnTypeProviderInterface
 
         // Unknown type, default includes null, or default is mixed (implicitly includes null):
         // fall back to string|null
-        if ($second_arg_type === null
+        if (!$second_arg_type instanceof \Psalm\Type\Union
             || $second_arg_type->isNullable()
             || $second_arg_type->hasMixed()
         ) {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -305,8 +305,15 @@ final class Plugin implements PluginEntryPointInterface
 
         require_once __DIR__ . '/Handlers/Rules/ModelMakeHandler.php';
         $registration->registerHooksFromClass(Handlers\Rules\ModelMakeHandler::class);
+        // NoEnvOutsideConfigHandler must be registered BEFORE EnvHandler.
+        // Both handle 'env()' via FunctionReturnTypeProviderInterface; Psalm dispatches handlers
+        // in registration order and stops at the first non-null return. NoEnvOutsideConfigHandler
+        // always returns null (it only emits an issue), so the chain continues to EnvHandler for
+        // type narrowing. Reversing the order would silently suppress the NoEnvOutsideConfig issue.
         require_once __DIR__ . '/Handlers/Rules/NoEnvOutsideConfigHandler.php';
         $registration->registerHooksFromClass(Handlers\Rules\NoEnvOutsideConfigHandler::class);
+        require_once __DIR__ . '/Handlers/Helpers/EnvHandler.php';
+        $registration->registerHooksFromClass(Handlers\Helpers\EnvHandler::class);
 
         // Unlike TranslationKeyHandler (which always runs for type narrowing),
         // MissingViewHandler provides no type information — skip entirely when disabled

--- a/tests/Type/psalm.xml
+++ b/tests/Type/psalm.xml
@@ -21,5 +21,10 @@
     </plugins>
     <issueHandlers>
         <MissingPureAnnotation errorLevel="info" />
+        <!-- NoEnvOutsideConfig is a linting rule, not a type issue. psalm-tester runs
+             Psalm on temp files in sys_get_temp_dir(), which don't match the /tests/
+             pattern that NoEnvOutsideConfigHandler uses to auto-exclude test code, so
+             env() calls in PHPT tests would emit this issue spuriously. -->
+        <PluginIssue name="NoEnvOutsideConfig" errorLevel="info" />
     </issueHandlers>
 </psalm>

--- a/tests/Type/tests/Helpers/EnvHandlerTest.phpt
+++ b/tests/Type/tests/Helpers/EnvHandlerTest.phpt
@@ -1,0 +1,63 @@
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * env() return type narrowing based on the default value argument.
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/707
+ */
+
+function env_no_default(): void
+{
+    $_result = env('FOO');
+    /** @psalm-check-type-exact $_result = string|null */
+}
+
+function env_null_default(): void
+{
+    $_result = env('FOO', null);
+    /** @psalm-check-type-exact $_result = string|null */
+}
+
+function env_string_default(): void
+{
+    $_result = env('FOO', 'bar');
+    /** @psalm-check-type-exact $_result = string */
+}
+
+function env_false_default(): void
+{
+    $_result = env('FOO', false);
+    /** @psalm-check-type-exact $_result = string|false */
+}
+
+function env_bool_default(bool $default): void
+{
+    $_result = env('FOO', $default);
+    /** @psalm-check-type-exact $_result = string|bool */
+}
+
+function env_int_default(int $default): void
+{
+    $_result = env('FOO', $default);
+    /** @psalm-check-type-exact $_result = string|int */
+}
+
+function env_float_default(float $default): void
+{
+    $_result = env('FOO', $default);
+    /** @psalm-check-type-exact $_result = string|float */
+}
+
+function env_mixed_default(mixed $default): void
+{
+    $_result = env('FOO', $default);
+    /** @psalm-check-type-exact $_result = string|null */
+}
+
+function env_nullable_int_default(?int $default): void
+{
+    $_result = env('FOO', $default);
+    /** @psalm-check-type-exact $_result = string|null */
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

`env()` always returned `string|null` regardless of the default argument.

## Related

Fixes #707

## Solution Description

Added `EnvHandler` (`FunctionReturnTypeProviderInterface`) that narrows the return type based on the default argument:

- `env('KEY')` → `string|null` (unchanged)
- `env('KEY', null)` → `string|null` (unchanged)
- `env('KEY', 'bar')` → `string`
- `env('KEY', false)` → `string|false`
- `env('KEY', $int)` → `string|int`

Matches Larastan's approach: the "env var is set" case is modelled as `string`. The runtime can also return `bool` for `"true"`/`"false"` string values, but resolving that statically would require knowing the var's value at analysis time.

**Registration note:** `NoEnvOutsideConfigHandler` and the new `EnvHandler` both handle `env()` via `FunctionReturnTypeProviderInterface`. Psalm dispatches in registration order and stops at the first non-null return, so `NoEnvOutsideConfigHandler` (which always returns `null`) must stay registered first.

## Checklist
- [x] Tests cover the change (`tests/Type/tests/Helpers/EnvHandlerTest.phpt` with 9 cases)
