### PR TITLE
Fix false-positive DocblockTypeContradiction on filled()/blank() guards with nullable strings

### DIFF
--- a/stubs/common/Support/helpers.stubphp
+++ b/stubs/common/Support/helpers.stubphp
@@ -31,10 +31,28 @@ class NullObject {
 /**
  * Determine if the given value is "blank".
  *
+ * The conditional branches are nested (not unioned) to avoid a Psalm
+ * over-narrowing edge case. A unioned clause such as
+ * `$value is (null|''|array<never, never>)` collapses the whole
+ * conditional to the narrow branch for an input that only partially
+ * overlaps with the union (e.g. `string` intersects `''` but is not a
+ * subtype of the union), making `blank(?string)` infer literal `true`.
+ * Splitting each literal into its own `is null`, `is ''`,
+ * `is array<never, never>` check keeps non-matching inputs flowing
+ * through to `bool`. See
+ * https://github.com/psalm/psalm-plugin-laravel/issues/751.
+ *
  * @param  mixed  $value
+ * @psalm-assert-if-false !null $value
  * @psalm-return ($value is (bool|numeric|non-empty-array)
  *  ? false
- *  : ($value is (null|''|array<never, never>) ? true : bool)
+ *  : ($value is null
+ *      ? true
+ *      : ($value is ''
+ *          ? true
+ *          : ($value is array<never, never> ? true : bool)
+ *      )
+ *    )
  * )
  */
 function blank($value) {}
@@ -76,10 +94,19 @@ function e($value, $doubleEncode = true) {}
 /**
  * Determine if a value is "filled".
  *
+ * See {@see blank()} for the rationale behind the nested conditional shape.
+ *
  * @param  mixed  $value
+ * @psalm-assert-if-true !null $value
  * @psalm-return ($value is (bool|numeric|non-empty-array)
  *  ? true
- *  : ($value is (null|''|array<never, never>) ? false : bool)
+ *  : ($value is null
+ *      ? false
+ *      : ($value is ''
+ *          ? false
+ *          : ($value is array<never, never> ? false : bool)
+ *      )
+ *    )
  * )
  */
 function filled($value) {}

--- a/tests/Type/tests/Helpers/SupportHelpersTest.phpt
+++ b/tests/Type/tests/Helpers/SupportHelpersTest.phpt
@@ -154,6 +154,92 @@ function non_empty_string_is_unknown_filled_or_not(): bool
     return filled('  ');
 }
 
+// Regression tests for https://github.com/psalm/psalm-plugin-laravel/issues/751.
+// Conditional return types must not collapse to literal `true`/`false` for
+// wider input types that only partially overlap with the narrow clauses.
+// These use @psalm-check-type-exact so a regression to the old stub (which
+// returned literal `false`/`true` here) fails the test. A plain `: bool`
+// return would silently accept the literal subtype.
+function nullable_string_is_unknown_filled_or_not(?string $value): bool
+{
+    $result = filled($value);
+    /** @psalm-check-type-exact $result = bool */;
+    return $result;
+}
+
+function nullable_string_is_unknown_blank_or_not(?string $value): bool
+{
+    $result = blank($value);
+    /** @psalm-check-type-exact $result = bool */;
+    return $result;
+}
+
+function string_is_unknown_filled_or_not(string $value): bool
+{
+    $result = filled($value);
+    /** @psalm-check-type-exact $result = bool */;
+    return $result;
+}
+
+function array_is_unknown_blank_or_not(array $value): bool
+{
+    $result = blank($value);
+    /** @psalm-check-type-exact $result = bool */;
+    return $result;
+}
+
+function mixed_is_unknown_filled_or_not(mixed $value): bool
+{
+    $result = filled($value);
+    /** @psalm-check-type-exact $result = bool */;
+    return $result;
+}
+
+/**
+ * Union that straddles multiple narrow clauses (`string` overlaps with `''`,
+ * `array` overlaps with `array<never, never>`). Exercises the nested-conditional
+ * rationale from the stub comment.
+ *
+ * @param string|array $value
+ */
+function string_or_array_union_is_unknown_filled_or_not($value): bool
+{
+    $result = filled($value);
+    /** @psalm-check-type-exact $result = bool */;
+    return $result;
+}
+
+/**
+ * The exact reproduction from the issue: assignment inside the condition.
+ *
+ * @param callable(): ?string $fetch
+ */
+function filled_guard_with_assignment_in_condition(callable $fetch): string
+{
+    if (filled($handler = $fetch())) {
+        return $handler . '(';
+    }
+    return 'fallback';
+}
+
+// Assertion-based narrowing: `if (filled($nullable))` narrows the nullable
+// away, which makes the idiomatic guard pattern `filled($x)` work end-to-end.
+function filled_narrows_nullable_string_to_non_null(?string $value): string
+{
+    if (filled($value)) {
+        return $value;
+    }
+    return 'fallback';
+}
+
+function blank_narrows_nullable_string_to_non_null(?string $value): string
+{
+    if (! blank($value)) {
+        return $value;
+    }
+    return 'fallback';
+}
+
 function object_get_returns_first_arg_when_second_is_null(\stdClass $object): \stdClass
 {
     return object_get($object, null);


### PR DESCRIPTION
Closes #751.

## Summary

- The `filled()` / `blank()` stubs used `$value is (null|''|array<never, never>)` as the narrow clause in their conditional return types.
- Psalm treated that union check as matching for `string` inputs (because `''` overlaps with `string`), collapsing the whole conditional to the narrow branch. `filled(?string)` inferred literal `false`, `blank(?string)` inferred literal `true`, producing false `DocblockTypeContradiction` errors on idiomatic guards like `if (filled($nullableString)) { ... }`.
- In filamentphp/filament the reporter measured 245 of 476 (52%) `DocblockTypeContradiction` errors at `errorLevel=1` coming from this one stub.

## What changed

- Nest the narrow clause into per-literal `is null` / `is ''` / `is array<never, never>` checks so partially overlapping inputs fall through to `bool`.
- Add `@psalm-assert-if-true !null $value` on `filled()` and `@psalm-assert-if-false !null $value` on `blank()`. These are sound (Laravel's `blank(null) === true`), and enable the common guard to narrow `?string` to `string` inside the true branch.

## Coverage

Regression tests in `tests/Type/tests/Helpers/SupportHelpersTest.phpt` cover:

- `?string`, `string`, `array`, `mixed`, and `string|array` inputs resolve to `bool` (not `true`/`false`).
- The exact reproduction from the issue: `if (filled($handler = $fetch()))`.
- Guard-pattern narrowing: `if (filled($nullable))` narrows `?string` to `string`.

All use `@psalm-check-type-exact` so a future regression to the unioned form fails the test (a plain `: bool` return would silently accept the literal subtype).