### PR TITLE
Survive broken AliasLoader entries in FacadeMapProvider

### DIFF
--- a/src/Providers/FacadeMapProvider.php
+++ b/src/Providers/FacadeMapProvider.php
@@ -38,15 +38,38 @@ final class FacadeMapProvider
         $aliases = AliasLoader::getInstance()->getAliases();
 
         foreach ($aliases as $alias => $facadeClass) {
-            if (!\is_subclass_of($facadeClass, Facade::class)) {
-                continue;
-            }
-
             try {
+                // is_subclass_of() invokes the autoloader for unknown classes.
+                // For entries in AliasLoader's registry, that routes back through
+                // AliasLoader::load(), which calls class_alias($target, $alias).
+                //
+                // Some published packages ship a misconfigured self-referential
+                // entry: mateffy/laravel-introspect declares
+                //   "aliases": { "Introspect": "Introspect" }
+                // in composer.json (extra.laravel.aliases). Laravel's package
+                // discovery registers this verbatim, so AliasLoader tries
+                // class_alias('Introspect', 'Introspect'). No real class named
+                // 'Introspect' exists in the global namespace (the actual Facade
+                // is Mateffy\Introspect\Facades\Introspect), so PHP emits a
+                // "Class not found" warning.
+                //
+                // Under Psalm, that warning is promoted to a RuntimeException by
+                // Psalm\Internal\ErrorHandler, which without this guard propagates
+                // out of __invoke() and disables the plugin for the whole run.
+                // Catching it lets the iteration skip the broken entry and
+                // continue mapping the remaining (valid) facades. See issue #745.
+                if (!\is_subclass_of($facadeClass, Facade::class)) {
+                    continue;
+                }
+
                 $root = $facadeClass::getFacadeRoot();
             } catch (\Throwable $e) {
-                // BindingResolutionException is normal for unbound facades.
-                // \Error can occur for missing classes (e.g. optional Symfony packages).
+                // Catches both:
+                //  - errors raised while autoloading $facadeClass above (broken
+                //    aliases, parse errors in the target file, missing parents)
+                //  - BindingResolutionException or \Error from getFacadeRoot()
+                //    when the facade's container binding is absent or depends on
+                //    optional packages (e.g. Symfony components not installed).
                 $progress->debug("Laravel plugin: FacadeMapProvider skipped {$facadeClass}: {$e->getMessage()}\n");
                 continue;
             }

--- a/tests/Unit/Providers/FacadeMapProviderTest.php
+++ b/tests/Unit/Providers/FacadeMapProviderTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Tests\Unit\Providers;
+
+use Illuminate\Foundation\AliasLoader;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Providers\ApplicationProvider;
+use Psalm\LaravelPlugin\Providers\FacadeMapProvider;
+use Psalm\Progress\VoidProgress;
+
+#[CoversClass(FacadeMapProvider::class)]
+final class FacadeMapProviderTest extends TestCase
+{
+    /**
+     * Reproduces issue #745: the mateffy/laravel-introspect package publishes
+     * a self-referential alias via composer.json:
+     *
+     *     "extra": { "laravel": { "aliases": { "Introspect": "Introspect" } } }
+     *
+     * AliasLoader stores this literally, so when anything triggers
+     * spl_autoload('Introspect'), AliasLoader::load() calls
+     * class_alias('Introspect', 'Introspect') and PHP emits "Class not found".
+     * Psalm's error handler promotes that warning to an exception.
+     *
+     * FacadeMapProvider::init() calls is_subclass_of($facadeClass, Facade::class)
+     * on every alias entry, which is what triggers the autoload. Without the
+     * catch, one broken package disables the whole plugin for the run.
+     *
+     * This test registers a broken alias, installs a warnings-as-exceptions
+     * handler (mirroring Psalm's behavior), and verifies init() completes.
+     */
+    #[Test]
+    public function init_survives_self_referential_broken_alias(): void
+    {
+        ApplicationProvider::bootApp();
+
+        $aliasLoader = AliasLoader::getInstance();
+        $originalAliases = $aliasLoader->getAliases();
+
+        // Register the same broken pattern published by mateffy/laravel-introspect.
+        $aliasLoader->setAliases($originalAliases + ['Introspect_Test745' => 'Introspect_Test745']);
+
+        // Mirror Psalm\Internal\ErrorHandler: promote non-suppressed warnings to exceptions.
+        // PHPUnit strips E_WARNING from error_reporting, so bypass that gate here —
+        // we want to simulate Psalm's strict handler that throws on every warning.
+        $originalReporting = \error_reporting(\E_ALL);
+        \set_error_handler(static function (int $errno, string $message): bool {
+            if ((\error_reporting() & $errno) === 0) {
+                return false;
+            }
+
+            throw new \RuntimeException($message);
+        });
+
+        try {
+            FacadeMapProvider::init(new VoidProgress());
+            $this->addToAssertionCount(1); // reached without an uncaught exception
+        } finally {
+            \restore_error_handler();
+            \error_reporting($originalReporting);
+            $aliasLoader->setAliases($originalAliases);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #745.

When an installed package registers a self-referential alias (e.g. [`mateffy/laravel-introspect`](https://github.com/Capevace/laravel-introspect) registers `'Introspect' => 'Introspect'`), the plugin crashes during init with:

```
RuntimeException: PHP Error: Class "Introspect" not found in
vendor/laravel/framework/src/Illuminate/Foundation/AliasLoader.php:79
```

## Root cause

`FacadeMapProvider::init()` iterates `AliasLoader::getAliases()` and calls `is_subclass_of($facadeClass, Facade::class)` on each entry. `is_subclass_of()` triggers the autoloader, which routes through Laravel's `AliasLoader::load()`, which calls `class_alias('Introspect', 'Introspect')`. The source class doesn't exist, so PHP raises a warning. Psalm's error handler promotes the warning to a `RuntimeException`, the plugin's outer `catch` swallows it, and the entire plugin is disabled for the run.

The existing `try/catch` only wraps `getFacadeRoot()` (line 45-52). `is_subclass_of()` on line 41 runs first and is unprotected.

## Fix

Move the `is_subclass_of()` call inside the existing `try/catch`. Broken aliases are skipped with a debug message instead of aborting the plugin.

## Verification

Reproduced locally with a fresh Laravel 12 app + `mateffy/laravel-introspect` + plugin installed via path symlink:

- Before: `Warning: Laravel plugin has been disabled for this run`
- After: `No errors found!` (plugin initializes cleanly)

## Out of scope

The bug-report URL in the warning also showed a path-collapse artifact (`vendosrc/...` instead of `vendor/.../src/...`). That's a separate bug in `IssueUrlGenerator::sanitizeTrace()` and will be fixed in a follow-up.