### PR TITLE
fix: narrow `app(static::class, ...)` and `class-string<Foo>` arguments

### DIFF
--- a/src/Util/ContainerResolver.php
+++ b/src/Util/ContainerResolver.php
@@ -7,8 +7,10 @@ namespace Psalm\LaravelPlugin\Util;
 use PhpParser\Node\Arg;
 use Psalm\LaravelPlugin\Providers\ApplicationProvider;
 use Psalm\NodeTypeProvider;
+use Psalm\Type\Atomic\TClassString;
 use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Atomic\TTemplateParamClass;
 use Psalm\Type\Union;
 
 final class ContainerResolver
@@ -59,28 +61,75 @@ final class ContainerResolver
         }
 
         $firstArgType = $nodeTypeProvider->getType($call_args[0]->value);
+        if ($firstArgType === null) {
+            return null;
+        }
 
-        if ($firstArgType && $firstArgType->isSingleStringLiteral()) {
-            $abstract = $firstArgType->getSingleStringLiteral()->value;
-            $concrete = self::resolveFromApplicationContainer($abstract);
+        if ($firstArgType->isSingleStringLiteral()) {
+            return self::resolveFromLiteralString($firstArgType->getSingleStringLiteral()->value);
+        }
 
-            if (\is_null($concrete)) {
-                return null;
-            }
+        if (!$firstArgType->isSingle()) {
+            return null;
+        }
 
-            // todo: is there a better way to check if this is a literal class string?
-            if (\class_exists($concrete)) {
-                return new Union([
-                    new TNamedObject($concrete),
-                ]);
-            }
-
-            // the likes of publicPath, which returns a literal string
-            return new Union([
-                TLiteralString::make($concrete),
-            ]);
+        $atomic = $firstArgType->getSingleAtomic();
+        if ($atomic instanceof TClassString) {
+            return self::resolveFromClassString($atomic);
         }
 
         return null;
+    }
+
+    private static function resolveFromLiteralString(string $abstract): ?Union
+    {
+        $concrete = self::resolveFromApplicationContainer($abstract);
+
+        if ($concrete === null) {
+            return null;
+        }
+
+        // todo: is there a better way to check if this is a literal class string?
+        if (\class_exists($concrete)) {
+            return new Union([
+                new TNamedObject($concrete),
+            ]);
+        }
+
+        // the likes of publicPath, which returns a literal string
+        return new Union([
+            TLiteralString::make($concrete),
+        ]);
+    }
+
+    /**
+     * Resolves `app($classString)` / `resolve($classString)` / `make($classString)` where
+     * `$classString` is typed as a `class-string<Foo>` atomic rather than a literal.
+     *
+     * This covers both `static::class` (Psalm encodes it as `TClassString($fq_class_name,
+     * new TNamedObject($fq_class_name, is_static: true))`, see ClassConstAnalyzer) and
+     * variables typed as `class-string<Foo>`.
+     *
+     * @psalm-pure
+     */
+    private static function resolveFromClassString(TClassString $atomic): ?Union
+    {
+        $asType = $atomic->as_type;
+        if ($asType === null) {
+            // Bare `class-string` (no constraint). We cannot narrow further.
+            return null;
+        }
+
+        if ($atomic instanceof TTemplateParamClass) {
+            // `class-string<T>` template parameter. Resolving to the upper bound would
+            // mask template tracking at the call site (a correctly-T-returning statement
+            // would become InvalidReturnStatement), so falling back to mixed is
+            // conservative until the plugin can project T into the return type.
+            return null;
+        }
+
+        // For `static::class`, $asType already carries `is_static: true` and renders as
+        // `Foo&static`, preserving late static binding through callers.
+        return new Union([$asType]);
     }
 }

--- a/src/Util/ContainerResolver.php
+++ b/src/Util/ContainerResolver.php
@@ -61,7 +61,7 @@ final class ContainerResolver
         }
 
         $firstArgType = $nodeTypeProvider->getType($call_args[0]->value);
-        if ($firstArgType === null) {
+        if (!$firstArgType instanceof \Psalm\Type\Union) {
             return null;
         }
 
@@ -115,7 +115,7 @@ final class ContainerResolver
     private static function resolveFromClassString(TClassString $atomic): ?Union
     {
         $asType = $atomic->as_type;
-        if ($asType === null) {
+        if (!$asType instanceof \Psalm\Type\Atomic\TNamedObject) {
             // Bare `class-string` (no constraint). We cannot narrow further.
             return null;
         }

--- a/tests/Type/tests/ContainerClassStringTest.phpt
+++ b/tests/Type/tests/ContainerClassStringTest.phpt
@@ -1,0 +1,88 @@
+--FILE--
+<?php declare(strict_types=1);
+
+// Regression for #750: `app(static::class, ...)` / `resolve(static::class, ...)`
+// previously returned `mixed`, cascading into MixedAssignment and MixedMethodCall
+// across Laravel ecosystem codebases (Filament, Livewire, Nova, Spatie packages).
+
+abstract class Widget
+{
+    public function configure(): static
+    {
+        return $this;
+    }
+
+    // Mirrors Filament's static factory pattern: the factory resolves through the
+    // container so subclasses can swap bindings or constructor args without
+    // overriding the factory.
+    public static function makeViaApp(string $label): static
+    {
+        $static = app(static::class, ['label' => $label]);
+        /** @psalm-check-type-exact $static = Widget&static */
+        return $static->configure();
+    }
+
+    public static function makeViaResolve(string $label): static
+    {
+        $static = resolve(static::class, ['label' => $label]);
+        /** @psalm-check-type-exact $static = Widget&static */
+        return $static;
+    }
+
+    // The method-return-type provider path: ContainerHandler::getMethodReturnType on
+    // `Application::make()` and `Application::makeWith()` goes through the same resolver.
+    public static function makeViaContainerMake(): static
+    {
+        $static = app()->make(static::class);
+        /** @psalm-check-type-exact $static = Widget&static */
+        return $static;
+    }
+
+    public static function makeViaContainerMakeWith(string $label): static
+    {
+        $static = app()->makeWith(static::class, ['label' => $label]);
+        /** @psalm-check-type-exact $static = Widget&static */
+        return $static;
+    }
+
+    // OffsetHandler::getMethodReturnType routes `offsetGet` through the same resolver,
+    // so `$container[static::class]` should narrow identically.
+    public static function makeViaOffsetGet(): static
+    {
+        $static = app()[static::class];
+        /** @psalm-check-type-exact $static = Widget&static */
+        return $static;
+    }
+}
+
+// `app($classString)` where `$classString: class-string<Redirector>` resolves to
+// Redirector. Covers dynamic class-string variables, not just `::class` literals.
+/** @param class-string<\Illuminate\Routing\Redirector> $class */
+function makeFromClassString(string $class): \Illuminate\Routing\Redirector
+{
+    return app($class);
+}
+
+// `class-string<T>` (template parameter) intentionally falls back to mixed.
+// Resolving to the upper bound would trigger false InvalidReturnStatement at call
+// sites that correctly return T, because the upper bound is a supertype of T.
+/**
+ * @template T of \Illuminate\Routing\Redirector
+ */
+final class TemplatedFactory
+{
+    /**
+     * @param class-string<T> $class
+     */
+    public function make(string $class): void
+    {
+        $r = app($class);
+        /** @psalm-check-type-exact $r = mixed */
+        $r;
+    }
+}
+
+?>
+--EXPECTF--
+MixedAssignment on line %d: Unable to determine the type that $r is being assigned to
+UnusedVariable on line %d: $r is never referenced or the value is not used


### PR DESCRIPTION
Closes #750.

## Problem

`ContainerResolver::resolvePsalmTypeFromApplicationContainerViaArgs()` only matched literal strings. The idiomatic `app(static::class, [...])` / `resolve(static::class, [...])` pattern (used by Filament, Livewire, Nova, many Spatie packages) returned `mixed`, cascading into `MixedAssignment` and `MixedMethodCall` across downstream call sites. The reporter observed ~141 such errors in Filament alone.

## Fix

The resolver now also accepts single `TClassString` atomics.

- For `static::class`, Psalm's `ClassConstAnalyzer` encodes the class-const read as `TClassString($fq, TNamedObject($fq, is_static: true))`. Returning that existing `as_type` unchanged preserves the `Foo&static` rendering, so late static binding flows through `app(static::class)->method()`.
- For plain `class-string<Foo>` variables, the resolver returns the constrained class.
- For `class-string<T>` template parameters, the resolver falls back to `mixed`. Returning the upper bound would be a supertype of `T`, triggering false `InvalidReturnStatement` at call sites that correctly return a `T`-typed value.

The existing literal-string branch and the public API are unchanged.

## Test

`tests/Type/tests/ContainerClassStringTest.phpt` exercises all four routes through the resolver:

- `app(static::class)` / `resolve(static::class)` (function return type provider)
- `app()->make(static::class)` / `app()->makeWith(static::class)` (method return type provider)
- `app()[static::class]` (offset handler)
- `app($var)` with `$var: class-string<Redirector>` (dynamic class-string variables)

and pins the template-parameter fallback so the conservative `null` return is protected from regressions.

`composer test` passes (lint + psalm + 452 unit tests + 270 type tests).