### PR TITLE
Silence misleading autoloader warning for anonymous `Model` subclasses

### DIFF
--- a/src/Handlers/Eloquent/ModelRegistrationHandler.php
+++ b/src/Handlers/Eloquent/ModelRegistrationHandler.php
@@ -62,6 +62,19 @@ final class ModelRegistrationHandler implements AfterCodebasePopulatedInterface
                 continue;
             }
 
+            // Anonymous Model subclasses (e.g. `new class extends Model {}`) get a
+            // synthetic FQCN from Psalm that no autoloader can resolve, so skip them
+            // before class_exists() to avoid a misleading warning. Psalm leaves
+            // $storage->location null for anonymous classes (there is no name node
+            // to locate); stmt_location carries the `class { ... }` position and is
+            // the correct source of the declaring file path.
+            if (
+                $storage->stmt_location !== null
+                && self::isSyntheticAnonymousClassName($storage->name, $storage->stmt_location->file_path)
+            ) {
+                continue;
+            }
+
             // Force-load the class via Composer's autoloader so that runtime
             // reflection works in property handlers (e.g. getTable(), getCasts())
             try {
@@ -76,6 +89,36 @@ final class ModelRegistrationHandler implements AfterCodebasePopulatedInterface
 
             self::registerHandlersForModel($codebase, $storage);
         }
+    }
+
+    /**
+     * Detects the synthetic FQCN Psalm assigns to anonymous classes. Psalm builds
+     * them as `{sanitized_file_path}_{line}_{startFilePos}` (prefixed by the
+     * surrounding namespace), and they are never autoloadable.
+     *
+     * @see \Psalm\Internal\Analyzer\ClassAnalyzer::getAnonymousClassName()
+     * @psalm-pure
+     */
+    private static function isSyntheticAnonymousClassName(string $fqcn, string $filePath): bool
+    {
+        if ($filePath === '') {
+            return false;
+        }
+
+        $lastSeparator = \strrpos($fqcn, '\\');
+        $shortName = $lastSeparator === false ? $fqcn : \substr($fqcn, $lastSeparator + 1);
+
+        // Quick reject: every synthetic anonymous name ends in `_<line>_<startFilePos>`.
+        // Real model class names (User, Post, ...) fail this in O(1), letting us skip
+        // the more expensive path-sanitisation below for ~all real classlikes.
+        if (\preg_match('/_\d+_\d+$/', $shortName) !== 1) {
+            return false;
+        }
+
+        // Mirrors the sanitisation in ClassAnalyzer::getAnonymousClassName().
+        $sanitizedPath = \preg_replace('/[^A-Za-z0-9]/', '_', $filePath) ?? '';
+
+        return \str_starts_with($shortName, $sanitizedPath . '_');
     }
 
     private static function registerHandlersForModel(Codebase $codebase, ClassLikeStorage $storage): void

--- a/tests/Type/tests/Model/AnonymousModelSubclassTest.phpt
+++ b/tests/Type/tests/Model/AnonymousModelSubclassTest.phpt
@@ -1,0 +1,15 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Eloquent\Model;
+
+// Regression: analysing `new class extends Model {}` must not trigger the plugin's
+// "class could not be loaded by autoloader" warning, nor any type errors.
+// Psalm assigns these a synthetic FQCN that is never autoloadable; the plugin
+// now detects and skips them in ModelRegistrationHandler.
+function test_anonymous_model_subclass(): Model
+{
+    return new class extends Model {};
+}
+?>
+--EXPECTF--

--- a/tests/Unit/Handlers/Eloquent/AnonymousClassDetectionTest.php
+++ b/tests/Unit/Handlers/Eloquent/AnonymousClassDetectionTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Eloquent;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Handlers\Eloquent\ModelRegistrationHandler;
+
+/**
+ * Tests that Psalm's synthetic FQCNs for anonymous classes (e.g. `new class extends Model {}`)
+ * are recognised and skipped, so the plugin doesn't emit a misleading "class could not be loaded
+ * by autoloader" warning for names that are never autoloadable.
+ *
+ * @see \Psalm\Internal\Analyzer\ClassAnalyzer::getAnonymousClassName()
+ */
+#[CoversClass(ModelRegistrationHandler::class)]
+final class AnonymousClassDetectionTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('anonymousNames')]
+    public function it_detects_synthetic_anonymous_class_names(string $fqcn, string $filePath): void
+    {
+        $this->assertTrue($this->call($fqcn, $filePath));
+    }
+
+    #[Test]
+    #[DataProvider('regularNames')]
+    public function it_ignores_regular_class_names(string $fqcn, string $filePath): void
+    {
+        $this->assertFalse($this->call($fqcn, $filePath));
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function anonymousNames(): iterable
+    {
+        // Real-world example from Algolia\ScoutExtended (motivating case for this fix).
+        yield 'algolia scout aggregator' => [
+            'Algolia\\ScoutExtended\\Searchable\\_Users_alies_code_IxDF_IxDF_web_vendor_algolia_scout_extended_src_Searchable_Aggregator_php_279_6842',
+            '/Users/alies/code/IxDF/IxDF-web/vendor/algolia/scout-extended/src/Searchable/Aggregator.php',
+        ];
+
+        yield 'namespaced unix path' => [
+            'App\\Models\\_home_app_src_Foo_php_10_42',
+            '/home/app/src/Foo.php',
+        ];
+
+        yield 'no namespace' => [
+            '_home_app_src_Foo_php_5_20',
+            '/home/app/src/Foo.php',
+        ];
+
+        // Windows paths get sanitised to start with a drive letter (e.g. `C`).
+        yield 'windows path' => [
+            'App\\C__path_to_Foo_php_3_12',
+            'C:\\path\\to\\Foo.php',
+        ];
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function regularNames(): iterable
+    {
+        yield 'plain model class' => [
+            'App\\Models\\User',
+            '/home/app/src/Models/User.php',
+        ];
+
+        yield 'short name does not match sanitised file path' => [
+            'App\\Models\\_home_other_file_php_1_1',
+            '/home/app/src/Models/User.php',
+        ];
+
+        yield 'missing line/pos suffix' => [
+            'App\\_home_app_src_Foo_php',
+            '/home/app/src/Foo.php',
+        ];
+
+        yield 'single numeric suffix (not line_pos)' => [
+            'App\\_home_app_src_Foo_php_10',
+            '/home/app/src/Foo.php',
+        ];
+
+        yield 'empty file path' => [
+            'App\\Models\\_10_20',
+            '',
+        ];
+
+        yield 'class with trailing digits but no path prefix' => [
+            'App\\Models\\Snapshot_1_2',
+            '/home/app/src/Models/Snapshot.php',
+        ];
+    }
+
+    private function call(string $fqcn, string $filePath): bool
+    {
+        $method = new \ReflectionMethod(ModelRegistrationHandler::class, 'isSyntheticAnonymousClassName');
+
+        return (bool) $method->invoke(null, $fqcn, $filePath);
+    }
+}


### PR DESCRIPTION
## Issue to Solve

When running Psalm on real-world projects that include Algolia Scout Extended (or anything else that uses `new class extends Model {}`), the plugin emits a warning like:

```
Warning: Laravel plugin: skipping model
'Algolia\ScoutExtended\Searchable\_Users_alies_code_IxDF_IxDF_web_vendor_algolia_scout_extended_src_Searchable_Aggregator_php_279_6842':
class could not be loaded by autoloader
```

Psalm assigns synthetic FQCNs to anonymous classes via [`ClassAnalyzer::getAnonymousClassName()`](https://github.com/vimeo/psalm/blob/master/src/Psalm/Internal/Analyzer/ClassAnalyzer.php) (format: `{sanitized_file_path}_{line}_{startFilePos}`). These names are never autoloadable, so `class_exists()` in `ModelRegistrationHandler::afterCodebasePopulated()` always fails for them, triggering the misleading warning.

Root case in the wild: `vendor/algolia/scout-extended/src/Searchable/Aggregator.php:279` does `$model = $this->model ?? new class extends Model {};` to get a throwaway model for `__call` forwarding.

## Solution Description

Detect Psalm's synthetic anonymous-class name and `continue` past it before the `class_exists()` check, keeping the warning for legitimate autoloader failures.

Key details:
- Uses `$storage->stmt_location` (not `$storage->location`, which Psalm leaves `null` for anonymous classes since there is no name node to locate).
- New `isSyntheticAnonymousClassName()` helper mirrors Psalm's name format exactly (`preg_replace('/[^A-Za-z0-9]/', '_', $filePath) . '_' . line . '_' . pos`).
- Cheap `_\d+_\d+$` suffix regex runs first; the full path sanitisation only runs when the suffix matches, so the overhead is negligible over ~15k classlikes.

Verified with:
- Manual reproduction in a minimal project containing `new class extends Model {}`, before vs. after (warning gone).
- Full suite green (271 type tests + 462 unit tests).

## Tests

- `tests/Unit/Handlers/Eloquent/AnonymousClassDetectionTest.php`: 10 data-provider cases including the real-world Algolia FQCN, Unix/Windows/no-namespace paths, plus negative cases (plain model names, mismatched file path, missing/partial numeric suffix, empty path, trailing digits without prefix).
- `tests/Type/tests/Model/AnonymousModelSubclassTest.phpt`: PHPT smoke test covering `new class extends Model {}` end-to-end through psalm-tester.

## Checklist
- [x] Tests cover the change (unit test in `tests/Unit/` and type test in `tests/Type/`)
