### PR TITLE
Fix `InvalidArgument` on arrow-function closures in `Builder::where` family (#776)

### DIFF
--- a/stubs/common/Database/Eloquent/Builder.stubphp
+++ b/stubs/common/Database/Eloquent/Builder.stubphp
@@ -379,6 +379,8 @@ class Builder implements BuilderContract
 
     /**
      * @param  (\Closure(self<TModel>): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  mixed   $operator
+     * @param  mixed   $value
      * @param  string  $boolean
      * @psalm-return TModel|null
      *

--- a/stubs/common/Database/Eloquent/Builder.stubphp
+++ b/stubs/common/Database/Eloquent/Builder.stubphp
@@ -81,7 +81,7 @@ class Builder implements BuilderContract
     /**
      * Add a basic where clause to the query.
      *
-     * @param  (\Closure(static): void)|(\Closure(static): static)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  (\Closure(self<TModel>): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed   $operator
      * @param  mixed   $value
      * @param  string  $boolean
@@ -378,7 +378,7 @@ class Builder implements BuilderContract
     public function firstOrCreate(array $attributes = [], \Closure|array $values = []) {}
 
     /**
-     * @param  (\Closure(static): void)|(\Closure(static): static)|non-empty-string|list<non-empty-string>|int, mixed>|\Illuminate\Database\Query\Expression  $column
+     * @param  (\Closure(self<TModel>): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  string  $boolean
      * @psalm-return TModel|null
      *
@@ -669,7 +669,7 @@ class Builder implements BuilderContract
     /**
      * Add a basic "where not" clause to the query.
      *
-     * @param  (\Closure(static): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  (\Closure(self<TModel>): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
@@ -684,7 +684,7 @@ class Builder implements BuilderContract
     /**
      * Add an "or where not" clause to the query.
      *
-     * @param  (\Closure(static): mixed)|array|string|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  (\Closure(self<TModel>): mixed)|array|string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @return self<TModel>

--- a/stubs/common/Database/Eloquent/Relations/BelongsToMany.stubphp
+++ b/stubs/common/Database/Eloquent/Relations/BelongsToMany.stubphp
@@ -176,11 +176,16 @@ class BelongsToMany extends Relation
     public function firstOr($columns = ['*'], \Closure $callback = null) {}
 
     /**
-     * @param  (\Closure(static): void)|(\Closure(static): static)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
+     * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
      * @return (TRelatedModel&object{pivot: TPivotModel})|null
+     *
+     * @psalm-taint-sink sql $column
+     * @psalm-taint-escape sql
+     * @psalm-flow ($operator, $value) -> return
+     * @psalm-taint-specialize
      */
     public function firstWhere($column, $operator = null, $value = null, $boolean = 'and') {}
 

--- a/tests/Type/tests/Builder/BuilderTypesTest.phpt
+++ b/tests/Type/tests/Builder/BuilderTypesTest.phpt
@@ -121,6 +121,36 @@ function test_whereDateWithInt(Builder $builder): Builder
 {
     return $builder->whereDate('created_at', '>', 1);
 }
+
+/**
+ * Regression for https://github.com/psalm/psalm-plugin-laravel/issues/776
+ * Arrow-function closure returns the chained Builder (`mixed`-compatible),
+ * not `void` or `static`. Must not raise InvalidArgument.
+ */
+function test_where_arrow_closure(): Builder
+{
+    return Customer::query()->where(fn ($q) => $q->where('email', 'x')->orWhere('name', 'y'));
+}
+
+/**
+ * Regression for https://github.com/psalm/psalm-plugin-laravel/issues/776
+ * Long-form closure with explicit `void` return must remain accepted.
+ */
+function test_where_long_form_closure(): Builder
+{
+    return Customer::query()->where(function ($q): void {
+        $q->where('email', 'x')->orWhere('name', 'y');
+    });
+}
+
+/**
+ * Regression for https://github.com/psalm/psalm-plugin-laravel/issues/776
+ * Same closure shape on firstWhere (a sibling stub fixed in the same PR).
+ */
+function test_firstWhere_arrow_closure(): ?Customer
+{
+    return Customer::query()->firstWhere(fn ($q) => $q->where('email', 'x'));
+}
 ?>
 --EXPECTF--
 InvalidArgument on line %d: Argument 3 of Illuminate\Database\Eloquent\Builder::whereDate expects DateTimeInterface|null|string, but 1 provided

--- a/tests/Type/tests/Relation/BelongsToManyPivotTest.phpt
+++ b/tests/Type/tests/Relation/BelongsToManyPivotTest.phpt
@@ -86,5 +86,17 @@ function test_model_method_with_4_params_returns_correctly(): BelongsToMany
 {
     return (new Mechanic())->specializationsWithPivot();
 }
+
+/**
+ * Regression for https://github.com/psalm/psalm-plugin-laravel/issues/776
+ * Arrow-function closure on BelongsToMany::firstWhere must not raise InvalidArgument.
+ *
+ * @param BelongsToMany<MechanicSpecialization, Mechanic, SpecializationPivot, 'pivot'> $relation
+ */
+function test_belongsToMany_firstWhere_arrow_closure(BelongsToMany $relation): void
+{
+    $_ = $relation->firstWhere(fn ($q) => $q->where('name', 'x'));
+    /** @psalm-check-type-exact $_ = MechanicSpecialization&object{pivot: SpecializationPivot}|null */
+}
 ?>
 --EXPECTF--


### PR DESCRIPTION
## Issue to Solve

`Builder::where(fn ($q) => $q->where('x', 'y'))` raises a false-positive `InvalidArgument`. The stub declared the closure as `(\Closure(static): void)|(\Closure(static): static)`, so an arrow function whose body returns a `Builder` (implicit `mixed`) matched neither branch. Long-form `function ($q) { ... }` bodies happened to match the `void` branch, but equivalent arrow forms did not. At runtime, Laravel discards the closure's return value, so accepting any return type is semantically correct.

## Related

Fixes #776.

Seen in the wild in pterodactyl/panel: `SftpAuthenticationController.php:92`, `BackupRepository.php:42`, `SettingsRepository.php:49`.

## Solution Description

Stubs updated to `(\Closure(self<TModel>): mixed)` on Builder (or `\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed` on the relation):

- `Builder::where` (line 84)
- `Builder::firstWhere` (line 381) — also collapses a malformed `@param` (`…|int, mixed>|…` was a broken generic that Psalm silently dropped, falling the type back to `mixed`). Signature now matches `where()`, which is correct because `firstWhere = $this->where(...)->first()`.
- `Builder::whereNot` (line 672) and `Builder::orWhereNot` (line 687) — same closure param pattern applied for consistency (same root cause, previously untested).
- `BelongsToMany::firstWhere` (line 179) — same change, and adds the SQL taint annotations (`@psalm-taint-sink sql $column`, `@psalm-taint-escape sql`, `@psalm-flow ($operator, $value) -> return`, `@psalm-taint-specialize`) that were missing on this method. Tainted column names on `BelongsToMany::firstWhere($tainted, ...)` were previously not flagged.

**Trade-off — `self<TModel>` vs Laravel's `static`.** Psalm 7 does not specialize `static` inside closure parameter positions against the receiver's generic binding: a stub declaring `\Closure(static): mixed` causes arrow-fn bidirectional inference to fail because `static` is not unified with `Builder<TModel>` in the receiver context. `self<TModel>` is the idiom that the rest of this stub already uses for returns (`@return self<TModel>`). The cost is that custom Builder subclasses (`class UserBuilder extends Builder`) with typed closure parameters (`function (UserBuilder $q) { ... }`) lose late-static-binding precision. In practice, almost all where-family closures are untyped, and the common-case arrow form is the one users actually hit.

Regression tests added:
- `tests/Type/tests/Builder/BuilderTypesTest.phpt` — arrow `where`, long-form `where`, and arrow `firstWhere`.
- `tests/Type/tests/Relation/BelongsToManyPivotTest.phpt` — arrow `BelongsToMany::firstWhere` with exact-type check on the pivot-intersected return.

Full type suite (275 tests) and Psalm self-analysis pass.

## Checklist

- [x] Tests cover the change (type tests in `tests/Type/`)
