### PR TITLE
fix: round-3 review issues for #724

### DIFF
--- a/src/Handlers/Collections/HigherOrderCollectionProxyHandler.php
+++ b/src/Handlers/Collections/HigherOrderCollectionProxyHandler.php
@@ -111,7 +111,7 @@ final class HigherOrderCollectionProxyHandler implements
         $source = $event->getStatementsSource();
         $calleeType = $source->getNodeTypeProvider()->getType($expr->var);
 
-        if (!$calleeType instanceof \Psalm\Type\Union) {
+        if (!$calleeType instanceof Union) {
             return;
         }
 
@@ -160,7 +160,7 @@ final class HigherOrderCollectionProxyHandler implements
                 self::extractCalledMethodName($expr),
             );
 
-            if ($returnType instanceof \Psalm\Type\Union) {
+            if ($returnType instanceof Union) {
                 $event->setReturnTypeCandidate($returnType);
             }
 

--- a/tests/Type/tests/CollectNeverNeverTest.phpt
+++ b/tests/Type/tests/CollectNeverNeverTest.phpt
@@ -113,4 +113,4 @@ function mutable_accumulator_push_then_each(): void
 }
 
 ?>
---EXPECT--
+--EXPECTF--

--- a/tests/Type/tests/Collection/HigherOrderCollectionProxyTest.phpt
+++ b/tests/Type/tests/Collection/HigherOrderCollectionProxyTest.phpt
@@ -312,14 +312,25 @@ final class HigherOrderCollectionProxyTest
     }
 
     /**
-     * sum resolves the called method return type for precision.
+     * hasMany returns bool (boolean proxy, shares the BOOLEAN_METHODS path with contains/every).
      * @param Collection<int, Customer> $users
      */
-    public function sumResolvesMethodReturnType(Collection $users): void
+    public function hasManyReturnType(Collection $users): void
     {
-        $_result = $users->sum->getKey();
-        /** @psalm-check-type-exact $_result = int|string */
+        $_result = $users->hasMany->trashed();
+        /** @psalm-check-type-exact $_result = bool */
     }
+
+    /**
+     * percentage returns float|int|null (aggregation proxy, same path as avg/average).
+     * @param Collection<int, Customer> $users
+     */
+    public function percentageReturnType(Collection $users): void
+    {
+        $_result = $users->percentage->getKey();
+        /** @psalm-check-type-exact $_result = float|int|null */
+    }
+
     /**
      * sortByDesc->method() chaining must not produce InvalidMethodCall.
      * Previously Psalm inferred int via @mixin TValue and failed on ->values() on int.
@@ -334,4 +345,4 @@ final class HigherOrderCollectionProxyTest
 }
 
 ?>
---EXPECT--
+--EXPECTF--


### PR DESCRIPTION
Fixes remaining round-3 review issues on #724.

- Use short `Union` instead of `\Psalm\Type\Union` FQCN on lines 114/163 (`Union` is already imported at line 26)
- Remove duplicate `sumResolvesMethodReturnType()` test (identical to `sumReturnType()`)
- Add `hasManyReturnType()` and `percentageReturnType()` tests for the previously untested proxy paths
- Normalize `--EXPECT--` to `--EXPECTF--` in new test files (matches `Collection/` directory convention)