### PR TITLE
Validate `Config::array()` and `Config::collection()` default argument type

### DIFF
--- a/stubs/common/Config/Repository.stubphp
+++ b/stubs/common/Config/Repository.stubphp
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Config;
+
+class Repository
+{
+    /**
+     * Get the specified array configuration value.
+     *
+     * Psalm tightens $default to reject plain scalar values (string, int, bool, etc.)
+     * because passing a non-array, non-null, non-Closure default guarantees an
+     * InvalidArgumentException at runtime when the key is absent (the method throws
+     * if the resolved value is not an array). Closures are accepted because
+     * Arr::get() invokes them via value() before the array check.
+     *
+     * @param  (\Closure():(array<array-key, mixed>|null))|array<array-key, mixed>|null  $default
+     * @return array<array-key, mixed>
+     */
+    public function array(string $key, \Closure|array|null $default = null): array {}
+
+    /**
+     * Get the specified array configuration value as a collection.
+     *
+     * Same $default restriction as array(): collection() delegates to array(),
+     * so the same runtime throw applies for non-array, non-null, non-Closure defaults.
+     *
+     * @param  (\Closure():(array<array-key, mixed>|null))|array<array-key, mixed>|null  $default
+     * @return \Illuminate\Support\Collection<array-key, mixed>
+     */
+    public function collection(string $key, \Closure|array|null $default = null): \Illuminate\Support\Collection {}
+}

--- a/tests/Type/tests/ConfigRepositoryTest.phpt
+++ b/tests/Type/tests/ConfigRepositoryTest.phpt
@@ -1,0 +1,90 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Config\Repository;
+
+// Valid: no default (null implied)
+function test_array_no_default(Repository $config): void
+{
+    $_result = $config->array('foo');
+    /** @psalm-check-type-exact $_result = array<array-key, mixed> */
+}
+
+// Valid: explicit null default
+function test_array_null_default(Repository $config): array
+{
+    return $config->array('foo', null);
+}
+
+// Valid: array default
+function test_array_array_default(Repository $config): array
+{
+    return $config->array('foo', ['bar' => 1]);
+}
+
+// Valid: Closure default returning array — Laravel calls it via Arr::get() → value()
+function test_array_closure_array_default(Repository $config): array
+{
+    return $config->array('foo', fn () => ['bar' => 1]);
+}
+
+// Valid: Closure default returning null — same resolution path
+function test_array_closure_null_default(Repository $config): array
+{
+    return $config->array('foo', fn () => null);
+}
+
+// Valid: collection, no default
+function test_collection_no_default(Repository $config): void
+{
+    $_result = $config->collection('foo');
+    /** @psalm-check-type-exact $_result = Illuminate\Support\Collection<array-key, mixed> */
+}
+
+// Valid: collection, null default
+function test_collection_null_default(Repository $config): \Illuminate\Support\Collection
+{
+    return $config->collection('foo', null);
+}
+
+// Valid: collection, array default
+function test_collection_array_default(Repository $config): \Illuminate\Support\Collection
+{
+    return $config->collection('foo', ['bar' => 1]);
+}
+
+// Valid: collection, Closure default returning array
+function test_collection_closure_default(Repository $config): \Illuminate\Support\Collection
+{
+    return $config->collection('foo', fn () => ['bar' => 1]);
+}
+
+// Invalid: string default for array() — always throws at runtime when key is absent
+function test_array_string_default_is_invalid(Repository $config): array
+{
+    return $config->array('foo', 'fallback');
+}
+
+// Invalid: int default for array() — always throws at runtime when key is absent
+function test_array_int_default_is_invalid(Repository $config): array
+{
+    return $config->array('foo', 42);
+}
+
+// Invalid: string default for collection() — delegates to array(), same runtime throw
+function test_collection_string_default_is_invalid(Repository $config): \Illuminate\Support\Collection
+{
+    return $config->collection('foo', 'fallback');
+}
+
+// Invalid: int default for collection() — delegates to array(), same runtime throw
+function test_collection_int_default_is_invalid(Repository $config): \Illuminate\Support\Collection
+{
+    return $config->collection('foo', 42);
+}
+?>
+--EXPECTF--
+InvalidArgument on line %d: Argument 2 of Illuminate\Config\Repository::array expects array<array-key, mixed>|impure-Closure():(array<array-key, mixed>|null)|null, but 'fallback' provided
+InvalidArgument on line %d: Argument 2 of Illuminate\Config\Repository::array expects array<array-key, mixed>|impure-Closure():(array<array-key, mixed>|null)|null, but 42 provided
+InvalidArgument on line %d: Argument 2 of Illuminate\Config\Repository::collection expects array<array-key, mixed>|impure-Closure():(array<array-key, mixed>|null)|null, but 'fallback' provided
+InvalidArgument on line %d: Argument 2 of Illuminate\Config\Repository::collection expects array<array-key, mixed>|impure-Closure():(array<array-key, mixed>|null)|null, but 42 provided


### PR DESCRIPTION
## Issue to Solve

`Config::array()` and `Config::collection()` accept any type for `$default`, but passing a scalar value (string, int, bool, etc.) always causes a runtime `InvalidArgumentException` when the config key is absent — the methods throw if the resolved value is not an array.

## Related

Fixes #729

## Solution Description

Added `stubs/common/Config/Repository.stubphp` that tightens `$default` on both methods to `(\Closure():(array<array-key, mixed>|null))|array<array-key, mixed>|null` — matching Laravel's own PHPDoc exactly. Closures are included because `Arr::get()` invokes them via `value()` before the `is_array()` check.

Verified via `tests/Type/tests/ConfigRepositoryTest.phpt`: valid defaults (null, array, Closure) pass without errors; scalar defaults (`'fallback'`, `42`) emit `InvalidArgument`.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
