### PR TITLE
Register Carbon lazy class stubs to prevent MissingDependency errors

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin;
 
-use Composer\InstalledVersions;
 use Illuminate\Foundation\Application;
 use Psalm\Internal\Analyzer\ProjectAnalyzer;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaAggregator;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SqlSchemaParser;
 use Psalm\LaravelPlugin\Providers\ApplicationProvider;
+use Psalm\LaravelPlugin\Providers\CarbonStubProvider;
 use Psalm\LaravelPlugin\Providers\FacadeMapProvider;
 use Psalm\LaravelPlugin\Providers\SchemaStateProvider;
 use Psalm\LaravelPlugin\Util\IssueUrlGenerator;
@@ -199,112 +199,7 @@ final class Plugin implements PluginEntryPointInterface
 
         $registration->addStubFile(self::getAliasStubLocation($pluginConfig));
 
-        $this->registerCarbonLazyStubs($registration, $output);
-    }
-
-    /**
-     * Register Carbon's "lazy" class definitions as Psalm stubs.
-     *
-     * Carbon declares three classes via runtime `require` from vendor/nesbot/carbon/lazy/,
-     * picking between pairs of files based on PHP and Symfony versions:
-     *
-     * - Carbon\DatePeriodBase           — CarbonPeriod.php:50 (PHP_VERSION < 8.2)
-     * - Carbon\LazyTranslator           — Translator.php:27 (TranslatorInterface::trans() return type)
-     * - Carbon\MessageFormatter\LazyMessageFormatter — MessageFormatterMapper.php:23 (trans() param type)
-     *
-     * The lazy/ directory is not in Carbon's composer autoload, so Psalm cannot resolve
-     * these classes statically. Without stubs, Psalm reports MissingDependency on
-     * CarbonPeriod, Translator, and MessageFormatterMapper.
-     *
-     * Carbon ships an extension.neon for PHPStan (bootstrapFiles: UnprotectedDatePeriod.php)
-     * but no Psalm equivalent. We register Carbon's own lazy files as stubs — no class
-     * duplication, automatically inheriting any upstream changes.
-     *
-     * Variant selection mirrors Carbon's own runtime choice so the plugin stays in sync
-     * with the variant actually loaded at runtime (important when older Symfony pins
-     * translation-contracts 2.x, which lacks the return type on `trans()`).
-     */
-    private function registerCarbonLazyStubs(RegistrationInterface $registration, \Psalm\Progress\Progress $output): void
-    {
-        if (! InstalledVersions::isInstalled('nesbot/carbon')) {
-            return;
-        }
-
-        $carbonRoot = InstalledVersions::getInstallPath('nesbot/carbon');
-
-        if ($carbonRoot === null) {
-            return;
-        }
-
-        $translatorVariant = $this->symfonyTranslatorHasReturnType() ? 'Strong' : 'Weak';
-        $formatterVariant = $this->symfonyMessageFormatterFirstParamHasType() ? 'Strong' : 'Weak';
-
-        $lazyStubs = [
-            // Carbon\DatePeriodBase — picked at CarbonPeriod.php:50 via `PHP_VERSION < 8.2`.
-            // Plugin requires PHP 8.2+ (composer.json), so Unprotected is always correct.
-            $carbonRoot . '/lazy/Carbon/UnprotectedDatePeriod.php',
-
-            $carbonRoot . "/lazy/Carbon/Translator{$translatorVariant}Type.php",
-
-            $carbonRoot . "/lazy/Carbon/MessageFormatter/MessageFormatterMapper{$formatterVariant}Type.php",
-        ];
-
-        foreach ($lazyStubs as $stub) {
-            if (\is_file($stub)) {
-                $registration->addStubFile($stub);
-            } else {
-                $output->warning(
-                    "Laravel plugin: Carbon lazy stub not found at '{$stub}'. "
-                    . 'CarbonPeriod / Translator / MessageFormatterMapper types may not resolve.',
-                );
-            }
-        }
-    }
-
-    /**
-     * Mirror of Carbon\Translator.php:20-25 — Carbon's ternary reads `class_exists(TranslatorInterface::class)`
-     * which is always false for interfaces (PHP returns false from class_exists() for interfaces),
-     * so Carbon effectively always reflects the concrete `Symfony\Component\Translation\Translator`
-     * class. We reflect the same class so our stub choice stays in lockstep with Carbon's runtime
-     * pick even when translation-contracts is pinned at an older major than symfony/translation.
-     */
-    private function symfonyTranslatorHasReturnType(): bool
-    {
-        try {
-            if (\class_exists(\Symfony\Component\Translation\Translator::class)) {
-                return (new \ReflectionMethod(
-                    \Symfony\Component\Translation\Translator::class,
-                    'trans',
-                ))->hasReturnType();
-            }
-        } catch (\ReflectionException) {
-            // Fall through to the default.
-        }
-
-        // Symfony not installed or reflection failed — default to the modern (strong) variant.
-        return true;
-    }
-
-    /**
-     * Mirror of Carbon\MessageFormatter\MessageFormatterMapper.php:23 — picks the "strong type"
-     * variant when Symfony's MessageFormatterInterface::format() first parameter is typed.
-     */
-    private function symfonyMessageFormatterFirstParamHasType(): bool
-    {
-        try {
-            if (! \interface_exists(\Symfony\Component\Translation\Formatter\MessageFormatterInterface::class)) {
-                return true;
-            }
-
-            $params = (new \ReflectionMethod(
-                \Symfony\Component\Translation\Formatter\MessageFormatterInterface::class,
-                'format',
-            ))->getParameters();
-
-            return isset($params[0]) && $params[0]->hasType();
-        } catch (\ReflectionException) {
-            return true;
-        }
+        CarbonStubProvider::register($registration, $output);
     }
 
     private function registerHandlers(RegistrationInterface $registration, PluginConfig $pluginConfig): void

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin;
 
+use Composer\InstalledVersions;
 use Illuminate\Foundation\Application;
 use Psalm\Internal\Analyzer\ProjectAnalyzer;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaAggregator;
@@ -197,6 +198,113 @@ final class Plugin implements PluginEntryPointInterface
         }
 
         $registration->addStubFile(self::getAliasStubLocation($pluginConfig));
+
+        $this->registerCarbonLazyStubs($registration, $output);
+    }
+
+    /**
+     * Register Carbon's "lazy" class definitions as Psalm stubs.
+     *
+     * Carbon declares three classes via runtime `require` from vendor/nesbot/carbon/lazy/,
+     * picking between pairs of files based on PHP and Symfony versions:
+     *
+     * - Carbon\DatePeriodBase           — CarbonPeriod.php:50 (PHP_VERSION < 8.2)
+     * - Carbon\LazyTranslator           — Translator.php:27 (TranslatorInterface::trans() return type)
+     * - Carbon\MessageFormatter\LazyMessageFormatter — MessageFormatterMapper.php:23 (trans() param type)
+     *
+     * The lazy/ directory is not in Carbon's composer autoload, so Psalm cannot resolve
+     * these classes statically. Without stubs, Psalm reports MissingDependency on
+     * CarbonPeriod, Translator, and MessageFormatterMapper.
+     *
+     * Carbon ships an extension.neon for PHPStan (bootstrapFiles: UnprotectedDatePeriod.php)
+     * but no Psalm equivalent. We register Carbon's own lazy files as stubs — no class
+     * duplication, automatically inheriting any upstream changes.
+     *
+     * Variant selection mirrors Carbon's own runtime choice so the plugin stays in sync
+     * with the variant actually loaded at runtime (important when older Symfony pins
+     * translation-contracts 2.x, which lacks the return type on `trans()`).
+     */
+    private function registerCarbonLazyStubs(RegistrationInterface $registration, \Psalm\Progress\Progress $output): void
+    {
+        if (! InstalledVersions::isInstalled('nesbot/carbon')) {
+            return;
+        }
+
+        $carbonRoot = InstalledVersions::getInstallPath('nesbot/carbon');
+
+        if ($carbonRoot === null) {
+            return;
+        }
+
+        $translatorVariant = self::symfonyTranslatorHasReturnType() ? 'Strong' : 'Weak';
+        $formatterVariant = self::symfonyMessageFormatterFirstParamHasType() ? 'Strong' : 'Weak';
+
+        $lazyStubs = [
+            // Carbon\DatePeriodBase — picked at CarbonPeriod.php:50 via `PHP_VERSION < 8.2`.
+            // Plugin requires PHP 8.2+ (composer.json), so Unprotected is always correct.
+            $carbonRoot . '/lazy/Carbon/UnprotectedDatePeriod.php',
+
+            $carbonRoot . "/lazy/Carbon/Translator{$translatorVariant}Type.php",
+
+            $carbonRoot . "/lazy/Carbon/MessageFormatter/MessageFormatterMapper{$formatterVariant}Type.php",
+        ];
+
+        foreach ($lazyStubs as $stub) {
+            if (\is_file($stub)) {
+                $registration->addStubFile($stub);
+            } else {
+                $output->warning(
+                    "Laravel plugin: Carbon lazy stub not found at '{$stub}'. "
+                    . 'CarbonPeriod / Translator / MessageFormatterMapper types may not resolve.',
+                );
+            }
+        }
+    }
+
+    /**
+     * Mirror of Carbon\Translator.php:20-25 — Carbon's ternary reads `class_exists(TranslatorInterface::class)`
+     * which is always false for interfaces (PHP returns false from class_exists() for interfaces),
+     * so Carbon effectively always reflects the concrete `Symfony\Component\Translation\Translator`
+     * class. We reflect the same class so our stub choice stays in lockstep with Carbon's runtime
+     * pick even when translation-contracts is pinned at an older major than symfony/translation.
+     */
+    private static function symfonyTranslatorHasReturnType(): bool
+    {
+        try {
+            if (\class_exists(\Symfony\Component\Translation\Translator::class)) {
+                return (new \ReflectionMethod(
+                    \Symfony\Component\Translation\Translator::class,
+                    'trans',
+                ))->hasReturnType();
+            }
+        } catch (\ReflectionException) {
+            // Fall through to the default.
+        }
+
+        // Symfony not installed or reflection failed — default to the modern (strong) variant.
+        return true;
+    }
+
+    /**
+     * Mirror of Carbon\MessageFormatter\MessageFormatterMapper.php:23 — picks the "strong type"
+     * variant when Symfony's MessageFormatterInterface::format() first parameter is typed.
+     */
+    private static function symfonyMessageFormatterFirstParamHasType(): bool
+    {
+        try {
+            if (! \interface_exists(\Symfony\Component\Translation\Formatter\MessageFormatterInterface::class)) {
+                return true;
+            }
+
+            $params = (new \ReflectionMethod(
+                \Symfony\Component\Translation\Formatter\MessageFormatterInterface::class,
+                'format',
+            ))->getParameters();
+
+            return isset($params[0]) && $params[0]->hasType();
+        } catch (\ReflectionException) {
+            return true;
+        }
     }
 
     private function registerHandlers(RegistrationInterface $registration, PluginConfig $pluginConfig): void

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -236,8 +236,8 @@ final class Plugin implements PluginEntryPointInterface
             return;
         }
 
-        $translatorVariant = self::symfonyTranslatorHasReturnType() ? 'Strong' : 'Weak';
-        $formatterVariant = self::symfonyMessageFormatterFirstParamHasType() ? 'Strong' : 'Weak';
+        $translatorVariant = $this->symfonyTranslatorHasReturnType() ? 'Strong' : 'Weak';
+        $formatterVariant = $this->symfonyMessageFormatterFirstParamHasType() ? 'Strong' : 'Weak';
 
         $lazyStubs = [
             // Carbon\DatePeriodBase — picked at CarbonPeriod.php:50 via `PHP_VERSION < 8.2`.
@@ -268,7 +268,7 @@ final class Plugin implements PluginEntryPointInterface
      * class. We reflect the same class so our stub choice stays in lockstep with Carbon's runtime
      * pick even when translation-contracts is pinned at an older major than symfony/translation.
      */
-    private static function symfonyTranslatorHasReturnType(): bool
+    private function symfonyTranslatorHasReturnType(): bool
     {
         try {
             if (\class_exists(\Symfony\Component\Translation\Translator::class)) {
@@ -289,7 +289,7 @@ final class Plugin implements PluginEntryPointInterface
      * Mirror of Carbon\MessageFormatter\MessageFormatterMapper.php:23 — picks the "strong type"
      * variant when Symfony's MessageFormatterInterface::format() first parameter is typed.
      */
-    private static function symfonyMessageFormatterFirstParamHasType(): bool
+    private function symfonyMessageFormatterFirstParamHasType(): bool
     {
         try {
             if (! \interface_exists(\Symfony\Component\Translation\Formatter\MessageFormatterInterface::class)) {

--- a/src/Providers/CarbonStubProvider.php
+++ b/src/Providers/CarbonStubProvider.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Providers;
+
+use Composer\InstalledVersions;
+use Psalm\Plugin\RegistrationInterface;
+use Psalm\Progress\Progress;
+
+/**
+ * Registers Carbon's "lazy" class definitions as Psalm stubs.
+ *
+ * Carbon declares three classes via runtime `require` from vendor/nesbot/carbon/lazy/,
+ * picking between pairs of files based on PHP and Symfony versions:
+ *
+ * - Carbon\DatePeriodBase                           — CarbonPeriod.php:50 (PHP_VERSION < 8.2)
+ * - Carbon\LazyTranslator                           — Translator.php:20-29 (Translator::trans() return type)
+ * - Carbon\MessageFormatter\LazyMessageFormatter    — MessageFormatterMapper.php:21-25 (format() first-param type)
+ *
+ * The `lazy/` directory is not in Carbon's composer autoload, so Psalm cannot resolve
+ * these classes statically. Without stubs, Psalm reports `MissingDependency` on
+ * `CarbonPeriod`, `Translator`, and `MessageFormatterMapper`.
+ *
+ * Carbon ships an `extension.neon` for PHPStan (`bootstrapFiles: UnprotectedDatePeriod.php`)
+ * but no Psalm equivalent. We register Carbon's own lazy files as stubs — no class
+ * duplication, automatically inheriting any upstream changes.
+ *
+ * Variant selection mirrors Carbon's own runtime choice so the plugin stays in sync with
+ * the variant actually loaded at runtime (important when older Symfony pins
+ * `translation-contracts` 2.x, which lacks the return type on `trans()`).
+ *
+ * @internal
+ */
+final class CarbonStubProvider
+{
+    public static function register(RegistrationInterface $registration, Progress $output): void
+    {
+        if (! InstalledVersions::isInstalled('nesbot/carbon')) {
+            return;
+        }
+
+        $carbonRoot = InstalledVersions::getInstallPath('nesbot/carbon');
+
+        if ($carbonRoot === null) {
+            return;
+        }
+
+        $translatorVariant = self::symfonyTranslatorHasReturnType() ? 'Strong' : 'Weak';
+        $formatterVariant = self::symfonyMessageFormatterFirstParamHasType() ? 'Strong' : 'Weak';
+
+        $lazyStubs = [
+            // Carbon\DatePeriodBase — picked at CarbonPeriod.php:50 via `PHP_VERSION < 8.2`.
+            // Plugin requires PHP 8.2+ (composer.json), so Unprotected is always correct.
+            $carbonRoot . '/lazy/Carbon/UnprotectedDatePeriod.php',
+
+            $carbonRoot . "/lazy/Carbon/Translator{$translatorVariant}Type.php",
+
+            $carbonRoot . "/lazy/Carbon/MessageFormatter/MessageFormatterMapper{$formatterVariant}Type.php",
+        ];
+
+        foreach ($lazyStubs as $stub) {
+            if (\is_file($stub)) {
+                $registration->addStubFile($stub);
+            } else {
+                $output->warning(
+                    "Laravel plugin: Carbon lazy stub not found at '{$stub}'. "
+                    . 'CarbonPeriod / Translator / MessageFormatterMapper types may not resolve.',
+                );
+            }
+        }
+    }
+
+    /**
+     * Mirror of Carbon\Translator.php:20-25 — Carbon's ternary reads `class_exists(TranslatorInterface::class)`
+     * which is always false for interfaces (PHP returns false from class_exists() for interfaces),
+     * so Carbon effectively always reflects the concrete `Symfony\Component\Translation\Translator`
+     * class. We reflect the same class so our stub choice stays in lockstep with Carbon's runtime
+     * pick even when translation-contracts is pinned at an older major than symfony/translation.
+     */
+    private static function symfonyTranslatorHasReturnType(): bool
+    {
+        try {
+            if (\class_exists(\Symfony\Component\Translation\Translator::class)) {
+                return (new \ReflectionMethod(
+                    \Symfony\Component\Translation\Translator::class,
+                    'trans',
+                ))->hasReturnType();
+            }
+        } catch (\ReflectionException) {
+            // Fall through to the default.
+        }
+
+        // Symfony not installed or reflection failed — default to the modern (strong) variant.
+        return true;
+    }
+
+    /**
+     * Mirror of Carbon\MessageFormatter\MessageFormatterMapper.php:21-25 — picks the "strong type"
+     * variant when Symfony's MessageFormatterInterface::format() first parameter is typed.
+     */
+    private static function symfonyMessageFormatterFirstParamHasType(): bool
+    {
+        try {
+            if (! \interface_exists(\Symfony\Component\Translation\Formatter\MessageFormatterInterface::class)) {
+                return true;
+            }
+
+            $params = (new \ReflectionMethod(
+                \Symfony\Component\Translation\Formatter\MessageFormatterInterface::class,
+                'format',
+            ))->getParameters();
+
+            return isset($params[0]) && $params[0]->hasType();
+        } catch (\ReflectionException) {
+            return true;
+        }
+    }
+}

--- a/tests/Type/tests/CarbonLazyStubsTest.phpt
+++ b/tests/Type/tests/CarbonLazyStubsTest.phpt
@@ -1,0 +1,45 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Carbon\CarbonPeriod;
+use Carbon\Translator;
+use Carbon\MessageFormatter\MessageFormatterMapper;
+
+// Carbon loads three classes (DatePeriodBase, LazyTranslator, LazyMessageFormatter)
+// from vendor/nesbot/carbon/lazy/ via runtime `require`. That directory is not in
+// Carbon's composer autoload, so without the plugin's stub registration Psalm
+// reports MissingDependency on the classes below.
+
+// CarbonPeriod extends Carbon\DatePeriodBase — iteration relies on the parent.
+function iterate_carbon_period(CarbonPeriod $period): array
+{
+    $dates = [];
+    foreach ($period as $date) {
+        $dates[] = $date->format('Y-m-d');
+    }
+    return $dates;
+}
+
+$_period = CarbonPeriod::create('2026-01-01', '1 day', '2026-01-10');
+/** @psalm-check-type-exact $_period = \Carbon\CarbonPeriod */
+
+// Exercises a CarbonPeriod method that returns CarbonInterface. If DatePeriodBase
+// stays unresolved Psalm widens the return to mixed, and this declared type fails.
+function get_start(CarbonPeriod $period): \Carbon\CarbonInterface
+{
+    return $period->getStartDate();
+}
+
+// Translator extends Carbon\LazyTranslator.
+function translate(Translator $translator): string
+{
+    return $translator->trans('greeting');
+}
+
+// MessageFormatterMapper extends Carbon\MessageFormatter\LazyMessageFormatter.
+function format_message(MessageFormatterMapper $mapper): string
+{
+    return $mapper->format('hello', 'en', []);
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

Every Laravel app that uses `CarbonPeriod`, `Carbon\Translator`, or `Carbon\MessageFormatter\MessageFormatterMapper` sees Psalm emit:

```
MissingDependency: Carbon\CarbonPeriod depends on class or interface carbon\dateperiodbase that does not exist
```

Root cause: Carbon declares three classes (`DatePeriodBase`, `LazyTranslator`, `LazyMessageFormatter`) via runtime `require` from `vendor/nesbot/carbon/lazy/`, a directory outside Carbon's composer autoload. Psalm can't resolve these parents statically.

Carbon already solves this upstream for PHPStan via `extension.neon` (`bootstrapFiles: UnprotectedDatePeriod.php`). No Psalm equivalent ships.

## Solution Description

`Plugin::registerCarbonLazyStubs()` locates `vendor/nesbot/carbon` through `\Composer\InstalledVersions::getInstallPath()` (matching the pattern in `IssueUrlGenerator` and `MigrationCache`) and registers Carbon's own lazy files as Psalm stubs via `$registration->addStubFile()`. No duplication, no maintenance burden: any upstream change in Carbon is inherited automatically.

Variant selection mirrors Carbon's runtime pick so the plugin stays in lockstep with whichever variant Carbon actually loads:

- **`DatePeriodBase`**: always uses `UnprotectedDatePeriod.php` (the PHP >= 8.2 variant). Plugin requires PHP 8.2+, so this is always correct.
- **`LazyTranslator`**: reflects `Symfony\Component\Translation\Translator::trans()->hasReturnType()` and picks `TranslatorStrongType.php` / `TranslatorWeakType.php` accordingly. This mirrors Carbon's own `Translator.php:20-29` (Carbon's `class_exists(TranslatorInterface::class)` returns `false` for interfaces, so it always falls through to reflecting the concrete class).
- **`LazyMessageFormatter`**: reflects `Symfony\Component\Translation\Formatter\MessageFormatterInterface::format()` first parameter type, matching `MessageFormatterMapper.php:21-25`.

Missing files log via `$output->warning()` (not `debug()`, which is a no-op in `DefaultProgress`) so users see meaningful feedback if Carbon ever restructures its `lazy/` layout.

Verified with a new regression test (`tests/Type/tests/CarbonLazyStubsTest.phpt`) that:

- fails without the fix with `MissingDependency` on `Carbon\CarbonPeriod`
- passes with the fix
- forces full parent-class resolution through `DatePeriodBase` by asserting `CarbonPeriod::getStartDate()` returns `\Carbon\CarbonInterface` (Psalm would widen to `mixed` if the stub weren't registered).

## Checklist

- [x] Tests cover the change (type test in `tests/Type/`)
