### PR TITLE
Include plugin configuration in bug-report issue body

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -54,7 +54,7 @@ final class Plugin implements PluginEntryPointInterface
             $this->registerHandlers($registration, $pluginConfig);
             $this->registerStubs($registration, $pluginConfig, $output);
         } catch (\Throwable $throwable) {
-            $this->handleInternalError($throwable, $output, $pluginConfig->failOnInternalError);
+            $this->handleInternalError($throwable, $output, $pluginConfig);
         }
     }
 
@@ -701,12 +701,26 @@ final class Plugin implements PluginEntryPointInterface
     }
 
     /** @throws \Throwable */
-    private function handleInternalError(\Throwable $throwable, \Psalm\Progress\Progress $output, bool $failOnInternalError): void
+    private function handleInternalError(\Throwable $throwable, \Psalm\Progress\Progress $output, PluginConfig $pluginConfig): void
     {
         $output->warning("Laravel plugin error on initialisation: {$throwable->getMessage()}");
-        $output->warning('Laravel plugin has been disabled for this run, please report about this issue: ' . IssueUrlGenerator::generate($throwable));
 
-        if ($failOnInternalError) {
+        // URL generation is best-effort — a secondary failure here (e.g. a
+        // throwable with a broken __toString(), a corrupt composer installed.php)
+        // must never shadow the original init error that the user actually cares
+        // about, so we fall back to a plain issue-tracker link. The secondary
+        // error is still surfaced as a separate warning so plugin maintainers can
+        // spot regressions in the URL generator during self-analysis.
+        try {
+            $url = IssueUrlGenerator::generate($throwable, $pluginConfig);
+        } catch (\Throwable $urlGenerationFailure) {
+            $output->warning("Laravel plugin failed to build a detailed report URL: {$urlGenerationFailure->getMessage()}");
+            $url = 'https://github.com/psalm/psalm-plugin-laravel/issues';
+        }
+
+        $output->warning('Laravel plugin has been disabled for this run, please report about this issue: ' . $url);
+
+        if ($pluginConfig->failOnInternalError) {
             throw $throwable;
         }
     }

--- a/src/Util/IssueUrlGenerator.php
+++ b/src/Util/IssueUrlGenerator.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace Psalm\LaravelPlugin\Util;
 
 use Composer\InstalledVersions;
+use Psalm\LaravelPlugin\PluginConfig;
 
 /** @internal */
 final class IssueUrlGenerator
 {
-    public static function generate(\Throwable $throwable): string
+    public static function generate(\Throwable $throwable, PluginConfig $pluginConfig): string
     {
         return \sprintf(
             'https://github.com/psalm/psalm-plugin-laravel/issues/new?template=bug_report.md&title=%s&body=%s',
             \urlencode('Plugin initialization error: ' . self::sanitizeTitle($throwable->getMessage())),
-            \urlencode(self::buildBody($throwable)),
+            \urlencode(self::buildBody($throwable, $pluginConfig)),
         );
     }
 
@@ -40,7 +41,7 @@ final class IssueUrlGenerator
         return \trim($message);
     }
 
-    private static function buildBody(\Throwable $throwable): string
+    private static function buildBody(\Throwable $throwable, PluginConfig $pluginConfig): string
     {
         $versions = self::collectVersions();
         $trace = self::sanitizeTrace($throwable->__toString());
@@ -56,9 +57,94 @@ final class IssueUrlGenerator
             $body .= "\n";
         }
 
+        $body .= "**Plugin configuration:**\n";
+        foreach (self::pluginConfigLines($pluginConfig) as $line) {
+            $body .= "{$line}\n";
+        }
+
+        $body .= "\n";
+
         $body .= "```\n{$trace}\n```";
 
         return $body;
+    }
+
+    /**
+     * Serialise PluginConfig's public fields into human-readable bullet lines.
+     *
+     * cachePath passes through sanitizeCachePath() rather than the trace sanitizer
+     * because typical cache paths (e.g. "/Users/alice/.psalm-cache/plugin-laravel",
+     * "/var/folders/…/T/psalm-laravel-…") don't contain a "vendor/" or "src/"
+     * segment, so sanitizeTrace() would leave them untouched and leak the user's
+     * home directory into the bug-report body.
+     *
+     * @return list<string>
+     */
+    private static function pluginConfigLines(PluginConfig $pluginConfig): array
+    {
+        return [
+            "- modelPropertiesColumnFallback: {$pluginConfig->modelPropertiesColumnFallback->value}",
+            '- resolveDynamicWhereClauses: ' . self::formatBool($pluginConfig->resolveDynamicWhereClauses),
+            '- findMissingTranslations: ' . self::formatBool($pluginConfig->findMissingTranslations),
+            '- findMissingViews: ' . self::formatBool($pluginConfig->findMissingViews),
+            '- cachePath: ' . self::sanitizeCachePath($pluginConfig->cachePath),
+            '- failOnInternalError: ' . self::formatBool($pluginConfig->failOnInternalError),
+        ];
+    }
+
+    /** @psalm-pure */
+    private static function formatBool(bool $value): string
+    {
+        return $value ? 'true' : 'false';
+    }
+
+    /**
+     * Anonymise an absolute cache path so the bug-report body doesn't leak the
+     * reporter's home directory or username.
+     *
+     * First-match wins, in order of specificity:
+     *   1. under getcwd()              → "./<rest>"
+     *   2. under sys_get_temp_dir()    → "<tmp>/<rest>"
+     *   3. under $HOME / $USERPROFILE  → "~/<rest>"
+     *   4. otherwise fall back to sanitizeTrace(), which handles vendor/src
+     *      segments for the uncommon case where cache sits inside a checkout.
+     *
+     * Not marked @psalm-pure — getenv/getcwd/sys_get_temp_dir are impure.
+     */
+    private static function sanitizeCachePath(string $path): string
+    {
+        $prefixes = [];
+
+        $cwd = \getcwd();
+        if (\is_string($cwd)) {
+            $prefixes[] = ['.', $cwd];
+        }
+
+        $tmp = \sys_get_temp_dir();
+        if ($tmp !== '') {
+            $prefixes[] = ['<tmp>', $tmp];
+        }
+
+        foreach (['HOME', 'USERPROFILE'] as $var) {
+            $home = \getenv($var);
+            if (\is_string($home) && $home !== '') {
+                $prefixes[] = ['~', $home];
+                break;
+            }
+        }
+
+        foreach ($prefixes as [$replacement, $prefix]) {
+            if ($path === $prefix) {
+                return $replacement;
+            }
+
+            $prefixWithSep = \rtrim($prefix, \DIRECTORY_SEPARATOR) . \DIRECTORY_SEPARATOR;
+            if (\str_starts_with($path, $prefixWithSep)) {
+                return $replacement . \DIRECTORY_SEPARATOR . \substr($path, \strlen($prefixWithSep));
+            }
+        }
+
+        return self::sanitizeTrace($path);
     }
 
     /**

--- a/tests/Unit/Util/IssueUrlGeneratorTest.php
+++ b/tests/Unit/Util/IssueUrlGeneratorTest.php
@@ -39,7 +39,7 @@ final class IssueUrlGeneratorTest extends TestCase
     #[Test]
     public function url_points_to_new_issue_form_with_bug_report_template(): void
     {
-        $url = IssueUrlGenerator::generate(new \RuntimeException('boom'), self::defaultConfig());
+        $url = IssueUrlGenerator::generate(new \RuntimeException('boom'), $this->defaultConfig());
 
         $this->assertStringStartsWith('https://github.com/psalm/psalm-plugin-laravel/issues/new?template=bug_report.md', $url);
     }
@@ -47,7 +47,7 @@ final class IssueUrlGeneratorTest extends TestCase
     #[Test]
     public function title_prefixes_plugin_initialization_error(): void
     {
-        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException('boom'), self::defaultConfig()));
+        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException('boom'), $this->defaultConfig()));
 
         $this->assertSame('Plugin initialization error: boom', $title);
     }
@@ -64,7 +64,7 @@ final class IssueUrlGeneratorTest extends TestCase
             . '/Users/matthewdally/docker/business-directory/vendor/laravel/framework/src/Illuminate/Foundation/AliasLoader.php:79'
             . ' for command with CLI args "./vendor/bin/psalm --no-cache --config=psalm.xml"';
 
-        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException($rawMessage), self::defaultConfig()));
+        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException($rawMessage), $this->defaultConfig()));
 
         $this->assertSame('Plugin initialization error: Class "Introspect" not found', $title);
     }
@@ -74,7 +74,7 @@ final class IssueUrlGeneratorTest extends TestCase
     {
         $rawMessage = 'Class "Foo" not found in C:\\Users\\John Doe\\project\\src\\File.php:12';
 
-        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException($rawMessage), self::defaultConfig()));
+        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException($rawMessage), $this->defaultConfig()));
 
         $this->assertSame('Plugin initialization error: Class "Foo" not found', $title);
     }
@@ -93,7 +93,7 @@ final class IssueUrlGeneratorTest extends TestCase
     #[DataProvider('leadingPhpPrefixes')]
     public function title_strips_leading_php_level_prefix(string $rawMessage, string $expectedTail): void
     {
-        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException($rawMessage), self::defaultConfig()));
+        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException($rawMessage), $this->defaultConfig()));
 
         $this->assertSame('Plugin initialization error: ' . $expectedTail, $title);
     }
@@ -101,7 +101,7 @@ final class IssueUrlGeneratorTest extends TestCase
     #[Test]
     public function title_does_not_strip_non_php_colon_prefixes(): void
     {
-        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException('Class not found: Foo'), self::defaultConfig()));
+        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException('Class not found: Foo'), $this->defaultConfig()));
 
         $this->assertSame('Plugin initialization error: Class not found: Foo', $title);
     }
@@ -118,7 +118,7 @@ final class IssueUrlGeneratorTest extends TestCase
             . '/Users/matthewdally/docker/business-directory/vendor/laravel/framework/src/Illuminate/Foundation/AliasLoader.php:79'
             . ' for command with CLI args "./vendor/bin/psalm --no-cache --config=psalm.xml"';
 
-        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException($rawMessage), self::defaultConfig()));
+        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException($rawMessage), $this->defaultConfig()));
         $expectedTitle = 'Plugin initialization error: Class "Introspect" not found';
 
         $this->assertSame($expectedTitle, $title);
@@ -128,7 +128,7 @@ final class IssueUrlGeneratorTest extends TestCase
     #[Test]
     public function body_includes_fenced_trace_block(): void
     {
-        $body = $this->bodyFrom(IssueUrlGenerator::generate(new \RuntimeException('boom'), self::defaultConfig()));
+        $body = $this->bodyFrom(IssueUrlGenerator::generate(new \RuntimeException('boom'), $this->defaultConfig()));
 
         $this->assertStringContainsString("```\n", $body);
         $this->assertStringContainsString('RuntimeException', $body);
@@ -138,7 +138,7 @@ final class IssueUrlGeneratorTest extends TestCase
     #[Test]
     public function body_lists_plugin_version_from_installed_versions(): void
     {
-        $body = $this->bodyFrom(IssueUrlGenerator::generate(new \RuntimeException('boom'), self::defaultConfig()));
+        $body = $this->bodyFrom(IssueUrlGenerator::generate(new \RuntimeException('boom'), $this->defaultConfig()));
 
         // psalm/plugin-laravel is this very package — always resolvable during test runs.
         $this->assertStringContainsString('**Versions:**', $body);
@@ -148,7 +148,7 @@ final class IssueUrlGeneratorTest extends TestCase
     #[Test]
     public function body_includes_plugin_configuration_section_with_default_values(): void
     {
-        $body = $this->bodyFrom(IssueUrlGenerator::generate(new \RuntimeException('boom'), self::defaultConfig()));
+        $body = $this->bodyFrom(IssueUrlGenerator::generate(new \RuntimeException('boom'), $this->defaultConfig()));
 
         $this->assertStringContainsString('**Plugin configuration:**', $body);
         $this->assertStringContainsString('- modelPropertiesColumnFallback: migrations', $body);
@@ -200,7 +200,7 @@ final class IssueUrlGeneratorTest extends TestCase
     public function body_sanitises_cache_path_under_cwd_prefix(): void
     {
         $cwd = \getcwd();
-        self::assertIsString($cwd);
+        $this->assertIsString($cwd);
         $cachePath = $cwd . \DIRECTORY_SEPARATOR . '.psalm-cache' . \DIRECTORY_SEPARATOR . 'plugin-laravel';
 
         $body = $this->bodyFromCachePath($cachePath);
@@ -259,9 +259,9 @@ final class IssueUrlGeneratorTest extends TestCase
             $publicProperties[] = $property->getName();
         }
 
-        self::assertNotEmpty($publicProperties, 'PluginConfig should expose at least one public property');
+        $this->assertNotEmpty($publicProperties, 'PluginConfig should expose at least one public property');
 
-        $body = $this->bodyFrom(IssueUrlGenerator::generate(new \RuntimeException('boom'), self::defaultConfig()));
+        $body = $this->bodyFrom(IssueUrlGenerator::generate(new \RuntimeException('boom'), $this->defaultConfig()));
 
         foreach ($publicProperties as $name) {
             $this->assertStringContainsString("- {$name}: ", $body, "Plugin configuration section is missing '{$name}'");
@@ -271,7 +271,7 @@ final class IssueUrlGeneratorTest extends TestCase
     #[Test]
     public function body_renders_plugin_configuration_between_versions_and_trace(): void
     {
-        $body = $this->bodyFrom(IssueUrlGenerator::generate(new \RuntimeException('boom'), self::defaultConfig()));
+        $body = $this->bodyFrom(IssueUrlGenerator::generate(new \RuntimeException('boom'), $this->defaultConfig()));
 
         $versionsPos = \strpos($body, '**Versions:**');
         $configPos = \strpos($body, '**Plugin configuration:**');
@@ -406,7 +406,7 @@ final class IssueUrlGeneratorTest extends TestCase
         $this->assertSame($input, $output);
     }
 
-    private static function defaultConfig(): PluginConfig
+    private function defaultConfig(): PluginConfig
     {
         return PluginConfig::fromXml(null);
     }

--- a/tests/Unit/Util/IssueUrlGeneratorTest.php
+++ b/tests/Unit/Util/IssueUrlGeneratorTest.php
@@ -8,15 +8,38 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\PluginConfig;
 use Psalm\LaravelPlugin\Util\IssueUrlGenerator;
 
 #[CoversClass(IssueUrlGenerator::class)]
 final class IssueUrlGeneratorTest extends TestCase
 {
+    private ?string $originalCachePathEnv = null;
+
+    protected function setUp(): void
+    {
+        $env = \getenv('PSALM_LARAVEL_PLUGIN_CACHE_PATH');
+        $this->originalCachePathEnv = $env !== false ? $env : null;
+
+        // Start each test from a known-clean baseline; a developer-exported value
+        // otherwise leaks into `defaultConfig()` and silently changes what the
+        // body_includes_plugin_configuration_section_* tests actually assert.
+        \putenv('PSALM_LARAVEL_PLUGIN_CACHE_PATH');
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->originalCachePathEnv !== null) {
+            \putenv('PSALM_LARAVEL_PLUGIN_CACHE_PATH=' . $this->originalCachePathEnv);
+        } else {
+            \putenv('PSALM_LARAVEL_PLUGIN_CACHE_PATH');
+        }
+    }
+
     #[Test]
     public function url_points_to_new_issue_form_with_bug_report_template(): void
     {
-        $url = IssueUrlGenerator::generate(new \RuntimeException('boom'));
+        $url = IssueUrlGenerator::generate(new \RuntimeException('boom'), self::defaultConfig());
 
         $this->assertStringStartsWith('https://github.com/psalm/psalm-plugin-laravel/issues/new?template=bug_report.md', $url);
     }
@@ -24,7 +47,7 @@ final class IssueUrlGeneratorTest extends TestCase
     #[Test]
     public function title_prefixes_plugin_initialization_error(): void
     {
-        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException('boom')));
+        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException('boom'), self::defaultConfig()));
 
         $this->assertSame('Plugin initialization error: boom', $title);
     }
@@ -41,7 +64,7 @@ final class IssueUrlGeneratorTest extends TestCase
             . '/Users/matthewdally/docker/business-directory/vendor/laravel/framework/src/Illuminate/Foundation/AliasLoader.php:79'
             . ' for command with CLI args "./vendor/bin/psalm --no-cache --config=psalm.xml"';
 
-        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException($rawMessage)));
+        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException($rawMessage), self::defaultConfig()));
 
         $this->assertSame('Plugin initialization error: Class "Introspect" not found', $title);
     }
@@ -51,7 +74,7 @@ final class IssueUrlGeneratorTest extends TestCase
     {
         $rawMessage = 'Class "Foo" not found in C:\\Users\\John Doe\\project\\src\\File.php:12';
 
-        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException($rawMessage)));
+        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException($rawMessage), self::defaultConfig()));
 
         $this->assertSame('Plugin initialization error: Class "Foo" not found', $title);
     }
@@ -70,7 +93,7 @@ final class IssueUrlGeneratorTest extends TestCase
     #[DataProvider('leadingPhpPrefixes')]
     public function title_strips_leading_php_level_prefix(string $rawMessage, string $expectedTail): void
     {
-        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException($rawMessage)));
+        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException($rawMessage), self::defaultConfig()));
 
         $this->assertSame('Plugin initialization error: ' . $expectedTail, $title);
     }
@@ -78,7 +101,7 @@ final class IssueUrlGeneratorTest extends TestCase
     #[Test]
     public function title_does_not_strip_non_php_colon_prefixes(): void
     {
-        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException('Class not found: Foo')));
+        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException('Class not found: Foo'), self::defaultConfig()));
 
         $this->assertSame('Plugin initialization error: Class not found: Foo', $title);
     }
@@ -95,7 +118,7 @@ final class IssueUrlGeneratorTest extends TestCase
             . '/Users/matthewdally/docker/business-directory/vendor/laravel/framework/src/Illuminate/Foundation/AliasLoader.php:79'
             . ' for command with CLI args "./vendor/bin/psalm --no-cache --config=psalm.xml"';
 
-        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException($rawMessage)));
+        $title = $this->titleFrom(IssueUrlGenerator::generate(new \RuntimeException($rawMessage), self::defaultConfig()));
         $expectedTitle = 'Plugin initialization error: Class "Introspect" not found';
 
         $this->assertSame($expectedTitle, $title);
@@ -105,7 +128,7 @@ final class IssueUrlGeneratorTest extends TestCase
     #[Test]
     public function body_includes_fenced_trace_block(): void
     {
-        $body = $this->bodyFrom(IssueUrlGenerator::generate(new \RuntimeException('boom')));
+        $body = $this->bodyFrom(IssueUrlGenerator::generate(new \RuntimeException('boom'), self::defaultConfig()));
 
         $this->assertStringContainsString("```\n", $body);
         $this->assertStringContainsString('RuntimeException', $body);
@@ -115,11 +138,150 @@ final class IssueUrlGeneratorTest extends TestCase
     #[Test]
     public function body_lists_plugin_version_from_installed_versions(): void
     {
-        $body = $this->bodyFrom(IssueUrlGenerator::generate(new \RuntimeException('boom')));
+        $body = $this->bodyFrom(IssueUrlGenerator::generate(new \RuntimeException('boom'), self::defaultConfig()));
 
         // psalm/plugin-laravel is this very package — always resolvable during test runs.
         $this->assertStringContainsString('**Versions:**', $body);
         $this->assertStringContainsString('- psalm/plugin-laravel:', $body);
+    }
+
+    #[Test]
+    public function body_includes_plugin_configuration_section_with_default_values(): void
+    {
+        $body = $this->bodyFrom(IssueUrlGenerator::generate(new \RuntimeException('boom'), self::defaultConfig()));
+
+        $this->assertStringContainsString('**Plugin configuration:**', $body);
+        $this->assertStringContainsString('- modelPropertiesColumnFallback: migrations', $body);
+        $this->assertStringContainsString('- resolveDynamicWhereClauses: true', $body);
+        $this->assertStringContainsString('- findMissingTranslations: false', $body);
+        $this->assertStringContainsString('- findMissingViews: false', $body);
+        $this->assertStringContainsString('- cachePath:', $body);
+        $this->assertStringContainsString('- failOnInternalError: false', $body);
+    }
+
+    #[Test]
+    public function body_reflects_overridden_plugin_configuration_values(): void
+    {
+        $xml = new \SimpleXMLElement(
+            '<pluginClass>'
+            . '<modelProperties columnFallback="none" />'
+            . '<resolveDynamicWhereClauses value="false" />'
+            . '<findMissingTranslations value="true" />'
+            . '<findMissingViews value="true" />'
+            . '<failOnInternalError value="true" />'
+            . '</pluginClass>',
+        );
+        $config = PluginConfig::fromXml($xml);
+
+        $body = $this->bodyFrom(IssueUrlGenerator::generate(new \RuntimeException('boom'), $config));
+
+        $this->assertStringContainsString('- modelPropertiesColumnFallback: none', $body);
+        $this->assertStringContainsString('- resolveDynamicWhereClauses: false', $body);
+        $this->assertStringContainsString('- findMissingTranslations: true', $body);
+        $this->assertStringContainsString('- findMissingViews: true', $body);
+        $this->assertStringContainsString('- failOnInternalError: true', $body);
+    }
+
+    /**
+     * Vendor fallback: an absolute prefix containing a vendor/ segment collapses
+     * to a relative vendor/... path — useful for the uncommon case where the
+     * cache sits inside a checkout rather than under cwd / tmp / HOME.
+     */
+    #[Test]
+    public function body_sanitises_cache_path_under_vendor_prefix(): void
+    {
+        $body = $this->bodyFromCachePath('/nowhere/project/vendor/psalm-cache/plugin-laravel');
+
+        $this->assertStringContainsString('- cachePath: vendor/psalm-cache/plugin-laravel', $body);
+        $this->assertStringNotContainsString('/nowhere/project', $body);
+    }
+
+    #[Test]
+    public function body_sanitises_cache_path_under_cwd_prefix(): void
+    {
+        $cwd = \getcwd();
+        self::assertIsString($cwd);
+        $cachePath = $cwd . \DIRECTORY_SEPARATOR . '.psalm-cache' . \DIRECTORY_SEPARATOR . 'plugin-laravel';
+
+        $body = $this->bodyFromCachePath($cachePath);
+
+        $expected = '- cachePath: .' . \DIRECTORY_SEPARATOR . '.psalm-cache' . \DIRECTORY_SEPARATOR . 'plugin-laravel';
+        $this->assertStringContainsString($expected, $body);
+    }
+
+    #[Test]
+    public function body_sanitises_cache_path_under_temp_dir_prefix(): void
+    {
+        $tmp = \sys_get_temp_dir();
+        $cachePath = \rtrim($tmp, \DIRECTORY_SEPARATOR) . \DIRECTORY_SEPARATOR . 'psalm-laravel-unit-test';
+
+        $body = $this->bodyFromCachePath($cachePath);
+
+        $this->assertStringContainsString('- cachePath: <tmp>' . \DIRECTORY_SEPARATOR . 'psalm-laravel-unit-test', $body);
+    }
+
+    /**
+     * Path under $HOME (but not under cwd) collapses to "~/..." so the reporter's
+     * username does not leak into the bug-report body. This covers the realistic
+     * default when Psalm's cache directory resolves outside the project root
+     * (e.g. global cache under the user's home).
+     */
+    #[Test]
+    public function body_sanitises_cache_path_under_home_prefix(): void
+    {
+        $home = \getenv('HOME');
+        if (!\is_string($home) || $home === '') {
+            self::markTestSkipped('$HOME is not available on this platform');
+        }
+
+        // Choose a sibling of the project root so cwd does NOT also match — the
+        // cwd check would otherwise fire first and produce "./..." instead of "~/...".
+        $cachePath = \rtrim($home, \DIRECTORY_SEPARATOR) . \DIRECTORY_SEPARATOR . '.psalm-laravel-test-cache';
+
+        $body = $this->bodyFromCachePath($cachePath);
+
+        $this->assertStringContainsString('- cachePath: ~' . \DIRECTORY_SEPARATOR . '.psalm-laravel-test-cache', $body);
+    }
+
+    /**
+     * Reflection-backed guard: every public property on PluginConfig must appear
+     * as a bullet in the rendered Plugin-configuration section. Catches the
+     * scenario where a future PluginConfig field is added but the renderer in
+     * IssueUrlGenerator::pluginConfigLines() is not updated, silently omitting
+     * plugin-relevant state from bug reports.
+     */
+    #[Test]
+    public function body_renders_every_public_plugin_config_field(): void
+    {
+        $reflection = new \ReflectionClass(PluginConfig::class);
+        $publicProperties = [];
+        foreach ($reflection->getProperties(\ReflectionProperty::IS_PUBLIC) as $property) {
+            $publicProperties[] = $property->getName();
+        }
+
+        self::assertNotEmpty($publicProperties, 'PluginConfig should expose at least one public property');
+
+        $body = $this->bodyFrom(IssueUrlGenerator::generate(new \RuntimeException('boom'), self::defaultConfig()));
+
+        foreach ($publicProperties as $name) {
+            $this->assertStringContainsString("- {$name}: ", $body, "Plugin configuration section is missing '{$name}'");
+        }
+    }
+
+    #[Test]
+    public function body_renders_plugin_configuration_between_versions_and_trace(): void
+    {
+        $body = $this->bodyFrom(IssueUrlGenerator::generate(new \RuntimeException('boom'), self::defaultConfig()));
+
+        $versionsPos = \strpos($body, '**Versions:**');
+        $configPos = \strpos($body, '**Plugin configuration:**');
+        $fencePos = \strpos($body, '```');
+
+        $this->assertIsInt($versionsPos);
+        $this->assertIsInt($configPos);
+        $this->assertIsInt($fencePos);
+        $this->assertLessThan($configPos, $versionsPos);
+        $this->assertLessThan($fencePos, $configPos);
     }
 
     /**
@@ -242,6 +404,22 @@ final class IssueUrlGeneratorTest extends TestCase
         $output = $this->invokeSanitizeTrace($input);
 
         $this->assertSame($input, $output);
+    }
+
+    private static function defaultConfig(): PluginConfig
+    {
+        return PluginConfig::fromXml(null);
+    }
+
+    /**
+     * Pin `cachePath` via the env var (the only writable path since PluginConfig's
+     * constructor is private) and return the URL body for a throwaway throwable.
+     */
+    private function bodyFromCachePath(string $cachePath): string
+    {
+        \putenv('PSALM_LARAVEL_PLUGIN_CACHE_PATH=' . $cachePath);
+
+        return $this->bodyFrom(IssueUrlGenerator::generate(new \RuntimeException('boom'), PluginConfig::fromXml(null)));
     }
 
     private function titleFrom(string $url): string


### PR DESCRIPTION
## Summary

`IssueUrlGenerator::generate()` now takes a `PluginConfig` as a required second argument and renders the configuration into the GitHub bug-report body. Maintainers get the plugin toggles (column fallback, dynamic-where resolution, find-missing translations/views, `cachePath`, `failOnInternalError`) alongside versions and the stack trace, making the out-of-the-box bug report actionable without back-and-forth.

### Privacy

`cachePath` is run through a new `sanitizeCachePath()` with first-match-wins prefix stripping (cwd → `sys_get_temp_dir()` → `$HOME` / `$USERPROFILE` → sanitizeTrace fallback) so the reporter's home directory and username do not leak into the body. The previous `sanitizeTrace()` path (vendor/src only) did not cover typical cache locations like `/Users/<name>/.psalm-cache/plugin-laravel` or `/var/folders/.../T/psalm-laravel-<hash>`.

### Error-handling

`Plugin::handleInternalError()` wraps the URL generator in a `try/catch` with a plain issue-tracker fallback URL, so a secondary failure while building the body cannot shadow the original init error. Any such secondary throwable is surfaced as its own warning so regressions in the URL generator remain observable during self-analysis.

## Tests

- 6 new `body_*` unit tests cover the configuration section, each sanitization tier (cwd/tmp/HOME/vendor), and a reflection-backed guard that every public `PluginConfig` property is rendered.
- 30 tests in `IssueUrlGeneratorTest` (up from 24), 492 unit tests total, 275 type tests, all green.