### PR TITLE
Resolve scope methods on Eloquent relation chains

### DIFF
--- a/src/Handlers/Magic/MethodForwardingHandler.php
+++ b/src/Handlers/Magic/MethodForwardingHandler.php
@@ -7,6 +7,7 @@ namespace Psalm\LaravelPlugin\Handlers\Magic;
 use PhpParser\Node\Expr\MethodCall;
 use Psalm\Codebase;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\LaravelPlugin\Handlers\Eloquent\BuilderScopeHandler;
 use Psalm\LaravelPlugin\Handlers\Eloquent\ModelMethodHandler;
 use Psalm\LaravelPlugin\Util\ModelPropertyResolver;
 use Psalm\Plugin\EventHandler\Event\MethodParamsProviderEvent;
@@ -38,6 +39,10 @@ use Psalm\Type\Union;
  * Column names are validated against the model's declared @property annotations;
  * unmatched columns fall through to mixed without an error.
  * Disable via <resolveDynamicWhereClauses value="false" /> in psalm.xml.
+ *
+ * Also resolves model scope methods called on relation chains
+ * (e.g., $user->posts()->published()->get() where Post::scopePublished() exists).
+ * Both legacy scope{Name}() methods and modern #[Scope] attribute methods are supported.
  */
 final class MethodForwardingHandler implements
     MethodReturnTypeProviderInterface,
@@ -69,12 +74,29 @@ final class MethodForwardingHandler implements
      */
     private static array $dynamicWhereCache = [];
 
+    /**
+     * Cache: "lowercase-relation-class::method" → related model class.
+     *
+     * Populated by resolveScopeOnRelation() when a scope is confirmed on the related model.
+     * Consulted by getMethodParams() so Psalm can validate call arguments without crashing
+     * on the missing HasMany::electric method storage.
+     *
+     * When the same method name is a scope on different related models via the same relation
+     * class (e.g. HasMany<Vehicle>::electric and HasMany<Report>::electric), the last write
+     * wins. In practice, scope methods with the same name have the same param structure,
+     * so this is harmless.
+     *
+     * @var array<string, class-string<\Illuminate\Database\Eloquent\Model>>
+     */
+    private static array $scopeParamsCache = [];
+
     /** @psalm-external-mutation-free */
     public static function init(ForwardingRule $rule): void
     {
         self::$rule = $rule;
         self::$sourceClassIndex = [];
         self::$searchClassIndex = [];
+        self::$scopeParamsCache = [];
 
         foreach ($rule->allSourceClasses() as $class) {
             self::$sourceClassIndex[\strtolower($class)] = true;
@@ -176,6 +198,14 @@ final class MethodForwardingHandler implements
             return $resolved;
         }
 
+        // Scope method fallback for Path 2: check if the method is a scope on the related model.
+        // Handles $relation->published() where the related model has scopePublished() or #[Scope] published().
+        $scopeResult = self::resolveScopeOnRelation($codebase, $methodName, $fqClassName, $templateParams);
+
+        if ($scopeResult instanceof Union) {
+            return $scopeResult;
+        }
+
         // Dynamic where{Column} fallback for Path 2 (opt-in).
         // This handles the case where the method arrives via __call rather than @mixin.
         if (self::$enableDynamicWhere && $templateParams !== null && self::isDynamicWhereMethod($methodName)) {
@@ -243,6 +273,15 @@ final class MethodForwardingHandler implements
                     continue;
                 }
             }
+        }
+
+        // Scope method on relation chain: return scope params to avoid an UnexpectedValueException
+        // crash in Psalm when checkMethodArgs tries to look up params for HasMany::scopeName.
+        // The model class is resolved from the cache populated by resolveScopeOnRelation().
+        $scopeKey = \strtolower($fqClassName) . '::' . $methodName;
+
+        if (isset(self::$scopeParamsCache[$scopeKey])) {
+            return ModelMethodHandler::getScopeParams($codebase, self::$scopeParamsCache[$scopeKey], $methodName) ?? [];
         }
 
         // Dynamic where{Column}: provide a variadic mixed signature so Psalm's magic-method
@@ -322,6 +361,20 @@ final class MethodForwardingHandler implements
 
             if ($resolved instanceof \Psalm\Type\Union) {
                 return $resolved;
+            }
+
+            // Scope method fallback: check if the method is a scope on the related model.
+            // Handles $relation->published() where Post::scopePublished() or #[Scope] published() exists.
+            // TRelatedModel is always the first template parameter on Relation subclasses.
+            $scopeResult = self::resolveScopeOnRelation(
+                $codebase,
+                $methodName,
+                $atomicType->value,
+                $atomicType->type_params,
+            );
+
+            if ($scopeResult instanceof Union) {
+                return $scopeResult;
             }
 
             // Dynamic where{Column} fallback (opt-in): preserve the Relation's generic type
@@ -440,6 +493,48 @@ final class MethodForwardingHandler implements
         }
 
         // Column exists on the model → method is fluent, return the full Relation type.
+        return new Union([
+            new TGenericObject($relationClass, $templateParams),
+        ]);
+    }
+
+    /**
+     * Attempt to resolve a scope method call on a relation chain.
+     *
+     * Returns the relation's generic type (e.g. HasMany<Post, User>) when the method
+     * name matches a scope defined on the related model — either a legacy scopeXxx() method
+     * (e.g. scopePublished → published()) or a modern #[Scope] attribute method.
+     * Returns null otherwise, letting Psalm fall through to its default handling.
+     *
+     * @param non-empty-list<Union>|list<Union>|null $templateParams Relation's template type parameters
+     */
+    private static function resolveScopeOnRelation(
+        Codebase $codebase,
+        string $methodName,
+        string $relationClass,
+        ?array $templateParams,
+    ): ?Union {
+        if ($templateParams === null || $templateParams === []) {
+            return null;
+        }
+
+        // TRelatedModel is always the first template parameter on Relation subclasses.
+        $modelClass = ModelPropertyResolver::extractModelFromUnion($templateParams[0]);
+
+        if ($modelClass === null) {
+            return null;
+        }
+
+        if (!BuilderScopeHandler::hasScopeMethod($codebase, $modelClass, $methodName)) {
+            return null;
+        }
+
+        // Populate params cache so getMethodParams() can provide params without crashing.
+        // Keyed by lowercase relation class + method to match the params provider lookup.
+        $cacheKey = \strtolower($relationClass) . '::' . $methodName;
+        self::$scopeParamsCache[$cacheKey] = $modelClass;
+
+        // Scope exists on the related model → method is fluent, return the full Relation type.
         return new Union([
             new TGenericObject($relationClass, $templateParams),
         ]);

--- a/src/Handlers/Magic/MethodForwardingHandler.php
+++ b/src/Handlers/Magic/MethodForwardingHandler.php
@@ -281,7 +281,11 @@ final class MethodForwardingHandler implements
         $scopeKey = \strtolower($fqClassName) . '::' . $methodName;
 
         if (isset(self::$scopeParamsCache[$scopeKey])) {
-            return ModelMethodHandler::getScopeParams($codebase, self::$scopeParamsCache[$scopeKey], $methodName) ?? [];
+            // Use the scope's actual params when available; fall back to a permissive variadic
+            // signature (same as the dynamic-where fallback) rather than returning [] (zero params),
+            // which would emit misleading TooManyArguments for scopes that accept arguments.
+            return ModelMethodHandler::getScopeParams($codebase, self::$scopeParamsCache[$scopeKey], $methodName)
+                ?? [new FunctionLikeParameter('args', by_ref: false, type: Type::getMixed(), is_variadic: true)];
         }
 
         // Dynamic where{Column}: provide a variadic mixed signature so Psalm's magic-method

--- a/tests/Type/tests/Relation/RelationChainScopeTest.phpt
+++ b/tests/Type/tests/Relation/RelationChainScopeTest.phpt
@@ -1,0 +1,108 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use App\Models\WorkOrder;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+/**
+ * Tests for scope method resolution on Eloquent Relation chains.
+ *
+ * Laravel's Eloquent Builder forwards calls to the related model's scope methods
+ * via __call. The MethodForwardingHandler now detects these scopes on the related
+ * model and preserves the Relation's generic type for fluent chaining.
+ *
+ * Uses explicit @var annotations to get stable relation types regardless of context.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/646
+ */
+
+// Modern #[Scope] attribute (no extra args): Vehicle::#[Scope] electric → electric()
+// Customer::vehicles() returns HasMany<Vehicle, Customer>
+function test_attribute_scope_on_hasmany(): void {
+    /** @var HasMany<\App\Models\Vehicle, Customer> $r */
+    $r = (new Customer())->vehicles();
+    $_ = $r->electric();
+    /** @psalm-check-type-exact $_ = HasMany<\App\Models\Vehicle, Customer> */
+}
+
+// Legacy scope with args: Vehicle::scopeByMake(Builder $query, string $make) → byMake('Toyota')
+function test_legacy_scope_with_args_on_hasmany(): void {
+    /** @var HasMany<\App\Models\Vehicle, Customer> $r */
+    $r = (new Customer())->vehicles();
+    $_ = $r->byMake('Toyota');
+    /** @psalm-check-type-exact $_ = HasMany<\App\Models\Vehicle, Customer> */
+}
+
+// Scope + terminal: scope preserves HasMany, first() returns the model type
+function test_scope_then_terminal_on_hasmany(): void {
+    /** @var HasMany<\App\Models\Vehicle, Customer> $r */
+    $r = (new Customer())->vehicles();
+    $_ = $r->electric()->first();
+    /** @psalm-check-type-exact $_ = \App\Models\Vehicle|null */
+}
+
+// Scope chaining: two scopes in a row preserve the Relation generic type
+function test_scope_chain_on_hasmany(): void {
+    /** @var HasMany<\App\Models\Vehicle, Customer> $r */
+    $r = (new Customer())->vehicles();
+    $_ = $r->electric()->byMake('Tesla');
+    /** @psalm-check-type-exact $_ = HasMany<\App\Models\Vehicle, Customer> */
+}
+
+// HasOne: Customer::primaryVehicle() returns HasOne<Vehicle, Customer>
+// Vehicle::#[Scope] electric → electric()
+function test_attribute_scope_on_hasone(): void {
+    /** @var HasOne<\App\Models\Vehicle, Customer> $r */
+    $r = (new Customer())->primaryVehicle();
+    $_ = $r->electric();
+    /** @psalm-check-type-exact $_ = HasOne<\App\Models\Vehicle, Customer> */
+}
+
+// BelongsTo: WorkOrder::vehicle() returns BelongsTo<Vehicle, WorkOrder>
+// Vehicle::scopeByMake → byMake()
+function test_legacy_scope_on_belongsto(): void {
+    /** @var BelongsTo<\App\Models\Vehicle, WorkOrder> $r */
+    $r = (new WorkOrder())->vehicle();
+    $_ = $r->byMake('Toyota');
+    /** @psalm-check-type-exact $_ = BelongsTo<\App\Models\Vehicle, WorkOrder> */
+}
+
+// HasManyThrough: legacy scope WorkOrder::scopeUrgent() → urgent()
+// Customer::workOrders() returns HasManyThrough<WorkOrder, Vehicle, Customer>
+function test_legacy_scope_on_hasmanythough(): void {
+    /** @var HasManyThrough<\App\Models\WorkOrder, \App\Models\Vehicle, Customer> $r */
+    $r = (new Customer())->workOrders();
+    $_ = $r->urgent();
+    /** @psalm-check-type-exact $_ = HasManyThrough<\App\Models\WorkOrder, \App\Models\Vehicle, Customer> */
+}
+
+// HasManyThrough + modern #[Scope] attribute: WorkOrder::completed()
+function test_attribute_scope_on_hasmanythough(): void {
+    /** @var HasManyThrough<\App\Models\WorkOrder, \App\Models\Vehicle, Customer> $r */
+    $r = (new Customer())->workOrders();
+    $_ = $r->completed();
+    /** @psalm-check-type-exact $_ = HasManyThrough<\App\Models\WorkOrder, \App\Models\Vehicle, Customer> */
+}
+
+// Scope + Builder method chain: scope then where() preserves the Relation generic type
+function test_scope_then_builder_method_chain(): void {
+    /** @var HasMany<\App\Models\Vehicle, Customer> $r */
+    $r = (new Customer())->vehicles();
+    $_ = $r->electric()->where('year', '>=', 2020);
+    /** @psalm-check-type-exact $_ = HasMany<\App\Models\Vehicle, Customer> */
+}
+
+// Negative: a method that is NOT a scope on the related model falls through to mixed.
+// The handler does not match it, Relation::__call returns mixed.
+function test_non_scope_method_falls_through(): void {
+    /** @var HasMany<\App\Models\Vehicle, Customer> $r */
+    $r = (new Customer())->vehicles();
+    $_ = $r->completelyFakeNotAScope();
+    /** @psalm-check-type-exact $_ = mixed */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Relation/RelationChainScopeTest.phpt
+++ b/tests/Type/tests/Relation/RelationChainScopeTest.phpt
@@ -73,7 +73,7 @@ function test_legacy_scope_on_belongsto(): void {
 
 // HasManyThrough: legacy scope WorkOrder::scopeUrgent() → urgent()
 // Customer::workOrders() returns HasManyThrough<WorkOrder, Vehicle, Customer>
-function test_legacy_scope_on_hasmanythough(): void {
+function test_legacy_scope_on_hasmanythrough(): void {
     /** @var HasManyThrough<\App\Models\WorkOrder, \App\Models\Vehicle, Customer> $r */
     $r = (new Customer())->workOrders();
     $_ = $r->urgent();
@@ -81,7 +81,7 @@ function test_legacy_scope_on_hasmanythough(): void {
 }
 
 // HasManyThrough + modern #[Scope] attribute: WorkOrder::completed()
-function test_attribute_scope_on_hasmanythough(): void {
+function test_attribute_scope_on_hasmanythrough(): void {
     /** @var HasManyThrough<\App\Models\WorkOrder, \App\Models\Vehicle, Customer> $r */
     $r = (new Customer())->workOrders();
     $_ = $r->completed();


### PR DESCRIPTION
## Issue to Solve

When calling a model scope through a relation chain, the plugin emits `UndefinedMagicMethod` and returns `mixed` instead of preserving the relation's generic type.

```php
// ❌ Before: UndefinedMagicMethod, result is mixed
$user->posts()->published()->get();

// ✅ After: resolves correctly, result is HasMany<Post, User>
$user->posts()->published()->get();
```

## Related

Fixes #646

## Solution Description

Extended `MethodForwardingHandler` with a new `resolveScopeOnRelation()` helper that fires in both resolution paths (Path 1: `@mixin` interception; Path 2: direct `__call`) after `ReturnTypeResolver::resolve()` finds no match in `Builder`/`QueryBuilder`.

The helper:
1. Extracts `TRelatedModel` from the relation's first template parameter
2. Delegates to `BuilderScopeHandler::hasScopeMethod()` to check for legacy `scopeXxx()` and modern `#[Scope]` attribute methods
3. Returns the relation's generic type when a scope is found (fluent return)

A `$scopeParamsCache` (reset in `init()`) bridges `getMethodReturnType` and `getMethodParams` so Psalm can validate call arguments without crashing on the synthetic `HasMany::published` method identifier.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/tests/Relation/RelationChainScopeTest.phpt`)