### PR TITLE
Widen `Collection::make`/`LazyCollection::make`/`collect()` for scalar inputs

### DIFF
--- a/stubs/common/Collections/helpers.stubphp
+++ b/stubs/common/Collections/helpers.stubphp
@@ -13,7 +13,7 @@
  * stubbed to widen generics on their return so fluent chains propagate concrete types.
  *
  * Accepts `scalar|\UnitEnum|null` too and narrows them to `Collection<int, $value>` on the result;
- * see `Collection::make()` in this stubs directory for the rationale behind the conditional ordering.
+ * see {@see \Illuminate\Support\Collection::make()} for the rationale behind the conditional ordering.
  *
  * @template TKey of array-key
  * @template TValue

--- a/stubs/common/Collections/helpers.stubphp
+++ b/stubs/common/Collections/helpers.stubphp
@@ -12,8 +12,9 @@
  * because `never` is the bottom type (subtype of everything), and methods like `merge()` / `push()` are
  * stubbed to widen generics on their return so fluent chains propagate concrete types.
  *
- * Accepts `scalar|\UnitEnum|null` too and narrows them to `Collection<int, $value>` on the result;
- * see {@see \Illuminate\Support\Collection::make()} for the rationale behind the conditional ordering.
+ * Accepts `scalar|\UnitEnum|null` too: `null` yields an empty `Collection<never, never>`, while
+ * scalar and `\UnitEnum` inputs narrow to `Collection<int, $value>`. See
+ * {@see \Illuminate\Support\Collection::make()} for the rationale behind the conditional ordering.
  *
  * @template TKey of array-key
  * @template TValue

--- a/stubs/common/Collections/helpers.stubphp
+++ b/stubs/common/Collections/helpers.stubphp
@@ -12,14 +12,20 @@
  * because `never` is the bottom type (subtype of everything), and methods like `merge()` / `push()` are
  * stubbed to widen generics on their return so fluent chains propagate concrete types.
  *
- * Also accepts `scalar|\UnitEnum|null`; see `Collection::make()` in this stubs directory for the
- * rationale behind the widening.
+ * Accepts `scalar|\UnitEnum|null` too and narrows them to `Collection<int, $value>` on the result;
+ * see `Collection::make()` in this stubs directory for the rationale behind the conditional ordering.
  *
  * @template TKey of array-key
  * @template TValue
  *
  * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|scalar|\UnitEnum|null  $value
- * @psalm-return \Illuminate\Support\Collection<TKey, TValue>
+ * @psalm-return (
+ *     $value is \Illuminate\Contracts\Support\Arrayable|iterable
+ *     ? \Illuminate\Support\Collection<TKey, TValue>
+ *     : ($value is null
+ *         ? \Illuminate\Support\Collection<never, never>
+ *         : \Illuminate\Support\Collection<int, $value>)
+ * )
  */
 function collect($value = []) {}
 

--- a/stubs/common/Collections/helpers.stubphp
+++ b/stubs/common/Collections/helpers.stubphp
@@ -12,10 +12,13 @@
  * because `never` is the bottom type (subtype of everything), and methods like `merge()` / `push()` are
  * stubbed to widen generics on their return so fluent chains propagate concrete types.
  *
+ * Also accepts `scalar|\UnitEnum|null`; see `Collection::make()` in this stubs directory for the
+ * rationale behind the widening.
+ *
  * @template TKey of array-key
  * @template TValue
  *
- * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|null  $value
+ * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|scalar|\UnitEnum|null  $value
  * @psalm-return \Illuminate\Support\Collection<TKey, TValue>
  */
 function collect($value = []) {}

--- a/stubs/common/Support/Collection.stubphp
+++ b/stubs/common/Support/Collection.stubphp
@@ -73,14 +73,13 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * Laravel's native docblock only types `Arrayable|iterable|null`, but the runtime accepts
      * scalars and UnitEnums too: `getArrayableItems()` wraps those via `Arr::wrap()` into a
      * single-element array (or `[]` for `null`). Widening the stub lets calls like
-     * `Collection::make('some')` type-check instead of triggering InvalidArgument.
+     * `Collection::make('some')` type-check instead of triggering InvalidArgument, and the
+     * conditional return preserves the exact scalar/enum value type on the result.
      *
-     * A narrower conditional return type (yielding `Collection<int, $items>` for the scalar
-     * branch) was tried and reverted: when the param union mixes templated alternatives with
-     * `scalar|\UnitEnum`, Psalm evaluates every branch of the conditional and emits a
-     * polluted union such as `Collection<int, scalar|\UnitEnum> | Collection<int, string>`
-     * for ordinary `Arrayable` / `iterable` inputs. The simple non-conditional return avoids
-     * that regression at the cost of slightly less tight scalar narrowing.
+     * The conditional is structured with the Arrayable|iterable check FIRST so that typed
+     * iterables keep their template parameters intact. Reversing the order (testing scalar
+     * first) causes Psalm to evaluate both branches for ordinary iterable inputs and emits
+     * a polluted union like `Collection<int, scalar|UnitEnum> | Collection<int, string>`.
      *
      * @psalm-mutation-free
      *
@@ -88,7 +87,13 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @template TMakeValue
      *
      * @param \Illuminate\Contracts\Support\Arrayable<TMakeKey, TMakeValue>|iterable<TMakeKey, TMakeValue>|scalar|\UnitEnum|null $items
-     * @return static<TMakeKey, TMakeValue>
+     * @return (
+     *     $items is \Illuminate\Contracts\Support\Arrayable|iterable
+     *     ? static<TMakeKey, TMakeValue>
+     *     : ($items is null
+     *         ? static<never, never>
+     *         : static<int, $items>)
+     * )
      */
     public static function make($items = []) {}
 

--- a/stubs/common/Support/Collection.stubphp
+++ b/stubs/common/Support/Collection.stubphp
@@ -68,6 +68,31 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     public static function empty() {}
 
     /**
+     * Create a new collection instance.
+     *
+     * Laravel's native docblock only types `Arrayable|iterable|null`, but the runtime accepts
+     * scalars and UnitEnums too: `getArrayableItems()` wraps those via `Arr::wrap()` into a
+     * single-element array (or `[]` for `null`). Widening the stub lets calls like
+     * `Collection::make('some')` type-check instead of triggering InvalidArgument.
+     *
+     * A narrower conditional return type (yielding `Collection<int, $items>` for the scalar
+     * branch) was tried and reverted: when the param union mixes templated alternatives with
+     * `scalar|\UnitEnum`, Psalm evaluates every branch of the conditional and emits a
+     * polluted union such as `Collection<int, scalar|\UnitEnum> | Collection<int, string>`
+     * for ordinary `Arrayable` / `iterable` inputs. The simple non-conditional return avoids
+     * that regression at the cost of slightly less tight scalar narrowing.
+     *
+     * @psalm-mutation-free
+     *
+     * @template TMakeKey of array-key
+     * @template TMakeValue
+     *
+     * @param \Illuminate\Contracts\Support\Arrayable<TMakeKey, TMakeValue>|iterable<TMakeKey, TMakeValue>|scalar|\UnitEnum|null $items
+     * @return static<TMakeKey, TMakeValue>
+     */
+    public static function make($items = []) {}
+
+    /**
      * Get the first item from the collection passing the given truth test.
      *
      * @psalm-mutation-free

--- a/stubs/common/Support/LazyCollection.stubphp
+++ b/stubs/common/Support/LazyCollection.stubphp
@@ -70,8 +70,8 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      *
      * Preserves Laravel's full param list for `LazyCollection::make()` (including
      * `Closure(): Generator` and `self`, the idiomatic lazy-generator pattern) and adds the
-     * `scalar|\UnitEnum|null` widening. See `Collection::make()` in this stubs directory for
-     * the rationale behind the conditional return type ordering.
+     * `scalar|\UnitEnum|null` widening. See {@see \Illuminate\Support\Collection::make()}
+     * for the rationale behind the conditional return type ordering.
      *
      * @psalm-mutation-free
      *

--- a/stubs/common/Support/LazyCollection.stubphp
+++ b/stubs/common/Support/LazyCollection.stubphp
@@ -64,4 +64,22 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @return static<never, never>
      */
     public static function empty() {}
+
+    /**
+     * Create a new collection instance.
+     *
+     * Preserves Laravel's full param list for `LazyCollection::make()` (including
+     * `Closure(): Generator` and `self`, the idiomatic lazy-generator pattern) and adds the
+     * `scalar|\UnitEnum|null` widening. See `Collection::make()` in this stubs directory for
+     * the rationale behind the widening and why no conditional return type is used.
+     *
+     * @psalm-mutation-free
+     *
+     * @template TMakeKey of array-key
+     * @template TMakeValue
+     *
+     * @param \Illuminate\Contracts\Support\Arrayable<TMakeKey, TMakeValue>|iterable<TMakeKey, TMakeValue>|(\Closure(): \Generator<TMakeKey, TMakeValue, mixed, void>)|self<TMakeKey, TMakeValue>|scalar|\UnitEnum|null $items
+     * @return static<TMakeKey, TMakeValue>
+     */
+    public static function make($items = []) {}
 }

--- a/stubs/common/Support/LazyCollection.stubphp
+++ b/stubs/common/Support/LazyCollection.stubphp
@@ -71,7 +71,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * Preserves Laravel's full param list for `LazyCollection::make()` (including
      * `Closure(): Generator` and `self`, the idiomatic lazy-generator pattern) and adds the
      * `scalar|\UnitEnum|null` widening. See `Collection::make()` in this stubs directory for
-     * the rationale behind the widening and why no conditional return type is used.
+     * the rationale behind the conditional return type ordering.
      *
      * @psalm-mutation-free
      *
@@ -79,7 +79,13 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @template TMakeValue
      *
      * @param \Illuminate\Contracts\Support\Arrayable<TMakeKey, TMakeValue>|iterable<TMakeKey, TMakeValue>|(\Closure(): \Generator<TMakeKey, TMakeValue, mixed, void>)|self<TMakeKey, TMakeValue>|scalar|\UnitEnum|null $items
-     * @return static<TMakeKey, TMakeValue>
+     * @return (
+     *     $items is \Illuminate\Contracts\Support\Arrayable|iterable|\Closure
+     *     ? static<TMakeKey, TMakeValue>
+     *     : ($items is null
+     *         ? static<never, never>
+     *         : static<int, $items>)
+     * )
      */
     public static function make($items = []) {}
 }

--- a/tests/Type/tests/Collection/CollectionMakeTest.phpt
+++ b/tests/Type/tests/Collection/CollectionMakeTest.phpt
@@ -7,12 +7,11 @@ use Illuminate\Support\LazyCollection;
 
 /**
  * `Collection::make` / `LazyCollection::make` / `collect()` accept scalars, UnitEnums, and null
- * at runtime via `getArrayableItems()` → `Arr::wrap()`. The stubs widen the parameter so those
- * calls type-check instead of raising InvalidArgument.
+ * at runtime via `getArrayableItems()` → `Arr::wrap()`, and the widened stubs narrow those
+ * inputs to `Collection<int, TScalar>` (matching the runtime `[$value]` wrapping).
  *
- * Scalar inputs intentionally do NOT narrow to `Collection<int, TScalar>`: that pattern pollutes
- * the return type for the common Arrayable/iterable path (see the Collection stub for details).
- * The `check-type-exact` assertions below are the regression-guard line for the supported shapes.
+ * Template inference for `Arrayable<K,V>` / `iterable<K,V>` is preserved because the conditional
+ * return type checks for those interfaces FIRST; see the Collection stub for the ordering note.
  */
 enum TestMakeColor: string
 {
@@ -21,37 +20,40 @@ enum TestMakeColor: string
 
 final class CollectionMakeTest
 {
-    /**
-     * Scalar inputs deliberately collapse to the generic form rather than narrowing to
-     * `Collection<int, 'some'>`: the narrower signature polluted the common
-     * Arrayable/iterable path (see the stub docblock). The exact-type assertion below
-     * is the guard so nobody re-introduces the narrowing without understanding the tradeoff.
-     */
-    public function scalarInputsResolveToGenericCollection(): void
+    public function scalarStringYieldsSingleElementCollection(): void
     {
-        $_s = Collection::make('some');
-        /** @psalm-check-type-exact $_s = Collection<array-key, mixed> */
-
-        $_i = Collection::make(42);
-        /** @psalm-check-type-exact $_i = Collection<array-key, mixed> */
-
-        $_b = Collection::make(true);
-        /** @psalm-check-type-exact $_b = Collection<array-key, mixed> */
-
-        $_f = Collection::make(1.5);
-        /** @psalm-check-type-exact $_f = Collection<array-key, mixed> */
+        $_c = Collection::make('some');
+        /** @psalm-check-type-exact $_c = Collection<int, 'some'> */
     }
 
-    public function unitEnumResolvesToGenericCollection(): void
+    public function scalarIntYieldsSingleElementCollection(): void
     {
-        $_e = Collection::make(TestMakeColor::Red);
-        /** @psalm-check-type-exact $_e = Collection<array-key, mixed> */
+        $_c = Collection::make(42);
+        /** @psalm-check-type-exact $_c = Collection<int, 42> */
     }
 
-    public function nullResolvesToGenericCollection(): void
+    public function scalarFloatYieldsSingleElementCollection(): void
     {
-        $_n = Collection::make(null);
-        /** @psalm-check-type-exact $_n = Collection<array-key, mixed> */
+        $_c = Collection::make(42.2);
+        /** @psalm-check-type-exact $_c = Collection<int, 42.2> */
+    }
+
+    public function scalarBoolYieldsSingleElementCollection(): void
+    {
+        $_c = Collection::make(true);
+        /** @psalm-check-type-exact $_c = Collection<int, true> */
+    }
+
+    public function unitEnumYieldsSingleElementCollection(): void
+    {
+        $_c = Collection::make(TestMakeColor::Red);
+        /** @psalm-check-type-exact $_c = Collection<int, TestMakeColor::Red> */
+    }
+
+    public function nullYieldsEmptyCollection(): void
+    {
+        $_c = Collection::make(null);
+        /** @psalm-check-type-exact $_c = Collection<never, never> */
     }
 
     public function listArrayPreservesKeyAndValueTypes(): void
@@ -67,8 +69,8 @@ final class CollectionMakeTest
     }
 
     /**
-     * Regression guard: previously the widened stub polluted this case with a spurious
-     * scalar-branch union like `Collection<int, scalar|\UnitEnum> | Collection<int, stdClass>`.
+     * Regression guard: a naive conditional would pollute this with a spurious
+     * `Collection<int, scalar|UnitEnum>` branch. The Arrayable|iterable-first ordering prevents that.
      *
      * @param iterable<int, \stdClass> $items
      */
@@ -78,49 +80,30 @@ final class CollectionMakeTest
         /** @psalm-check-type-exact $_c = Collection<int, stdClass> */
     }
 
-    /**
-     * Same regression guard for the `Arrayable` branch: the scalar widening must not
-     * leak into the inferred value type when the input is a typed Arrayable.
-     *
-     * @param Arrayable<int, string> $items
-     */
+    /** @param Arrayable<int, string> $items */
     public function typedArrayablePreservesItsTemplates(Arrayable $items): void
     {
         $_c = Collection::make($items);
         /** @psalm-check-type-exact $_c = Collection<int, string> */
     }
 
-    /**
-     * Passing an existing Collection: it implements Arrayable, so the Arrayable branch
-     * applies and the input templates are preserved.
-     *
-     * @param Collection<int, \stdClass> $items
-     */
+    /** @param Collection<int, \stdClass> $items */
     public function typedCollectionPreservesItsTemplates(Collection $items): void
     {
         $_c = Collection::make($items);
         /** @psalm-check-type-exact $_c = Collection<int, stdClass> */
     }
 
-    public function lazyCollectionScalarResolvesToGenericCollection(): void
+    public function lazyCollectionMakeScalarYieldsSingleElement(): void
     {
-        $_s = LazyCollection::make('some');
-        /** @psalm-check-type-exact $_s = LazyCollection<array-key, mixed> */
-
-        $_n = LazyCollection::make(null);
-        /** @psalm-check-type-exact $_n = LazyCollection<array-key, mixed> */
+        $_c = LazyCollection::make('some');
+        /** @psalm-check-type-exact $_c = LazyCollection<int, 'some'> */
     }
 
-    /**
-     * The `self<TMakeKey, TMakeValue>` alternative in the LazyCollection::make param union
-     * (distinct from the Arrayable/iterable branches used by `Collection::make`).
-     *
-     * @param LazyCollection<int, string> $items
-     */
-    public function lazyCollectionMakeSelfPreservesTemplates(LazyCollection $items): void
+    public function lazyCollectionMakeNullYieldsEmpty(): void
     {
-        $_c = LazyCollection::make($items);
-        /** @psalm-check-type-exact $_c = LazyCollection<int, string> */
+        $_c = LazyCollection::make(null);
+        /** @psalm-check-type-exact $_c = LazyCollection<never, never> */
     }
 
     public function lazyCollectionMakeListPreservesTypes(): void
@@ -142,12 +125,41 @@ final class CollectionMakeTest
         /** @psalm-check-type-exact $_c = LazyCollection<int, 1|2> */
     }
 
-    public function collectHelperScalarTypeChecks(): void
+    /** @param LazyCollection<int, string> $items */
+    public function lazyCollectionMakeSelfPreservesTemplates(LazyCollection $items): void
     {
-        collect('some');
-        collect(42);
-        collect(null);
-        collect(TestMakeColor::Red);
+        $_c = LazyCollection::make($items);
+        /** @psalm-check-type-exact $_c = LazyCollection<int, string> */
+    }
+
+    public function collectHelperScalarYieldsSingleElement(): void
+    {
+        $_c = collect('some');
+        /** @psalm-check-type-exact $_c = Collection<int, 'some'> */
+    }
+
+    public function collectHelperIntYieldsSingleElement(): void
+    {
+        $_c = collect(42);
+        /** @psalm-check-type-exact $_c = Collection<int, 42> */
+    }
+
+    public function collectHelperFloatYieldsSingleElement(): void
+    {
+        $_c = collect(42.2);
+        /** @psalm-check-type-exact $_c = Collection<int, 42.2> */
+    }
+
+    public function collectHelperNullYieldsEmpty(): void
+    {
+        $_c = collect(null);
+        /** @psalm-check-type-exact $_c = Collection<never, never> */
+    }
+
+    public function collectHelperUnitEnumYieldsSingleElement(): void
+    {
+        $_c = collect(TestMakeColor::Red);
+        /** @psalm-check-type-exact $_c = Collection<int, TestMakeColor::Red> */
     }
 
     public function collectHelperListPreservesTypes(): void

--- a/tests/Type/tests/Collection/CollectionMakeTest.phpt
+++ b/tests/Type/tests/Collection/CollectionMakeTest.phpt
@@ -1,0 +1,167 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
+
+/**
+ * `Collection::make` / `LazyCollection::make` / `collect()` accept scalars, UnitEnums, and null
+ * at runtime via `getArrayableItems()` → `Arr::wrap()`. The stubs widen the parameter so those
+ * calls type-check instead of raising InvalidArgument.
+ *
+ * Scalar inputs intentionally do NOT narrow to `Collection<int, TScalar>`: that pattern pollutes
+ * the return type for the common Arrayable/iterable path (see the Collection stub for details).
+ * The `check-type-exact` assertions below are the regression-guard line for the supported shapes.
+ */
+enum TestMakeColor: string
+{
+    case Red = 'red';
+}
+
+final class CollectionMakeTest
+{
+    /**
+     * Scalar inputs deliberately collapse to the generic form rather than narrowing to
+     * `Collection<int, 'some'>`: the narrower signature polluted the common
+     * Arrayable/iterable path (see the stub docblock). The exact-type assertion below
+     * is the guard so nobody re-introduces the narrowing without understanding the tradeoff.
+     */
+    public function scalarInputsResolveToGenericCollection(): void
+    {
+        $_s = Collection::make('some');
+        /** @psalm-check-type-exact $_s = Collection<array-key, mixed> */
+
+        $_i = Collection::make(42);
+        /** @psalm-check-type-exact $_i = Collection<array-key, mixed> */
+
+        $_b = Collection::make(true);
+        /** @psalm-check-type-exact $_b = Collection<array-key, mixed> */
+
+        $_f = Collection::make(1.5);
+        /** @psalm-check-type-exact $_f = Collection<array-key, mixed> */
+    }
+
+    public function unitEnumResolvesToGenericCollection(): void
+    {
+        $_e = Collection::make(TestMakeColor::Red);
+        /** @psalm-check-type-exact $_e = Collection<array-key, mixed> */
+    }
+
+    public function nullResolvesToGenericCollection(): void
+    {
+        $_n = Collection::make(null);
+        /** @psalm-check-type-exact $_n = Collection<array-key, mixed> */
+    }
+
+    public function listArrayPreservesKeyAndValueTypes(): void
+    {
+        $_c = Collection::make([1, 2, 3]);
+        /** @psalm-check-type-exact $_c = Collection<int<0, 2>, 1|2|3> */
+    }
+
+    public function associativeArrayPreservesKeyAndValueTypes(): void
+    {
+        $_c = Collection::make(['a' => 1, 'b' => 2]);
+        /** @psalm-check-type-exact $_c = Collection<'a'|'b', 1|2> */
+    }
+
+    /**
+     * Regression guard: previously the widened stub polluted this case with a spurious
+     * scalar-branch union like `Collection<int, scalar|\UnitEnum> | Collection<int, stdClass>`.
+     *
+     * @param iterable<int, \stdClass> $items
+     */
+    public function typedIterablePreservesItsTemplates(iterable $items): void
+    {
+        $_c = Collection::make($items);
+        /** @psalm-check-type-exact $_c = Collection<int, stdClass> */
+    }
+
+    /**
+     * Same regression guard for the `Arrayable` branch: the scalar widening must not
+     * leak into the inferred value type when the input is a typed Arrayable.
+     *
+     * @param Arrayable<int, string> $items
+     */
+    public function typedArrayablePreservesItsTemplates(Arrayable $items): void
+    {
+        $_c = Collection::make($items);
+        /** @psalm-check-type-exact $_c = Collection<int, string> */
+    }
+
+    /**
+     * Passing an existing Collection: it implements Arrayable, so the Arrayable branch
+     * applies and the input templates are preserved.
+     *
+     * @param Collection<int, \stdClass> $items
+     */
+    public function typedCollectionPreservesItsTemplates(Collection $items): void
+    {
+        $_c = Collection::make($items);
+        /** @psalm-check-type-exact $_c = Collection<int, stdClass> */
+    }
+
+    public function lazyCollectionScalarResolvesToGenericCollection(): void
+    {
+        $_s = LazyCollection::make('some');
+        /** @psalm-check-type-exact $_s = LazyCollection<array-key, mixed> */
+
+        $_n = LazyCollection::make(null);
+        /** @psalm-check-type-exact $_n = LazyCollection<array-key, mixed> */
+    }
+
+    /**
+     * The `self<TMakeKey, TMakeValue>` alternative in the LazyCollection::make param union
+     * (distinct from the Arrayable/iterable branches used by `Collection::make`).
+     *
+     * @param LazyCollection<int, string> $items
+     */
+    public function lazyCollectionMakeSelfPreservesTemplates(LazyCollection $items): void
+    {
+        $_c = LazyCollection::make($items);
+        /** @psalm-check-type-exact $_c = LazyCollection<int, string> */
+    }
+
+    public function lazyCollectionMakeListPreservesTypes(): void
+    {
+        $_c = LazyCollection::make([1, 2, 3]);
+        /** @psalm-check-type-exact $_c = LazyCollection<int<0, 2>, 1|2|3> */
+    }
+
+    /**
+     * The Closure-returning-Generator form is the central LazyCollection use case.
+     * Regression guard so the stub widening never drops this.
+     */
+    public function lazyCollectionMakeAcceptsGeneratorClosure(): void
+    {
+        $_c = LazyCollection::make(static function () {
+            yield 1;
+            yield 2;
+        });
+        /** @psalm-check-type-exact $_c = LazyCollection<int, 1|2> */
+    }
+
+    public function collectHelperScalarTypeChecks(): void
+    {
+        collect('some');
+        collect(42);
+        collect(null);
+        collect(TestMakeColor::Red);
+    }
+
+    public function collectHelperListPreservesTypes(): void
+    {
+        $_c = collect([1, 2, 3]);
+        /** @psalm-check-type-exact $_c = Collection<int<0, 2>, 1|2|3> */
+    }
+
+    /** @param Arrayable<int, string> $items */
+    public function collectHelperArrayablePreservesTemplates(Arrayable $items): void
+    {
+        $_c = collect($items);
+        /** @psalm-check-type-exact $_c = Collection<int, string> */
+    }
+}
+?>
+--EXPECT--

--- a/tests/Type/tests/Collection/CollectionMakeTest.phpt
+++ b/tests/Type/tests/Collection/CollectionMakeTest.phpt
@@ -7,8 +7,9 @@ use Illuminate\Support\LazyCollection;
 
 /**
  * `Collection::make` / `LazyCollection::make` / `collect()` accept scalars, UnitEnums, and null
- * at runtime via `getArrayableItems()` → `Arr::wrap()`, and the widened stubs narrow those
- * inputs to `Collection<int, TScalar>` (matching the runtime `[$value]` wrapping).
+ * at runtime via `getArrayableItems()` → `Arr::wrap()`: scalars and UnitEnums are wrapped as
+ * `[$value]` and the widened stubs narrow them to `Collection<int, TScalar>`, while `null` is
+ * wrapped to `[]` and yields an empty `Collection<never, never>`.
  *
  * Template inference for `Arrayable<K,V>` / `iterable<K,V>` is preserved because the conditional
  * return type checks for those interfaces FIRST; see the Collection stub for the ordering note.


### PR DESCRIPTION
## Summary

`Collection::make('some')` (and the equivalent `LazyCollection::make` / `collect()` calls) raised a false-positive InvalidArgument under Psalm. At runtime these entry points delegate to `getArrayableItems()`, which wraps `scalar | UnitEnum | null` via `Arr::wrap()` into a single-element array (or `[]` for null). Laravel's native docblock does not reflect that, so the plugin widens the stub parameter to match.

The return type also narrows precisely on the scalar branch:

```php
Collection::make('some');  // Collection<int, 'some'>
collect(42);               // Collection<int, 42>
collect(42.2);             // Collection<int, 42.2>
Collection::make(null);    // Collection<never, never>
```

Typed iterable inputs keep their template parameters intact:

```php
/** @param Arrayable<int, string> $a */
Collection::make($a);      // Collection<int, string>
```

## What changed

- `stubs/common/Support/Collection.stubphp`: added a `make()` stub with a widened `@param` and a conditional return that narrows scalar/enum/null inputs.
- `stubs/common/Support/LazyCollection.stubphp`: same pattern, with the `Closure(): Generator` and `self` alternatives preserved (the central lazy-generator pattern).
- `stubs/common/Collections/helpers.stubphp`: widened the `collect()` helper with the matching conditional return.
- `tests/Type/tests/Collection/CollectionMakeTest.phpt`: new PHPT exercising scalar narrowing, null, UnitEnum, list/assoc array, typed Arrayable / iterable / Collection / LazyCollection / Closure-Generator inputs.

## Design note

The conditional return type checks for `Arrayable | iterable | Closure` FIRST, then `null`, then falls through to `static<int, $items>` for the scalar branch. An earlier naive ordering (scalar-first) polluted the return type for ordinary iterable inputs with a spurious `Collection<int, scalar|UnitEnum>` branch. The positive-check-first ordering keeps typed iterable templates intact while still narrowing scalar literals.

## Verification

- Type tests: 276/276 pass.
- Psalm self-analysis: clean.
- PHPT regression guards: Arrayable<K,V>, iterable<K,V>, Collection<K,V>, LazyCollection self<K,V>, Closure(): Generator<K,V,mixed,void>, scalar literals (string/int/float/bool), UnitEnum, null, list and associative arrays.