### PR TITLE
Shorten bug-report title and prevent vendorsrc path collapse in `IssueUrlGenerator`

### DIFF
--- a/src/Util/IssueUrlGenerator.php
+++ b/src/Util/IssueUrlGenerator.php
@@ -70,18 +70,24 @@ final class IssueUrlGenerator
      *
      * Runs two passes — vendor first, then src — instead of one alternation. On a
      * checkout like "/Users/alice/src/project/vendor/laravel/framework/src/..." the
-     * single-regex alternation `(vendor/|src/)` with a non-greedy middle would stop
-     * at the *first* `src/` in the absolute prefix and leak "project/vendor/...".
-     * Collapsing vendor first lets the greedy-enough middle consume the whole
-     * absolute prefix up to `vendor/`; the subsequent src pass only fires when no
-     * `vendor/` segment exists, and its lookbehind prevents it from re-matching the
-     * `src/` inside an already-relativised "vendor/laravel/framework/src/..." path.
+     * single-regex alternation `(vendor/|src/)` would stop at the *first* `src/` in
+     * the absolute prefix and leak "project/vendor/...". Splitting into two passes
+     * lets the vendor pass consume the whole absolute prefix up to `vendor/`, and
+     * the subsequent src pass only fires when no `vendor/` segment exists.
+     *
+     * The middle segment is **greedy**, so each pass prefers the LAST `vendor/` or
+     * `src/` segment in an absolute path. That matters for paths like
+     * "/Users/alice/src/project/src/Plugin.php" (no vendor, `src/` twice): a
+     * non-greedy middle would match the first `src/` and leak "project/src/…",
+     * whereas the greedy middle collapses the whole prefix down to `src/Plugin.php`.
+     * Vendor paths containing an inner `src/` (e.g. "vendor/laravel/framework/src/…")
+     * are still safe because the src pass's lookbehind requires a boundary before
+     * the leading path separator — and once vendor has been collapsed, nothing in
+     * the relative "vendor/.../src/..." path is preceded by one.
      *
      * Each path prefix is anchored to a safe boundary (start-of-line, whitespace, or
      * one of the quote/paren characters that PHP stack traces use around stringified
-     * arguments, e.g. `#0 /path/File.php(79): Foo->bar('/dev/some/path', 79)`). The
-     * middle segment is non-greedy so that vendor paths containing an inner "src/"
-     * directory are not collapsed into "vendorsrc/...".
+     * arguments, e.g. `#0 /path/File.php(79): Foo->bar('/dev/some/path', 79)`).
      *
      * @psalm-pure
      */
@@ -98,7 +104,7 @@ final class IssueUrlGenerator
 
         // Vendor pass: collapses any absolute prefix up to "vendor/".
         $trace = (string) \preg_replace(
-            '#' . $boundary . '[A-Za-z]?:?' . $sep . '(?:[^\s:()]*?' . $sep . ')?(vendor' . $sep . ')#u',
+            '#' . $boundary . '[A-Za-z]?:?' . $sep . '(?:[^\s:()]*' . $sep . ')?(vendor' . $sep . ')#u',
             '$1',
             $trace,
         );
@@ -107,7 +113,7 @@ final class IssueUrlGenerator
         // Won't re-match an already-relativised "vendor/.../src/..." because the
         // lookbehind requires a safe boundary before the leading path separator.
         return (string) \preg_replace(
-            '#' . $boundary . '[A-Za-z]?:?' . $sep . '(?:[^\s:()]*?' . $sep . ')?(src' . $sep . ')#u',
+            '#' . $boundary . '[A-Za-z]?:?' . $sep . '(?:[^\s:()]*' . $sep . ')?(src' . $sep . ')#u',
             '$1',
             $trace,
         );

--- a/src/Util/IssueUrlGenerator.php
+++ b/src/Util/IssueUrlGenerator.php
@@ -30,7 +30,9 @@ final class IssueUrlGenerator
         $message = (string) \preg_replace('/\s+for command with CLI args\s+".*$/s', '', $message);
 
         // Drop " in /absolute/path/to/file.php:123" fragments that leak the reporter's filesystem.
-        $message = (string) \preg_replace('/\s+in\s+\S+\.php:\d+/u', '', $message);
+        // Non-greedy match (`.+?`) instead of `\S+` so Windows paths containing spaces
+        // (e.g. "C:\Users\John Doe\file.php:12") are also handled.
+        $message = (string) \preg_replace('/\s+in\s+.+?\.php:\d+/u', '', $message);
 
         // Strip a leading "PHP (Fatal error|Error|Warning|Notice): " prefix that duplicates context.
         $message = (string) \preg_replace('/^PHP\s+(?:Fatal\s+error|Error|Warning|Notice):\s+/i', '', $message);
@@ -66,17 +68,18 @@ final class IssueUrlGenerator
      * e.g. "/home/user/project/vendor/psalm/..." → "vendor/psalm/..."
      *      "/home/user/project/src/Plugin.php"   → "src/Plugin.php"
      *
-     * The path prefix is anchored to start-of-line or whitespace (via lookbehind),
-     * and the middle segment is non-greedy so that vendor paths containing an
-     * inner "src/" directory (e.g. "vendor/laravel/framework/src/...") are not
-     * collapsed into "vendorsrc/...".
+     * The path prefix is anchored to a safe boundary (start-of-line, whitespace, or one of
+     * the quote/paren characters that PHP stack traces use around stringified arguments,
+     * e.g. `#0 /path/File.php(79): Foo->bar('/dev/some/path', 79)`). The middle segment is
+     * non-greedy so that vendor paths containing an inner "src/" directory
+     * (e.g. "vendor/laravel/framework/src/...") are not collapsed into "vendorsrc/...".
      *
      * @psalm-pure
      */
     private static function sanitizeTrace(string $trace): string
     {
         return (string) \preg_replace(
-            '#(?<=\s|^)[A-Za-z]?:?[\\/](?:[^\s:()]*?[\\/])?(vendor[\\/]|src[\\/])#u',
+            '#(?<=\s|^|\'|"|\()[A-Za-z]?:?[\\/](?:[^\s:()]*?[\\/])?(vendor[\\/]|src[\\/])#u',
             '$1',
             $trace,
         );

--- a/src/Util/IssueUrlGenerator.php
+++ b/src/Util/IssueUrlGenerator.php
@@ -13,9 +13,29 @@ final class IssueUrlGenerator
     {
         return \sprintf(
             'https://github.com/psalm/psalm-plugin-laravel/issues/new?template=bug_report.md&title=%s&body=%s',
-            \urlencode("Plugin initialization error: {$throwable->getMessage()}"),
+            \urlencode('Plugin initialization error: ' . self::sanitizeTitle($throwable->getMessage())),
             \urlencode(self::buildBody($throwable)),
         );
+    }
+
+    /**
+     * Strip noisy, environment-specific fragments from the raw throwable message so the
+     * GitHub issue title stays short and free of private filesystem paths.
+     *
+     * @psalm-pure
+     */
+    private static function sanitizeTitle(string $message): string
+    {
+        // Drop the "for command with CLI args \"...\"" suffix Psalm appends to wrapped PHP errors.
+        $message = (string) \preg_replace('/\s+for command with CLI args\s+".*$/s', '', $message);
+
+        // Drop " in /absolute/path/to/file.php:123" fragments that leak the reporter's filesystem.
+        $message = (string) \preg_replace('/\s+in\s+\S+\.php:\d+/u', '', $message);
+
+        // Strip a leading "PHP (Fatal error|Error|Warning|Notice): " prefix that duplicates context.
+        $message = (string) \preg_replace('/^PHP\s+(?:Fatal\s+error|Error|Warning|Notice):\s+/i', '', $message);
+
+        return \trim($message);
     }
 
     private static function buildBody(\Throwable $throwable): string
@@ -43,16 +63,23 @@ final class IssueUrlGenerator
      * Remove absolute paths from the trace to avoid leaking private filesystem info.
      * Keeps only the path relative to the project/vendor root.
      *
+     * e.g. "/home/user/project/vendor/psalm/..." → "vendor/psalm/..."
+     *      "/home/user/project/src/Plugin.php"   → "src/Plugin.php"
+     *
+     * The path prefix is anchored to start-of-line or whitespace (via lookbehind),
+     * and the middle segment is non-greedy so that vendor paths containing an
+     * inner "src/" directory (e.g. "vendor/laravel/framework/src/...") are not
+     * collapsed into "vendorsrc/...".
+     *
      * @psalm-pure
      */
     private static function sanitizeTrace(string $trace): string
     {
-        // Replace absolute paths up to and including /vendor/ or a known package dir
-        // e.g. "/home/user/project/vendor/psalm/..." → "vendor/psalm/..."
-        $trace = (string) \preg_replace('#[A-Za-z]?:?[\\/](?:[^\s:()]*[\\/])?(vendor[\\/])#u', '$1', $trace);
-
-        // Replace any remaining absolute paths to src/ within this package
-        return (string) \preg_replace('#[A-Za-z]?:?[\\/](?:[^\s:()]*[\\/])?(src[\\/])#u', '$1', $trace);
+        return (string) \preg_replace(
+            '#(?<=\s|^)[A-Za-z]?:?[\\/](?:[^\s:()]*?[\\/])?(vendor[\\/]|src[\\/])#u',
+            '$1',
+            $trace,
+        );
     }
 
     /** @return array<string, string> */

--- a/src/Util/IssueUrlGenerator.php
+++ b/src/Util/IssueUrlGenerator.php
@@ -68,18 +68,39 @@ final class IssueUrlGenerator
      * e.g. "/home/user/project/vendor/psalm/..." → "vendor/psalm/..."
      *      "/home/user/project/src/Plugin.php"   → "src/Plugin.php"
      *
-     * The path prefix is anchored to a safe boundary (start-of-line, whitespace, or one of
-     * the quote/paren characters that PHP stack traces use around stringified arguments,
-     * e.g. `#0 /path/File.php(79): Foo->bar('/dev/some/path', 79)`). The middle segment is
-     * non-greedy so that vendor paths containing an inner "src/" directory
-     * (e.g. "vendor/laravel/framework/src/...") are not collapsed into "vendorsrc/...".
+     * Runs two passes — vendor first, then src — instead of one alternation. On a
+     * checkout like "/Users/alice/src/project/vendor/laravel/framework/src/..." the
+     * single-regex alternation `(vendor/|src/)` with a non-greedy middle would stop
+     * at the *first* `src/` in the absolute prefix and leak "project/vendor/...".
+     * Collapsing vendor first lets the greedy-enough middle consume the whole
+     * absolute prefix up to `vendor/`; the subsequent src pass only fires when no
+     * `vendor/` segment exists, and its lookbehind prevents it from re-matching the
+     * `src/` inside an already-relativised "vendor/laravel/framework/src/..." path.
+     *
+     * Each path prefix is anchored to a safe boundary (start-of-line, whitespace, or
+     * one of the quote/paren characters that PHP stack traces use around stringified
+     * arguments, e.g. `#0 /path/File.php(79): Foo->bar('/dev/some/path', 79)`). The
+     * middle segment is non-greedy so that vendor paths containing an inner "src/"
+     * directory are not collapsed into "vendorsrc/...".
      *
      * @psalm-pure
      */
     private static function sanitizeTrace(string $trace): string
     {
+        $boundary = '(?<=\s|^|\'|"|\()';
+
+        // Vendor pass: collapses any absolute prefix up to "vendor/".
+        $trace = (string) \preg_replace(
+            '#' . $boundary . '[A-Za-z]?:?[\\/](?:[^\s:()]*?[\\/])?(vendor[\\/])#u',
+            '$1',
+            $trace,
+        );
+
+        // Src pass: collapses any absolute prefix up to "src/".
+        // Won't re-match an already-relativised "vendor/.../src/..." because the
+        // lookbehind requires a safe boundary before the leading path separator.
         return (string) \preg_replace(
-            '#(?<=\s|^|\'|"|\()[A-Za-z]?:?[\\/](?:[^\s:()]*?[\\/])?(vendor[\\/]|src[\\/])#u',
+            '#' . $boundary . '[A-Za-z]?:?[\\/](?:[^\s:()]*?[\\/])?(src[\\/])#u',
             '$1',
             $trace,
         );

--- a/src/Util/IssueUrlGenerator.php
+++ b/src/Util/IssueUrlGenerator.php
@@ -89,9 +89,16 @@ final class IssueUrlGenerator
     {
         $boundary = '(?<=\s|^|\'|"|\()';
 
+        // Path-separator character class. `[\\\\/]` in this single-quoted PHP string
+        // becomes the two-char PCRE pattern `[\\/]`, which matches one backslash OR
+        // one forward slash. Writing `[\\/]` in the source would instead produce the
+        // PCRE pattern `[\/]` — that only matches `/` and silently skips Windows
+        // backslash paths, so the extra escaping is load-bearing.
+        $sep = '[\\\\/]';
+
         // Vendor pass: collapses any absolute prefix up to "vendor/".
         $trace = (string) \preg_replace(
-            '#' . $boundary . '[A-Za-z]?:?[\\/](?:[^\s:()]*?[\\/])?(vendor[\\/])#u',
+            '#' . $boundary . '[A-Za-z]?:?' . $sep . '(?:[^\s:()]*?' . $sep . ')?(vendor' . $sep . ')#u',
             '$1',
             $trace,
         );
@@ -100,7 +107,7 @@ final class IssueUrlGenerator
         // Won't re-match an already-relativised "vendor/.../src/..." because the
         // lookbehind requires a safe boundary before the leading path separator.
         return (string) \preg_replace(
-            '#' . $boundary . '[A-Za-z]?:?[\\/](?:[^\s:()]*?[\\/])?(src[\\/])#u',
+            '#' . $boundary . '[A-Za-z]?:?' . $sep . '(?:[^\s:()]*?' . $sep . ')?(src' . $sep . ')#u',
             '$1',
             $trace,
         );

--- a/tests/Unit/Util/IssueUrlGeneratorTest.php
+++ b/tests/Unit/Util/IssueUrlGeneratorTest.php
@@ -220,7 +220,7 @@ final class IssueUrlGeneratorTest extends TestCase
 
         $output = self::invokeSanitizeTrace($input);
 
-        self::assertSame('#0 src/Plugin.php(42): X->y()', $output);
+        $this->assertSame('#0 src/Plugin.php(42): X->y()', $output);
     }
 
     #[Test]

--- a/tests/Unit/Util/IssueUrlGeneratorTest.php
+++ b/tests/Unit/Util/IssueUrlGeneratorTest.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Util;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Util\IssueUrlGenerator;
+use ReflectionMethod;
+
+use function parse_str;
+use function parse_url;
+use function strlen;
+
+use const PHP_URL_QUERY;
+
+#[CoversClass(IssueUrlGenerator::class)]
+final class IssueUrlGeneratorTest extends TestCase
+{
+    #[Test]
+    public function url_points_to_new_issue_form_with_bug_report_template(): void
+    {
+        $url = IssueUrlGenerator::generate(new \RuntimeException('boom'));
+
+        self::assertStringStartsWith(
+            'https://github.com/psalm/psalm-plugin-laravel/issues/new?template=bug_report.md',
+            $url,
+        );
+    }
+
+    #[Test]
+    public function title_prefixes_plugin_initialization_error(): void
+    {
+        $title = self::titleFrom(IssueUrlGenerator::generate(new \RuntimeException('boom')));
+
+        self::assertSame('Plugin initialization error: boom', $title);
+    }
+
+    /**
+     * Reproduces the real-world title reported by a user against an absolute Laravel
+     * path (see issue #745). The raw PHP-Error-wrapped-by-Psalm message contains an
+     * absolute path and a trailing CLI args blob — both must be stripped.
+     */
+    #[Test]
+    public function title_matches_hand_edited_version_from_reported_issue(): void
+    {
+        $rawMessage = 'PHP Error: Class "Introspect" not found in '
+            . '/Users/matthewdally/docker/business-directory/vendor/laravel/framework/src/Illuminate/Foundation/AliasLoader.php:79'
+            . ' for command with CLI args "./vendor/bin/psalm --no-cache --config=psalm.xml"';
+
+        $title = self::titleFrom(IssueUrlGenerator::generate(new \RuntimeException($rawMessage)));
+
+        self::assertSame(
+            'Plugin initialization error: Class "Introspect" not found',
+            $title,
+        );
+    }
+
+    #[Test]
+    public function title_strips_windows_paths_containing_spaces(): void
+    {
+        $rawMessage = 'Class "Foo" not found in C:\\Users\\John Doe\\project\\src\\File.php:12';
+
+        $title = self::titleFrom(IssueUrlGenerator::generate(new \RuntimeException($rawMessage)));
+
+        self::assertSame('Plugin initialization error: Class "Foo" not found', $title);
+    }
+
+    /** @return iterable<string, array{string, string}> */
+    public static function leadingPhpPrefixes(): iterable
+    {
+        yield 'PHP Error' => ['PHP Error: Something broke', 'Something broke'];
+        yield 'PHP Fatal error' => ['PHP Fatal error: Something broke', 'Something broke'];
+        yield 'PHP Warning' => ['PHP Warning: Something broke', 'Something broke'];
+        yield 'PHP Notice' => ['PHP Notice: Something broke', 'Something broke'];
+        yield 'case insensitive' => ['PHP fatal ERROR: Something broke', 'Something broke'];
+    }
+
+    #[Test]
+    #[DataProvider('leadingPhpPrefixes')]
+    public function title_strips_leading_php_level_prefix(string $rawMessage, string $expectedTail): void
+    {
+        $title = self::titleFrom(IssueUrlGenerator::generate(new \RuntimeException($rawMessage)));
+
+        self::assertSame('Plugin initialization error: ' . $expectedTail, $title);
+    }
+
+    #[Test]
+    public function title_does_not_strip_non_php_colon_prefixes(): void
+    {
+        $title = self::titleFrom(IssueUrlGenerator::generate(new \RuntimeException('Class not found: Foo')));
+
+        self::assertSame('Plugin initialization error: Class not found: Foo', $title);
+    }
+
+    /**
+     * Guard against long titles sneaking back in via future regressions —
+     * the sanitised title for the reported example must stay well under the
+     * original raw message length so GitHub's issue form does not truncate it.
+     */
+    #[Test]
+    public function sanitised_title_is_shorter_than_raw_message(): void
+    {
+        $rawMessage = 'PHP Error: Class "Introspect" not found in '
+            . '/Users/matthewdally/docker/business-directory/vendor/laravel/framework/src/Illuminate/Foundation/AliasLoader.php:79'
+            . ' for command with CLI args "./vendor/bin/psalm --no-cache --config=psalm.xml"';
+
+        $title = self::titleFrom(IssueUrlGenerator::generate(new \RuntimeException($rawMessage)));
+        $expectedTitle = 'Plugin initialization error: Class "Introspect" not found';
+
+        self::assertSame($expectedTitle, $title);
+        self::assertLessThan(strlen($rawMessage), strlen($expectedTitle));
+    }
+
+    #[Test]
+    public function body_includes_fenced_trace_block(): void
+    {
+        $body = self::bodyFrom(IssueUrlGenerator::generate(new \RuntimeException('boom')));
+
+        self::assertStringContainsString("```\n", $body);
+        self::assertStringContainsString('RuntimeException', $body);
+        self::assertStringContainsString('boom', $body);
+    }
+
+    #[Test]
+    public function body_lists_plugin_version_from_installed_versions(): void
+    {
+        $body = self::bodyFrom(IssueUrlGenerator::generate(new \RuntimeException('boom')));
+
+        // psalm/plugin-laravel is this very package — always resolvable during test runs.
+        self::assertStringContainsString('**Versions:**', $body);
+        self::assertStringContainsString('- psalm/plugin-laravel:', $body);
+    }
+
+    /**
+     * The trace-specific tests exercise the private `sanitizeTrace()` directly so the
+     * synthetic absolute paths we want to observe are not entangled with PHPUnit's own
+     * stack-frame-argument truncation, which otherwise rewrites them as `/foo/bar/ap...`
+     * before the sanitizer can see a `vendor/` or `src/` segment.
+     */
+    private static function invokeSanitizeTrace(string $input): string
+    {
+        $method = new ReflectionMethod(IssueUrlGenerator::class, 'sanitizeTrace');
+
+        return (string) $method->invoke(null, $input);
+    }
+
+    #[Test]
+    public function trace_collapses_absolute_vendor_path(): void
+    {
+        $input = '#0 /home/bob/app/vendor/vimeo/psalm/src/Foo.php(99): Bar->baz()';
+
+        $output = self::invokeSanitizeTrace($input);
+
+        self::assertSame(
+            '#0 vendor/vimeo/psalm/src/Foo.php(99): Bar->baz()',
+            $output,
+        );
+    }
+
+    #[Test]
+    public function trace_collapses_absolute_src_path(): void
+    {
+        $input = '#0 /home/bob/psalm-plugin-laravel/src/Plugin.php(697): X->y()';
+
+        $output = self::invokeSanitizeTrace($input);
+
+        self::assertSame('#0 src/Plugin.php(697): X->y()', $output);
+    }
+
+    /**
+     * Regression: on checkouts like /Users/alice/src/project/vendor/… a naive
+     * `(vendor/|src/)` alternation would stop at the earlier /src/ in the home
+     * dir and leak "project/vendor/…". The vendor pass must consume the whole
+     * prefix.
+     */
+    #[Test]
+    public function trace_does_not_leak_src_inside_absolute_prefix_when_vendor_is_present(): void
+    {
+        $input = '#0 /Users/alice/src/project/vendor/laravel/framework/src/Illuminate/F.php(9): A->b()';
+
+        $output = self::invokeSanitizeTrace($input);
+
+        self::assertSame(
+            '#0 vendor/laravel/framework/src/Illuminate/F.php(9): A->b()',
+            $output,
+        );
+    }
+
+    /**
+     * Regression: vendor paths contain an inner "src/" directory
+     * (vendor/laravel/framework/src/…). A too-greedy regex would collapse that
+     * to "vendorsrc/…" and lose the framework path.
+     */
+    #[Test]
+    public function trace_preserves_inner_src_inside_vendor_path(): void
+    {
+        $input = '#0 /home/u/app/vendor/laravel/framework/src/Illuminate/Foundation/AliasLoader.php(79): X->y()';
+
+        $output = self::invokeSanitizeTrace($input);
+
+        self::assertSame(
+            '#0 vendor/laravel/framework/src/Illuminate/Foundation/AliasLoader.php(79): X->y()',
+            $output,
+        );
+        self::assertStringNotContainsString('vendorsrc', $output);
+    }
+
+    #[Test]
+    public function trace_sanitises_quoted_path_arguments_in_stack_frame(): void
+    {
+        $input = "#0 /a/vendor/b.php(9): X->y('/dev/vendor/z.php', 79)";
+
+        $output = self::invokeSanitizeTrace($input);
+
+        self::assertSame(
+            "#0 vendor/b.php(9): X->y('vendor/z.php', 79)",
+            $output,
+        );
+    }
+
+    #[Test]
+    public function trace_collapses_windows_backslash_path(): void
+    {
+        $input = '#0 C:\\Users\\carol\\src\\app\\vendor\\laravel\\framework\\src\\Foo.php(1): X->y()';
+
+        $output = self::invokeSanitizeTrace($input);
+
+        self::assertSame(
+            '#0 vendor\\laravel\\framework\\src\\Foo.php(1): X->y()',
+            $output,
+        );
+    }
+
+    #[Test]
+    public function trace_only_collapses_src_when_no_vendor_segment_exists(): void
+    {
+        // When no vendor/ segment exists, the src pass handles the rewrite.
+        $input = '#0 /home/u/project/src/Plugin.php(42): X->y()';
+
+        $output = self::invokeSanitizeTrace($input);
+
+        self::assertSame('#0 src/Plugin.php(42): X->y()', $output);
+    }
+
+    #[Test]
+    public function trace_leaves_already_relative_paths_untouched(): void
+    {
+        $input = '#0 vendor/already/relative.php(1): X->y()';
+
+        $output = self::invokeSanitizeTrace($input);
+
+        self::assertSame($input, $output);
+    }
+
+    private static function titleFrom(string $url): string
+    {
+        $query = parse_url($url, PHP_URL_QUERY);
+        self::assertIsString($query);
+
+        $params = [];
+        parse_str($query, $params);
+
+        self::assertArrayHasKey('title', $params);
+        self::assertIsString($params['title']);
+
+        return $params['title'];
+    }
+
+    private static function bodyFrom(string $url): string
+    {
+        $query = parse_url($url, PHP_URL_QUERY);
+        self::assertIsString($query);
+
+        $params = [];
+        parse_str($query, $params);
+
+        self::assertArrayHasKey('body', $params);
+        self::assertIsString($params['body']);
+
+        return $params['body'];
+    }
+}

--- a/tests/Unit/Util/IssueUrlGeneratorTest.php
+++ b/tests/Unit/Util/IssueUrlGeneratorTest.php
@@ -207,6 +207,22 @@ final class IssueUrlGeneratorTest extends TestCase
         $this->assertSame('#0 vendor\\laravel\\framework\\src\\Foo.php(1): X->y()', $output);
     }
 
+    /**
+     * Regression: nested `.../src/.../src/...` paths with no vendor segment.
+     * A non-greedy middle in the src pass would stop at the first `src/` in the
+     * absolute prefix and leak "project/src/...". The greedy middle prefers the
+     * last `src/` segment and collapses the whole prefix.
+     */
+    #[Test]
+    public function trace_collapses_nested_src_paths_without_vendor_segment(): void
+    {
+        $input = '#0 /Users/alice/src/project/src/Plugin.php(42): X->y()';
+
+        $output = self::invokeSanitizeTrace($input);
+
+        self::assertSame('#0 src/Plugin.php(42): X->y()', $output);
+    }
+
     #[Test]
     public function trace_only_collapses_src_when_no_vendor_segment_exists(): void
     {

--- a/tests/Unit/Util/IssueUrlGeneratorTest.php
+++ b/tests/Unit/Util/IssueUrlGeneratorTest.php
@@ -218,7 +218,7 @@ final class IssueUrlGeneratorTest extends TestCase
     {
         $input = '#0 /Users/alice/src/project/src/Plugin.php(42): X->y()';
 
-        $output = self::invokeSanitizeTrace($input);
+        $output = $this->invokeSanitizeTrace($input);
 
         $this->assertSame('#0 src/Plugin.php(42): X->y()', $output);
     }

--- a/tests/Unit/Util/IssueUrlGeneratorTest.php
+++ b/tests/Unit/Util/IssueUrlGeneratorTest.php
@@ -9,13 +9,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psalm\LaravelPlugin\Util\IssueUrlGenerator;
-use ReflectionMethod;
-
-use function parse_str;
-use function parse_url;
-use function strlen;
-
-use const PHP_URL_QUERY;
 
 #[CoversClass(IssueUrlGenerator::class)]
 final class IssueUrlGeneratorTest extends TestCase
@@ -25,18 +18,15 @@ final class IssueUrlGeneratorTest extends TestCase
     {
         $url = IssueUrlGenerator::generate(new \RuntimeException('boom'));
 
-        self::assertStringStartsWith(
-            'https://github.com/psalm/psalm-plugin-laravel/issues/new?template=bug_report.md',
-            $url,
-        );
+        $this->assertStringStartsWith('https://github.com/psalm/psalm-plugin-laravel/issues/new?template=bug_report.md', $url);
     }
 
     #[Test]
     public function title_prefixes_plugin_initialization_error(): void
     {
-        $title = self::titleFrom(IssueUrlGenerator::generate(new \RuntimeException('boom')));
+        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException('boom')));
 
-        self::assertSame('Plugin initialization error: boom', $title);
+        $this->assertSame('Plugin initialization error: boom', $title);
     }
 
     /**
@@ -51,12 +41,9 @@ final class IssueUrlGeneratorTest extends TestCase
             . '/Users/matthewdally/docker/business-directory/vendor/laravel/framework/src/Illuminate/Foundation/AliasLoader.php:79'
             . ' for command with CLI args "./vendor/bin/psalm --no-cache --config=psalm.xml"';
 
-        $title = self::titleFrom(IssueUrlGenerator::generate(new \RuntimeException($rawMessage)));
+        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException($rawMessage)));
 
-        self::assertSame(
-            'Plugin initialization error: Class "Introspect" not found',
-            $title,
-        );
+        $this->assertSame('Plugin initialization error: Class "Introspect" not found', $title);
     }
 
     #[Test]
@@ -64,9 +51,9 @@ final class IssueUrlGeneratorTest extends TestCase
     {
         $rawMessage = 'Class "Foo" not found in C:\\Users\\John Doe\\project\\src\\File.php:12';
 
-        $title = self::titleFrom(IssueUrlGenerator::generate(new \RuntimeException($rawMessage)));
+        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException($rawMessage)));
 
-        self::assertSame('Plugin initialization error: Class "Foo" not found', $title);
+        $this->assertSame('Plugin initialization error: Class "Foo" not found', $title);
     }
 
     /** @return iterable<string, array{string, string}> */
@@ -83,17 +70,17 @@ final class IssueUrlGeneratorTest extends TestCase
     #[DataProvider('leadingPhpPrefixes')]
     public function title_strips_leading_php_level_prefix(string $rawMessage, string $expectedTail): void
     {
-        $title = self::titleFrom(IssueUrlGenerator::generate(new \RuntimeException($rawMessage)));
+        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException($rawMessage)));
 
-        self::assertSame('Plugin initialization error: ' . $expectedTail, $title);
+        $this->assertSame('Plugin initialization error: ' . $expectedTail, $title);
     }
 
     #[Test]
     public function title_does_not_strip_non_php_colon_prefixes(): void
     {
-        $title = self::titleFrom(IssueUrlGenerator::generate(new \RuntimeException('Class not found: Foo')));
+        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException('Class not found: Foo')));
 
-        self::assertSame('Plugin initialization error: Class not found: Foo', $title);
+        $this->assertSame('Plugin initialization error: Class not found: Foo', $title);
     }
 
     /**
@@ -108,31 +95,31 @@ final class IssueUrlGeneratorTest extends TestCase
             . '/Users/matthewdally/docker/business-directory/vendor/laravel/framework/src/Illuminate/Foundation/AliasLoader.php:79'
             . ' for command with CLI args "./vendor/bin/psalm --no-cache --config=psalm.xml"';
 
-        $title = self::titleFrom(IssueUrlGenerator::generate(new \RuntimeException($rawMessage)));
+        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException($rawMessage)));
         $expectedTitle = 'Plugin initialization error: Class "Introspect" not found';
 
-        self::assertSame($expectedTitle, $title);
-        self::assertLessThan(strlen($rawMessage), strlen($expectedTitle));
+        $this->assertSame($expectedTitle, $title);
+        $this->assertLessThan(\strlen($rawMessage), \strlen($expectedTitle));
     }
 
     #[Test]
     public function body_includes_fenced_trace_block(): void
     {
-        $body = self::bodyFrom(IssueUrlGenerator::generate(new \RuntimeException('boom')));
+        $body = $this->bodyFrom(IssueUrlGenerator::generate(new \RuntimeException('boom')));
 
-        self::assertStringContainsString("```\n", $body);
-        self::assertStringContainsString('RuntimeException', $body);
-        self::assertStringContainsString('boom', $body);
+        $this->assertStringContainsString("```\n", $body);
+        $this->assertStringContainsString('RuntimeException', $body);
+        $this->assertStringContainsString('boom', $body);
     }
 
     #[Test]
     public function body_lists_plugin_version_from_installed_versions(): void
     {
-        $body = self::bodyFrom(IssueUrlGenerator::generate(new \RuntimeException('boom')));
+        $body = $this->bodyFrom(IssueUrlGenerator::generate(new \RuntimeException('boom')));
 
         // psalm/plugin-laravel is this very package — always resolvable during test runs.
-        self::assertStringContainsString('**Versions:**', $body);
-        self::assertStringContainsString('- psalm/plugin-laravel:', $body);
+        $this->assertStringContainsString('**Versions:**', $body);
+        $this->assertStringContainsString('- psalm/plugin-laravel:', $body);
     }
 
     /**
@@ -141,9 +128,9 @@ final class IssueUrlGeneratorTest extends TestCase
      * stack-frame-argument truncation, which otherwise rewrites them as `/foo/bar/ap...`
      * before the sanitizer can see a `vendor/` or `src/` segment.
      */
-    private static function invokeSanitizeTrace(string $input): string
+    private function invokeSanitizeTrace(string $input): string
     {
-        $method = new ReflectionMethod(IssueUrlGenerator::class, 'sanitizeTrace');
+        $method = new \ReflectionMethod(IssueUrlGenerator::class, 'sanitizeTrace');
 
         return (string) $method->invoke(null, $input);
     }
@@ -153,12 +140,9 @@ final class IssueUrlGeneratorTest extends TestCase
     {
         $input = '#0 /home/bob/app/vendor/vimeo/psalm/src/Foo.php(99): Bar->baz()';
 
-        $output = self::invokeSanitizeTrace($input);
+        $output = $this->invokeSanitizeTrace($input);
 
-        self::assertSame(
-            '#0 vendor/vimeo/psalm/src/Foo.php(99): Bar->baz()',
-            $output,
-        );
+        $this->assertSame('#0 vendor/vimeo/psalm/src/Foo.php(99): Bar->baz()', $output);
     }
 
     #[Test]
@@ -166,9 +150,9 @@ final class IssueUrlGeneratorTest extends TestCase
     {
         $input = '#0 /home/bob/psalm-plugin-laravel/src/Plugin.php(697): X->y()';
 
-        $output = self::invokeSanitizeTrace($input);
+        $output = $this->invokeSanitizeTrace($input);
 
-        self::assertSame('#0 src/Plugin.php(697): X->y()', $output);
+        $this->assertSame('#0 src/Plugin.php(697): X->y()', $output);
     }
 
     /**
@@ -182,12 +166,9 @@ final class IssueUrlGeneratorTest extends TestCase
     {
         $input = '#0 /Users/alice/src/project/vendor/laravel/framework/src/Illuminate/F.php(9): A->b()';
 
-        $output = self::invokeSanitizeTrace($input);
+        $output = $this->invokeSanitizeTrace($input);
 
-        self::assertSame(
-            '#0 vendor/laravel/framework/src/Illuminate/F.php(9): A->b()',
-            $output,
-        );
+        $this->assertSame('#0 vendor/laravel/framework/src/Illuminate/F.php(9): A->b()', $output);
     }
 
     /**
@@ -200,13 +181,10 @@ final class IssueUrlGeneratorTest extends TestCase
     {
         $input = '#0 /home/u/app/vendor/laravel/framework/src/Illuminate/Foundation/AliasLoader.php(79): X->y()';
 
-        $output = self::invokeSanitizeTrace($input);
+        $output = $this->invokeSanitizeTrace($input);
 
-        self::assertSame(
-            '#0 vendor/laravel/framework/src/Illuminate/Foundation/AliasLoader.php(79): X->y()',
-            $output,
-        );
-        self::assertStringNotContainsString('vendorsrc', $output);
+        $this->assertSame('#0 vendor/laravel/framework/src/Illuminate/Foundation/AliasLoader.php(79): X->y()', $output);
+        $this->assertStringNotContainsString('vendorsrc', $output);
     }
 
     #[Test]
@@ -214,12 +192,9 @@ final class IssueUrlGeneratorTest extends TestCase
     {
         $input = "#0 /a/vendor/b.php(9): X->y('/dev/vendor/z.php', 79)";
 
-        $output = self::invokeSanitizeTrace($input);
+        $output = $this->invokeSanitizeTrace($input);
 
-        self::assertSame(
-            "#0 vendor/b.php(9): X->y('vendor/z.php', 79)",
-            $output,
-        );
+        $this->assertSame("#0 vendor/b.php(9): X->y('vendor/z.php', 79)", $output);
     }
 
     #[Test]
@@ -227,12 +202,9 @@ final class IssueUrlGeneratorTest extends TestCase
     {
         $input = '#0 C:\\Users\\carol\\src\\app\\vendor\\laravel\\framework\\src\\Foo.php(1): X->y()';
 
-        $output = self::invokeSanitizeTrace($input);
+        $output = $this->invokeSanitizeTrace($input);
 
-        self::assertSame(
-            '#0 vendor\\laravel\\framework\\src\\Foo.php(1): X->y()',
-            $output,
-        );
+        $this->assertSame('#0 vendor\\laravel\\framework\\src\\Foo.php(1): X->y()', $output);
     }
 
     #[Test]
@@ -241,9 +213,9 @@ final class IssueUrlGeneratorTest extends TestCase
         // When no vendor/ segment exists, the src pass handles the rewrite.
         $input = '#0 /home/u/project/src/Plugin.php(42): X->y()';
 
-        $output = self::invokeSanitizeTrace($input);
+        $output = $this->invokeSanitizeTrace($input);
 
-        self::assertSame('#0 src/Plugin.php(42): X->y()', $output);
+        $this->assertSame('#0 src/Plugin.php(42): X->y()', $output);
     }
 
     #[Test]
@@ -251,35 +223,35 @@ final class IssueUrlGeneratorTest extends TestCase
     {
         $input = '#0 vendor/already/relative.php(1): X->y()';
 
-        $output = self::invokeSanitizeTrace($input);
+        $output = $this->invokeSanitizeTrace($input);
 
-        self::assertSame($input, $output);
+        $this->assertSame($input, $output);
     }
 
-    private static function titleFrom(string $url): string
+    private function titleFrom(string $url): string
     {
-        $query = parse_url($url, PHP_URL_QUERY);
-        self::assertIsString($query);
+        $query = \parse_url($url, \PHP_URL_QUERY);
+        $this->assertIsString($query);
 
         $params = [];
-        parse_str($query, $params);
+        \parse_str($query, $params);
 
-        self::assertArrayHasKey('title', $params);
-        self::assertIsString($params['title']);
+        $this->assertArrayHasKey('title', $params);
+        $this->assertIsString($params['title']);
 
         return $params['title'];
     }
 
-    private static function bodyFrom(string $url): string
+    private function bodyFrom(string $url): string
     {
-        $query = parse_url($url, PHP_URL_QUERY);
-        self::assertIsString($query);
+        $query = \parse_url($url, \PHP_URL_QUERY);
+        $this->assertIsString($query);
 
         $params = [];
-        parse_str($query, $params);
+        \parse_str($query, $params);
 
-        self::assertArrayHasKey('body', $params);
-        self::assertIsString($params['body']);
+        $this->assertArrayHasKey('body', $params);
+        $this->assertIsString($params['body']);
 
         return $params['body'];
     }


### PR DESCRIPTION
## Issue to Solve

The auto-generated GitHub issue URL produced by `IssueUrlGenerator` fills the title with noise that the reporter has to hand-edit before submitting:

- Psalm wraps `PHP Error: …` with a trailing `for command with CLI args "./vendor/bin/psalm …"` suffix.
- The raw message contains absolute paths like ` in /Users/matthewdally/docker/business-directory/vendor/laravel/framework/src/Illuminate/Foundation/AliasLoader.php:79`, which blow the title length out and leak private filesystem info.
- The `PHP Error:` prefix duplicates the "Plugin initialization error:" prefix we already prepend.

Example from a recent report (`#745`): the reporter opened the issue, then had to rename the title twice, ending at the much cleaner `Plugin initialization error: Class "Introspect" not found`.

`sanitizeTrace()` in the issue body has a related set of concerns: it must not collapse vendor paths that contain an inner `src/` segment (e.g. `vendor/laravel/framework/src/…`) into `vendorsrc/…`, must cover Windows backslash paths and quoted argument paths from stack frames, and must pick the last `vendor/` or `src/` segment in paths where one of those appears more than once in the absolute prefix (e.g. `/Users/alice/src/project/src/Plugin.php`).

## Solution Description

1. New private `sanitizeTitle()` called from `generate()` strips three fragments from the throwable message before URL-encoding it into the `title=` query parameter:
   - `\s+for command with CLI args\s+".*$` suffix.
   - `\s+in\s+.+?\.php:\d+` path+line leaks — non-greedy `.+?` rather than `\S+` so Windows paths with spaces are handled.
   - Leading `PHP (Fatal error|Error|Warning|Notice):\s+` prefix (case-insensitive).

   The full stack trace is still placed into the issue body, so debug info is not lost — only the URL title is compressed.

2. `sanitizeTrace()` runs two sequential passes — vendor first, then src — each with:
   - A boundary lookbehind `(?<=\s|^|'|"|\()` so quoted / parenthesised path arguments in PHP stack frames are also sanitized.
   - A **greedy** middle segment so each pass prefers the LAST `vendor/` or `src/` in the absolute prefix. This collapses cases like `/Users/alice/src/project/src/Plugin.php` to `src/Plugin.php` instead of leaking `project/src/…`, and `/Users/alice/src/project/vendor/…` to `vendor/…` instead of stopping at the earlier `src/`.
   - A path-separator character class declared as `'[\\\\/]'` (single-quoted PHP → PCRE `[\\/]`) so both forward slashes and Windows backslashes are matched. Writing the more obvious `'[\\/]'` would produce PCRE `[\/]` and silently skip backslash paths; a comment at the declaration explains why the extra escaping is load-bearing.

3. New `tests/Unit/Util/IssueUrlGeneratorTest.php` with 22 tests covering URL shape, the real-world Introspect title, Windows paths with spaces, each `PHP …:` prefix variant, the body's `**Versions:**` and fenced trace blocks, and every trace regression listed above. Trace tests exercise the private `sanitizeTrace()` via reflection so PHPUnit's stack-frame-argument truncation does not entangle the assertions.

Verified via Psalm self-analysis and `phpunit tests/Unit/Util/IssueUrlGeneratorTest.php`.

On the reported Introspect example the title now reads exactly: `Plugin initialization error: Class "Introspect" not found`.

## Checklist

- [x] Tests cover the change (`tests/Unit/Util/IssueUrlGeneratorTest.php`).
- [x] Change verified against the real-world example from the Introspect bug report.
