### PR TITLE
Add @property-read stubs for higher-order collection proxies

### DIFF
--- a/stubs/common/Database/Eloquent/Collection.stubphp
+++ b/stubs/common/Database/Eloquent/Collection.stubphp
@@ -13,6 +13,9 @@ use Illuminate\Support\Collection as BaseCollection;
  * Psalm does not inherit @property-read from a parent class when template parameters
  * are remapped via @extends, so these annotations must be repeated here with TModel.
  *
+ * The list mirrors EnumeratesValues::$proxies exactly — do not edit without checking that array.
+ * Note: $hasMany here is a collection method (not an Eloquent relationship).
+ *
  * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $average
  * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $avg
  * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $contains

--- a/stubs/common/Database/Eloquent/Collection.stubphp
+++ b/stubs/common/Database/Eloquent/Collection.stubphp
@@ -9,6 +9,42 @@ use Illuminate\Support\Collection as BaseCollection;
  * @template TKey of array-key
  * @template TModel of \Illuminate\Database\Eloquent\Model
  * @extends \Illuminate\Support\Collection<TKey, TModel>
+ *
+ * Psalm does not inherit @property-read from a parent class when template parameters
+ * are remapped via @extends, so these annotations must be repeated here with TModel.
+ *
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $average
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $avg
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $contains
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $doesntContain
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $each
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $every
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $filter
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $first
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $flatMap
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $groupBy
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $hasMany
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $hasSole
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $keyBy
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $last
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $map
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $max
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $min
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $partition
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $percentage
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $reject
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $skipUntil
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $skipWhile
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $some
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $sortBy
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $sortByDesc
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $sum
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $takeUntil
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $takeWhile
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $unique
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $unless
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $until
+ * @property-read \Illuminate\Support\HigherOrderCollectionProxy<TKey, TModel> $when
  */
 class Collection extends BaseCollection implements QueueableCollection
 {

--- a/stubs/common/Support/Collection.stubphp
+++ b/stubs/common/Support/Collection.stubphp
@@ -16,6 +16,9 @@ use Illuminate\Support\Traits\EnumeratesValues;
  * These annotations are declared directly here so that TKey/TValue resolve to the class-level
  * template parameters and higher-order proxy method calls are properly typed.
  *
+ * The list mirrors EnumeratesValues::$proxies exactly — do not edit without checking that array.
+ * Note: $hasMany here is a collection method (not an Eloquent relationship).
+ *
  * @property-read HigherOrderCollectionProxy<TKey, TValue> $average
  * @property-read HigherOrderCollectionProxy<TKey, TValue> $avg
  * @property-read HigherOrderCollectionProxy<TKey, TValue> $contains

--- a/stubs/common/Support/Collection.stubphp
+++ b/stubs/common/Support/Collection.stubphp
@@ -11,6 +11,43 @@ use Illuminate\Support\Traits\EnumeratesValues;
  * @template TValue
  * @implements \ArrayAccess<TKey, TValue>
  * @implements \Illuminate\Support\Enumerable<TKey, TValue>
+ *
+ * Psalm does not resolve @property-read from trait template parameters when using @use bindings.
+ * These annotations are declared directly here so that TKey/TValue resolve to the class-level
+ * template parameters and higher-order proxy method calls are properly typed.
+ *
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $average
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $avg
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $contains
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $doesntContain
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $each
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $every
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $filter
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $first
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $flatMap
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $groupBy
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $hasMany
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $hasSole
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $keyBy
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $last
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $map
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $max
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $min
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $partition
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $percentage
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $reject
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $skipUntil
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $skipWhile
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $some
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $sortBy
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $sortByDesc
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $sum
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $takeUntil
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $takeWhile
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $unique
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $unless
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $until
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $when
  */
 class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerable
 {

--- a/stubs/common/Support/LazyCollection.stubphp
+++ b/stubs/common/Support/LazyCollection.stubphp
@@ -1,0 +1,56 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
+use Illuminate\Support\Traits\EnumeratesValues;
+
+/**
+ * @template TKey of array-key
+ * @template-covariant TValue
+ * @implements \Illuminate\Support\Enumerable<TKey, TValue>
+ *
+ * Psalm does not resolve @property-read from trait template parameters when using @use bindings.
+ * These annotations are declared directly here so that TKey/TValue resolve to the class-level
+ * template parameters and higher-order proxy method calls are properly typed.
+ *
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $average
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $avg
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $contains
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $doesntContain
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $each
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $every
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $filter
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $first
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $flatMap
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $groupBy
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $hasMany
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $hasSole
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $keyBy
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $last
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $map
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $max
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $min
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $partition
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $percentage
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $reject
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $skipUntil
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $skipWhile
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $some
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $sortBy
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $sortByDesc
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $sum
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $takeUntil
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $takeWhile
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $unique
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $unless
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $until
+ * @property-read HigherOrderCollectionProxy<TKey, TValue> $when
+ */
+class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
+{
+    /**
+     * @use \Illuminate\Support\Traits\EnumeratesValues<TKey, TValue>
+     */
+    use EnumeratesValues;
+}

--- a/stubs/common/Support/LazyCollection.stubphp
+++ b/stubs/common/Support/LazyCollection.stubphp
@@ -14,6 +14,9 @@ use Illuminate\Support\Traits\EnumeratesValues;
  * These annotations are declared directly here so that TKey/TValue resolve to the class-level
  * template parameters and higher-order proxy method calls are properly typed.
  *
+ * The list mirrors EnumeratesValues::$proxies exactly — do not edit without checking that array.
+ * Note: $hasMany here is a collection method (not an Eloquent relationship).
+ *
  * @property-read HigherOrderCollectionProxy<TKey, TValue> $average
  * @property-read HigherOrderCollectionProxy<TKey, TValue> $avg
  * @property-read HigherOrderCollectionProxy<TKey, TValue> $contains

--- a/tests/Type/tests/Collection/HigherOrderProxyNegativeTest.phpt
+++ b/tests/Type/tests/Collection/HigherOrderProxyNegativeTest.phpt
@@ -1,0 +1,34 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
+
+class AnyModel extends Model {}
+
+// Properties not in the $proxies list fall through to __get() which returns mixed.
+// If stubs accidentally added @property-read for all properties, these assertions would fail.
+/** @param Collection<int, stdClass> $collection */
+function testUndefinedProxyOnCollection(Collection $collection): void
+{
+    /** @psalm-check-type-exact $_nonexistent = mixed */
+    $_nonexistent = $collection->nonexistent;
+}
+
+/** @param LazyCollection<int, stdClass> $lazy */
+function testUndefinedProxyOnLazyCollection(LazyCollection $lazy): void
+{
+    /** @psalm-check-type-exact $_nonexistent = mixed */
+    $_nonexistent = $lazy->nonexistent;
+}
+
+/** @param EloquentCollection<int, AnyModel> $eloquent */
+function testUndefinedProxyOnEloquentCollection(EloquentCollection $eloquent): void
+{
+    /** @psalm-check-type-exact $_nonexistent = mixed */
+    $_nonexistent = $eloquent->nonexistent;
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Collection/HigherOrderProxyTest.phpt
+++ b/tests/Type/tests/Collection/HigherOrderProxyTest.phpt
@@ -19,26 +19,22 @@ class User extends Model
 /** @param Collection<int, User> $collection */
 function testCollectionProxyTypes(Collection $collection): void
 {
-    /** @psalm-check-type-exact $mapProxy = HigherOrderCollectionProxy<int, User> */
-    $mapProxy = $collection->map;
-    unset($mapProxy);
+    /** @psalm-check-type-exact $_mapProxy = HigherOrderCollectionProxy<int, User> */
+    $_mapProxy = $collection->map;
 
-    /** @psalm-check-type-exact $filterProxy = HigherOrderCollectionProxy<int, User> */
-    $filterProxy = $collection->filter;
-    unset($filterProxy);
+    /** @psalm-check-type-exact $_filterProxy = HigherOrderCollectionProxy<int, User> */
+    $_filterProxy = $collection->filter;
 
-    /** @psalm-check-type-exact $rejectProxy = HigherOrderCollectionProxy<int, User> */
-    $rejectProxy = $collection->reject;
-    unset($rejectProxy);
+    /** @psalm-check-type-exact $_rejectProxy = HigherOrderCollectionProxy<int, User> */
+    $_rejectProxy = $collection->reject;
 }
 
 // Collection — string keys (TKey must propagate through the stub)
 /** @param Collection<string, User> $collection */
 function testCollectionStringKeyedProxy(Collection $collection): void
 {
-    /** @psalm-check-type-exact $proxy = HigherOrderCollectionProxy<string, User> */
-    $proxy = $collection->map;
-    unset($proxy);
+    /** @psalm-check-type-exact $_proxy = HigherOrderCollectionProxy<string, User> */
+    $_proxy = $collection->map;
 }
 
 // Method calls on the proxy are typed via @mixin TValue
@@ -58,17 +54,14 @@ function testMethodCallViaProxy(Collection $collection): bool
 /** @param LazyCollection<int, User> $lazy */
 function testLazyCollectionProxyTypes(LazyCollection $lazy): void
 {
-    /** @psalm-check-type-exact $proxy = HigherOrderCollectionProxy<int, User> */
-    $proxy = $lazy->map;
-    unset($proxy);
+    /** @psalm-check-type-exact $_proxy = HigherOrderCollectionProxy<int, User> */
+    $_proxy = $lazy->map;
 
-    /** @psalm-check-type-exact $filter = HigherOrderCollectionProxy<int, User> */
-    $filter = $lazy->filter;
-    unset($filter);
+    /** @psalm-check-type-exact $_filter = HigherOrderCollectionProxy<int, User> */
+    $_filter = $lazy->filter;
 
-    /** @psalm-check-type-exact $reject = HigherOrderCollectionProxy<int, User> */
-    $reject = $lazy->reject;
-    unset($reject);
+    /** @psalm-check-type-exact $_reject = HigherOrderCollectionProxy<int, User> */
+    $_reject = $lazy->reject;
 }
 
 /** @param LazyCollection<int, User> $lazy */
@@ -82,23 +75,27 @@ function testLazyMethodCallViaProxy(LazyCollection $lazy): bool
 
 // EloquentCollection — TModel must replace TValue in the proxy generic
 /** @param EloquentCollection<int, User> $eloquent */
-function testEloquentCollectionProxyTypes(EloquentCollection $eloquent): void
+function testEloquentCollectionIntKeyedProxy(EloquentCollection $eloquent): void
 {
-    /** @psalm-check-type-exact $proxy = HigherOrderCollectionProxy<int, User> */
-    $proxy = $eloquent->map;
-    unset($proxy);
+    /** @psalm-check-type-exact $_proxy = HigherOrderCollectionProxy<int, User> */
+    $_proxy = $eloquent->map;
 
-    /** @psalm-check-type-exact $eachProxy = HigherOrderCollectionProxy<int, User> */
-    $eachProxy = $eloquent->each;
-    unset($eachProxy);
+    /** @psalm-check-type-exact $_eachProxy = HigherOrderCollectionProxy<int, User> */
+    $_eachProxy = $eloquent->each;
 
-    /** @psalm-check-type-exact $filter = HigherOrderCollectionProxy<int, User> */
-    $filter = $eloquent->filter;
-    unset($filter);
+    /** @psalm-check-type-exact $_filter = HigherOrderCollectionProxy<int, User> */
+    $_filter = $eloquent->filter;
 
-    /** @psalm-check-type-exact $reject = HigherOrderCollectionProxy<int, User> */
-    $reject = $eloquent->reject;
-    unset($reject);
+    /** @psalm-check-type-exact $_reject = HigherOrderCollectionProxy<int, User> */
+    $_reject = $eloquent->reject;
+}
+
+// EloquentCollection — string keys (TKey propagation through @extends remapping)
+/** @param EloquentCollection<string, User> $eloquent */
+function testEloquentCollectionStringKeyedProxy(EloquentCollection $eloquent): void
+{
+    /** @psalm-check-type-exact $_proxy = HigherOrderCollectionProxy<string, User> */
+    $_proxy = $eloquent->map;
 }
 
 /** @param EloquentCollection<int, User> $eloquent */

--- a/tests/Type/tests/Collection/HigherOrderProxyTest.phpt
+++ b/tests/Type/tests/Collection/HigherOrderProxyTest.phpt
@@ -1,0 +1,113 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Illuminate\Support\HigherOrderCollectionProxy;
+use Illuminate\Support\LazyCollection;
+
+class User extends Model
+{
+    public function sendWelcomeEmail(): bool
+    {
+        return true;
+    }
+}
+
+// Collection — integer keys
+/** @param Collection<int, User> $collection */
+function testCollectionProxyTypes(Collection $collection): void
+{
+    /** @psalm-check-type-exact $mapProxy = HigherOrderCollectionProxy<int, User> */
+    $mapProxy = $collection->map;
+    unset($mapProxy);
+
+    /** @psalm-check-type-exact $filterProxy = HigherOrderCollectionProxy<int, User> */
+    $filterProxy = $collection->filter;
+    unset($filterProxy);
+
+    /** @psalm-check-type-exact $rejectProxy = HigherOrderCollectionProxy<int, User> */
+    $rejectProxy = $collection->reject;
+    unset($rejectProxy);
+}
+
+// Collection — string keys (TKey must propagate through the stub)
+/** @param Collection<string, User> $collection */
+function testCollectionStringKeyedProxy(Collection $collection): void
+{
+    /** @psalm-check-type-exact $proxy = HigherOrderCollectionProxy<string, User> */
+    $proxy = $collection->map;
+    unset($proxy);
+}
+
+// Method calls on the proxy are typed via @mixin TValue
+/** @param Collection<int, User> $collection */
+function testMethodCallViaProxy(Collection $collection): bool
+{
+    /**
+     * Method calls on the proxy are typed via @mixin TValue.
+     * @psalm-check-type-exact $result = bool
+     */
+    $result = $collection->each->sendWelcomeEmail();
+
+    return $result;
+}
+
+// LazyCollection
+/** @param LazyCollection<int, User> $lazy */
+function testLazyCollectionProxyTypes(LazyCollection $lazy): void
+{
+    /** @psalm-check-type-exact $proxy = HigherOrderCollectionProxy<int, User> */
+    $proxy = $lazy->map;
+    unset($proxy);
+
+    /** @psalm-check-type-exact $filter = HigherOrderCollectionProxy<int, User> */
+    $filter = $lazy->filter;
+    unset($filter);
+
+    /** @psalm-check-type-exact $reject = HigherOrderCollectionProxy<int, User> */
+    $reject = $lazy->reject;
+    unset($reject);
+}
+
+/** @param LazyCollection<int, User> $lazy */
+function testLazyMethodCallViaProxy(LazyCollection $lazy): bool
+{
+    /** @psalm-check-type-exact $result = bool */
+    $result = $lazy->each->sendWelcomeEmail();
+
+    return $result;
+}
+
+// EloquentCollection — TModel must replace TValue in the proxy generic
+/** @param EloquentCollection<int, User> $eloquent */
+function testEloquentCollectionProxyTypes(EloquentCollection $eloquent): void
+{
+    /** @psalm-check-type-exact $proxy = HigherOrderCollectionProxy<int, User> */
+    $proxy = $eloquent->map;
+    unset($proxy);
+
+    /** @psalm-check-type-exact $eachProxy = HigherOrderCollectionProxy<int, User> */
+    $eachProxy = $eloquent->each;
+    unset($eachProxy);
+
+    /** @psalm-check-type-exact $filter = HigherOrderCollectionProxy<int, User> */
+    $filter = $eloquent->filter;
+    unset($filter);
+
+    /** @psalm-check-type-exact $reject = HigherOrderCollectionProxy<int, User> */
+    $reject = $eloquent->reject;
+    unset($reject);
+}
+
+/** @param EloquentCollection<int, User> $eloquent */
+function testEloquentMethodCallViaProxy(EloquentCollection $eloquent): bool
+{
+    /** @psalm-check-type-exact $result = bool */
+    $result = $eloquent->each->sendWelcomeEmail();
+
+    return $result;
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

Accessing higher-order collection proxies like `$collection->map` or `$collection->each` produced `HigherOrderCollectionProxy` with unbound template parameters (`TKey as array-key, TValue as mixed`) instead of the collection's concrete types.

This caused method calls on the proxy — e.g. `$users->each->sendEmail()` — to be typed as `mixed` rather than the correct return type.

## Related

Closes #718

## Solution Description

Psalm does not propagate `@property-read` from trait docblocks when template parameters are bound via `@use`, nor does it inherit them from a parent class when parameters are remapped via `@extends`. To work around this, the 32 proxy properties defined in `EnumeratesValues::$proxies` are declared directly on `Collection`, `LazyCollection`, and `EloquentCollection`.

With the fix:
- `$collection->map` correctly returns `HigherOrderCollectionProxy<TKey, TValue>` with concrete types
- Method calls on the proxy (via `HigherOrderCollectionProxy`'s `@mixin TValue`) are properly typed: `$users->each->sendEmail()` → `bool`
- Property access on the proxy (`$users->map->name`) still fails — Psalm does not follow `@mixin TValue` for properties, which is a Psalm limitation unrelated to this change

## Checklist
- [x] Tests cover the change (type test in `tests/Type/tests/Collection/HigherOrderProxyTest.phpt`)
