### PR TITLE
Add conditional return type stub for `Str::replace()`

### DIFF
--- a/stubs/common/Support/Str.stubphp
+++ b/stubs/common/Support/Str.stubphp
@@ -14,4 +14,22 @@ class Str
      * @psalm-flow ($string) -> return
      */
     public static function of($string) {}
+
+    /**
+     * Replace all occurrences of the search string with the replacement string.
+     *
+     * When $subject is a plain string, the return type narrows to string.
+     * When $subject is a Traversable<TKey, string>, the return type narrows to array<TKey, string>.
+     * Adapted from Larastan's stub; uses array-key (not scalar) for TKey to correctly model PHP array key types.
+     *
+     * @template TKey of array-key
+     * @template TSubject of string|iterable<string>|\Traversable<TKey, string>
+     *
+     * @param  string|iterable<string>  $search
+     * @param  string|iterable<string>  $replace
+     * @param  TSubject  $subject
+     * @param  bool  $caseSensitive
+     * @return ($subject is \Traversable ? array<TKey, string> : TSubject)
+     */
+    public static function replace($search, $replace, $subject, $caseSensitive = true) {}
 }

--- a/tests/Type/tests/Support/StrReplaceTest.phpt
+++ b/tests/Type/tests/Support/StrReplaceTest.phpt
@@ -1,0 +1,47 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Str;
+
+/**
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/717
+ */
+
+/** When $subject is a string, Str::replace() must return string, not string|string[]. */
+function test_str_replace_with_string_subject(string $subject): void
+{
+    $_result = Str::replace('foo', 'bar', $subject);
+    /** @psalm-check-type-exact $_result = string */
+}
+
+/** When $subject is a string with array search/replace, must still return string. */
+function test_str_replace_with_array_search_and_string_subject(string $subject): void
+{
+    $_result = Str::replace(['foo', 'baz'], ['bar', 'qux'], $subject);
+    /** @psalm-check-type-exact $_result = string */
+}
+
+/**
+ * When $subject is array<int, string>, must return array<int, string> (key-preserving).
+ * Exercises the non-Traversable array branch of the conditional return type.
+ *
+ * @param array<int, string> $subjects
+ */
+function test_str_replace_with_array_subject(array $subjects): void
+{
+    $_result = Str::replace('foo', 'bar', $subjects);
+    /** @psalm-check-type-exact $_result = array<int, string> */
+}
+
+/**
+ * When $subject is a Traversable<int, string>, must return array<int, string>.
+ *
+ * @param \Traversable<int, string> $subjects
+ */
+function test_str_replace_with_traversable_subject(\Traversable $subjects): void
+{
+    $_result = Str::replace('foo', 'bar', $subjects);
+    /** @psalm-check-type-exact $_result = array<int, string> */
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

`Str::replace()` always returned `string|string[]` regardless of whether `$subject` was a plain string, losing type information in the common single-string case.

## Related

Closes #717

## Solution Description

Added a conditional return type stub in `stubs/common/Support/Str.stubphp`:

- `string` subject → narrows to `string`
- `array<TKey, string>` subject → returns `array<TKey, string>` (key-preserving)
- `Traversable<TKey, string>` subject → returns `array<TKey, string>`

Uses `array-key` (not `scalar`) for `TKey`, correctly bounding PHP array key types and matching Psalm's own `str_replace` stub pattern. This improves on Larastan's equivalent stub which uses the broader `scalar` bound.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/tests/Support/StrReplaceTest.phpt`)
