### PR TITLE
Narrow `Collection::whereNotNull()` return type to remove null from TValue

### DIFF
--- a/src/Handlers/Collections/CollectionFilterHandler.php
+++ b/src/Handlers/Collections/CollectionFilterHandler.php
@@ -6,6 +6,7 @@ namespace Psalm\LaravelPlugin\Handlers\Collections;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
+use PhpParser\Node\Expr\ConstFetch;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
 use Psalm\Type\Atomic;
@@ -19,19 +20,25 @@ use Psalm\Type\Atomic\TString;
 use Psalm\Type\Union;
 
 /**
- * Narrows Collection::filter() return type when called without a callback.
+ * Narrows Collection::filter() and Collection::whereNotNull() return types.
  *
- * Laravel's filter() with no arguments calls array_filter(), which removes all
- * falsy values. The most impactful narrowing is removing `null` and `false` from
- * TValue, covering the vast majority of real-world usage (e.g., ->map()->filter()).
+ * filter() without a callback:
+ *   Calls array_filter(), removing all falsy values. Removes `null` and `false` from
+ *   TValue and narrows `string` → `non-falsy-string`, `array` → `non-empty-array`.
+ *
+ * whereNotNull() without a key argument:
+ *   Removes only `null` from TValue (does not narrow other falsy types).
  *
  * Not covered (intentionally, 80/20):
  * - Numeric falsy types (0, 0.0) are not narrowed — Psalm has no `non-zero-int` atomic
  *   type, so the complexity of constructing `int<min, -1>|int<1, max>` isn't worth it.
  * - `Enumerable` type-hints — the handler only fires for Collection and LazyCollection
  *   concrete types, not the Enumerable interface.
+ * - whereNotNull($key) with a string key — we don't narrow TValue when filtering by a
+ *   nested field key, since the item type itself is unchanged.
  *
  * @see https://github.com/psalm/psalm-plugin-laravel/issues/441
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/706
  */
 final class CollectionFilterHandler implements MethodReturnTypeProviderInterface
 {
@@ -49,13 +56,25 @@ final class CollectionFilterHandler implements MethodReturnTypeProviderInterface
     #[\Override]
     public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Union
     {
-        if ($event->getMethodNameLowercase() !== 'filter') {
-            return null;
+        $method = $event->getMethodNameLowercase();
+
+        if ($method === 'filter') {
+            return self::handleFilter($event);
         }
 
+        if ($method === 'wherenotnull') {
+            return self::handleWhereNotNull($event);
+        }
+
+        return null;
+    }
+
+    /** @psalm-mutation-free */
+    private static function handleFilter(MethodReturnTypeProviderEvent $event): ?Union
+    {
         // Only narrow when called with no arguments (or explicit null).
         // With a callback, we can't know what it filters — let Psalm use the default.
-        if (! self::isCalledWithoutCallback($event)) {
+        if (! self::isCalledWithoutArgOrNull($event)) {
             return null;
         }
 
@@ -68,24 +87,65 @@ final class CollectionFilterHandler implements MethodReturnTypeProviderInterface
         $tValue = $templateTypeParameters[1];
 
         $narrowed = self::removeFalsyTypes($tValue);
-        if (!$narrowed instanceof \Psalm\Type\Union) {
+        if ($narrowed === null) {
             return null; // nothing to narrow, or would become empty
         }
 
-        // Return the same Collection subclass with narrowed TValue.
-        // is_static: true preserves the `&static` intersection, matching filter()'s `return static`.
+        return self::buildNarrowedReturn($event, $tKey, $narrowed);
+    }
+
+    /** @psalm-mutation-free */
+    private static function handleWhereNotNull(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        // Only narrow when called with no key (or explicit null key).
+        // With a string key, whereNotNull filters by a nested field — TValue type is unchanged.
+        if (! self::isCalledWithoutArgOrNull($event)) {
+            return null;
+        }
+
+        $templateTypeParameters = $event->getTemplateTypeParameters();
+        if ($templateTypeParameters === null || \count($templateTypeParameters) < 2) {
+            return null;
+        }
+
+        $tKey = $templateTypeParameters[0];
+        $tValue = $templateTypeParameters[1];
+
+        $narrowed = self::removeNullType($tValue);
+        if ($narrowed === null) {
+            return null; // nothing to narrow, or would become empty
+        }
+
+        return self::buildNarrowedReturn($event, $tKey, $narrowed);
+    }
+
+    /**
+     * Build the narrowed return type with the same Collection subclass and is_static.
+     * @psalm-mutation-free
+     */
+    private static function buildNarrowedReturn(
+        MethodReturnTypeProviderEvent $event,
+        Union $tKey,
+        Union $narrowedValue,
+    ): Union {
+        // is_static: true preserves the `&static` intersection, matching `return static`.
         $className = $event->getCalledFqClasslikeName() ?? $event->getFqClasslikeName();
 
         return new Union([
-            new TGenericObject($className, [$tKey, $narrowed], is_static: true),
+            new TGenericObject($className, [$tKey, $narrowedValue], is_static: true),
         ]);
     }
 
     /**
-     * Check if filter() was called with no arguments or with an explicit null literal.
+     * Check if the method was called with no arguments or with an explicit null literal.
+     *
+     * Both filter(null) and whereNotNull(null) treat an explicit null argument as
+     * equivalent to no argument — it means "no callback" and "filter by value itself",
+     * respectively.
+     *
      * @psalm-mutation-free
      */
-    private static function isCalledWithoutCallback(MethodReturnTypeProviderEvent $event): bool
+    private static function isCalledWithoutArgOrNull(MethodReturnTypeProviderEvent $event): bool
     {
         $args = $event->getCallArgs();
 
@@ -93,10 +153,10 @@ final class CollectionFilterHandler implements MethodReturnTypeProviderInterface
             return true;
         }
 
-        // filter(null) — explicit null is equivalent to no callback
+        // Explicit null literal is equivalent to no argument for both filter() and whereNotNull()
         if (\count($args) === 1) {
             $argValue = $args[0]->value;
-            if ($argValue instanceof \PhpParser\Node\Expr\ConstFetch
+            if ($argValue instanceof ConstFetch
                 && \strtolower($argValue->name->toString()) === 'null') {
                 return true;
             }
@@ -106,10 +166,41 @@ final class CollectionFilterHandler implements MethodReturnTypeProviderInterface
     }
 
     /**
+     * Remove only `null` from the union type. Used for whereNotNull() narrowing.
+     *
+     * Unlike removeFalsyTypes(), this does not remove `false` or narrow strings/arrays,
+     * since whereNotNull() only guarantees items are !== null.
+     *
+     * Returns null if nothing changed or narrowing would leave the union empty.
+     * @psalm-mutation-free
+     */
+    private static function removeNullType(Union $type): ?Union
+    {
+        $atomics = $type->getAtomicTypes();
+        $filtered = [];
+        $changed = false;
+
+        foreach ($atomics as $atomic) {
+            if ($atomic instanceof TNull) {
+                $changed = true;
+                continue;
+            }
+
+            $filtered[] = $atomic;
+        }
+
+        if (! $changed || $filtered === []) {
+            return null;
+        }
+
+        return new Union($filtered);
+    }
+
+    /**
      * Remove falsy types and narrow remaining types to their non-empty variants.
      *
      * - Removes `null` and `false` entirely
-     * - Narrows `string` → `non-empty-string`, `array` → `non-empty-array`
+     * - Narrows `string` → `non-falsy-string`, `array` → `non-empty-array`
      *
      * Returns null if nothing changed or narrowing would leave the union empty.
      * @psalm-mutation-free

--- a/src/Handlers/Collections/CollectionFilterHandler.php
+++ b/src/Handlers/Collections/CollectionFilterHandler.php
@@ -87,7 +87,7 @@ final class CollectionFilterHandler implements MethodReturnTypeProviderInterface
         $tValue = $templateTypeParameters[1];
 
         $narrowed = self::removeFalsyTypes($tValue);
-        if (!$narrowed instanceof \Psalm\Type\Union) {
+        if (! $narrowed instanceof Union) {
             return null; // nothing to narrow, or would become empty
         }
 
@@ -112,7 +112,7 @@ final class CollectionFilterHandler implements MethodReturnTypeProviderInterface
         $tValue = $templateTypeParameters[1];
 
         $narrowed = self::removeNullType($tValue);
-        if (!$narrowed instanceof \Psalm\Type\Union) {
+        if (! $narrowed instanceof Union) {
             return null; // nothing to narrow, or would become empty
         }
 

--- a/src/Handlers/Collections/CollectionFilterHandler.php
+++ b/src/Handlers/Collections/CollectionFilterHandler.php
@@ -87,7 +87,7 @@ final class CollectionFilterHandler implements MethodReturnTypeProviderInterface
         $tValue = $templateTypeParameters[1];
 
         $narrowed = self::removeFalsyTypes($tValue);
-        if ($narrowed === null) {
+        if (!$narrowed instanceof \Psalm\Type\Union) {
             return null; // nothing to narrow, or would become empty
         }
 
@@ -112,7 +112,7 @@ final class CollectionFilterHandler implements MethodReturnTypeProviderInterface
         $tValue = $templateTypeParameters[1];
 
         $narrowed = self::removeNullType($tValue);
-        if ($narrowed === null) {
+        if (!$narrowed instanceof \Psalm\Type\Union) {
             return null; // nothing to narrow, or would become empty
         }
 

--- a/tests/Type/tests/CollectionWhereNotNullTest.phpt
+++ b/tests/Type/tests/CollectionWhereNotNullTest.phpt
@@ -1,0 +1,129 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
+
+/**
+ * whereNotNull() without a key removes null from TValue.
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/706
+ */
+final class CollectionWhereNotNullTest
+{
+    /** @param Collection<int, string|null> $collection */
+    public function whereNotNullRemovesNull(Collection $collection): void
+    {
+        $_filtered = $collection->whereNotNull();
+        /** @psalm-check-type-exact $_filtered = Collection<int, string>&static */
+    }
+
+    /** @param Collection<int, int|null> $collection */
+    public function whereNotNullRemovesNullFromInt(Collection $collection): void
+    {
+        $_filtered = $collection->whereNotNull();
+        /** @psalm-check-type-exact $_filtered = Collection<int, int>&static */
+    }
+
+    /**
+     * whereNotNull() does NOT remove false — it only guards against null.
+     * @param Collection<int, string|false> $collection
+     */
+    public function whereNotNullDoesNotRemoveFalse(Collection $collection): void
+    {
+        $_filtered = $collection->whereNotNull();
+        /** @psalm-check-type-exact $_filtered = Collection<int, false|string>&static */
+    }
+
+    /**
+     * whereNotNull() removes null but does NOT narrow string to non-falsy-string.
+     * This distinguishes whereNotNull() from filter(), which would narrow string → non-falsy-string.
+     * @param Collection<int, string|int|null> $collection
+     */
+    public function whereNotNullOnlyRemovesNull(Collection $collection): void
+    {
+        $_filtered = $collection->whereNotNull();
+        /** @psalm-check-type-exact $_filtered = Collection<int, int|string>&static */
+    }
+
+    /**
+     * whereNotNull(null) is equivalent to whereNotNull() — explicit null key means filter by item value.
+     * @param Collection<int, string|null> $collection
+     */
+    public function whereNotNullWithExplicitNullKey(Collection $collection): void
+    {
+        $_filtered = $collection->whereNotNull(null);
+        /** @psalm-check-type-exact $_filtered = Collection<int, string>&static */
+    }
+
+    /**
+     * whereNotNull('key') filters by a nested field — TValue is unchanged (can't narrow).
+     * @param Collection<int, array{name: string|null}> $collection
+     */
+    public function whereNotNullWithStringKeyDoesNotNarrow(Collection $collection): void
+    {
+        $_filtered = $collection->whereNotNull('name');
+        /** @psalm-check-type-exact $_filtered = Collection<int, array{name: null|string}>&static */
+    }
+
+    /** @param LazyCollection<int, string|null> $collection */
+    public function lazyCollectionWhereNotNullRemovesNull(LazyCollection $collection): void
+    {
+        $_filtered = $collection->whereNotNull();
+        /** @psalm-check-type-exact $_filtered = LazyCollection<int, string>&static */
+    }
+
+    /**
+     * When TValue has no null, handler defers to Psalm's default.
+     * @param Collection<int, string> $collection
+     */
+    public function whereNotNullWithNothingToNarrow(Collection $collection): void
+    {
+        $_filtered = $collection->whereNotNull();
+        /** @psalm-check-type-exact $_filtered = Collection<int, string>&static */
+    }
+
+    /**
+     * Eloquent Collection extends Support Collection, so the handler fires for it too.
+     * @param \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model> $collection
+     */
+    public function eloquentCollectionWhereNotNullPassesThrough(
+        \Illuminate\Database\Eloquent\Collection $collection,
+    ): void {
+        $_filtered = $collection->whereNotNull();
+        /** @psalm-check-type-exact $_filtered = \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model>&static */
+    }
+
+    /**
+     * The primary use case from the issue: map() produces nullable, then whereNotNull() cleans it.
+     * @param Collection<int, string> $collection
+     */
+    public function mapThenWhereNotNull(Collection $collection): void
+    {
+        $_filtered = $collection
+            ->map(fn (string $item): ?string => strlen($item) > 3 ? $item : null)
+            ->whereNotNull();
+        /** @psalm-check-type-exact $_filtered = Collection<int, string>&static */
+    }
+
+    /**
+     * non-empty-string is preserved (not widened) — whereNotNull only strips null.
+     * @param Collection<int, non-empty-string|null> $collection
+     */
+    public function whereNotNullPreservesNonEmptyString(Collection $collection): void
+    {
+        $_filtered = $collection->whereNotNull();
+        /** @psalm-check-type-exact $_filtered = Collection<int, non-empty-string>&static */
+    }
+
+    /**
+     * The original issue's use case.
+     * @param Collection<int, string|null> $items
+     */
+    public function originalIssueUseCase(Collection $items): void
+    {
+        $_filtered = $items->whereNotNull();
+        /** @psalm-check-type-exact $_filtered = Collection<int, string>&static */
+    }
+}
+?>
+--EXPECT--


### PR DESCRIPTION
## Issue to Solve

`Collection::whereNotNull()` without a key argument should remove `null` from the collection's value type, mirroring the existing `filter()` narrowing.

```php
/** @var Collection<int, string|null> $items */
$filtered = $items->whereNotNull();
// before: Collection<int, string|null>&static
// after:  Collection<int, string>&static
```

## Related

Closes #706

## Solution Description

Extended `CollectionFilterHandler` to also intercept `whereNotNull()` calls:

- When called with no key (or explicit `null` key): removes `null` from TValue
- When called with a string key (`whereNotNull('field')`): no narrowing — the item type is unchanged, only some items are removed
- Unlike `filter()`, does **not** remove `false` or narrow `string` → `non-falsy-string`; `whereNotNull` uses strict `!==` against `null` only

`LazyCollection` is covered via the existing `getClassLikeNames()` registration.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/tests/CollectionWhereNotNullTest.phpt`)
