### PR TITLE
Fix `BelongsToMany`/`MorphToMany` stubs to declare 4 template params, restoring pivot types in return values

### DIFF
--- a/stubs/common/Database/Eloquent/Relations/BelongsToMany.stubphp
+++ b/stubs/common/Database/Eloquent/Relations/BelongsToMany.stubphp
@@ -5,7 +5,9 @@ namespace Illuminate\Database\Eloquent\Relations;
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
  * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
- * @template-extends Relation<TRelatedModel, TDeclaringModel, \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>>
+ * @template TPivotModel of \Illuminate\Database\Eloquent\Relations\Pivot = \Illuminate\Database\Eloquent\Relations\Pivot
+ * @template TAccessor of string = 'pivot'
+ * @template-extends Relation<TRelatedModel, TDeclaringModel, \Illuminate\Database\Eloquent\Collection<int, TRelatedModel&object{pivot: TPivotModel}>>
  * @mixin \Illuminate\Database\Eloquent\Builder<TRelatedModel>
  */
 class BelongsToMany extends Relation
@@ -13,18 +15,33 @@ class BelongsToMany extends Relation
     use Concerns\InteractsWithPivotTable;
 
     /**
+     * Specify the custom pivot model to use for the relationship.
+     *
+     * The @psalm-this-out annotation is intended to narrow TPivotModel on the
+     * returned instance. Full generic-param narrowing via @psalm-this-out is
+     * a known Psalm 7 limitation; the annotation is included for forward
+     * compatibility as Psalm's support matures.
+     *
+     * @template TNewPivotModel of \Illuminate\Database\Eloquent\Relations\Pivot
+     * @param  class-string<TNewPivotModel>  $class
+     * @psalm-this-out static<TRelatedModel, TDeclaringModel, TNewPivotModel, TAccessor>
+     * @return $this
+     */
+    public function using($class) {}
+
+    /**
      * @template T
      * @psalm-param T $id
      * @param  int|non-empty-string|array<int|non-empty-string>|\Illuminate\Contracts\Support\Arrayable<int|non-empty-string>  $id
      * @param  list<non-empty-string>  $columns
-     * @psalm-return (T is (array|\Illuminate\Contracts\Support\Arrayable) ? \Illuminate\Support\Collection<int, TRelatedModel> : TRelatedModel)
+     * @psalm-return (T is (array|\Illuminate\Contracts\Support\Arrayable) ? \Illuminate\Database\Eloquent\Collection<int, TRelatedModel&object{pivot: TPivotModel}> : TRelatedModel&object{pivot: TPivotModel})
      */
     public function findOrNew($id, $columns = ['*']) {}
 
     /**
      * @param  array<string, mixed>  $attributes
      * @param  array<string, mixed>  $values
-     * @return TRelatedModel
+     * @return TRelatedModel&object{pivot: TPivotModel}
      */
     public function firstOrNew(array $attributes = [], array $values = []) {}
 
@@ -33,7 +50,7 @@ class BelongsToMany extends Relation
      * @param  (\Closure(): array<string, mixed>)|array<string, mixed>  $values
      * @param  array<string, mixed>  $joining
      * @param  bool   $touch
-     * @return TRelatedModel
+     * @return TRelatedModel&object{pivot: TPivotModel}
      */
     public function firstOrCreate(array $attributes = [], \Closure|array $values = [], array $joining = [], $touch = true) {}
 
@@ -42,7 +59,7 @@ class BelongsToMany extends Relation
      * @param  array<string, mixed>  $values
      * @param  array<string, mixed>  $joining
      * @param  bool   $touch
-     * @return TRelatedModel
+     * @return TRelatedModel&object{pivot: TPivotModel}
      */
     public function updateOrCreate(array $attributes, array $values = [], array $joining = [], $touch = true) {}
 
@@ -51,14 +68,14 @@ class BelongsToMany extends Relation
      * @psalm-param T $id
      * @param  mixed  $id
      * @param  list<non-empty-string>  $columns
-     * @psalm-return (T is (array|\Illuminate\Contracts\Support\Arrayable) ? \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>|null : TRelatedModel|null)
+     * @psalm-return (T is (array|\Illuminate\Contracts\Support\Arrayable) ? \Illuminate\Database\Eloquent\Collection<int, TRelatedModel&object{pivot: TPivotModel}>|null : (TRelatedModel&object{pivot: TPivotModel})|null)
      */
     public function find($id, $columns = ['*']) {}
 
     /**
      * @param  \Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<array-key, int|string>  $ids
      * @param  list<non-empty-string>  $columns
-     * @return \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>
+     * @return \Illuminate\Database\Eloquent\Collection<int, TRelatedModel&object{pivot: TPivotModel}>
      */
     public function findMany($ids, $columns = ['*']) {}
 
@@ -66,7 +83,7 @@ class BelongsToMany extends Relation
      * @template T
      * @psalm-param T $id
      * @param  list<non-empty-string>  $columns
-     * @psalm-return (T is (array|\Illuminate\Contracts\Support\Arrayable) ? \Illuminate\Database\Eloquent\Collection<int, TRelatedModel> : TRelatedModel)
+     * @psalm-return (T is (array|\Illuminate\Contracts\Support\Arrayable) ? \Illuminate\Database\Eloquent\Collection<int, TRelatedModel&object{pivot: TPivotModel}> : TRelatedModel&object{pivot: TPivotModel})
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
@@ -74,7 +91,7 @@ class BelongsToMany extends Relation
 
     /**
      * @param  list<non-empty-string>  $columns
-     * @return TRelatedModel|null
+     * @return (TRelatedModel&object{pivot: TPivotModel})|null
      */
     public function first($columns = ['*']) {}
 
@@ -82,7 +99,7 @@ class BelongsToMany extends Relation
      * Execute the query and get the first result or throw an exception.
      *
      * @param  list<non-empty-string>  $columns
-     * @return TRelatedModel
+     * @return TRelatedModel&object{pivot: TPivotModel}
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
@@ -92,14 +109,14 @@ class BelongsToMany extends Relation
      * @param  array<string, mixed>  $attributes
      * @param  array<string, mixed>  $joining
      * @param  bool   $touch
-     * @return TRelatedModel
+     * @return TRelatedModel&object{pivot: TPivotModel}
      */
     public function create(array $attributes = [], array $joining = [], $touch = true) {}
 
     /**
      * @param  iterable<array<string, mixed>>  $records
      * @param  array<array-key, array<string, mixed>>  $joinings
-     * @return list<TRelatedModel>
+     * @return list<TRelatedModel&object{pivot: TPivotModel}>
      */
     public function createMany(iterable $records, array $joinings = []) {}
 
@@ -114,7 +131,7 @@ class BelongsToMany extends Relation
     public function withPivot($columns) {}
 
     /**
-     * @return \Traversable<int, TRelatedModel>
+     * @return \Traversable<int, TRelatedModel&object{pivot: TPivotModel}>
      */
     public function getResults() {}
 
@@ -123,7 +140,7 @@ class BelongsToMany extends Relation
      * @param  array<int, mixed>  $columns
      * @param  string  $pageName
      * @param  int|null  $page
-     * @return \Illuminate\Pagination\LengthAwarePaginator<int, TRelatedModel>
+     * @return \Illuminate\Pagination\LengthAwarePaginator<int, TRelatedModel&object{pivot: TPivotModel}>
      */
     public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null) {}
 
@@ -134,7 +151,7 @@ class BelongsToMany extends Relation
      * @param  array<int, mixed>  $columns
      * @param  string  $pageName
      * @param  int|null  $page
-     * @return \Illuminate\Pagination\Paginator<int, TRelatedModel>
+     * @return \Illuminate\Pagination\Paginator<int, TRelatedModel&object{pivot: TPivotModel}>
      */
     public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null) {}
 
@@ -145,7 +162,7 @@ class BelongsToMany extends Relation
      * @param  array<int, mixed>  $columns
      * @param  string  $cursorName
      * @param  string|null  $cursor
-     * @return \Illuminate\Pagination\CursorPaginator<int, TRelatedModel>
+     * @return \Illuminate\Pagination\CursorPaginator<int, TRelatedModel&object{pivot: TPivotModel}>
      */
     public function cursorPaginate($perPage = null, $columns = ['*'], $cursorName = 'cursor', $cursor = null) {}
 
@@ -154,7 +171,7 @@ class BelongsToMany extends Relation
      *
      * @param  \Closure|array  $columns
      * @param  (\Closure(): TValue)|null  $callback
-     * @return TRelatedModel|TValue
+     * @return (TRelatedModel&object{pivot: TPivotModel})|TValue
      */
     public function firstOr($columns = ['*'], \Closure $callback = null) {}
 
@@ -163,7 +180,7 @@ class BelongsToMany extends Relation
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
-     * @return TRelatedModel|null
+     * @return (TRelatedModel&object{pivot: TPivotModel})|null
      */
     public function firstWhere($column, $operator = null, $value = null, $boolean = 'and') {}
 
@@ -174,7 +191,7 @@ class BelongsToMany extends Relation
      * @param  T  $id
      * @param  list<non-empty-string>|\Closure  $columns
      * @param  (\Closure(): TValue)|null  $callback
-     * @psalm-return (T is (array|\Illuminate\Contracts\Support\Arrayable) ? \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>|TValue : TRelatedModel|TValue)
+     * @psalm-return (T is (array|\Illuminate\Contracts\Support\Arrayable) ? \Illuminate\Database\Eloquent\Collection<int, TRelatedModel&object{pivot: TPivotModel}>|TValue : (TRelatedModel&object{pivot: TPivotModel})|TValue)
      */
     public function findOr($id, $columns = ['*'], \Closure $callback = null) {}
 
@@ -185,7 +202,7 @@ class BelongsToMany extends Relation
      * @param  (\Closure(): array<string, mixed>)|array<string, mixed>  $values
      * @param  array<string, mixed>  $joining
      * @param  bool  $touch
-     * @return TRelatedModel
+     * @return TRelatedModel&object{pivot: TPivotModel}
      */
     public function createOrFirst(array $attributes = [], \Closure|array $values = [], array $joining = [], $touch = true) {}
 
@@ -195,7 +212,7 @@ class BelongsToMany extends Relation
      * @param  TRelatedModel  $model
      * @param  array<string, mixed>  $pivotAttributes
      * @param  bool  $touch
-     * @return TRelatedModel
+     * @return TRelatedModel&object{pivot: TPivotModel}
      */
     public function save(\Illuminate\Database\Eloquent\Model $model, array $pivotAttributes = [], $touch = true) {}
 
@@ -205,14 +222,14 @@ class BelongsToMany extends Relation
      * @param  TRelatedModel  $model
      * @param  array<string, mixed>  $pivotAttributes
      * @param  bool  $touch
-     * @return TRelatedModel
+     * @return TRelatedModel&object{pivot: TPivotModel}
      */
     public function saveQuietly(\Illuminate\Database\Eloquent\Model $model, array $pivotAttributes = [], $touch = true) {}
 
     /**
      * Get a lazy collection for the given query.
      *
-     * @return \Illuminate\Support\LazyCollection<int, TRelatedModel>
+     * @return \Illuminate\Support\LazyCollection<int, TRelatedModel&object{pivot: TPivotModel}>
      */
     public function cursor() {}
 
@@ -220,7 +237,7 @@ class BelongsToMany extends Relation
      * Query lazily, by chunks of the given size.
      *
      * @param  int  $chunkSize
-     * @return \Illuminate\Support\LazyCollection<int, TRelatedModel>
+     * @return \Illuminate\Support\LazyCollection<int, TRelatedModel&object{pivot: TPivotModel}>
      */
     public function lazy($chunkSize = 1000) {}
 
@@ -230,7 +247,7 @@ class BelongsToMany extends Relation
      * @param  int  $chunkSize
      * @param  string|null  $column
      * @param  string|null  $alias
-     * @return \Illuminate\Support\LazyCollection<int, TRelatedModel>
+     * @return \Illuminate\Support\LazyCollection<int, TRelatedModel&object{pivot: TPivotModel}>
      */
     public function lazyById($chunkSize = 1000, $column = null, $alias = null) {}
 
@@ -240,7 +257,7 @@ class BelongsToMany extends Relation
      * @param  int  $chunkSize
      * @param  string|null  $column
      * @param  string|null  $alias
-     * @return \Illuminate\Support\LazyCollection<int, TRelatedModel>
+     * @return \Illuminate\Support\LazyCollection<int, TRelatedModel&object{pivot: TPivotModel}>
      */
     public function lazyByIdDesc($chunkSize = 1000, $column = null, $alias = null) {}
 }

--- a/stubs/common/Database/Eloquent/Relations/MorphToMany.stubphp
+++ b/stubs/common/Database/Eloquent/Relations/MorphToMany.stubphp
@@ -5,7 +5,9 @@ namespace Illuminate\Database\Eloquent\Relations;
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
  * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
- * @template-extends BelongsToMany<TRelatedModel, TDeclaringModel>
+ * @template TPivotModel of \Illuminate\Database\Eloquent\Relations\Pivot = \Illuminate\Database\Eloquent\Relations\MorphPivot
+ * @template TAccessor of string = 'pivot'
+ * @template-extends BelongsToMany<TRelatedModel, TDeclaringModel, TPivotModel, TAccessor>
  * @mixin \Illuminate\Database\Eloquent\Builder<TRelatedModel>
  */
 class MorphToMany extends BelongsToMany

--- a/tests/Application/app/Models/Mechanic.php
+++ b/tests/Application/app/Models/Mechanic.php
@@ -46,6 +46,16 @@ final class Mechanic extends Model
     }
 
     /**
+     * Specializations with a custom pivot model — used to test 4-template BelongsToMany.
+     *
+     * @psalm-return BelongsToMany<MechanicSpecialization, $this, SpecializationPivot, 'pivot'>
+     */
+    public function specializationsWithPivot(): BelongsToMany
+    {
+        return $this->belongsToMany(MechanicSpecialization::class)->using(SpecializationPivot::class);
+    }
+
+    /**
      * Admin bookmarks for this mechanic (inverse of Admin::mechanics()).
      *
      * @psalm-return MorphToMany<Admin>

--- a/tests/Application/app/Models/SpecializationPivot.php
+++ b/tests/Application/app/Models/SpecializationPivot.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+/**
+ * Custom pivot model for the Mechanic <-> MechanicSpecialization relationship.
+ *
+ * Used in type tests to verify that BelongsToMany's TPivotModel template
+ * param is properly propagated through find/first/create methods.
+ *
+ * @property int $mechanic_id
+ * @property int $mechanic_specialization_id
+ * @property string|null $certified_at
+ */
+final class SpecializationPivot extends Pivot
+{
+    protected $table = 'mechanic_mechanic_specialization';
+}

--- a/tests/Type/tests/Collection/CustomCollectionTest.phpt
+++ b/tests/Type/tests/Collection/CustomCollectionTest.phpt
@@ -11,6 +11,8 @@ use App\Models\Vehicle;
 use App\Models\WorkOrder;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\MorphPivot;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 
 /**
  * Models with custom collections should return the custom collection type
@@ -145,7 +147,7 @@ function test_relation_get_custom_collection(\Illuminate\Database\Eloquent\Relat
 
 // --- BelongsToMany::get() on a model with custom collection ---
 
-/** @param \Illuminate\Database\Eloquent\Relations\BelongsToMany<Part, \App\Models\Shop> $relation */
+/** @param \Illuminate\Database\Eloquent\Relations\BelongsToMany<Part, \App\Models\Shop, Pivot, 'pivot'> $relation */
 function test_belongsToMany_get_custom_collection(\Illuminate\Database\Eloquent\Relations\BelongsToMany $relation): PartCollection
 {
     /** @psalm-check-type-exact $result = PartCollection<int, Part> */
@@ -155,7 +157,7 @@ function test_belongsToMany_get_custom_collection(\Illuminate\Database\Eloquent\
 
 // --- BelongsToMany::findMany() on a model with custom collection ---
 
-/** @param \Illuminate\Database\Eloquent\Relations\BelongsToMany<Part, \App\Models\Shop> $relation */
+/** @param \Illuminate\Database\Eloquent\Relations\BelongsToMany<Part, \App\Models\Shop, Pivot, 'pivot'> $relation */
 function test_belongsToMany_findMany_custom_collection(\Illuminate\Database\Eloquent\Relations\BelongsToMany $relation): PartCollection
 {
     /** @psalm-check-type-exact $result = PartCollection<int, Part> */
@@ -165,7 +167,7 @@ function test_belongsToMany_findMany_custom_collection(\Illuminate\Database\Eloq
 
 // --- MorphToMany::get() on a model with custom collection ---
 
-/** @param \Illuminate\Database\Eloquent\Relations\MorphToMany<WorkOrder, \App\Models\Shop> $relation */
+/** @param \Illuminate\Database\Eloquent\Relations\MorphToMany<WorkOrder, \App\Models\Shop, MorphPivot, 'pivot'> $relation */
 function test_morphToMany_get_custom_collection(\Illuminate\Database\Eloquent\Relations\MorphToMany $relation): WorkOrderCollection
 {
     /** @psalm-check-type-exact $result = WorkOrderCollection<int, WorkOrder> */

--- a/tests/Type/tests/Helpers/StubReturnTypeTest.phpt
+++ b/tests/Type/tests/Helpers/StubReturnTypeTest.phpt
@@ -5,6 +5,7 @@ use App\Models\Customer;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 
 /**
@@ -67,8 +68,8 @@ function test_query_builder_distinct(QueryBuilder $builder): QueryBuilder
 }
 
 /**
- * @param BelongsToMany<Customer, Customer> $relation
- * @return BelongsToMany<Customer, Customer>
+ * @param BelongsToMany<Customer, Customer, Pivot, 'pivot'> $relation
+ * @return BelongsToMany<Customer, Customer, Pivot, 'pivot'>
  */
 function test_belongs_to_many_with_pivot(BelongsToMany $relation): BelongsToMany
 {

--- a/tests/Type/tests/Relation/BelongsToManyPivotTest.phpt
+++ b/tests/Type/tests/Relation/BelongsToManyPivotTest.phpt
@@ -1,0 +1,90 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Mechanic;
+use App\Models\MechanicSpecialization;
+use App\Models\SpecializationPivot;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+/**
+ * Regression tests for https://github.com/psalm/psalm-plugin-laravel/issues/709
+ *
+ * BelongsToMany now declares 4 template params (TRelatedModel, TDeclaringModel,
+ * TPivotModel, TAccessor) matching Laravel's native annotations. Previously the
+ * stub declared only 2 params, causing TooManyTemplateParams for the native
+ * 4-param usage and stripping pivot types from method return types.
+ */
+
+// --- No TooManyTemplateParams for 4-param generics ---
+
+/**
+ * 4-param annotation must be accepted without TooManyTemplateParams.
+ *
+ * @param BelongsToMany<MechanicSpecialization, Mechanic, SpecializationPivot, 'pivot'> $relation
+ * @return BelongsToMany<MechanicSpecialization, Mechanic, SpecializationPivot, 'pivot'>
+ */
+function test_four_template_params_accepted(BelongsToMany $relation): BelongsToMany
+{
+    return $relation;
+}
+
+// --- Return types carry the pivot intersection ---
+
+/**
+ * first() return type must include the pivot intersection.
+ *
+ * @param BelongsToMany<MechanicSpecialization, Mechanic, SpecializationPivot, 'pivot'> $relation
+ */
+function test_first_infers_pivot_intersection(BelongsToMany $relation): void
+{
+    $_ = $relation->first();
+    /** @psalm-check-type-exact $_ = MechanicSpecialization&object{pivot: SpecializationPivot}|null */
+}
+
+/**
+ * firstOrFail() return type must include the pivot intersection (non-null).
+ *
+ * @param BelongsToMany<MechanicSpecialization, Mechanic, SpecializationPivot, 'pivot'> $relation
+ */
+function test_firstOrFail_infers_pivot_intersection(BelongsToMany $relation): void
+{
+    $_ = $relation->firstOrFail();
+    /** @psalm-check-type-exact $_ = MechanicSpecialization&object{pivot: SpecializationPivot} */
+}
+
+/**
+ * create() return type must include the pivot intersection.
+ *
+ * @param BelongsToMany<MechanicSpecialization, Mechanic, SpecializationPivot, 'pivot'> $relation
+ */
+function test_create_infers_pivot_intersection(BelongsToMany $relation): void
+{
+    $_ = $relation->create(['name' => 'Brakes']);
+    /** @psalm-check-type-exact $_ = MechanicSpecialization&object{pivot: SpecializationPivot} */
+}
+
+// --- using() is callable and accepts a class-string<TPivotModel> ---
+
+/**
+ * using() must accept a class-string of a Pivot subclass.
+ * The @psalm-this-out annotation is present for future Psalm narrowing support;
+ * in Psalm 7, TPivotModel narrowing via @psalm-this-out is not yet fully
+ * propagated through generic params.
+ *
+ * @param BelongsToMany<MechanicSpecialization, Mechanic, Pivot, 'pivot'> $relation
+ */
+function test_using_accepts_pivot_class(BelongsToMany $relation): BelongsToMany
+{
+    return $relation->using(SpecializationPivot::class);
+}
+
+/**
+ * Model method with 4-param annotation is callable and assignable to BelongsToMany.
+ */
+function test_model_method_with_4_params_returns_correctly(): BelongsToMany
+{
+    return (new Mechanic())->specializationsWithPivot();
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Relation/ForwardingHandlerTest.phpt
+++ b/tests/Type/tests/Relation/ForwardingHandlerTest.phpt
@@ -10,6 +10,7 @@ use App\Models\WorkOrder;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 
 /**
  * Tests for MethodForwardingHandler: verifies that method calls on Eloquent Relations
@@ -58,17 +59,17 @@ function test_mixin_only_preserves_relation_type(): void {
 
 // Different Relation subclass: BelongsToMany (verifies template params work beyond HasOne)
 function test_belongsToMany_where_preserves_relation_type(): void {
-    /** @var BelongsToMany<Part, WorkOrder> $r */
+    /** @var BelongsToMany<Part, WorkOrder, Pivot, 'pivot'> $r */
     $r = (new WorkOrder())->parts();
     $_ = $r->where('active', true);
-    /** @psalm-check-type-exact $_ = BelongsToMany<Part, WorkOrder> */
+    /** @psalm-check-type-exact $_ = BelongsToMany<Part, WorkOrder, Pivot, 'pivot'> */
 }
 
 function test_belongsToMany_orderBy_preserves_relation_type(): void {
-    /** @var BelongsToMany<Part, WorkOrder> $r */
+    /** @var BelongsToMany<Part, WorkOrder, Pivot, 'pivot'> $r */
     $r = (new WorkOrder())->parts();
     $_ = $r->orderBy('name');
-    /** @psalm-check-type-exact $_ = BelongsToMany<Part, WorkOrder> */
+    /** @psalm-check-type-exact $_ = BelongsToMany<Part, WorkOrder, Pivot, 'pivot'> */
 }
 
 // Non-fluent: first() resolved via Relation stub (workaround for Psalm mixin template bug)


### PR DESCRIPTION
## Issue to Solve

`BelongsToMany` stub declared only 2 template params (`TRelatedModel`, `TDeclaringModel`), while Laravel's source declares 4. This caused two regressions:

1. `TooManyTemplateParams` error when annotating with all 4 params (`BelongsToMany<Role, User, RoleUser, 'pivot'>`)
2. Pivot type stripped from method return values — `first()`, `create()`, `firstOrCreate()`, etc. returned bare `TRelatedModel` instead of `TRelatedModel&object{pivot: TPivotModel}`, causing `UndefinedMagicPropertyFetch` on `->pivot`

## Related

Fixes #709

## Solution Description

**`BelongsToMany.stubphp`**: Added the missing `TPivotModel` and `TAccessor` templates with defaults matching Laravel's source:
```php
@template TPivotModel of Pivot = Pivot
@template TAccessor of string = 'pivot'
```

Updated `@template-extends` and all find/first/create/save/lazy/paginate return types to carry `TRelatedModel&object{pivot: TPivotModel}`.

Added `using()` with `@psalm-this-out` for forward compatibility when Psalm adds full generic-param narrowing support.

**`MorphToMany.stubphp`**: Same 4-template treatment; `TPivotModel` defaults to `MorphPivot` (matching Laravel).

**Tests**: New `BelongsToManyPivotTest.phpt` verifies 4-param annotations are accepted and return types carry the pivot intersection. Updated existing tests to use explicit 4-param annotations where `@psalm-check-type-exact` requires the full expanded type.

**Breaking change**: Annotations using `BelongsToMany<T, U>` (2 params) will now get `MissingTemplateParam` at strict error levels. Users should migrate to `BelongsToMany<T, U, Pivot, 'pivot'>`.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/tests/Relation/BelongsToManyPivotTest.phpt`)
