### PR TITLE
Stop `NoEnvOutsideConfig` from firing inside analysed project's config/

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -7,6 +7,7 @@ use Rector\CodingStyle\Rector\If_\NullableCompareToNullRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertEmptyNullableObjectToAssertInstanceofRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\ValueObject\PhpVersion;
 
@@ -23,4 +24,8 @@ return RectorConfig::configure()
         EncapsedStringsToSprintfRector::class,
         SplitDoubleAssignRector::class,
         StringClassNameToClassConstantRector::class, // analyzed classes are not always auto-loaded
+        // Rewrites `assertNull($nullableObj)` to `assertNotInstanceOf(Obj::class, $nullableObj)`.
+        // Too permissive for unit tests: `assertNotInstanceOf` passes for null, scalars, arrays,
+        // and unrelated objects — losing the precise null-only intent.
+        AssertEmptyNullableObjectToAssertInstanceofRector::class,
     ]);

--- a/src/Handlers/Rules/NoEnvOutsideConfigHandler.php
+++ b/src/Handlers/Rules/NoEnvOutsideConfigHandler.php
@@ -21,14 +21,6 @@ use Psalm\Type\Union;
  */
 final class NoEnvOutsideConfigHandler implements FunctionReturnTypeProviderInterface
 {
-    private static string $configPath = '';
-
-    /** @psalm-external-mutation-free */
-    public static function init(string $configPath): void
-    {
-        self::$configPath = \rtrim($configPath, \DIRECTORY_SEPARATOR);
-    }
-
     /**
      * @inheritDoc
      * @psalm-pure
@@ -61,15 +53,15 @@ final class NoEnvOutsideConfigHandler implements FunctionReturnTypeProviderInter
         return null;
     }
 
-    /** @psalm-external-mutation-free */
+    /**
+     * Match any path with a `config` directory segment.
+     * Covers apps, published packages, vendor dirs, and monorepo sub-packages.
+     *
+     * @psalm-pure
+     */
     private static function isInsideConfigDirectory(string $filePath): bool
     {
-        if (self::$configPath === '') {
-            return false;
-        }
-
-        return \str_starts_with($filePath, self::$configPath . \DIRECTORY_SEPARATOR)
-            || $filePath === self::$configPath;
+        return \str_contains($filePath, \DIRECTORY_SEPARATOR . 'config' . \DIRECTORY_SEPARATOR);
     }
 
     /** @psalm-pure */

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -42,10 +42,6 @@ final class Plugin implements PluginEntryPointInterface
             // to also register for facade/alias classes that proxy to their service.
             FacadeMapProvider::init($output);
 
-            Handlers\Rules\NoEnvOutsideConfigHandler::init(
-                ApplicationProvider::getApp()->configPath(),
-            );
-
             // Always called — provides type narrowing (string vs array) regardless
             // of whether findMissingTranslations is enabled
             $this->initTranslationKeyHandler($output, $pluginConfig->findMissingTranslations);

--- a/tests/Unit/Handlers/Rules/NoEnvOutsideConfigHandlerTest.php
+++ b/tests/Unit/Handlers/Rules/NoEnvOutsideConfigHandlerTest.php
@@ -15,7 +15,6 @@ use Psalm\Context;
 use Psalm\LaravelPlugin\Handlers\Rules\NoEnvOutsideConfigHandler;
 use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
 use Psalm\StatementsSource;
-use Psalm\Type\Union;
 
 #[CoversClass(NoEnvOutsideConfigHandler::class)]
 final class NoEnvOutsideConfigHandlerTest extends TestCase
@@ -47,9 +46,11 @@ final class NoEnvOutsideConfigHandlerTest extends TestCase
     }
 
     /**
-     * Files inside any config/ segment or tests/ directory should not trigger the issue.
-     * If the handler incorrectly tried to emit an issue, it would throw because no Psalm
-     * runtime is initialized in unit tests.
+     * The handler always returns null — it only emits an issue as a side effect.
+     * For allowed files, no issue is emitted, so the return value is null and
+     * downstream EnvHandler runs afterwards to narrow the return type.
+     * If the handler incorrectly tried to emit an issue here, IssueBuffer::accepts()
+     * would throw because no Psalm runtime is initialized in unit tests.
      */
     #[Test]
     #[DataProvider('allowedFileProvider')]
@@ -57,7 +58,7 @@ final class NoEnvOutsideConfigHandlerTest extends TestCase
     {
         $event = $this->createEvent($filePath);
 
-        $this->assertNotInstanceOf(Union::class, NoEnvOutsideConfigHandler::getFunctionReturnType($event));
+        $this->assertNull(NoEnvOutsideConfigHandler::getFunctionReturnType($event));
     }
 
     /**

--- a/tests/Unit/Handlers/Rules/NoEnvOutsideConfigHandlerTest.php
+++ b/tests/Unit/Handlers/Rules/NoEnvOutsideConfigHandlerTest.php
@@ -58,7 +58,7 @@ final class NoEnvOutsideConfigHandlerTest extends TestCase
     {
         $event = $this->createEvent($filePath);
 
-        $this->assertNotInstanceOf(\Psalm\Type\Union::class, NoEnvOutsideConfigHandler::getFunctionReturnType($event));
+        $this->assertNull(NoEnvOutsideConfigHandler::getFunctionReturnType($event));
     }
 
     /**

--- a/tests/Unit/Handlers/Rules/NoEnvOutsideConfigHandlerTest.php
+++ b/tests/Unit/Handlers/Rules/NoEnvOutsideConfigHandlerTest.php
@@ -62,8 +62,8 @@ final class NoEnvOutsideConfigHandlerTest extends TestCase
     }
 
     /**
-     * Sanity check for the structural matcher: paths without a literal `/config/`
-     * segment (including substring look-alikes like `configuration/` and `.config/`)
+     * Sanity check for the structural matcher: paths without a path segment named
+     * `config` (including substring look-alikes like `configuration/` and `.config/`)
      * should be treated as outside the config directory.
      *
      * Reaching the emit branch calls IssueBuffer::accepts(), which delegates to

--- a/tests/Unit/Handlers/Rules/NoEnvOutsideConfigHandlerTest.php
+++ b/tests/Unit/Handlers/Rules/NoEnvOutsideConfigHandlerTest.php
@@ -15,15 +15,11 @@ use Psalm\Context;
 use Psalm\LaravelPlugin\Handlers\Rules\NoEnvOutsideConfigHandler;
 use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
 use Psalm\StatementsSource;
+use Psalm\Type\Union;
 
 #[CoversClass(NoEnvOutsideConfigHandler::class)]
 final class NoEnvOutsideConfigHandlerTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        NoEnvOutsideConfigHandler::init('/project/config');
-    }
-
     #[Test]
     public function returns_env_function_id(): void
     {
@@ -31,20 +27,29 @@ final class NoEnvOutsideConfigHandlerTest extends TestCase
     }
 
     /**
+     * Paths are built from DIRECTORY_SEPARATOR to stay consistent with the handler,
+     * which uses DIRECTORY_SEPARATOR for its segment match. Psalm normalizes file
+     * paths to the host separator before dispatching to plugins.
+     *
      * @return iterable<string, array{string}>
      */
     public static function allowedFileProvider(): iterable
     {
-        yield 'config file' => ['/project/config/app.php'];
-        yield 'config subdirectory' => ['/project/config/services/api.php'];
-        yield 'test file' => ['/project/tests/Unit/MyTest.php'];
-        yield 'feature test' => ['/project/tests/Feature/MyTest.php'];
+        $s = \DIRECTORY_SEPARATOR;
+
+        yield 'app config file' => ["{$s}project{$s}config{$s}app.php"];
+        yield 'app config subdirectory' => ["{$s}project{$s}config{$s}services{$s}api.php"];
+        yield 'package config' => ["{$s}home{$s}dev{$s}spatie{$s}laravel-backup{$s}config{$s}backup.php"];
+        yield 'monorepo sub-package config' => ["{$s}monorepo{$s}packages{$s}forms{$s}config{$s}forms.php"];
+        yield 'vendor package config' => ["{$s}project{$s}vendor{$s}spatie{$s}laravel-backup{$s}config{$s}backup.php"];
+        yield 'test file' => ["{$s}project{$s}tests{$s}Unit{$s}MyTest.php"];
+        yield 'feature test' => ["{$s}project{$s}tests{$s}Feature{$s}MyTest.php"];
     }
 
     /**
-     * Files inside config/ or tests/ should not trigger the issue.
-     * If the handler incorrectly tried to emit an issue, it would throw
-     * because no Psalm runtime is initialized in unit tests.
+     * Files inside any config/ segment or tests/ directory should not trigger the issue.
+     * If the handler incorrectly tried to emit an issue, it would throw because no Psalm
+     * runtime is initialized in unit tests.
      */
     #[Test]
     #[DataProvider('allowedFileProvider')]
@@ -52,17 +57,41 @@ final class NoEnvOutsideConfigHandlerTest extends TestCase
     {
         $event = $this->createEvent($filePath);
 
-        $this->assertNotInstanceOf(\Psalm\Type\Union::class, NoEnvOutsideConfigHandler::getFunctionReturnType($event));
+        $this->assertNotInstanceOf(Union::class, NoEnvOutsideConfigHandler::getFunctionReturnType($event));
+    }
+
+    /**
+     * Sanity check for the structural matcher: paths without a literal `/config/`
+     * segment (including substring look-alikes like `configuration/` and `.config/`)
+     * should be treated as outside the config directory.
+     *
+     * Reaching the emit branch calls IssueBuffer::accepts(), which delegates to
+     * Config::getInstance() and throws UnexpectedValueException('No config initialized')
+     * when Psalm isn't bootstrapped. We assert that specific exception to confirm the
+     * handler actually reached issue emission, rather than throwing somewhere earlier.
+     *
+     * @return iterable<string, array{string}>
+     */
+    public static function rejectedFileProvider(): iterable
+    {
+        $s = \DIRECTORY_SEPARATOR;
+
+        yield 'application code' => ["{$s}project{$s}app{$s}Services{$s}PaymentService.php"];
+        yield 'substring-not-segment (prefix)' => ["{$s}project{$s}app{$s}configuration{$s}Foo.php"];
+        yield 'substring-not-segment (suffix)' => ["{$s}project{$s}app{$s}myconfig{$s}Foo.php"];
+        yield 'hidden config dir' => ["{$s}project{$s}.config{$s}foo.php"];
     }
 
     #[Test]
-    public function trailing_separator_in_config_path_is_normalized(): void
+    #[DataProvider('rejectedFileProvider')]
+    public function rejects_non_config_files(string $filePath): void
     {
-        NoEnvOutsideConfigHandler::init('/project/config/');
+        $event = $this->createEvent($filePath);
 
-        $event = $this->createEvent('/project/config/app.php');
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('No config initialized');
 
-        $this->assertNotInstanceOf(\Psalm\Type\Union::class, NoEnvOutsideConfigHandler::getFunctionReturnType($event));
+        NoEnvOutsideConfigHandler::getFunctionReturnType($event);
     }
 
     private function createEvent(string $filePath): FunctionReturnTypeProviderEvent

--- a/tests/Unit/Handlers/Rules/NoEnvOutsideConfigHandlerTest.php
+++ b/tests/Unit/Handlers/Rules/NoEnvOutsideConfigHandlerTest.php
@@ -58,7 +58,7 @@ final class NoEnvOutsideConfigHandlerTest extends TestCase
     {
         $event = $this->createEvent($filePath);
 
-        $this->assertNull(NoEnvOutsideConfigHandler::getFunctionReturnType($event));
+        $this->assertNotInstanceOf(\Psalm\Type\Union::class, NoEnvOutsideConfigHandler::getFunctionReturnType($event));
     }
 
     /**

--- a/tests/Unit/Handlers/Rules/NoEnvOutsideConfigHandlerTest.php
+++ b/tests/Unit/Handlers/Rules/NoEnvOutsideConfigHandlerTest.php
@@ -89,7 +89,7 @@ final class NoEnvOutsideConfigHandlerTest extends TestCase
         $event = $this->createEvent($filePath);
 
         $this->expectException(\UnexpectedValueException::class);
-        $this->expectExceptionMessage('No config initialized');
+        $this->expectExceptionMessageMatches('/config.*initializ|initializ.*config/i');
 
         NoEnvOutsideConfigHandler::getFunctionReturnType($event);
     }


### PR DESCRIPTION
Fixes #756.

## Summary

`NoEnvOutsideConfigHandler::isInsideConfigDirectory()` compared file paths against `self::$configPath`, initialised in `Plugin.php` from `ApplicationProvider::getApp()->configPath()`. That resolves to Orchestra Testbench's internal config path (under the plugin's own vendor tree), which never matches the analysed project's real files. Every Laravel application or package got `NoEnvOutsideConfig` false positives on its own `config/*.php` files (the canonical, documented place to call `env()`).

## Fix

Replace the prefix check with a structural segment match:

```php
str_contains($filePath, DIRECTORY_SEPARATOR.'config'.DIRECTORY_SEPARATOR)
```

Mirrors the existing `isTestFile()` helper in the same class. Matches Laravel apps, standalone packages (`/spatie/laravel-backup/config/backup.php`), vendor dirs, and monorepo sub-packages (`/monorepo/packages/forms/config/forms.php`). Drops the now-dead `init()`, `$configPath` field, and the corresponding `Plugin.php` wiring. The helper is now `@psalm-pure` (no static state).

## Tests

- Paths in the data providers are built from `DIRECTORY_SEPARATOR` to stay consistent with the handler.
- `rejects_non_config_files` pins the exception path through `IssueBuffer::accepts()` → `Config::getInstance()` (`UnexpectedValueException('No config initialized')`), asserting the handler actually reached the emit branch.
- Added substring-lookalike guards (`configuration/` prefix, `myconfig/` suffix, `.config/` hidden dir) so the segment matcher regression surface is covered.
- Dropped the old `trailing_separator_in_config_path_is_normalized` test (exercised `init()`, which no longer exists).
- Verified end-to-end against a minimal Laravel app: `env()` in `config/app.php` now passes cleanly; `env()` in `app/Service.php` still emits `NoEnvOutsideConfig`.