### PR TITLE
Validate `dispatch()` arguments against job/event constructor signature

### DIFF
--- a/src/Handlers/Jobs/DispatchableHandler.php
+++ b/src/Handlers/Jobs/DispatchableHandler.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Jobs;
+
+use Illuminate\Foundation\Bus\Dispatchable as BusDispatchable;
+use Illuminate\Foundation\Events\Dispatchable as EventsDispatchable;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use Psalm\Codebase;
+use Psalm\CodeLocation;
+use Psalm\Internal\Analyzer\Statements\Expression\CallAnalyzer;
+use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\Internal\MethodIdentifier;
+use Psalm\Internal\Type\TemplateResult;
+use Psalm\Issue\TooManyArguments;
+use Psalm\IssueBuffer;
+use Psalm\Plugin\EventHandler\AfterExpressionAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterExpressionAnalysisEvent;
+
+/**
+ * Validates arguments passed to Dispatchable dispatch/broadcast methods against the job or event's
+ * __construct() signature.
+ *
+ * Both Bus\Dispatchable (jobs) and Events\Dispatchable (events) forward their variadic arguments
+ * directly to new static(...$arguments). Because dispatch() is declared as dispatch(mixed ...$arguments),
+ * Psalm cannot detect argument mismatches without this handler re-checking the forwarded arguments
+ * against the actual constructor.
+ *
+ * Covered methods:
+ * - Bus\Dispatchable:   dispatch(), dispatchIf(), dispatchUnless(), dispatchSync(), dispatchAfterResponse()
+ * - Events\Dispatchable: dispatch(), dispatchIf(), dispatchUnless(), broadcast()
+ *
+ * For dispatchIf/dispatchUnless the first argument is the $boolean condition —
+ * the remaining arguments are forwarded to the constructor.
+ */
+final class DispatchableHandler implements AfterExpressionAnalysisInterface
+{
+    /**
+     * Maps lowercase method names to whether the first argument is a condition (and should be skipped).
+     * Covers both Bus\Dispatchable and Events\Dispatchable methods.
+     *
+     * @var array<lowercase-string, bool>
+     */
+    private const DISPATCH_METHODS = [
+        'dispatch'              => false,  // all args → constructor
+        'dispatchsync'          => false,  // Bus\Dispatchable only
+        'dispatchafterresponse' => false,  // Bus\Dispatchable only
+        'dispatchif'            => true,   // skip first $boolean arg
+        'dispatchunless'        => true,   // skip first $boolean arg
+        'broadcast'             => false,  // Events\Dispatchable only, all args → constructor
+    ];
+
+    /**
+     * Cache: "{fqcn}#{methodName}" → bool (is this method from a Dispatchable trait?).
+     * The declaring_method_ids are set during scanning and are stable for the worker's lifetime.
+     *
+     * @var array<string, bool>
+     */
+    private static array $dispatchableCache = [];
+
+    /** @inheritDoc */
+    #[\Override]
+    public static function afterExpressionAnalysis(AfterExpressionAnalysisEvent $event): ?bool
+    {
+        $expr = $event->getExpr();
+
+        if (!$expr instanceof StaticCall) {
+            return null;
+        }
+
+        // Only handle named method calls (not dynamic ::$method())
+        if (!$expr->name instanceof Identifier) {
+            return null;
+        }
+
+        $methodName = \strtolower($expr->name->name);
+
+        if (!isset(self::DISPATCH_METHODS[$methodName])) {
+            return null;
+        }
+
+        // Only handle named class references (not dynamic $class::dispatch())
+        if (!$expr->class instanceof Name) {
+            return null;
+        }
+
+        $className = $expr->class->getAttribute('resolvedName');
+        if (!\is_string($className)) {
+            return null;
+        }
+
+        $codebase = $event->getCodebase();
+
+        if (!$codebase->classExists($className)) {
+            return null;
+        }
+
+        // Only handle calls where the method comes from one of the Dispatchable traits.
+        // If the class overrides dispatch() with its own signature, skip —
+        // Psalm already validates that call correctly.
+        if (!self::isDispatchableMethod($className, $methodName, $codebase)) {
+            return null;
+        }
+
+        $source = $event->getStatementsSource();
+        if (!$source instanceof StatementsAnalyzer) {
+            return null;
+        }
+
+        $isConditionFirst = self::DISPATCH_METHODS[$methodName];
+
+        // For dispatchIf/dispatchUnless the first arg is the $boolean condition.
+        // Strip it before comparing against the constructor signature.
+        // array_values(array_slice()) re-indexes and produces list<Arg> for both branches.
+        $constructorArgs = \array_values(\array_slice($expr->getArgs(), $isConditionFirst ? 1 : 0));
+
+        $constructorId = new MethodIdentifier($className, '__construct');
+
+        if (!$codebase->methods->methodExists($constructorId)) {
+            // No __construct: zero arguments expected.
+            if ($constructorArgs !== []) {
+                IssueBuffer::maybeAdd(
+                    new TooManyArguments(
+                        'Class ' . $className . ' has no constructor, but arguments were passed to '
+                            . self::shortClassName($className) . '::' . $expr->name->name . '()',
+                        new CodeLocation($source, $expr),
+                        $className . '::__construct',
+                    ),
+                    $source->getSuppressedIssues(),
+                );
+            }
+
+            return null;
+        }
+
+        // Delegate full argument validation (count + types) to Psalm's standard
+        // argument checker. This emits TooFewArguments, TooManyArguments,
+        // InvalidArgument, etc. — exactly the same errors as new ClassName(...).
+        CallAnalyzer::checkMethodArgs(
+            $constructorId,
+            $constructorArgs,
+            new TemplateResult([], []),
+            $event->getContext(),
+            new CodeLocation($source, $expr),
+            $source,
+        );
+
+        return null;
+    }
+
+    /**
+     * Returns true when the given method on $className is declared in one of the Dispatchable traits
+     * (either Bus\Dispatchable or Events\Dispatchable).
+     * If the class overrides the method itself, this returns false and we skip validation
+     * (Psalm already handles the actual declared signature).
+     *
+     * @psalm-external-mutation-free
+     */
+    private static function isDispatchableMethod(string $className, string $methodName, Codebase $codebase): bool
+    {
+        $cacheKey = $className . '#' . $methodName;
+        if (isset(self::$dispatchableCache[$cacheKey])) {
+            return self::$dispatchableCache[$cacheKey];
+        }
+
+        try {
+            $classStorage = $codebase->classlike_storage_provider->get(\strtolower($className));
+        } catch (\InvalidArgumentException) {
+            return self::$dispatchableCache[$cacheKey] = false;
+        }
+
+        $declaringId = $classStorage->declaring_method_ids[$methodName] ?? null;
+
+        if ($declaringId === null) {
+            return self::$dispatchableCache[$cacheKey] = false;
+        }
+
+        $result = $declaringId->fq_class_name === BusDispatchable::class
+            || $declaringId->fq_class_name === EventsDispatchable::class;
+
+        return self::$dispatchableCache[$cacheKey] = $result;
+    }
+
+    /** @psalm-pure */
+    private static function shortClassName(string $fqcn): string
+    {
+        $pos = \strrpos($fqcn, '\\');
+
+        return $pos !== false ? \substr($fqcn, $pos + 1) : $fqcn;
+    }
+}

--- a/src/Handlers/Jobs/DispatchableHandler.php
+++ b/src/Handlers/Jobs/DispatchableHandler.php
@@ -162,7 +162,7 @@ final class DispatchableHandler implements AfterExpressionAnalysisInterface
     private static function isDispatchableMethod(string $className, string $methodName, Codebase $codebase): bool
     {
         $cacheKey = $className . '#' . $methodName;
-        if (isset(self::$dispatchableCache[$cacheKey])) {
+        if (\array_key_exists($cacheKey, self::$dispatchableCache)) {
             return self::$dispatchableCache[$cacheKey];
         }
 

--- a/src/Handlers/Magic/MethodForwardingHandler.php
+++ b/src/Handlers/Magic/MethodForwardingHandler.php
@@ -509,7 +509,7 @@ final class MethodForwardingHandler implements
         // snapshot taken on the first call could be incomplete for subsequent method checks.
         // The per-(model, method) $dynamicWhereCache still prevents redundant lookups.
         // "$first_name" → "firstname", "$title" → "title"
-        foreach ($storage->pseudo_property_get_types as $propName => $_) {
+        foreach (array_keys($storage->pseudo_property_get_types) as $propName) {
             $normalized = \strtolower(\str_replace(['$', '_'], '', $propName));
 
             if ($normalized === $columnSuffix) {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -307,6 +307,9 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/SuppressHandler.php';
         $registration->registerHooksFromClass(Handlers\SuppressHandler::class);
 
+        require_once __DIR__ . '/Handlers/Jobs/DispatchableHandler.php';
+        $registration->registerHooksFromClass(Handlers\Jobs\DispatchableHandler::class);
+
         require_once __DIR__ . '/Handlers/Rules/ModelMakeHandler.php';
         $registration->registerHooksFromClass(Handlers\Rules\ModelMakeHandler::class);
         // NoEnvOutsideConfigHandler must be registered BEFORE EnvHandler.

--- a/tests/Type/tests/DispatchableTest.phpt
+++ b/tests/Type/tests/DispatchableTest.phpt
@@ -1,0 +1,161 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Jobs;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Bus\Dispatchable as BusDispatchable;
+use Illuminate\Foundation\Events\Dispatchable as EventsDispatchable;
+
+class User extends Model {}
+
+/** Bus job: two required constructor params */
+class SendEmail
+{
+    use BusDispatchable;
+
+    public function __construct(private User $user, private string $subject) {}
+    public function handle(): void {}
+}
+
+/** Bus job: no constructor args */
+class NoArgJob
+{
+    use BusDispatchable;
+    public function handle(): void {}
+}
+
+/** Bus job: optional arg with default */
+class OptionalArgJob
+{
+    use BusDispatchable;
+    public function __construct(private string $locale = 'en') {}
+    public function handle(): void {}
+}
+
+/** Bus job that overrides dispatch() — our handler must NOT interfere */
+class CustomDispatchJob
+{
+    use BusDispatchable;
+
+    public function __construct(private User $user) {}
+
+    /** @return \Illuminate\Foundation\Bus\PendingDispatch */
+    public static function dispatch(User $user): \Illuminate\Foundation\Bus\PendingDispatch
+    {
+        return static::newPendingDispatch(new self($user));
+    }
+
+    public function handle(): void {}
+}
+
+/** Event using Events\Dispatchable — also validated */
+class OrderShipped
+{
+    use EventsDispatchable;
+
+    public function __construct(public readonly User $user, public readonly int $orderId) {}
+}
+
+function test_dispatch_validation(User $user): void
+{
+    // OK — correct args; dispatch() returns PendingDispatch
+    $_pending = SendEmail::dispatch($user, 'Hello');
+    /** @psalm-check-type-exact $_pending = \Illuminate\Foundation\Bus\PendingDispatch */
+
+    // Error — missing $subject
+    SendEmail::dispatch($user);
+
+    // Error — too many args
+    SendEmail::dispatch($user, 'Hello', 'extra');
+
+    // Error — wrong type for $user param (string instead of User)
+    SendEmail::dispatch('not-a-user', 'Hello');
+
+    // No-arg job: OK
+    NoArgJob::dispatch();
+
+    // No-arg job: Error — too many args
+    NoArgJob::dispatch('extra');
+
+    // Optional arg job: both valid
+    OptionalArgJob::dispatch();
+    OptionalArgJob::dispatch('fr');
+
+    // Custom dispatch() override — handler skips, no errors from us
+    CustomDispatchJob::dispatch($user);
+}
+
+function test_dispatchif_validation(User $user): void
+{
+    // OK — condition + correct constructor args
+    SendEmail::dispatchIf(true, $user, 'Hello');
+
+    // Error — missing $subject (condition arg excluded)
+    SendEmail::dispatchIf(true, $user);
+
+    // Error — too many constructor args
+    SendEmail::dispatchIf(true, $user, 'Hello', 'extra');
+}
+
+function test_dispatchunless_validation(User $user): void
+{
+    // OK — condition + correct constructor args
+    SendEmail::dispatchUnless(false, $user, 'Hello');
+
+    // Error — missing $subject
+    SendEmail::dispatchUnless(false, $user);
+}
+
+function test_dispatchsync_validation(User $user): void
+{
+    // OK
+    SendEmail::dispatchSync($user, 'Hello');
+
+    // Error — missing $subject
+    SendEmail::dispatchSync($user);
+}
+
+function test_dispatchafterresponse_validation(User $user): void
+{
+    // OK
+    SendEmail::dispatchAfterResponse($user, 'Hello');
+
+    // Error — missing $subject
+    SendEmail::dispatchAfterResponse($user);
+}
+
+function test_events_dispatchable(User $user): void
+{
+    // OK — correct args
+    OrderShipped::dispatch($user, 1);
+
+    // Error — missing $orderId
+    OrderShipped::dispatch($user);
+
+    // OK — condition + correct args
+    OrderShipped::dispatchIf(true, $user, 1);
+
+    // Error — missing $orderId (condition excluded)
+    OrderShipped::dispatchIf(true, $user);
+
+    // OK — broadcast all args
+    OrderShipped::broadcast($user, 1);
+
+    // Error — missing $orderId
+    OrderShipped::broadcast($user);
+}
+?>
+--EXPECTF--
+TooFewArguments on line %d: Too few arguments for App\Jobs\SendEmail::__construct - expecting subject to be passed
+TooManyArguments on line %d: Too many arguments for App\Jobs\SendEmail::__construct - expecting 2 but saw 3
+InvalidArgument on line %d: Argument 1 of App\Jobs\SendEmail::__construct expects App\Jobs\User, but 'not-a-user' provided
+TooManyArguments on line %d: Class App\Jobs\NoArgJob has no constructor, but arguments were passed to NoArgJob::dispatch()
+TooFewArguments on line %d: Too few arguments for App\Jobs\SendEmail::__construct - expecting subject to be passed
+TooManyArguments on line %d: Too many arguments for App\Jobs\SendEmail::__construct - expecting 2 but saw 3
+TooFewArguments on line %d: Too few arguments for App\Jobs\SendEmail::__construct - expecting subject to be passed
+TooFewArguments on line %d: Too few arguments for App\Jobs\SendEmail::__construct - expecting subject to be passed
+TooFewArguments on line %d: Too few arguments for App\Jobs\SendEmail::__construct - expecting subject to be passed
+TooFewArguments on line %d: Too few arguments for App\Jobs\OrderShipped::__construct - expecting orderId to be passed
+TooFewArguments on line %d: Too few arguments for App\Jobs\OrderShipped::__construct - expecting orderId to be passed
+TooFewArguments on line %d: Too few arguments for App\Jobs\OrderShipped::__construct - expecting orderId to be passed


### PR DESCRIPTION
## Issue to Solve

`SomeJob::dispatch($user)` passes arguments through to `new static(...$arguments)`, but Psalm can't detect mismatches because `dispatch()` is typed as `dispatch(mixed ...$arguments)`.

## Related

Closes #698

## Solution Description

Added `DispatchableHandler` implementing `AfterExpressionAnalysisInterface`. When a `dispatch`-family static call is detected on a class whose method comes from `Illuminate\Foundation\Bus\Dispatchable` or `Illuminate\Foundation\Events\Dispatchable`, the handler delegates argument validation to `CallAnalyzer::checkMethodArgs()` with the job/event's constructor `MethodIdentifier`. This emits the same standard Psalm issues (`TooFewArguments`, `TooManyArguments`, `InvalidArgument`) as a direct `new ClassName()` call.

Covers: `dispatch()`, `dispatchIf()`, `dispatchUnless()`, `dispatchSync()`, `dispatchAfterResponse()` (Bus) and `dispatch()`, `dispatchIf()`, `dispatchUnless()`, `broadcast()` (Events). For `dispatchIf`/`dispatchUnless` the first `$boolean` argument is excluded before checking against the constructor.

Classes that override `dispatch()` with their own signature are skipped — Psalm already validates those calls directly.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/tests/DispatchableTest.phpt`)
- [ ] Documentation is updated (if needed, otherwise remove this item)
