### PR TITLE
Add missing `@psalm-taint-sink file` methods to Filesystem/FilesystemAdapter stubs

### DIFF
--- a/stubs/common/Filesystem/Filesystem.stubphp
+++ b/stubs/common/Filesystem/Filesystem.stubphp
@@ -350,7 +350,7 @@ class Filesystem
      *
      * @psalm-taint-sink file $directory
      */
-    public function allDirectories(string $directory): array {}
+    public function allDirectories($directory): array {}
 
     /**
      * Ensure a directory exists.

--- a/stubs/common/Filesystem/Filesystem.stubphp
+++ b/stubs/common/Filesystem/Filesystem.stubphp
@@ -133,6 +133,18 @@ class Filesystem
     public function link($target, $link) {}
 
     /**
+     * Create a relative symlink to the target file or directory.
+     *
+     * @param  string  $target
+     * @param  string  $link
+     * @return void
+     *
+     * @psalm-taint-sink file $target
+     * @psalm-taint-sink file $link
+     */
+    public function relativeLink($target, $link) {}
+
+    /**
      * Determine if a file or directory exists.
      *
      * Not a taint sink: file_exists() is a read-only boolean check with
@@ -222,4 +234,190 @@ class Filesystem
      * @psalm-taint-sink file $path
      */
     public function replaceInFile($search, $replace, $path) {}
+
+    /**
+     * Get the file type of a given file.
+     *
+     * @param  string  $path
+     * @return string|false
+     *
+     * @psalm-taint-sink file $path
+     */
+    public function type($path) {}
+
+    /**
+     * Get the MIME type of a given file.
+     *
+     * @param  string  $path
+     * @return string|false
+     *
+     * @psalm-taint-sink file $path
+     */
+    public function mimeType($path) {}
+
+    /**
+     * Guess the file extension from the MIME type of a given file.
+     *
+     * @param  string  $path
+     * @return string|null
+     *
+     * @psalm-taint-sink file $path
+     */
+    public function guessExtension($path) {}
+
+    /**
+     * Determine if two files are the same by comparing their hashes.
+     *
+     * @param  string  $firstFile
+     * @param  string  $secondFile
+     * @return bool
+     *
+     * @psalm-taint-sink file $firstFile
+     * @psalm-taint-sink file $secondFile
+     */
+    public function hasSameHash($firstFile, $secondFile) {}
+
+    /**
+     * Get the file size of a given file.
+     *
+     * @param  string  $path
+     * @return int
+     *
+     * @psalm-taint-sink file $path
+     */
+    public function size($path) {}
+
+    /**
+     * Get the file's last modification time.
+     *
+     * @param  string  $path
+     * @return int
+     *
+     * @psalm-taint-sink file $path
+     */
+    public function lastModified($path) {}
+
+    /**
+     * Find path names matching a given pattern.
+     *
+     * @param  string  $pattern
+     * @param  int  $flags
+     * @return array
+     *
+     * @psalm-taint-sink file $pattern
+     */
+    public function glob($pattern, $flags = 0) {}
+
+    /**
+     * Get an array of all files in a directory.
+     *
+     * @param  string  $directory
+     * @param  bool  $hidden
+     * @param  array|string|int  $depth
+     * @return \Symfony\Component\Finder\SplFileInfo[]
+     *
+     * @psalm-taint-sink file $directory
+     */
+    public function files($directory, $hidden = false, array|string|int $depth = 0) {}
+
+    /**
+     * Get all of the files from the given directory (recursive).
+     *
+     * @param  string  $directory
+     * @param  bool  $hidden
+     * @return \Symfony\Component\Finder\SplFileInfo[]
+     *
+     * @psalm-taint-sink file $directory
+     */
+    public function allFiles($directory, $hidden = false) {}
+
+    /**
+     * Get all of the directories within a given directory.
+     *
+     * @param  string  $directory
+     * @param  array|string|int  $depth
+     * @return array
+     *
+     * @psalm-taint-sink file $directory
+     */
+    public function directories($directory, array|string|int $depth = 0) {}
+
+    /**
+     * Get all the directories within a given directory (recursive).
+     *
+     * @param  string  $directory
+     * @return array
+     *
+     * @psalm-taint-sink file $directory
+     */
+    public function allDirectories(string $directory): array {}
+
+    /**
+     * Ensure a directory exists.
+     *
+     * @param  string  $path
+     * @param  int  $mode
+     * @param  bool  $recursive
+     * @return void
+     *
+     * @psalm-taint-sink file $path
+     */
+    public function ensureDirectoryExists($path, $mode = 0755, $recursive = true) {}
+
+    /**
+     * Move a directory.
+     *
+     * @param  string  $from
+     * @param  string  $to
+     * @param  bool  $overwrite
+     * @return bool
+     *
+     * @psalm-taint-sink file $from
+     * @psalm-taint-sink file $to
+     */
+    public function moveDirectory($from, $to, $overwrite = false) {}
+
+    /**
+     * Copy a directory from one location to another.
+     *
+     * @param  string  $directory
+     * @param  string  $destination
+     * @param  int|null  $options
+     * @return bool
+     *
+     * @psalm-taint-sink file $directory
+     * @psalm-taint-sink file $destination
+     */
+    public function copyDirectory($directory, $destination, $options = null) {}
+
+    /**
+     * Recursively delete a directory.
+     *
+     * @param  string  $directory
+     * @param  bool  $preserve
+     * @return bool
+     *
+     * @psalm-taint-sink file $directory
+     */
+    public function deleteDirectory($directory, $preserve = false) {}
+
+    /**
+     * Remove all of the directories within a given directory.
+     *
+     * @param  string  $directory
+     * @return bool
+     *
+     * @psalm-taint-sink file $directory
+     */
+    public function deleteDirectories($directory) {}
+
+    /**
+     * Empty the specified directory of all files and folders.
+     *
+     * @param  string  $directory
+     * @return bool
+     *
+     * @psalm-taint-sink file $directory
+     */
+    public function cleanDirectory($directory) {}
 }

--- a/stubs/common/Filesystem/FilesystemAdapter.stubphp
+++ b/stubs/common/Filesystem/FilesystemAdapter.stubphp
@@ -289,7 +289,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      *
      * @psalm-taint-sink file $path
      */
-    public function checksum(string $path, array $options = []) {}
+    public function checksum($path, array $options = []) {}
 
     /**
      * Get the mime-type of a given file.

--- a/stubs/common/Filesystem/FilesystemAdapter.stubphp
+++ b/stubs/common/Filesystem/FilesystemAdapter.stubphp
@@ -248,4 +248,108 @@ class FilesystemAdapter implements CloudFilesystemContract
      * @psalm-taint-sink file $directory
      */
     public function deleteDirectory($directory) {}
+
+    /**
+     * Get the visibility for the given path.
+     *
+     * @param  string  $path
+     * @return string
+     *
+     * @psalm-taint-sink file $path
+     */
+    public function getVisibility($path) {}
+
+    /**
+     * Set the visibility for the given path.
+     *
+     * @param  string  $path
+     * @param  string  $visibility
+     * @return bool
+     *
+     * @psalm-taint-sink file $path
+     */
+    public function setVisibility($path, $visibility) {}
+
+    /**
+     * Get the file size of a given file.
+     *
+     * @param  string  $path
+     * @return int
+     *
+     * @psalm-taint-sink file $path
+     */
+    public function size($path) {}
+
+    /**
+     * Get the checksum for a file.
+     *
+     * @param  string  $path
+     * @param  array  $options
+     * @return string|false
+     *
+     * @psalm-taint-sink file $path
+     */
+    public function checksum(string $path, array $options = []) {}
+
+    /**
+     * Get the mime-type of a given file.
+     *
+     * @param  string  $path
+     * @return string|false
+     *
+     * @psalm-taint-sink file $path
+     */
+    public function mimeType($path) {}
+
+    /**
+     * Get the file's last modification time.
+     *
+     * @param  string  $path
+     * @return int
+     *
+     * @psalm-taint-sink file $path
+     */
+    public function lastModified($path) {}
+
+    /**
+     * Get an array of all files in a directory.
+     *
+     * @param  string|null  $directory
+     * @param  bool  $recursive
+     * @return array
+     *
+     * @psalm-taint-sink file $directory
+     */
+    public function files($directory = null, $recursive = false) {}
+
+    /**
+     * Get all of the files from the given directory (recursive).
+     *
+     * @param  string|null  $directory
+     * @return array
+     *
+     * @psalm-taint-sink file $directory
+     */
+    public function allFiles($directory = null) {}
+
+    /**
+     * Get all of the directories within a given directory.
+     *
+     * @param  string|null  $directory
+     * @param  bool  $recursive
+     * @return array
+     *
+     * @psalm-taint-sink file $directory
+     */
+    public function directories($directory = null, $recursive = false) {}
+
+    /**
+     * Get all the directories within a given directory (recursive).
+     *
+     * @param  string|null  $directory
+     * @return array
+     *
+     * @psalm-taint-sink file $directory
+     */
+    public function allDirectories($directory = null) {}
 }

--- a/stubs/common/Filesystem/LockableFile.stubphp
+++ b/stubs/common/Filesystem/LockableFile.stubphp
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Filesystem;
+
+class LockableFile
+{
+    /**
+     * Create a new LockableFile instance.
+     *
+     * @param  string  $path
+     * @param  string  $mode
+     *
+     * @psalm-taint-sink file $path
+     */
+    public function __construct($path, $mode) {}
+}

--- a/tests/Type/tests/TaintAnalysis/TaintedFileFilesystem.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedFileFilesystem.phpt
@@ -3,11 +3,109 @@
 --FILE--
 <?php declare(strict_types=1);
 
-function downloadAttachment(\Illuminate\Http\Request $request) {
-    $filePath = $request->input('file');
-    $fs = new \Illuminate\Filesystem\Filesystem();
-    $fs->get($filePath);
+/**
+ * Filesystem methods that accept a user-controlled path
+ * are file-taint sinks — an attacker could read, overwrite,
+ * delete, or traverse the filesystem via path traversal.
+ */
+
+function fsGet(\Illuminate\Http\Request $request, \Illuminate\Filesystem\Filesystem $fs): void {
+    $fs->get($request->input('path'));
+}
+
+function fsRelativeLink(\Illuminate\Http\Request $request, \Illuminate\Filesystem\Filesystem $fs): void {
+    $fs->relativeLink($request->input('target'), $request->input('link'));
+}
+
+function fsType(\Illuminate\Http\Request $request, \Illuminate\Filesystem\Filesystem $fs): void {
+    $fs->type($request->input('path'));
+}
+
+function fsMimeType(\Illuminate\Http\Request $request, \Illuminate\Filesystem\Filesystem $fs): void {
+    $fs->mimeType($request->input('path'));
+}
+
+function fsGuessExtension(\Illuminate\Http\Request $request, \Illuminate\Filesystem\Filesystem $fs): void {
+    $fs->guessExtension($request->input('path'));
+}
+
+function fsHasSameHash(\Illuminate\Http\Request $request, \Illuminate\Filesystem\Filesystem $fs): void {
+    $fs->hasSameHash($request->input('first'), $request->input('second'));
+}
+
+function fsSize(\Illuminate\Http\Request $request, \Illuminate\Filesystem\Filesystem $fs): void {
+    $fs->size($request->input('path'));
+}
+
+function fsLastModified(\Illuminate\Http\Request $request, \Illuminate\Filesystem\Filesystem $fs): void {
+    $fs->lastModified($request->input('path'));
+}
+
+function fsGlob(\Illuminate\Http\Request $request, \Illuminate\Filesystem\Filesystem $fs): void {
+    $fs->glob($request->input('pattern'));
+}
+
+function fsFiles(\Illuminate\Http\Request $request, \Illuminate\Filesystem\Filesystem $fs): void {
+    $fs->files($request->input('dir'));
+}
+
+function fsAllFiles(\Illuminate\Http\Request $request, \Illuminate\Filesystem\Filesystem $fs): void {
+    $fs->allFiles($request->input('dir'));
+}
+
+function fsDirectories(\Illuminate\Http\Request $request, \Illuminate\Filesystem\Filesystem $fs): void {
+    $fs->directories($request->input('dir'));
+}
+
+function fsAllDirectories(\Illuminate\Http\Request $request, \Illuminate\Filesystem\Filesystem $fs): void {
+    $fs->allDirectories($request->input('dir'));
+}
+
+function fsEnsureDirectoryExists(\Illuminate\Http\Request $request, \Illuminate\Filesystem\Filesystem $fs): void {
+    $fs->ensureDirectoryExists($request->input('path'));
+}
+
+function fsMoveDirectory(\Illuminate\Http\Request $request, \Illuminate\Filesystem\Filesystem $fs): void {
+    $fs->moveDirectory($request->input('from'), $request->input('to'));
+}
+
+function fsCopyDirectory(\Illuminate\Http\Request $request, \Illuminate\Filesystem\Filesystem $fs): void {
+    $fs->copyDirectory($request->input('dir'), $request->input('dest'));
+}
+
+function fsDeleteDirectory(\Illuminate\Http\Request $request, \Illuminate\Filesystem\Filesystem $fs): void {
+    $fs->deleteDirectory($request->input('dir'));
+}
+
+function fsDeleteDirectories(\Illuminate\Http\Request $request, \Illuminate\Filesystem\Filesystem $fs): void {
+    $fs->deleteDirectories($request->input('dir'));
+}
+
+function fsCleanDirectory(\Illuminate\Http\Request $request, \Illuminate\Filesystem\Filesystem $fs): void {
+    $fs->cleanDirectory($request->input('dir'));
 }
 ?>
 --EXPECTF--
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
 %ATaintedFile on line %d: Detected tainted file handling

--- a/tests/Type/tests/TaintAnalysis/TaintedFileFilesystemAdapter.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedFileFilesystemAdapter.phpt
@@ -82,8 +82,58 @@ function storageWriteStream(\Illuminate\Http\Request $request, \Illuminate\Files
 function storageTemporaryUploadUrl(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
     $fs->temporaryUploadUrl($request->input('path'), new \DateTimeImmutable('+1 hour'));
 }
+
+function storageGetVisibility(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
+    $fs->getVisibility($request->input('path'));
+}
+
+function storageSetVisibility(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
+    $fs->setVisibility($request->input('path'), 'public');
+}
+
+function storageSize(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
+    $fs->size($request->input('path'));
+}
+
+function storageChecksum(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
+    $fs->checksum($request->input('path'));
+}
+
+function storageMimeType(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
+    $fs->mimeType($request->input('path'));
+}
+
+function storageLastModified(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
+    $fs->lastModified($request->input('path'));
+}
+
+function storageFiles(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
+    $fs->files($request->input('dir'));
+}
+
+function storageAllFiles(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
+    $fs->allFiles($request->input('dir'));
+}
+
+function storageDirectories(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
+    $fs->directories($request->input('dir'));
+}
+
+function storageAllDirectories(\Illuminate\Http\Request $request, \Illuminate\Filesystem\FilesystemAdapter $fs): void {
+    $fs->allDirectories($request->input('dir'));
+}
 ?>
 --EXPECTF--
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedFile on line %d: Detected tainted file handling
 %ATaintedFile on line %d: Detected tainted file handling
 %ATaintedFile on line %d: Detected tainted file handling
 %ATaintedFile on line %d: Detected tainted file handling

--- a/tests/Type/tests/TaintAnalysis/TaintedFileLockableFile.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedFileLockableFile.phpt
@@ -1,0 +1,11 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+function openLockableFile(\Illuminate\Http\Request $request): void {
+    new \Illuminate\Filesystem\LockableFile($request->input('path'), 'r');
+}
+?>
+--EXPECTF--
+%ATaintedFile on line %d: Detected tainted file handling


### PR DESCRIPTION
## Issue to Solve

`Filesystem`, `FilesystemAdapter`, and `LockableFile` had ~30 methods accepting file paths with no `@psalm-taint-sink file` annotation, leaving path traversal vulnerabilities undetected (OWASP A01:2021).

## Related

Closes #565

## Solution Description

Added `@psalm-taint-sink file` to:

**`Filesystem`:** `relativeLink`, `type`, `mimeType`, `guessExtension`, `hasSameHash`, `size`, `lastModified`, `glob`, `files`, `allFiles`, `directories`, `allDirectories`, `ensureDirectoryExists`, `moveDirectory`, `copyDirectory`, `deleteDirectory`, `deleteDirectories`, `cleanDirectory`

**`FilesystemAdapter`:** `getVisibility`, `setVisibility`, `size`, `checksum`, `mimeType`, `lastModified`, `files`, `allFiles`, `directories`, `allDirectories`

**New stub:** `stubs/common/Filesystem/LockableFile.stubphp` — `__construct($path, $mode)` as a file sink (opens via `fopen`).

Note: read-only metadata methods (`type`, `mimeType`, `size`, `lastModified`, `checksum`, `getVisibility`) are annotated because they accept user-controlled paths that can probe arbitrary filesystem locations — distinguishing them from `exists()` which was intentionally excluded as a boolean-only check.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
