### PR TITLE
Port psalm-tester upgrade to 3.x (alies-dev/psalm-tester + sort-order fix)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,10 +33,10 @@
         "vimeo/psalm": "^6.16.1"
     },
     "require-dev": {
+        "alies-dev/psalm-tester": "dev-main",
         "friendsofphp/php-cs-fixer": "^3.94",
         "laravel/framework": "^11.35 || ^12.0",
         "phpunit/phpunit": "^11.5 || ^12.5",
-        "alies-dev/psalm-tester": "dev-main",
         "ramsey/collection": "^1.3",
         "rector/rector": "^2.3",
         "symfony/http-foundation": "^7.1 || ^8.0"

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "friendsofphp/php-cs-fixer": "^3.94",
         "laravel/framework": "^11.35 || ^12.0",
         "phpunit/phpunit": "^11.5 || ^12.5",
-        "phpyh/psalm-tester": "dev-batch",
+        "alies-dev/psalm-tester": "dev-main",
         "ramsey/collection": "^1.3",
         "rector/rector": "^2.3",
         "symfony/http-foundation": "^7.1 || ^8.0"

--- a/tests/Type/PsalmTest.php
+++ b/tests/Type/PsalmTest.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace Tests\Psalm\LaravelPlugin\Type;
 
+use AliesDev\PsalmTester\PsalmTester;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use PHPyh\PsalmTester\PsalmTester;
 
 final class PsalmTest extends TestCase
 {
     /** @var array<string, string> */
     private static array $batchResults = [];
 
-    /** @var array<string, \PHPyh\PsalmTester\PsalmTest> */
+    /** @var array<string, \AliesDev\PsalmTester\PsalmTest> */
     private static array $testData = [];
 
     /** @var array<string, string> relPath => skip reason */
@@ -30,21 +30,14 @@ final class PsalmTest extends TestCase
         $baseDir = self::baseDir();
 
         foreach (self::discoverPhptFiles($baseDir) as $absPath => $relPath) {
-            $skipReason = self::evaluateSkipIf($absPath);
+            $skipReason = \AliesDev\PsalmTester\PsalmTest::getSkipReason($absPath);
 
             if ($skipReason !== null) {
                 self::$skipReasons[$relPath] = $skipReason;
                 continue;
             }
 
-            // psalm-tester throws on unknown sections (including --SKIPIF--), so strip it
-            // before passing to fromPhptFile(). The temp file can be unlinked immediately
-            // because fromPhptFile() reads and parses the content on the spot.
-            $testerFile = self::stripSkipIfSection($absPath);
-            self::$testData[$relPath] = \PHPyh\PsalmTester\PsalmTest::fromPhptFile($testerFile);
-            if ($testerFile !== $absPath) {
-                \unlink($testerFile);
-            }
+            self::$testData[$relPath] = \AliesDev\PsalmTester\PsalmTest::fromPhptFile($absPath);
         }
 
         self::$batchResults = $tester->runBatch(self::$testData);
@@ -91,85 +84,5 @@ final class PsalmTest extends TestCase
             $relPath = \str_replace($baseDir, '', $filepath);
             yield $filepath => $relPath;
         }
-    }
-
-    /**
-     * Evaluate the --SKIPIF-- section of a PHPT file.
-     *
-     * Returns the skip reason if the section says to skip, or null otherwise.
-     * The SKIPIF section contains PHP code (starting with <?php) that echoes
-     * "skip <reason>" if the test should be skipped.
-     */
-    private static function evaluateSkipIf(string $phptFile): ?string
-    {
-        $content = \file_get_contents($phptFile);
-
-        if ($content === false) {
-            return null;
-        }
-
-        if (!\preg_match('/^--SKIPIF--\n(.*?)\n--/ms', $content, $matches)) {
-            return null; // No SKIPIF section
-        }
-
-        $skipifCode = $matches[1];
-        $tempFile = \tempnam(\sys_get_temp_dir(), 'psalm_skipif_');
-
-        if ($tempFile === false) {
-            return null;
-        }
-
-        \file_put_contents($tempFile, $skipifCode);
-
-        \ob_start();
-
-        try {
-            // Use a static closure to avoid leaking $this, and require the temp file
-            // so that the <?php tag in SKIPIF code is handled correctly.
-            (static function (string $file): void {
-                require $file;
-            })($tempFile);
-        } finally {
-            \unlink($tempFile);
-        }
-
-        $output = \trim(\ob_get_clean() ?: '');
-
-        if (\stripos($output, 'skip') === 0) {
-            return $output;
-        }
-
-        return null;
-    }
-
-    /**
-     * Return the path to pass to psalm-tester: the original file if it has no --SKIPIF-- section,
-     * or a temporary file with the SKIPIF section removed (psalm-tester throws on unknown sections).
-     *
-     * The caller is responsible for unlinking the returned path when it differs from $phptFile.
-     */
-    private static function stripSkipIfSection(string $phptFile): string
-    {
-        $content = \file_get_contents($phptFile);
-
-        if ($content === false) {
-            return $phptFile;
-        }
-
-        $stripped = \preg_replace('/^--SKIPIF--\n.*?\n(?=--)/ms', '', $content);
-
-        if ($stripped === null || $stripped === $content) {
-            return $phptFile; // No SKIPIF section, use original
-        }
-
-        $tempFile = \tempnam(\sys_get_temp_dir(), 'psalm_phpt_');
-
-        if ($tempFile === false) {
-            return $phptFile;
-        }
-
-        \file_put_contents($tempFile, $stripped);
-
-        return $tempFile;
     }
 }

--- a/tests/Type/README.md
+++ b/tests/Type/README.md
@@ -2,7 +2,7 @@
 
 These tests are written using PHPT: syntax, originally created to test PHP interpreter itself.
 
-For the basic usage, please check [phpyh/psalm-tester](https://github.com/phpyh/psalm-tester).
+For the basic usage, please check [alies-dev/psalm-tester](https://github.com/alies-dev/psalm-tester).
 
 To go deeper with PHPT syntax, please check [PHPT](https://qa.php.net/phpt_details.php) official guide.
 

--- a/tests/Type/tests/Builder/CustomQueryBuilderTest.phpt
+++ b/tests/Type/tests/Builder/CustomQueryBuilderTest.phpt
@@ -1,5 +1,5 @@
 --SKIPIF--
-<?php if (version_compare(\Illuminate\Foundation\Application::VERSION, '12.0.0', '<')) { echo 'skip requires Laravel 12+'; }
+<?php if (!\Composer\InstalledVersions::satisfies(new \Composer\Semver\VersionParser(), 'laravel/framework', '^12.0.0')) { echo 'skip requires Laravel 12+'; }
 --FILE--
 <?php declare(strict_types=1);
 

--- a/tests/Type/tests/Builder/CustomQueryBuilderTest.phpt
+++ b/tests/Type/tests/Builder/CustomQueryBuilderTest.phpt
@@ -1,5 +1,5 @@
 --SKIPIF--
-<?php if (!\Composer\InstalledVersions::satisfies(new \Composer\Semver\VersionParser(), 'laravel/framework', '^12.0.0')) { echo 'skip requires Laravel 12+'; }
+<?php require getcwd() . '/vendor/autoload.php'; if (!\Composer\InstalledVersions::satisfies(new \Composer\Semver\VersionParser(), 'laravel/framework', '^12.0.0')) { echo 'skip requires Laravel 12+'; }
 --FILE--
 <?php declare(strict_types=1);
 

--- a/tests/Type/tests/ConditionableTappableTest.phpt
+++ b/tests/Type/tests/ConditionableTappableTest.phpt
@@ -1,5 +1,5 @@
 --SKIPIF--
-<?php if (version_compare(\Illuminate\Foundation\Application::VERSION, '12.0.0', '<')) { echo 'skip requires Laravel 12+'; }
+<?php if (!\Composer\InstalledVersions::satisfies(new \Composer\Semver\VersionParser(), 'laravel/framework', '^12.0.0')) { echo 'skip requires Laravel 12+'; }
 --FILE--
 <?php declare(strict_types=1);
 

--- a/tests/Type/tests/ConditionableTappableTest.phpt
+++ b/tests/Type/tests/ConditionableTappableTest.phpt
@@ -1,5 +1,5 @@
 --SKIPIF--
-<?php if (!\Composer\InstalledVersions::satisfies(new \Composer\Semver\VersionParser(), 'laravel/framework', '^12.0.0')) { echo 'skip requires Laravel 12+'; }
+<?php require getcwd() . '/vendor/autoload.php'; if (!\Composer\InstalledVersions::satisfies(new \Composer\Semver\VersionParser(), 'laravel/framework', '^12.0.0')) { echo 'skip requires Laravel 12+'; }
 --FILE--
 <?php declare(strict_types=1);
 

--- a/tests/Type/tests/ConfigRepositoryTest.phpt
+++ b/tests/Type/tests/ConfigRepositoryTest.phpt
@@ -1,5 +1,5 @@
 --SKIPIF--
-<?php if (version_compare(\Illuminate\Foundation\Application::VERSION, '12.0.0', '<')) { echo 'skip requires Laravel 12+'; }
+<?php if (!\Composer\InstalledVersions::satisfies(new \Composer\Semver\VersionParser(), 'laravel/framework', '^12.0.0')) { echo 'skip requires Laravel 12+'; }
 --FILE--
 <?php declare(strict_types=1);
 

--- a/tests/Type/tests/ConfigRepositoryTest.phpt
+++ b/tests/Type/tests/ConfigRepositoryTest.phpt
@@ -1,5 +1,5 @@
 --SKIPIF--
-<?php if (!\Composer\InstalledVersions::satisfies(new \Composer\Semver\VersionParser(), 'laravel/framework', '^12.0.0')) { echo 'skip requires Laravel 12+'; }
+<?php require getcwd() . '/vendor/autoload.php'; if (!\Composer\InstalledVersions::satisfies(new \Composer\Semver\VersionParser(), 'laravel/framework', '^12.0.0')) { echo 'skip requires Laravel 12+'; }
 --FILE--
 <?php declare(strict_types=1);
 

--- a/tests/Type/tests/Http/PendingRequestTest.phpt
+++ b/tests/Type/tests/Http/PendingRequestTest.phpt
@@ -1,5 +1,5 @@
 --SKIPIF--
-<?php if (version_compare(\Illuminate\Foundation\Application::VERSION, '12.0.0', '<')) { echo 'skip requires Laravel 12+'; }
+<?php if (!\Composer\InstalledVersions::satisfies(new \Composer\Semver\VersionParser(), 'laravel/framework', '^12.0.0')) { echo 'skip requires Laravel 12+'; }
 --FILE--
 <?php declare(strict_types=1);
 

--- a/tests/Type/tests/Http/PendingRequestTest.phpt
+++ b/tests/Type/tests/Http/PendingRequestTest.phpt
@@ -1,5 +1,5 @@
 --SKIPIF--
-<?php if (!\Composer\InstalledVersions::satisfies(new \Composer\Semver\VersionParser(), 'laravel/framework', '^12.0.0')) { echo 'skip requires Laravel 12+'; }
+<?php require getcwd() . '/vendor/autoload.php'; if (!\Composer\InstalledVersions::satisfies(new \Composer\Semver\VersionParser(), 'laravel/framework', '^12.0.0')) { echo 'skip requires Laravel 12+'; }
 --FILE--
 <?php declare(strict_types=1);
 

--- a/tests/Type/tests/Http/RequestInputTest.phpt
+++ b/tests/Type/tests/Http/RequestInputTest.phpt
@@ -1,5 +1,5 @@
 --SKIPIF--
-<?php if (version_compare(\Illuminate\Foundation\Application::VERSION, '12.0.0', '<')) { echo 'skip requires Laravel 12+'; }
+<?php if (!\Composer\InstalledVersions::satisfies(new \Composer\Semver\VersionParser(), 'laravel/framework', '^12.0.0')) { echo 'skip requires Laravel 12+'; }
 --FILE--
 <?php declare(strict_types=1);
 

--- a/tests/Type/tests/Http/RequestInputTest.phpt
+++ b/tests/Type/tests/Http/RequestInputTest.phpt
@@ -1,5 +1,5 @@
 --SKIPIF--
-<?php if (!\Composer\InstalledVersions::satisfies(new \Composer\Semver\VersionParser(), 'laravel/framework', '^12.0.0')) { echo 'skip requires Laravel 12+'; }
+<?php require getcwd() . '/vendor/autoload.php'; if (!\Composer\InstalledVersions::satisfies(new \Composer\Semver\VersionParser(), 'laravel/framework', '^12.0.0')) { echo 'skip requires Laravel 12+'; }
 --FILE--
 <?php declare(strict_types=1);
 

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlDecryptRestoresTaint.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlDecryptRestoresTaint.phpt
@@ -20,9 +20,9 @@ function renderDecryptedInput(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedUserSecret on line %d: Detected tainted user secret leaking
-%ATaintedSystemSecret on line %d: Detected tainted system secret leaking
 %ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedSystemSecret on line %d: Detected tainted system secret leaking
+%ATaintedSystemSecret on line %d: Detected tainted system secret leaking
 %ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
 %ATaintedUserSecret on line %d: Detected tainted user secret leaking
-%ATaintedSystemSecret on line %d: Detected tainted system secret leaking
+%ATaintedUserSecret on line %d: Detected tainted user secret leaking

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlEncrypterDecryptString.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlEncrypterDecryptString.phpt
@@ -20,9 +20,9 @@ function renderDecryptedToken(\Illuminate\Http\Request $request, \Illuminate\Enc
 }
 ?>
 --EXPECTF--
-%ATaintedUserSecret on line %d: Detected tainted user secret leaking
-%ATaintedSystemSecret on line %d: Detected tainted system secret leaking
 %ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedSystemSecret on line %d: Detected tainted system secret leaking
+%ATaintedSystemSecret on line %d: Detected tainted system secret leaking
 %ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
 %ATaintedUserSecret on line %d: Detected tainted user secret leaking
-%ATaintedSystemSecret on line %d: Detected tainted system secret leaking
+%ATaintedUserSecret on line %d: Detected tainted user secret leaking

--- a/tests/Type/tests/TaintAnalysis/TaintedSsrfRedirect.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSsrfRedirect.phpt
@@ -9,5 +9,5 @@ function loginRedirect(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedSSRF on line %d: Detected tainted network request
 %ATaintedHeader on line %d: Detected tainted header
+%ATaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/TaintedSsrfRedirectorIntended.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSsrfRedirectorIntended.phpt
@@ -13,5 +13,5 @@ function loginRedirect(\Illuminate\Http\Request $request, \Illuminate\Routing\Re
 }
 ?>
 --EXPECTF--
-%ATaintedSSRF on line %d: Detected tainted network request
 %ATaintedHeader on line %d: Detected tainted header
+%ATaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/TaintedSsrfResponseFactoryRedirect.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSsrfResponseFactoryRedirect.phpt
@@ -23,9 +23,9 @@ function responseRedirectToIntended(\Illuminate\Http\Request $request, \Illumina
 }
 ?>
 --EXPECTF--
-%ATaintedSSRF on line %d: Detected tainted network request
 %ATaintedHeader on line %d: Detected tainted header
 %ATaintedSSRF on line %d: Detected tainted network request
 %ATaintedHeader on line %d: Detected tainted header
 %ATaintedSSRF on line %d: Detected tainted network request
 %ATaintedHeader on line %d: Detected tainted header
+%ATaintedSSRF on line %d: Detected tainted network request


### PR DESCRIPTION
Ports two master commits to 3.x:

- **08e1db8** `test: fix EXPECTF order for psalm-tester deterministic sort` — reorders same-line errors in 6 taint test files to match psalm-tester's new alphabetical sort (TaintedFile < TaintedInclude, TaintedHeader < TaintedSSRF, TaintedHtml < TaintedSystem < TaintedUser)
- **fb326d7** `chore: use alies-dev/psalm-tester` — switches from \`phpyh/psalm-tester: dev-batch\` to \`alies-dev/psalm-tester: dev-main\` and updates namespace from \`PHPyh\PsalmTester\` to \`AliesDev\PsalmTester\`

**3.x-specific adaptation:** \`PsalmTest.php\` now uses the upstream \`PsalmTest::getSkipReason()\` (added in the psalm-tester PR) instead of the self-contained \`evaluateSkipIf()\`/\`stripSkipIfSection()\` that was a workaround in the previous 3.x port — making it identical to master's version plus the skip-reason logic for L11/L12 version guards.