### PR TITLE
fix: race-safe `mkdir` in `getCacheLocation()` under parallel runs

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -694,8 +694,14 @@ final class Plugin implements PluginEntryPointInterface
     {
         $dir = $pluginConfig->cachePath;
 
-        if (!\is_dir($dir) && !\mkdir($dir, 0777, true) && !\is_dir($dir)) {
-            throw new \RuntimeException("Cache directory '{$dir}' does not exist and could not be created.");
+        // `@` suppresses the E_WARNING from a concurrent-mkdir race: Psalm's error
+        // handler promotes unsuppressed warnings to exceptions, which crashes parallel
+        // runners. The trailing `is_dir()` still catches real failures (e.g. EACCES).
+        if (!\is_dir($dir) && !@\mkdir($dir, 0777, true) && !\is_dir($dir)) {
+            $error = \error_get_last();
+            $reason = $error['message'] ?? 'unknown error';
+
+            throw new \RuntimeException("Cache directory '{$dir}' does not exist and could not be created: {$reason}.");
         }
 
         return $dir;


### PR DESCRIPTION
## Issue to Solve
`Plugin::getCacheLocation()` crashes under parallel Psalm runs. It uses the canonical `!is_dir() && !mkdir() && !is_dir()` idiom, but `mkdir()` still emits `E_WARNING` ("File exists") when a concurrent process wins the race. `Psalm\Internal\ErrorHandler` promotes unsuppressed warnings to `RuntimeException` (it checks `$error_code & error_reporting()` at `vendor/vimeo/psalm/src/Psalm/Internal/ErrorHandler.php:78`), so every losing process aborts plugin init with a fatal exception.

This surfaces when psalm-tester (`feature/parallel-batch` at `ce21007`) launches multiple Psalm processes concurrently via `proc_open`. Repro: https://github.com/psalm/psalm-plugin-laravel/actions/runs/24555775079/job/71791755205?pr=747.

## Related
No dedicated issue. The crash originally surfaced on PR #747 CI.

## Solution Description
Three small changes in `src/Plugin.php::getCacheLocation()`:

1. `@\mkdir(...)` suppresses the `E_WARNING` for the benign race case. PHP 8's `@` still silences `E_WARNING` via `error_reporting()`, which Psalm's handler honors.
2. The trailing `is_dir()` check is preserved, so genuine failures (EACCES, ENOSPC, read-only filesystem, parent is a file) still throw.
3. The `RuntimeException` now includes `error_get_last()['message']`, so non-race failures still surface the OS-level cause that `@` would otherwise swallow.

### Verification
- `composer psalm` is clean.
- `composer test` passes (429 unit tests, 269 type tests).

## Checklist
- [x] Tests cover the change. Existing `PluginConfigTest::get_cache_location_creates_and_returns_dir` covers the happy path; the race path cannot be deterministically simulated from a single PHPUnit process without forking, so no new test was added.
