### PR TITLE
fix: resolve `SoftDeletes` methods on base Builder instances

### DIFF
--- a/src/Handlers/Eloquent/BuilderScopeHandler.php
+++ b/src/Handlers/Eloquent/BuilderScopeHandler.php
@@ -38,9 +38,6 @@ use Psalm\Type\Union;
  */
 final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, MethodParamsProviderInterface
 {
-    /** Lowercase FQCN constant avoids repeated strtolower(Builder::class) calls on the hot path. */
-    private const BUILDER_CLASS_LOWER = 'illuminate\\database\\eloquent\\builder';
-
     /** @var array<string, bool> */
     private static array $scopeCache = [];
 
@@ -252,7 +249,7 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
         }
 
         foreach ($returnType->getAtomicTypes() as $type) {
-            if ($type instanceof TGenericObject && \strtolower($type->value) === self::BUILDER_CLASS_LOWER) {
+            if ($type instanceof TGenericObject && \strtolower($type->value) === \strtolower(Builder::class)) {
                 return self::$traitBuilderCache[$key] = true;
             }
         }
@@ -283,7 +280,7 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
         }
 
         foreach ($lhsType->getAtomicTypes() as $atomic) {
-            if ($atomic instanceof TGenericObject && \strtolower($atomic->value) === self::BUILDER_CLASS_LOWER) {
+            if ($atomic instanceof TGenericObject && \strtolower($atomic->value) === \strtolower(Builder::class)) {
                 return $atomic->type_params;
             }
         }

--- a/src/Handlers/Eloquent/BuilderScopeHandler.php
+++ b/src/Handlers/Eloquent/BuilderScopeHandler.php
@@ -70,20 +70,6 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
     private static array $baseBuilderTraitMethods = [];
 
     /**
-     * Check if any base-Builder trait methods have been registered yet.
-     *
-     * Used by {@see ModelRegistrationHandler} to skip scanning subsequent base-Builder
-     * models once the trait method signatures have been collected from the first model.
-     * SoftDeletes signatures are uniform across all models, so one registration suffices.
-     *
-     * @psalm-external-mutation-free
-     */
-    public static function hasBaseBuilderTraitMethods(): bool
-    {
-        return self::$baseBuilderTraitMethods !== [];
-    }
-
-    /**
      * Register trait-declared builder methods discovered on a base-Builder model.
      *
      * Called by {@see ModelRegistrationHandler} after extracting @method static annotations

--- a/src/Handlers/Eloquent/BuilderScopeHandler.php
+++ b/src/Handlers/Eloquent/BuilderScopeHandler.php
@@ -7,29 +7,97 @@ namespace Psalm\LaravelPlugin\Handlers\Eloquent;
 use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
 use Psalm\Codebase;
 use Psalm\Internal\MethodIdentifier;
 use Psalm\LaravelPlugin\Util\ModelPropertyResolver;
+use Psalm\Plugin\EventHandler\Event\MethodParamsProviderEvent;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\MethodParamsProviderInterface;
 use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\StatementsSource;
+use Psalm\Storage\FunctionLikeParameter;
 use Psalm\Type\Atomic\TGenericObject;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Union;
 
 /**
- * Handles scope method discovery on Eloquent Builder.
+ * Handles scope and trait-declared method resolution on Eloquent Builder instances.
  *
  * When a method call on Builder doesn't match a real method, checks the model for:
  * 1. Legacy scopeXxx() methods (e.g., scopeActive → active())
  * 2. Methods with #[Scope] attribute (e.g., #[Scope] active() → active())
- * 3. @method PHPDoc scopes are handled natively by Psalm
+ * 3. Trait-declared builder methods (e.g., SoftDeletes::withTrashed → withTrashed())
+ *    These are registered as Builder macros at runtime via global scopes
+ *    (e.g., SoftDeletingScope::extend), and declared via @method static returning
+ *    Builder<static> on the model trait.
+ * 4. @method PHPDoc scopes are handled natively by Psalm
  *
  * @internal
  */
-final class BuilderScopeHandler implements MethodReturnTypeProviderInterface
+final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, MethodParamsProviderInterface
 {
+    /** Lowercase FQCN constant avoids repeated strtolower(Builder::class) calls on the hot path. */
+    private const BUILDER_CLASS_LOWER = 'illuminate\\database\\eloquent\\builder';
+
     /** @var array<string, bool> */
     private static array $scopeCache = [];
+
+    /**
+     * Cache for isTraitBuilderMethod results.
+     *
+     * Separate from $scopeCache to keep concerns distinct.
+     *
+     * @var array<string, bool>
+     */
+    private static array $traitBuilderCache = [];
+
+    /**
+     * Registry of trait-declared builder methods for the base Builder class.
+     *
+     * Populated by {@see ModelRegistrationHandler} when processing base-Builder models
+     * (models that don't declare a custom builder). Keyed by lowercase method name.
+     * Since trait methods (e.g., SoftDeletes::withTrashed) have consistent signatures
+     * across all models, the first registration per method name is authoritative.
+     *
+     * Used by both the return type provider and the params provider so that Psalm can:
+     * - Infer the correct return type (Builder<TModel>) for these method calls
+     * - Validate call arguments without crashing on missing method params
+     *
+     * @var array<lowercase-string, list<FunctionLikeParameter>>
+     */
+    private static array $baseBuilderTraitMethods = [];
+
+    /**
+     * Check if any base-Builder trait methods have been registered yet.
+     *
+     * Used by {@see ModelRegistrationHandler} to skip scanning subsequent base-Builder
+     * models once the trait method signatures have been collected from the first model.
+     * SoftDeletes signatures are uniform across all models, so one registration suffices.
+     *
+     * @psalm-external-mutation-free
+     */
+    public static function hasBaseBuilderTraitMethods(): bool
+    {
+        return self::$baseBuilderTraitMethods !== [];
+    }
+
+    /**
+     * Register trait-declared builder methods discovered on a base-Builder model.
+     *
+     * Called by {@see ModelRegistrationHandler} after extracting @method static annotations
+     * that return Builder<static> from a model's pseudo_static_methods. The first registration
+     * per method name wins, since SoftDeletes' signatures are consistent across all models.
+     *
+     * @param array<lowercase-string, list<FunctionLikeParameter>> $methods
+     * @psalm-external-mutation-free
+     */
+    public static function registerBaseBuilderTraitMethods(array $methods): void
+    {
+        // array_merge would re-index; += preserves keys and keeps the first registration.
+        self::$baseBuilderTraitMethods += $methods;
+    }
 
     /**
      * @return list<string>
@@ -41,12 +109,35 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface
         return [Builder::class];
     }
 
+    /**
+     * Provide return types for scope and trait-declared builder method calls on Builder instances.
+     *
+     * Scope methods (via hasScopeMethod) need template params to identify the model — these
+     * are passed when Psalm resolves a known method, but NOT when routing through __call.
+     * Trait-declared builder methods (e.g., withTrashed) go through __call at runtime, so
+     * template params are absent; we recover them from the LHS expression type instead.
+     */
     #[\Override]
     public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Union
     {
         $methodName = $event->getMethodNameLowercase();
-        $codebase = $event->getSource()->getCodebase();
+        $source = $event->getSource();
+        $codebase = $source->getCodebase();
+
+        // Template params are provided when Psalm resolves a known Builder method via
+        // MethodCallReturnTypeFetcher (e.g., where(), get()). For magic __call routing
+        // (scope/trait methods), MissingMethodCallHandler calls the return type provider
+        // without forwarding the LHS type params. We recover them from the LHS expression.
         $templateTypeParameters = $event->getTemplateTypeParameters();
+
+        // For trait-declared builder methods (e.g., withTrashed), extract from LHS when
+        // template params are missing. Scope methods are skipped here: providing a return
+        // type for scope methods via this path would cause Psalm to call checkMethodArgs
+        // for Builder::scopeMethod, which has no method params and would crash.
+        // Scope instance calls (Customer::query()->active()) remain a known limitation.
+        if ($templateTypeParameters === null && isset(self::$baseBuilderTraitMethods[$methodName])) {
+            $templateTypeParameters = self::extractTemplateParamsFromCallStmt($event->getStmt(), $source);
+        }
 
         // Builder<TModel> — TModel is the first template param
         $modelClass = ModelPropertyResolver::extractModelFromUnion($templateTypeParameters[0] ?? null);
@@ -54,15 +145,50 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface
             return null;
         }
 
+        $builderReturn = new Union([
+            new TGenericObject(Builder::class, [
+                new Union([new TNamedObject($modelClass)]),
+            ]),
+        ]);
+
         if (self::hasScopeMethod($codebase, $modelClass, $methodName)) {
-            return new Union([
-                new TGenericObject(Builder::class, [
-                    new Union([new TNamedObject($modelClass)]),
-                ]),
-            ]);
+            return $builderReturn;
+        }
+
+        // Trait-declared builder methods (e.g., SoftDeletes::withTrashed) are registered
+        // as Builder macros at runtime via global scopes (e.g., SoftDeletingScope::extend).
+        // For base-Builder models, these @method static annotations remain in
+        // pseudo_static_methods and are handled here. Models with custom builders have
+        // these removed from pseudo_static_methods by ModelRegistrationHandler and handled
+        // by CustomBuilderMethodHandler instead.
+        // See https://github.com/psalm/psalm-plugin-laravel/issues/635
+        if (self::isTraitBuilderMethod($codebase, $modelClass, $methodName)) {
+            return $builderReturn;
         }
 
         return null;
+    }
+
+    /**
+     * Provide params for trait-declared builder method calls on Builder instances.
+     *
+     * When the return type provider returns a non-null type for a magic __call route,
+     * Psalm calls checkMethodArgs with the method identifier. Since Builder::withTrashed
+     * doesn't exist as a real method, getMethodParams would throw UnexpectedValueException
+     * unless we intercept it here with the params from the trait's @method static annotation.
+     *
+     * Only covers $baseBuilderTraitMethods (e.g., SoftDeletes methods); scope methods are
+     * not in this registry so this provider returns null for them (Psalm skips arg checking).
+     *
+     * @return list<FunctionLikeParameter>|null
+     * @psalm-external-mutation-free
+     */
+    #[\Override]
+    public static function getMethodParams(MethodParamsProviderEvent $event): ?array
+    {
+        /** @var lowercase-string $methodName */
+        $methodName = $event->getMethodNameLowercase();
+        return self::$baseBuilderTraitMethods[$methodName] ?? null;
     }
 
     /**
@@ -99,6 +225,84 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface
 
         self::$scopeCache[$key] = false;
         return false;
+    }
+
+    /**
+     * Check if the model has a trait-declared builder method for the given name.
+     *
+     * Looks for @method static annotations on the model (inherited from traits like
+     * SoftDeletes) whose return type is Builder<...>. These methods are registered as
+     * Builder macros at runtime and are valid on any Builder instance.
+     *
+     * Only applies to base-Builder models. Models with custom builders have these
+     * methods removed from pseudo_static_methods by ModelRegistrationHandler, so this
+     * check correctly returns false for them (they are handled by CustomBuilderMethodHandler).
+     *
+     * @param class-string<Model> $modelClass
+     * @param lowercase-string $methodName
+     * @psalm-external-mutation-free
+     */
+    private static function isTraitBuilderMethod(Codebase $codebase, string $modelClass, string $methodName): bool
+    {
+        $key = $modelClass . '::' . $methodName;
+        if (\array_key_exists($key, self::$traitBuilderCache)) {
+            return self::$traitBuilderCache[$key];
+        }
+
+        try {
+            $storage = $codebase->classlike_storage_provider->get(\strtolower($modelClass));
+        } catch (\InvalidArgumentException) {
+            return self::$traitBuilderCache[$key] = false;
+        }
+
+        $methodStorage = $storage->pseudo_static_methods[$methodName] ?? null;
+        if ($methodStorage === null) {
+            return self::$traitBuilderCache[$key] = false;
+        }
+
+        $returnType = $methodStorage->return_type;
+        if ($returnType === null) {
+            return self::$traitBuilderCache[$key] = false;
+        }
+
+        foreach ($returnType->getAtomicTypes() as $type) {
+            if ($type instanceof TGenericObject && \strtolower($type->value) === self::BUILDER_CLASS_LOWER) {
+                return self::$traitBuilderCache[$key] = true;
+            }
+        }
+
+        return self::$traitBuilderCache[$key] = false;
+    }
+
+    /**
+     * Extract Builder template type parameters from the LHS type of a method call.
+     *
+     * Used as a fallback when template params are not passed to the return type provider —
+     * specifically when Psalm routes unknown method calls through MissingMethodCallHandler,
+     * which invokes return type providers without forwarding the LHS object's type params.
+     *
+     * @return non-empty-list<Union>|null
+     */
+    private static function extractTemplateParamsFromCallStmt(
+        MethodCall|StaticCall $stmt,
+        StatementsSource $source,
+    ): ?array {
+        if (!$stmt instanceof MethodCall) {
+            return null;
+        }
+
+        $lhsType = $source->getNodeTypeProvider()->getType($stmt->var);
+        if ($lhsType === null) {
+            return null;
+        }
+
+        foreach ($lhsType->getAtomicTypes() as $atomic) {
+            if ($atomic instanceof TGenericObject && \strtolower($atomic->value) === self::BUILDER_CLASS_LOWER) {
+                return $atomic->type_params;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/Handlers/Eloquent/BuilderScopeHandler.php
+++ b/src/Handlers/Eloquent/BuilderScopeHandler.php
@@ -292,7 +292,7 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
         }
 
         $lhsType = $source->getNodeTypeProvider()->getType($stmt->var);
-        if ($lhsType === null) {
+        if (!$lhsType instanceof \Psalm\Type\Union) {
             return null;
         }
 

--- a/src/Handlers/Eloquent/ModelRegistrationHandler.php
+++ b/src/Handlers/Eloquent/ModelRegistrationHandler.php
@@ -117,6 +117,21 @@ final class ModelRegistrationHandler implements AfterCodebasePopulatedInterface
             );
         }
 
+        // For base-Builder models: register trait-declared builder methods (e.g., SoftDeletes::withTrashed)
+        // with BuilderScopeHandler so builder instance calls like Customer::query()->withTrashed() resolve.
+        // At runtime these are macros registered via global scopes (SoftDeletingScope::extend).
+        // BuilderScopeHandler needs both the return type and the params to avoid crashing Psalm's
+        // checkMethodArgs when it looks up Builder::withTrashed params.
+        // Short-circuit: once any model has registered the methods (first SoftDeletes model found),
+        // subsequent base-Builder models skip the scan since the signatures are uniform across models.
+        // See https://github.com/psalm/psalm-plugin-laravel/issues/635
+        if ($customBuilder === null && !BuilderScopeHandler::hasBaseBuilderTraitMethods()) {
+            $traitMethods = self::extractBuilderReturningMethods($storage);
+            if ($traitMethods !== []) {
+                BuilderScopeHandler::registerBaseBuilderTraitMethods($traitMethods);
+            }
+        }
+
         // Detect custom collection class via #[CollectedBy] attribute or newCollection() override.
         // Class is already loaded by autoloader above, so runtime reflection works.
         self::detectCustomCollection($codebase, $className);

--- a/src/Handlers/Eloquent/ModelRegistrationHandler.php
+++ b/src/Handlers/Eloquent/ModelRegistrationHandler.php
@@ -122,10 +122,11 @@ final class ModelRegistrationHandler implements AfterCodebasePopulatedInterface
         // At runtime these are macros registered via global scopes (SoftDeletingScope::extend).
         // BuilderScopeHandler needs both the return type and the params to avoid crashing Psalm's
         // checkMethodArgs when it looks up Builder::withTrashed params.
-        // Short-circuit: once any model has registered the methods (first SoftDeletes model found),
-        // subsequent base-Builder models skip the scan since the signatures are uniform across models.
+        // Scan every base-Builder model: different models may carry different builder-returning trait
+        // methods, so we must not stop early. The += merge keeps the first-seen signature for any
+        // given method name, which is correct since trait signatures are uniform across models.
         // See https://github.com/psalm/psalm-plugin-laravel/issues/635
-        if ($customBuilder === null && !BuilderScopeHandler::hasBaseBuilderTraitMethods()) {
+        if ($customBuilder === null) {
             $traitMethods = self::extractBuilderReturningMethods($storage);
             if ($traitMethods !== []) {
                 BuilderScopeHandler::registerBaseBuilderTraitMethods($traitMethods);

--- a/src/Handlers/Magic/MethodForwardingHandler.php
+++ b/src/Handlers/Magic/MethodForwardingHandler.php
@@ -509,7 +509,7 @@ final class MethodForwardingHandler implements
         // snapshot taken on the first call could be incomplete for subsequent method checks.
         // The per-(model, method) $dynamicWhereCache still prevents redundant lookups.
         // "$first_name" → "firstname", "$title" → "title"
-        foreach (array_keys($storage->pseudo_property_get_types) as $propName) {
+        foreach ($storage->pseudo_property_get_types as $propName => $_) {
             $normalized = \strtolower(\str_replace(['$', '_'], '', $propName));
 
             if ($normalized === $columnSuffix) {

--- a/src/Handlers/Magic/MethodForwardingHandler.php
+++ b/src/Handlers/Magic/MethodForwardingHandler.php
@@ -509,7 +509,7 @@ final class MethodForwardingHandler implements
         // snapshot taken on the first call could be incomplete for subsequent method checks.
         // The per-(model, method) $dynamicWhereCache still prevents redundant lookups.
         // "$first_name" → "firstname", "$title" → "title"
-        foreach ($storage->pseudo_property_get_types as $propName => $_) {
+        foreach (array_keys($storage->pseudo_property_get_types) as $propName) {
             $normalized = \strtolower(\str_replace(['$', '_'], '', $propName));
 
             if ($normalized === $columnSuffix) {

--- a/tests/Type/tests/Builder/StaticBuilderMethodsTest.phpt
+++ b/tests/Type/tests/Builder/StaticBuilderMethodsTest.phpt
@@ -2,6 +2,7 @@
 <?php declare(strict_types=1);
 
 use App\Models\Customer;
+use App\Models\Vehicle;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 
@@ -62,8 +63,13 @@ function test_static_legacy_scope(): void
 }
 
 /**
- * Modern #[Scope] attribute: the idiomatic call is through the Builder.
- * This exercises BuilderScopeHandler::hasScopeAttribute via the Builder path.
+ * Modern #[Scope] attribute: calling via the builder instance returns mixed.
+ *
+ * Known limitation: #[Scope] and legacy scopeXxx() methods on base-Builder models
+ * return mixed when called on builder instances. Psalm routes through Builder::__call,
+ * and BuilderScopeHandler cannot safely provide a return type here without also providing
+ * params (which require knowing the model class — unavailable in the params provider event).
+ * Custom-builder models don't have this limitation (CustomBuilderMethodHandler handles them).
  *
  * Calling Customer::verified() statically triggers InvalidStaticInvocation because
  * it's a real instance method — see test_scope_attribute_static_is_invalid below.
@@ -104,6 +110,62 @@ function test_soft_deletes_only_trashed_standard_builder(): void
     /** @psalm-check-type-exact $_result = Builder<Customer&static> */
 }
 
+// -----------------------------------------------------------------------
+// SoftDeletes on base Builder instances (issue #635).
+// Customer uses SoftDeletes with base Builder — trait @method static methods
+// must also resolve when called on Builder instances (e.g., Customer::query()->withTrashed()).
+// At runtime, SoftDeletingScope::extend() registers these as Builder macros.
+// See https://github.com/psalm/psalm-plugin-laravel/issues/635
+// -----------------------------------------------------------------------
+
+/** SoftDeletes withTrashed on base Builder instance returns Builder<Customer>. */
+function test_soft_deletes_with_trashed_via_query(): void
+{
+    $_result = Customer::query()->withTrashed();
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
+
+/** SoftDeletes onlyTrashed on base Builder instance returns Builder<Customer>. */
+function test_soft_deletes_only_trashed_via_query(): void
+{
+    $_result = Customer::query()->onlyTrashed();
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
+
+/** SoftDeletes withoutTrashed on base Builder instance returns Builder<Customer>. */
+function test_soft_deletes_without_trashed_via_query(): void
+{
+    $_result = Customer::query()->withoutTrashed();
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
+
+/** Chaining: withTrashed -> where -> get returns the correct collection type. */
+function test_soft_deletes_with_trashed_chain_to_get(): void
+{
+    $_result = Customer::query()->withTrashed()->where('active', true)->get();
+    /** @psalm-check-type-exact $_result = Collection<int, Customer> */
+}
+
+/** withTrashed accepts the optional bool argument without TooManyArguments. */
+function test_soft_deletes_with_trashed_bool_arg(): void
+{
+    $_result = Customer::query()->withTrashed(false);
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
+
+/**
+ * Negative test: model without SoftDeletes must NOT resolve withTrashed on its builder.
+ *
+ * isTraitBuilderMethod guards against false positives by checking the specific model's
+ * pseudo_static_methods — Vehicle has no SoftDeletes, so withTrashed remains unresolved
+ * even though Customer's registration has populated $baseBuilderTraitMethods.
+ */
+/** @return Builder<Vehicle> */
+function test_non_soft_deletes_query_with_trashed(): Builder
+{
+    return Vehicle::query()->withTrashed();
+}
+
 /** Negative test: non-existent methods must still be reported. */
 function test_nonexistent_method(): void
 {
@@ -113,4 +175,6 @@ function test_nonexistent_method(): void
 --EXPECTF--
 MixedReturnStatement on line %d: Could not infer a return type
 InvalidStaticInvocation on line %d: Method App\Models\Customer::verified is not static, but is called statically
+MixedReturnStatement on line %d: Could not infer a return type
+UndefinedMagicMethod on line %d: Magic method App\Builders\VehicleBuilder::withtrashed does not exist
 UndefinedMagicMethod on line %d: Magic method App\Models\Customer::completelyfakemethod does not exist


### PR DESCRIPTION
## Issue to Solve

`SoftDeletes` methods (`withTrashed`, `onlyTrashed`, `withoutTrashed`) returned `mixed` when called on base `Builder` instances:

```php
Customer::query()->withTrashed() // ❌ mixed — was broken
Customer::withTrashed()          // ✅ Builder<Customer&static> — already worked
```

## Related

Fixes #635

## Solution Description

Root cause: `MissingMethodCallHandler` calls return type providers without forwarding the LHS object's template params, so `BuilderScopeHandler` couldn't extract the model class from `Builder<Customer>`.

The fix has three parts:

1. **Params provider** — `BuilderScopeHandler` now also implements `MethodParamsProviderInterface`. When the return type provider returns non-null for a magic `__call` route, Psalm calls `checkMethodArgs` on `Builder::withTrashed` — which throws `UnexpectedValueException` if no params provider intercepts it. We store params from the trait's `@method static` annotation and return them here.

2. **LHS type extraction** — When template params are absent (magic method path), we recover them from the LHS expression type via `$source->getNodeTypeProvider()->getType($stmt->var)`. This only runs for registered trait methods, not scope methods (scope params require knowing the model class, which isn't available in `MethodParamsProviderEvent`).

3. **Model-specific guard** — `isTraitBuilderMethod` checks the specific model's `pseudo_static_methods` to prevent false positives (e.g., `Vehicle::query()->withTrashed()` correctly stays unresolved for non-SoftDeletes models).

Registration happens at model scan time in `ModelRegistrationHandler::registerHandlersForModel`. Every base-Builder model is scanned so that trait methods from any model are captured — the `+=` merge keeps first-seen signatures per method name (correct since trait signatures are uniform across models).

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
