### PR TITLE
Add Psalter plugin for upgrading relation PHPDoc annotations

### DIFF
--- a/docs/upgrade-v4.md
+++ b/docs/upgrade-v4.md
@@ -115,16 +115,13 @@ composer require --dev vimeo/psalm:^7.0.0-beta17
 composer require --dev psalm/plugin-laravel:^4.0
 
 # 4. Update relation generic annotations (add declaring model parameter)
-#    BelongsTo<Foo>        → BelongsTo<Foo, self>
-#    HasMany<Foo>          → HasMany<Foo, self>
-#    HasOne<Foo>           → HasOne<Foo, self>
-#    BelongsToMany<Foo>    → BelongsToMany<Foo, self>
-#    MorphOne<Foo>         → MorphOne<Foo, self>
-#    MorphMany<Foo>        → MorphMany<Foo, self>
-#    HasManyThrough<Foo>   → HasManyThrough<Foo, Intermediate, self>
-#    HasOneThrough<Foo>    → HasOneThrough<Foo, Intermediate, self>
 #
-#    Quick sed for the common cases (run from project root):
+#    Option A — Psalter plugin (handles @return and @psalm-return, AST-aware):
+vendor/bin/psalter --plugin=vendor/psalm/plugin-laravel/tools/psalter/UpgradeRelationAnnotations.php --dry-run
+vendor/bin/psalter --plugin=vendor/psalm/plugin-laravel/tools/psalter/UpgradeRelationAnnotations.php
+#    HasManyThrough / HasOneThrough are flagged with a warning — fix those manually.
+#
+#    Option B — sed (handles @psalm-return only, run from project root):
 find app -name '*.php' -exec grep -l '@psalm-return \(BelongsTo\|HasMany\|HasOne\|BelongsToMany\|MorphOne\|MorphMany\|MorphTo\|MorphToMany\)<' {} \; \
   | xargs sed -i 's/@psalm-return \(BelongsTo\|HasMany\|HasOne\|BelongsToMany\|MorphOne\|MorphMany\|MorphTo\|MorphToMany\)<\([^>]*\)>/@psalm-return \1<\2, self>/g'
 #    HasManyThrough / HasOneThrough need manual edits (add intermediate model).

--- a/tests/Unit/Tools/UpgradeRelationAnnotationsTest.php
+++ b/tests/Unit/Tools/UpgradeRelationAnnotationsTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Tools;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the UpgradeRelationAnnotations Psalter plugin.
+ *
+ * We test upgradeDocblock() directly — the public static method that
+ * contains the transformation logic — without needing a full Psalm
+ * analysis environment.
+ */
+#[CoversNothing]
+final class UpgradeRelationAnnotationsTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once dirname(__DIR__, 3) . '/tools/psalter/UpgradeRelationAnnotations.php';
+    }
+
+    // --- Auto-upgradeable relations ---
+
+    /**
+     * @param non-empty-string $input
+     * @param non-empty-string $expected
+     */
+    #[Test]
+    #[DataProvider('autoRelationProvider')]
+    public function it_adds_self_as_second_type_parameter(string $input, string $expected): void
+    {
+        $this->assertSame($expected, \UpgradeRelationAnnotations::upgradeDocblock($input));
+    }
+
+    /** @return iterable<string, array{non-empty-string, non-empty-string}> */
+    public static function autoRelationProvider(): iterable
+    {
+        $relations = [
+            'BelongsTo',
+            'BelongsToMany',
+            'HasMany',
+            'HasOne',
+            'MorphMany',
+            'MorphOne',
+            'MorphTo',
+            'MorphToMany',
+        ];
+
+        foreach ($relations as $relation) {
+            yield "@return {$relation}" => [
+                "/**\n * @return {$relation}<User>\n */",
+                "/**\n * @return {$relation}<User, self>\n */",
+            ];
+
+            yield "@psalm-return {$relation}" => [
+                "/**\n * @psalm-return {$relation}<User>\n */",
+                "/**\n * @psalm-return {$relation}<User, self>\n */",
+            ];
+        }
+    }
+
+    // --- Already-migrated annotations should be untouched ---
+
+    /**
+     * @param non-empty-string $docblock
+     */
+    #[Test]
+    #[DataProvider('unchangedProvider')]
+    public function it_leaves_already_migrated_and_manual_annotations_unchanged(string $docblock): void
+    {
+        $this->assertSame($docblock, \UpgradeRelationAnnotations::upgradeDocblock($docblock));
+    }
+
+    /** @return iterable<string, array{non-empty-string}> */
+    public static function unchangedProvider(): iterable
+    {
+        // Already has two params — skip.
+        yield 'BelongsTo already migrated' => ["/**\n * @return BelongsTo<User, self>\n */"];
+        yield 'HasMany already migrated' => ["/**\n * @return HasMany<Post, self>\n */"];
+
+        // Manual-only relations — never touch them.
+        yield 'HasManyThrough unchanged' => ["/**\n * @return HasManyThrough<Post>\n */"];
+        yield 'HasOneThrough unchanged' => ["/**\n * @return HasOneThrough<Post>\n */"];
+
+        // Non-return annotation — never touch.
+        yield '@param annotation untouched' => ["/**\n * @param BelongsTo<User> \$rel\n */"];
+        yield '@var annotation untouched' => ["/**\n * @var BelongsTo<User>\n */"];
+
+        // No annotation at all.
+        yield 'plain description' => ["/**\n * Get the user.\n */"];
+    }
+
+    // --- Edge cases ---
+
+    #[Test]
+    public function it_handles_fully_qualified_class_name(): void
+    {
+        $input = "/**\n * @return \\Illuminate\\Database\\Eloquent\\Relations\\BelongsTo<User>\n */";
+        $expected = "/**\n * @return \\Illuminate\\Database\\Eloquent\\Relations\\BelongsTo<User, self>\n */";
+
+        $this->assertSame($expected, \UpgradeRelationAnnotations::upgradeDocblock($input));
+    }
+
+    #[Test]
+    public function it_handles_nullable_return_type(): void
+    {
+        $input = "/**\n * @return ?BelongsTo<User>\n */";
+        $expected = "/**\n * @return ?BelongsTo<User, self>\n */";
+
+        $this->assertSame($expected, \UpgradeRelationAnnotations::upgradeDocblock($input));
+    }
+
+    #[Test]
+    public function it_handles_union_with_null(): void
+    {
+        $input = "/**\n * @return BelongsTo<User>|null\n */";
+        $expected = "/**\n * @return BelongsTo<User, self>|null\n */";
+
+        $this->assertSame($expected, \UpgradeRelationAnnotations::upgradeDocblock($input));
+    }
+
+    #[Test]
+    public function it_does_not_match_partial_class_names(): void
+    {
+        // 'MorphOneOrMany' starts with 'MorphOne' — should not be touched.
+        $input = "/**\n * @return MorphOneOrMany<User>\n */";
+
+        $this->assertSame($input, \UpgradeRelationAnnotations::upgradeDocblock($input));
+    }
+
+    #[Test]
+    public function it_handles_namespaced_type_argument(): void
+    {
+        // Fully-qualified model name as the type argument — common in strict codebases.
+        $input = "/**\n * @return BelongsTo<App\\Models\\User>\n */";
+        $expected = "/**\n * @return BelongsTo<App\\Models\\User, self>\n */";
+
+        $this->assertSame($expected, \UpgradeRelationAnnotations::upgradeDocblock($input));
+    }
+
+    #[Test]
+    public function it_upgrades_both_return_and_psalm_return_in_same_docblock(): void
+    {
+        // Both annotations in one docblock — common when adding a more precise psalm-return.
+        $input = "/**\n * @return BelongsTo<User>\n * @psalm-return BelongsTo<User>\n */";
+        $expected = "/**\n * @return BelongsTo<User, self>\n * @psalm-return BelongsTo<User, self>\n */";
+
+        $this->assertSame($expected, \UpgradeRelationAnnotations::upgradeDocblock($input));
+    }
+
+    #[Test]
+    public function it_upgrades_multiple_relations_on_the_same_line(): void
+    {
+        // Union of two auto-upgradeable relations on a single @return line.
+        $input = "/**\n * @return BelongsTo<User>|HasMany<Post>\n */";
+        $expected = "/**\n * @return BelongsTo<User, self>|HasMany<Post, self>\n */";
+
+        $this->assertSame($expected, \UpgradeRelationAnnotations::upgradeDocblock($input));
+    }
+
+    #[Test]
+    public function it_handles_single_line_docblock(): void
+    {
+        // Compact single-line docblock form has no newlines.
+        $input = '/** @return BelongsTo<User> */';
+        $expected = '/** @return BelongsTo<User, self> */';
+
+        $this->assertSame($expected, \UpgradeRelationAnnotations::upgradeDocblock($input));
+    }
+
+    #[Test]
+    public function it_does_not_transform_prose_containing_return_and_relation(): void
+    {
+        // A description line saying "will return BelongsTo<User> instance" must not be touched.
+        $input = "/**\n * Will return BelongsTo<User> instance.\n */";
+
+        $this->assertSame($input, \UpgradeRelationAnnotations::upgradeDocblock($input));
+    }
+
+    #[Test]
+    public function it_does_not_corrupt_nested_generic_type_arguments(): void
+    {
+        // Nested generics like HasMany<Collection<Post>> cannot be safely auto-upgraded —
+        // the regex stops at the first '>' and would produce HasMany<Collection<Post, self>>,
+        // corrupting the annotation. The plugin must leave these untouched.
+        $input = "/**\n * @return HasMany<Collection<Post>>\n */";
+
+        $this->assertSame($input, \UpgradeRelationAnnotations::upgradeDocblock($input));
+    }
+
+    #[Test]
+    public function it_upgrades_only_the_auto_relation_in_a_union_with_a_manual_relation(): void
+    {
+        // When an @return unions an auto-upgradeable relation with a manual-only one,
+        // only the auto side should gain ', self'. The manual side stays untouched.
+        $input = "/**\n * @return BelongsTo<User>|HasManyThrough<Post>\n */";
+        $expected = "/**\n * @return BelongsTo<User, self>|HasManyThrough<Post>\n */";
+
+        $this->assertSame($expected, \UpgradeRelationAnnotations::upgradeDocblock($input));
+    }
+}

--- a/tools/psalter/UpgradeRelationAnnotations.php
+++ b/tools/psalter/UpgradeRelationAnnotations.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Stmt\ClassMethod;
+use Psalm\FileManipulation;
+use Psalm\Plugin\EventHandler\AfterFunctionLikeAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterFunctionLikeAnalysisEvent;
+
+/**
+ * Psalter plugin that upgrades Eloquent relation PHPDoc annotations from
+ * psalm-plugin-laravel v3 to v4.
+ *
+ * v4 adds a TDeclaringModel template parameter to all relation return types.
+ * Run this plugin once to patch @return / @psalm-return annotations across
+ * your codebase automatically.
+ *
+ * Usage (run from your project root):
+ *
+ *   # Preview changes without writing files:
+ *   vendor/bin/psalter --plugin=vendor/psalm/plugin-laravel/tools/psalter/UpgradeRelationAnnotations.php --dry-run
+ *
+ *   # Apply changes:
+ *   vendor/bin/psalter --plugin=vendor/psalm/plugin-laravel/tools/psalter/UpgradeRelationAnnotations.php
+ *
+ * What is fixed automatically:
+ *
+ *   @return BelongsTo<User>      → @return BelongsTo<User, self>
+ *   @return HasMany<Post>        → @return HasMany<Post, self>
+ *   @return HasOne<Profile>      → @return HasOne<Profile, self>
+ *   @return BelongsToMany<Tag>   → @return BelongsToMany<Tag, self>
+ *   @return MorphOne<Image>      → @return MorphOne<Image, self>
+ *   @return MorphMany<Tag>       → @return MorphMany<Tag, self>
+ *   @return MorphTo<Model>       → @return MorphTo<Model, self>
+ *   @return MorphToMany<Tag>     → @return MorphToMany<Tag, self>
+ *
+ * What requires manual migration (a warning is emitted for these):
+ *
+ *   @return HasManyThrough<Post> → HasManyThrough<Post, TIntermediateModel, self>
+ *   @return HasOneThrough<Head>  → HasOneThrough<Head, TIntermediateModel, self>
+ *
+ * Both @return and @psalm-return annotations are handled.
+ * Fully-qualified names (e.g. \Illuminate\...\BelongsTo<User>) are also handled.
+ * Annotations that already have a comma in the type param slot are left unchanged.
+ */
+final class UpgradeRelationAnnotations implements AfterFunctionLikeAnalysisInterface
+{
+    /**
+     * Relations where TDeclaringModel becomes the second type parameter.
+     * BelongsToMany and MorphToMany also fall here: their TPivotModel and
+     * TAccessor params have defaults, so adding only `self` is sufficient.
+     *
+     * @var list<string>
+     */
+    private const AUTO_RELATIONS = [
+        'BelongsTo',
+        'BelongsToMany',
+        'HasMany',
+        'HasOne',
+        'MorphMany',
+        'MorphOne',
+        'MorphTo',
+        'MorphToMany',
+    ];
+
+    /**
+     * Relations that cannot be automatically migrated because TIntermediateModel
+     * must be inserted as the second type parameter, and we cannot infer it from
+     * the docblock alone.
+     *
+     * @var list<string>
+     */
+    private const MANUAL_RELATIONS = [
+        'HasManyThrough',
+        'HasOneThrough',
+    ];
+
+    /**
+     * Tracks locations already warned to avoid duplicate STDERR output
+     * when Psalm re-analyzes the same method in a different context pass.
+     *
+     * @var array<string, true>
+     */
+    private static array $warned = [];
+
+    public static function afterStatementAnalysis(AfterFunctionLikeAnalysisEvent $event): ?bool
+    {
+        $stmt = $event->getStmt();
+        $docComment = $stmt->getDocComment();
+
+        if ($docComment === null) {
+            return null;
+        }
+
+        $originalText = $docComment->getText();
+        $updatedText = self::upgradeDocblock($originalText);
+
+        // Only warn (and write files) when Psalter is running in alter mode.
+        // During a normal `psalm` run, alter_code is false and we skip both
+        // the warning output and the file manipulation to avoid side effects.
+        if ($event->getCodebase()->alter_code) {
+            self::warnIfManualMigrationNeeded($originalText, $stmt, $event);
+
+            if ($updatedText !== $originalText) {
+                // getEndFilePos() returns the inclusive offset of the last character ('/')
+                // in the closing '*/'. We add 1 to get an exclusive end for FileManipulation.
+                $replacements = $event->getFileReplacements();
+                $replacements[] = new FileManipulation(
+                    $docComment->getStartFilePos(),
+                    $docComment->getEndFilePos() + 1,
+                    $updatedText,
+                );
+                $event->setFileReplacements($replacements);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Apply all v3 → v4 transformations to a raw docblock string.
+     *
+     * Extracted as a public static method so it can be unit-tested
+     * without a running Psalm analysis environment.
+     */
+    public static function upgradeDocblock(string $docblock): string
+    {
+        $lines = \explode("\n", $docblock);
+
+        foreach ($lines as &$line) {
+            // Only process @return and @psalm-return annotation lines.
+            if (!\preg_match('/@(?:psalm-)?return\b/', $line)) {
+                continue;
+            }
+
+            foreach (self::AUTO_RELATIONS as $relation) {
+                // The \b word boundary prevents matching partial names like
+                // 'MorphOneOrMany'. The [^<,>]+ ensures we only match single-param
+                // annotations with no nested angle brackets (e.g. BelongsTo<User>),
+                // leaving annotations like HasMany<Collection<Post>> untouched to
+                // avoid silent corruption of the inner generic.
+                $line = (string) \preg_replace(
+                    '/\b' . $relation . '<([^<,>]+)>/',
+                    $relation . '<$1, self>',
+                    $line,
+                );
+            }
+        }
+
+        return \implode("\n", $lines);
+    }
+
+    /**
+     * Emit a one-time STDERR warning for relations that require manual migration.
+     * These have an additional TIntermediateModel parameter that we cannot infer.
+     *
+     * We check only @return / @psalm-return lines to avoid false positives from
+     * @param or @var annotations that mention these types.
+     */
+    private static function warnIfManualMigrationNeeded(
+        string $docblock,
+        FunctionLike $stmt,
+        AfterFunctionLikeAnalysisEvent $event,
+    ): void {
+        $pattern = '/\b(?:' . \implode('|', self::MANUAL_RELATIONS) . ')<([^<,>]+)>/';
+
+        $found = false;
+        foreach (\explode("\n", $docblock) as $line) {
+            if (\preg_match('/@(?:psalm-)?return\b/', $line) && \preg_match($pattern, $line)) {
+                $found = true;
+                break;
+            }
+        }
+
+        if (!$found) {
+            return;
+        }
+
+        $source = $event->getStatementsSource();
+        // Use the fully-qualified class name for readable output (e.g. App\Models\Post::posts)
+        // rather than the raw file path.
+        $fqcln = $source->getFQCLN();
+        $location = $fqcln !== null && $stmt instanceof ClassMethod
+            ? $fqcln . '::' . $stmt->name->name
+            : $source->getFilePath();
+
+        // De-duplicate: Psalm may re-analyze the same method in multiple context passes.
+        if (isset(self::$warned[$location])) {
+            return;
+        }
+        self::$warned[$location] = true;
+
+        \fwrite(
+            \STDERR,
+            'Manual migration needed: ' . $location . \PHP_EOL
+            . '  HasManyThrough / HasOneThrough require specifying the intermediate model:' . \PHP_EOL
+            . '  HasManyThrough<TRelated, TIntermediateModel, self>' . \PHP_EOL
+            . '  See: https://psalm.github.io/psalm-plugin-laravel/docs/upgrade-v4.html' . \PHP_EOL
+            . \PHP_EOL,
+        );
+    }
+}


### PR DESCRIPTION
## Issue to Solve

Step 4 of the v4 upgrade guide required users to manually run a `sed` one-liner to patch Eloquent relation PHPDoc annotations. The sed approach only handled `@psalm-return`, missed `@return`, and could not safely detect already-migrated annotations.

## Related

Closes #0

## Solution Description

Adds `tools/psalter/UpgradeRelationAnnotations.php` — a Psalter plugin that rewrites relation return annotations via Psalm's `AfterFunctionLikeAnalysisInterface` and `FileManipulation` API.

Run from the project root after upgrading the plugin:

```bash
# preview
vendor/bin/psalter --plugin=vendor/psalm/plugin-laravel/tools/psalter/UpgradeRelationAnnotations.php --dry-run

# apply
vendor/bin/psalter --plugin=vendor/psalm/plugin-laravel/tools/psalter/UpgradeRelationAnnotations.php
```

**Auto-upgraded** (all 8 relations that only need `, self` appended):
`BelongsTo`, `HasMany`, `HasOne`, `BelongsToMany`, `MorphOne`, `MorphMany`, `MorphTo`, `MorphToMany`

**Flagged with a warning** (intermediate model must be specified manually):
`HasManyThrough`, `HasOneThrough`

Design notes:
- Handles both `@return` and `@psalm-return`; handles FQCNs
- Only runs under Psalter alter mode (`Codebase::alter_code`) — no effect during normal `psalm` runs
- Warnings deduplicated via static array; emitted to STDERR with FQCLN (`App\Models\Post::relation`)
- Nested generics like `HasMany<Collection<Post>>` are intentionally left untouched to prevent silent corruption

## Checklist
- [x] Tests cover the change (34 unit tests in `tests/Unit/Tools/UpgradeRelationAnnotationsTest.php`)
- [x] Documentation is updated (`docs/upgrade-v4.md` step 4 now lists the plugin as Option A)
