### PR TITLE
tighten `filled()` to narrow `?string` to `non-empty-string`

### DIFF
--- a/stubs/common/Support/helpers.stubphp
+++ b/stubs/common/Support/helpers.stubphp
@@ -42,6 +42,13 @@ class NullObject {
  * through to `bool`. See
  * https://github.com/psalm/psalm-plugin-laravel/issues/751.
  *
+ * `blank()` carries only `@psalm-assert-if-false !null` and not a matching
+ * `!=''` line. Adding a second if-false assertion for the same variable
+ * undoes the earlier null narrowing in the current Psalm release, so this
+ * stub does not mirror the tighter assertion pair on `filled()`. See
+ * {@see filled()} for the rationale and
+ * https://github.com/psalm/psalm-plugin-laravel/issues/755 for context.
+ *
  * @param  mixed  $value
  * @psalm-assert-if-false !null $value
  * @psalm-return ($value is (bool|numeric|non-empty-array)
@@ -96,8 +103,36 @@ function e($value, $doubleEncode = true) {}
  *
  * See {@see blank()} for the rationale behind the nested conditional shape.
  *
+ * The two assertions combine so that `if (filled($x))` with `?string`
+ * narrows `$x` to `non-empty-string` inside the true branch. `!null` is a
+ * strict-type assertion; `!=''` is a loose-equality assertion (Psalm rejects
+ * `!null|''` because union types cannot follow a negation prefix in docblock
+ * assertions, so the two constraints are spelled on separate lines). Both
+ * are sound for the nullable-string case this stub targets: `filled($x)
+ * === true` on `?string` input implies `$x !== null` and `$x !== ''`.
+ * For wider `mixed`/union inputs the assertions are a best-effort narrowing;
+ * in the current Psalm release the `!=''` assertion is not applied beyond
+ * the string atomic, so values like `false` (which Laravel treats as
+ * filled and which is loosely equal to `''`) are not incorrectly removed.
+ * This is an implementation detail; if a future Psalm release starts
+ * applying the loose-equality assertion to other atomics, the `!=''` line
+ * may need to be dropped or replaced. Whitespace-only strings like
+ * `'   '` are blank at runtime but are not captured here; this is an
+ * accepted imprecision, already present in the conditional return type.
+ *
+ * `blank()` cannot mirror the `!=''` if-false assertion because the current
+ * Psalm release drops earlier if-false assertions when a loose-equality
+ * one is added alongside them, undoing the existing null narrowing. The
+ * two helpers are idiomatic inverses in Laravel; this stub asymmetry is a
+ * Psalm-specific workaround, not a recommendation. When a caller
+ * specifically wants `non-empty-string` narrowing, `filled($x)` delivers
+ * it; for all other cases `! blank($x)` and `filled($x)` remain
+ * interchangeable per Laravel's own docs. See
+ * https://github.com/psalm/psalm-plugin-laravel/issues/755.
+ *
  * @param  mixed  $value
  * @psalm-assert-if-true !null $value
+ * @psalm-assert-if-true !='' $value
  * @psalm-return ($value is (bool|numeric|non-empty-array)
  *  ? true
  *  : ($value is null

--- a/tests/Type/tests/Helpers/SupportHelpersTest.phpt
+++ b/tests/Type/tests/Helpers/SupportHelpersTest.phpt
@@ -240,6 +240,69 @@ function blank_narrows_nullable_string_to_non_null(?string $value): string
     return 'fallback';
 }
 
+// Regression tests for https://github.com/psalm/psalm-plugin-laravel/issues/755.
+// Tighter guard narrowing: `if (filled($x))` with `?string` narrows to
+// `non-empty-string` (not just `string`), because `filled()` is false for
+// both `null` and `''`. The combined `!null` + `!=''` assertions deliver
+// the tighter type. A regression to only `!null` (pre-#755 behavior) would
+// leave `$value` as `string` inside the branch and fail the exact check.
+function filled_narrows_nullable_string_to_non_empty_string(?string $value): string
+{
+    if (filled($value)) {
+        /** @psalm-check-type-exact $value = non-empty-string */;
+        return $value;
+    }
+    return 'fallback';
+}
+
+// `mixed` must not be over-narrowed. Psalm's loose-inequality reconciler
+// is effectively a no-op against `mixed` (there is no atomic to subtract
+// `''` from), so `mixed` stays `mixed` inside the true branch. `!null` is
+// also a no-op here because `mixed` already covers every possibility.
+function filled_does_not_over_narrow_mixed(mixed $value): mixed
+{
+    if (filled($value)) {
+        /** @psalm-check-type-exact $value = mixed */;
+        return $value;
+    }
+    return null;
+}
+
+/**
+ * Mixed union: `null` drops out, `string` narrows to `non-empty-string`,
+ * `int` and `array` survive. Verifies the new `!=''` assertion plays
+ * correctly with the existing nested conditional return type for a union
+ * that straddles multiple narrow clauses. The return type matches Psalm's
+ * normalized form (`array<array-key, mixed>`) so that the check-type-exact
+ * assertion and the declared return type are consistent.
+ *
+ * @param  array|int|string|null  $value
+ * @return array<array-key, mixed>|int|non-empty-string
+ */
+function filled_narrows_union_input($value)
+{
+    if (filled($value)) {
+        /** @psalm-check-type-exact $value = array<array-key, mixed>|int|non-empty-string */;
+        return $value;
+    }
+    return 0;
+}
+
+// `blank()` currently does not add a symmetric `!=''` if-false assertion
+// (see the `filled()` stub docblock for why), so `! blank($nullable)`
+// narrows only to `string`, not `non-empty-string`. This test documents
+// that limitation and will start failing if a future Psalm release lifts
+// the restriction, signaling the stub can be tightened.
+// @todo https://github.com/psalm/psalm-plugin-laravel/issues/755
+function blank_narrows_nullable_string_only_to_string(?string $value): string
+{
+    if (! blank($value)) {
+        /** @psalm-check-type-exact $value = string */;
+        return $value;
+    }
+    return 'fallback';
+}
+
 function object_get_returns_first_arg_when_second_is_null(\stdClass $object): \stdClass
 {
     return object_get($object, null);

--- a/tests/Type/tests/Helpers/SupportHelpersTest.phpt
+++ b/tests/Type/tests/Helpers/SupportHelpersTest.phpt
@@ -288,6 +288,25 @@ function filled_narrows_union_input($value)
     return 0;
 }
 
+/**
+ * Soundness regression lock-in: Laravel treats `false` as filled (`blank(false)
+ * === false`), but PHP's `false == ''` is true, so a strict reading of the
+ * `!=''` assertion would incorrectly subtract `false` from the input. The
+ * current Psalm release applies `!=''` only to the string atomic, so `false`
+ * survives inside the true branch. This test pins that behavior: if a future
+ * Psalm release starts applying the loose-equality assertion to `false`, the
+ * check-type-exact will fail and signal that the `!=''` line must be revised
+ * to keep `filled(false) === true` sound.
+ *
+ * @param  false|string|null  $value
+ */
+function filled_keeps_false_for_false_or_string_union($value): void
+{
+    if (filled($value)) {
+        /** @psalm-check-type-exact $value = false|non-empty-string */;
+    }
+}
+
 // `blank()` currently does not add a symmetric `!=''` if-false assertion
 // (see the `filled()` stub docblock for why), so `! blank($nullable)`
 // narrows only to `string`, not `non-empty-string`. This test documents


### PR DESCRIPTION
## Summary

Follow-up to #751 / #753. Adds `@psalm-assert-if-true !='' \$value` alongside the existing `!null` assertion on the `filled()` helper stub, so `if (filled(\$x))` with `?string` input narrows `\$x` to `non-empty-string` inside the true branch (instead of just `string`).

- Laravel's `blank()` returns `true` for both `null` and `''`, so when `filled(\$x) === true` on a nullable-string input the value is both non-null and non-empty. The tighter assertion exposes that to Psalm, producing a more useful type for string-manipulation code inside the guard.
- Psalm rejects `!null|''` in one assertion (union types cannot follow a negation prefix in docblock assertions), so the two constraints are spelled on separate lines: strict `!null` and loose `!=''`.
- Combining two `@psalm-assert-if-false` lines on `blank()` undoes the existing null narrowing in the current Psalm release. `blank()` therefore keeps its single `!null` assertion; the asymmetry is documented in the `blank()` docblock with a cross-reference to `filled()`. `! blank(\$x)` and `filled(\$x)` remain interchangeable per Laravel docs; the `filled()` recommendation is a Psalm-specific workaround, not a Laravel idiom.

## Coverage

New regression tests in `tests/Type/tests/Helpers/SupportHelpersTest.phpt`:
- `?string` narrows to `non-empty-string` inside `if (filled(\$x))` (primary regression test).
- `mixed` stays `mixed` (no over-narrowing via the loose-equality reconciler).
- `array|int|string|null` union narrows to `array<array-key, mixed>|int|non-empty-string`.
- `! blank(?string)` narrows only to `string` (documents the current asymmetry; will start failing if a future Psalm release lifts the combination restriction, signaling the stub can be tightened).

## Known tradeoff

`filled(\$bool)` now emits one additional `RedundantCondition: is never =string()` warning alongside the pre-existing `is never null` and `Operand of type true is always truthy` warnings that the conditional return type and `!null` assertion already produce. `filled(\$bool)` is semantically a no-op (filled is true for both `true` and `false` in Laravel), so sites that trigger the new warning are already flagged by Psalm.

Refs #755.