### PR TITLE
Ship `vendor/bin/psalm-laravel` with `init` subcommand

### DIFF
--- a/bin/psalm-laravel
+++ b/bin/psalm-laravel
@@ -3,6 +3,7 @@
 
 declare(strict_types=1);
 
+use Psalm\LaravelPlugin\Cli\AnalyzeCommand;
 use Psalm\LaravelPlugin\Cli\InitCommand;
 use Symfony\Component\Console\Application;
 
@@ -27,4 +28,12 @@ if (! class_exists(InitCommand::class)) {
 
 $application = new Application('psalm-laravel');
 $application->addCommand(new InitCommand());
+$application->addCommand(new AnalyzeCommand());
+
+// When invoked with no command, pick one based on workspace state: `init` if
+// psalm.xml is missing (first-run setup), otherwise `analyze` (everyday use).
+$cwd = getcwd();
+$hasPsalmConfig = is_string($cwd) && file_exists($cwd . DIRECTORY_SEPARATOR . 'psalm.xml');
+$application->setDefaultCommand($hasPsalmConfig ? 'analyze' : 'init');
+
 $application->run();

--- a/bin/psalm-laravel
+++ b/bin/psalm-laravel
@@ -1,0 +1,33 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use Psalm\LaravelPlugin\Cli\InitCommand;
+use Symfony\Component\Console\Application;
+
+$autoloadCandidates = [
+    // Installed as a dependency: vendor/psalm/plugin-laravel/bin/psalm-laravel
+    __DIR__ . '/../../../autoload.php',
+    // Running from a clone of this repo
+    __DIR__ . '/../vendor/autoload.php',
+];
+
+foreach ($autoloadCandidates as $candidate) {
+    if (file_exists($candidate)) {
+        require_once $candidate;
+        break;
+    }
+}
+
+if (! class_exists(InitCommand::class)) {
+    fwrite(STDERR, "psalm-laravel: could not locate Composer autoloader. Run `composer install` first.\n");
+    exit(1);
+}
+
+$application = new Application('psalm-laravel');
+// Application::add() is soft-deprecated in Symfony 7.4 in favor of addCommand(),
+// but addCommand() doesn't exist on 7.2/7.3. Keep add() until the minimum
+// supported Symfony Console version reaches 7.4.
+$application->add(new InitCommand());
+$application->run();

--- a/bin/psalm-laravel
+++ b/bin/psalm-laravel
@@ -26,8 +26,5 @@ if (! class_exists(InitCommand::class)) {
 }
 
 $application = new Application('psalm-laravel');
-// Application::add() is soft-deprecated in Symfony 7.4 in favor of addCommand(),
-// but addCommand() doesn't exist on 7.2/7.3. Keep add() until the minimum
-// supported Symfony Console version reaches 7.4.
-$application->add(new InitCommand());
+$application->addCommand(new InitCommand());
 $application->run();

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,12 @@
         "nikic/php-parser": "^5.0",
         "orchestra/testbench-core": "^10.0 || ^11.0",
         "psalm/psalm-plugin-api": "^0.1.0",
+        "symfony/console": "^7.2 || ^8.0",
         "vimeo/psalm": "^7.0.0-beta19 || dev-master"
     },
+    "bin": [
+        "bin/psalm-laravel"
+    ],
     "require-dev": {
         "alies-dev/psalm-tester": "dev-feature/parallel-batch",
         "friendsofphp/php-cs-fixer": "^3.94",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "nikic/php-parser": "^5.0",
         "orchestra/testbench-core": "^10.0 || ^11.0",
         "psalm/psalm-plugin-api": "^0.1.0",
-        "symfony/console": "^7.2 || ^8.0",
+        "symfony/console": "^7.4 || ^8.0",
         "vimeo/psalm": "^7.0.0-beta19 || dev-master"
     },
     "bin": [

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,3 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="7.0.0-beta17@a7f96f911fc869c40c48ec977e21f01a8ca534bd">
+<files psalm-version="7.0.0-beta19@7e751c06a756fa64dc4c759c09fe4a173afcb433">
+  <file src="bin/psalm-laravel">
+    <DeprecatedMethod>
+      <code><![CDATA[add]]></code>
+    </DeprecatedMethod>
+  </file>
 </files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,8 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="7.0.0-beta19@7e751c06a756fa64dc4c759c09fe4a173afcb433">
-  <file src="bin/psalm-laravel">
-    <DeprecatedMethod>
-      <code><![CDATA[add]]></code>
-    </DeprecatedMethod>
-  </file>
+<files psalm-version="7.0.0-beta17@a7f96f911fc869c40c48ec977e21f01a8ca534bd">
 </files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -10,6 +10,7 @@
 >
     <projectFiles>
         <directory name="src" />
+        <file name="bin/psalm-laravel" />
         <ignoreFiles allowMissingFiles="true">
             <directory name="vendor"/>
             <directory name="tests-app"/>

--- a/src/Cli/AnalyzeCommand.php
+++ b/src/Cli/AnalyzeCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Cli;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Runs Psalm on the current project by delegating to the `psalm` binary.
+ *
+ * Locates `vendor/bin/psalm` relative to the current working directory and
+ * execs it, passing the child's exit code through. Does not boot Psalm or
+ * Laravel itself — the child process owns analysis.
+ */
+#[AsCommand(
+    name: 'analyze',
+    description: 'Run Psalm analysis on the current project.',
+)]
+final class AnalyzeCommand extends Command
+{
+    /**
+     * @param string|null $workingDirectory Override the target directory; defaults to the process CWD.
+     *                                      Exposed for tests.
+     */
+    public function __construct(private readonly ?string $workingDirectory = null)
+    {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $cwd = $this->workingDirectory ?? \getcwd();
+        if ($cwd === false) {
+            $io->error('Unable to determine the current working directory.');
+            return Command::FAILURE;
+        }
+
+        $psalmBin = \rtrim($cwd, \DIRECTORY_SEPARATOR)
+            . \DIRECTORY_SEPARATOR . 'vendor'
+            . \DIRECTORY_SEPARATOR . 'bin'
+            . \DIRECTORY_SEPARATOR . 'psalm';
+
+        if (! \is_file($psalmBin)) {
+            $io->error(\sprintf(
+                'Could not find %s. Install Psalm with `composer require --dev vimeo/psalm`.',
+                $psalmBin,
+            ));
+            return Command::FAILURE;
+        }
+
+        $descriptors = [0 => \STDIN, 1 => \STDOUT, 2 => \STDERR];
+        $process = \proc_open([$psalmBin], $descriptors, $pipes, $cwd);
+
+        if (! \is_resource($process)) {
+            $io->error('Failed to launch Psalm.');
+            return Command::FAILURE;
+        }
+
+        return \proc_close($process);
+    }
+}

--- a/src/Cli/AnalyzeCommand.php
+++ b/src/Cli/AnalyzeCommand.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 #[AsCommand(
     name: 'analyze',
+    aliases: ['analyse'],
     description: 'Run Psalm analysis on the current project.',
 )]
 final class AnalyzeCommand extends Command

--- a/src/Cli/AnalyzeCommand.php
+++ b/src/Cli/AnalyzeCommand.php
@@ -17,11 +17,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  * execs it, passing the child's exit code through. Does not boot Psalm or
  * Laravel itself — the child process owns analysis.
  */
-#[AsCommand(
-    name: 'analyze',
-    aliases: ['analyse'],
-    description: 'Run Psalm analysis on the current project.',
-)]
+#[AsCommand(name: 'analyze', description: 'Run Psalm analysis on the current project.', aliases: ['analyse'])]
 final class AnalyzeCommand extends Command
 {
     /**

--- a/src/Cli/InitCommand.php
+++ b/src/Cli/InitCommand.php
@@ -23,13 +23,15 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 )]
 final class InitCommand extends Command
 {
+    private const DEFAULT_ERROR_LEVEL = '3';
+
     private const PSALM_XML_TEMPLATE = <<<'XML'
         <?xml version="1.0"?>
         <psalm
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns="https://getpsalm.org/schema/config"
             xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
-            errorLevel="3"
+            errorLevel="{{LEVEL}}"
             findUnusedCode="false"
             ensureOverrideAttribute="false"
         >
@@ -67,12 +69,28 @@ final class InitCommand extends Command
             InputOption::VALUE_NONE,
             'Overwrite an existing psalm.xml without prompting.',
         );
+        $this->addOption(
+            'level',
+            'l',
+            InputOption::VALUE_REQUIRED,
+            'Psalm errorLevel (1 = strictest, 8 = most lenient).',
+            self::DEFAULT_ERROR_LEVEL,
+        );
     }
 
     #[\Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
+
+        $levelOption = $input->getOption('level');
+        if (! \is_string($levelOption) || \preg_match('/^[1-8]$/', $levelOption) !== 1) {
+            $io->error(\sprintf(
+                'Invalid --level value %s. Must be an integer between 1 (strictest) and 8 (most lenient).',
+                \is_string($levelOption) ? "'{$levelOption}'" : 'of unexpected type',
+            ));
+            return Command::FAILURE;
+        }
 
         $cwd = $this->workingDirectory ?? \getcwd();
         if ($cwd === false) {
@@ -94,9 +112,11 @@ final class InitCommand extends Command
             }
         }
 
+        $contents = \str_replace('{{LEVEL}}', $levelOption, self::PSALM_XML_TEMPLATE);
+
         // Suppress the warning so we can surface error_get_last() ourselves —
         // blind "failed to write" messages send users hunting for the real cause.
-        $bytes = @\file_put_contents($targetPath, self::PSALM_XML_TEMPLATE);
+        $bytes = @\file_put_contents($targetPath, $contents);
         if ($bytes === false) {
             $error = \error_get_last();
             $reason = isset($error['message']) ? ': ' . $error['message'] : '';

--- a/src/Cli/InitCommand.php
+++ b/src/Cli/InitCommand.php
@@ -35,7 +35,7 @@ final class InitCommand extends Command
         >
             <projectFiles>
                 <directory name="."/>
-                <ignoreFiles>
+                <ignoreFiles allowMissingFiles="true">
                     <directory name="vendor"/>
                     <directory name="storage"/>
                     <directory name="bootstrap/cache"/>

--- a/src/Cli/InitCommand.php
+++ b/src/Cli/InitCommand.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Cli;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Writes a Laravel-tailored psalm.xml into the current working directory.
+ *
+ * Intentionally does NOT boot Psalm or Laravel so it remains safe to run when
+ * psalm.xml is broken or missing — the exact moment a user needs it.
+ */
+#[AsCommand(
+    name: 'init',
+    description: 'Generate a Laravel-tailored psalm.xml in the current directory.',
+)]
+final class InitCommand extends Command
+{
+    private const PSALM_XML_TEMPLATE = <<<'XML'
+        <?xml version="1.0"?>
+        <psalm
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="https://getpsalm.org/schema/config"
+            xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+            errorLevel="3"
+            findUnusedCode="false"
+            ensureOverrideAttribute="false"
+        >
+            <projectFiles>
+                <directory name="."/>
+                <ignoreFiles>
+                    <directory name="vendor"/>
+                    <directory name="storage"/>
+                    <directory name="bootstrap/cache"/>
+                </ignoreFiles>
+            </projectFiles>
+
+            <plugins>
+                <pluginClass class="Psalm\LaravelPlugin\Plugin"/>
+            </plugins>
+        </psalm>
+
+        XML;
+
+    /**
+     * @param string|null $workingDirectory Override the target directory; defaults to the process CWD.
+     *                                      Exposed for tests; users interact via the CLI only.
+     */
+    public function __construct(private readonly ?string $workingDirectory = null)
+    {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function configure(): void
+    {
+        $this->addOption(
+            'force',
+            'f',
+            InputOption::VALUE_NONE,
+            'Overwrite an existing psalm.xml without prompting.',
+        );
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $cwd = $this->workingDirectory ?? \getcwd();
+        if ($cwd === false) {
+            $io->error('Unable to determine the current working directory.');
+            return Command::FAILURE;
+        }
+
+        $targetPath = \rtrim($cwd, \DIRECTORY_SEPARATOR) . \DIRECTORY_SEPARATOR . 'psalm.xml';
+
+        if (\file_exists($targetPath) && $input->getOption('force') !== true) {
+            $shouldOverwrite = $io->confirm(
+                \sprintf('psalm.xml already exists at %s. Overwrite?', $targetPath),
+                false,
+            );
+
+            if (! $shouldOverwrite) {
+                $io->note('Left existing psalm.xml untouched.');
+                return Command::SUCCESS;
+            }
+        }
+
+        // Suppress the warning so we can surface error_get_last() ourselves —
+        // blind "failed to write" messages send users hunting for the real cause.
+        $bytes = @\file_put_contents($targetPath, self::PSALM_XML_TEMPLATE);
+        if ($bytes === false) {
+            $error = \error_get_last();
+            $reason = isset($error['message']) ? ': ' . $error['message'] : '';
+            $io->error(\sprintf('Failed to write %s%s', $targetPath, $reason));
+            return Command::FAILURE;
+        }
+
+        $io->success(\sprintf('Wrote %s.', $targetPath));
+        $io->writeln('Next step: run <info>vendor/bin/psalm</info>.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Cli/InitCommand.php
+++ b/src/Cli/InitCommand.php
@@ -47,6 +47,19 @@ final class InitCommand extends Command
             <plugins>
                 <pluginClass class="Psalm\LaravelPlugin\Plugin"/>
             </plugins>
+
+            <issueHandlers>
+                <ClassMustBeFinal errorLevel="suppress"/>
+                <MissingAbstractPureAnnotation errorLevel="suppress"/>
+                <MissingClosureReturnType errorLevel="suppress"/>
+                <MissingImmutableAnnotation errorLevel="suppress"/>
+                <MissingInterfaceImmutableAnnotation errorLevel="suppress"/>
+                <MissingOverrideAttribute errorLevel="suppress"/>
+                <MissingPureAnnotation errorLevel="suppress"/>
+                <RedundantCast errorLevel="suppress"/>
+                <RedundantCondition errorLevel="suppress"/>
+                <UnnecessaryVarAnnotation errorLevel="suppress"/>
+            </issueHandlers>
         </psalm>
 
         XML;

--- a/tests/Unit/Cli/AnalyzeCommandTest.php
+++ b/tests/Unit/Cli/AnalyzeCommandTest.php
@@ -38,6 +38,7 @@ final class AnalyzeCommandTest extends TestCase
         $command = new AnalyzeCommand($this->tempDir);
         $application = new Application();
         $application->addCommand($command);
+
         $tester = new CommandTester($application->find('analyze'));
 
         $exit = $tester->execute([]);

--- a/tests/Unit/Cli/AnalyzeCommandTest.php
+++ b/tests/Unit/Cli/AnalyzeCommandTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Cli;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Cli\AnalyzeCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(AnalyzeCommand::class)]
+final class AnalyzeCommandTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = \sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'psalm-laravel-analyze-' . \uniqid('', true);
+        if (! \mkdir($this->tempDir) && ! \is_dir($this->tempDir)) {
+            throw new \RuntimeException(\sprintf('Failed to create temp directory %s', $this->tempDir));
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if (\is_dir($this->tempDir)) {
+            @\rmdir($this->tempDir);
+        }
+    }
+
+    #[Test]
+    public function fails_cleanly_when_psalm_binary_is_missing(): void
+    {
+        $command = new AnalyzeCommand($this->tempDir);
+        $application = new Application();
+        $application->addCommand($command);
+        $tester = new CommandTester($application->find('analyze'));
+
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::FAILURE, $exit);
+        $this->assertStringContainsString('Could not find', $tester->getDisplay());
+        $this->assertStringContainsString('vendor/bin/psalm', \str_replace(\DIRECTORY_SEPARATOR, '/', $tester->getDisplay()));
+    }
+}

--- a/tests/Unit/Cli/AnalyzeCommandTest.php
+++ b/tests/Unit/Cli/AnalyzeCommandTest.php
@@ -47,4 +47,14 @@ final class AnalyzeCommandTest extends TestCase
         $this->assertStringContainsString('Could not find', $tester->getDisplay());
         $this->assertStringContainsString('vendor/bin/psalm', \str_replace(\DIRECTORY_SEPARATOR, '/', $tester->getDisplay()));
     }
+
+    #[Test]
+    public function analyse_is_registered_as_an_alias(): void
+    {
+        $application = new Application();
+        $application->addCommand(new AnalyzeCommand($this->tempDir));
+
+        // Application::find() accepts both the canonical name and any alias.
+        $this->assertSame($application->find('analyze'), $application->find('analyse'));
+    }
 }

--- a/tests/Unit/Cli/InitCommandTest.php
+++ b/tests/Unit/Cli/InitCommandTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Cli;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Cli\InitCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(InitCommand::class)]
+final class InitCommandTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = \sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'psalm-laravel-init-' . \uniqid('', true);
+        \mkdir($this->tempDir);
+    }
+
+    protected function tearDown(): void
+    {
+        $target = $this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml';
+        if (\file_exists($target)) {
+            \unlink($target);
+        }
+        \rmdir($this->tempDir);
+    }
+
+    #[Test]
+    public function writes_psalm_xml_when_absent(): void
+    {
+        $tester = $this->makeTester();
+
+        $exit = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        $target = $this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml';
+        self::assertFileExists($target);
+
+        $contents = \file_get_contents($target);
+        self::assertIsString($contents);
+        self::assertStringContainsString('errorLevel="3"', $contents);
+        self::assertStringContainsString('findUnusedCode="false"', $contents);
+        self::assertStringContainsString('ensureOverrideAttribute="false"', $contents);
+        self::assertStringContainsString('<pluginClass class="Psalm\\LaravelPlugin\\Plugin"/>', $contents);
+        self::assertStringContainsString('<directory name="vendor"/>', $contents);
+        self::assertStringContainsString('<directory name="storage"/>', $contents);
+        self::assertStringContainsString('<directory name="bootstrap/cache"/>', $contents);
+    }
+
+    #[Test]
+    public function generated_xml_is_well_formed(): void
+    {
+        $tester = $this->makeTester();
+        $tester->execute([]);
+
+        $target = $this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml';
+        $contents = \file_get_contents($target);
+        self::assertIsString($contents);
+
+        $previous = \libxml_use_internal_errors(true);
+        try {
+            $xml = \simplexml_load_string($contents);
+            self::assertNotFalse($xml, 'Generated psalm.xml must be well-formed XML.');
+            self::assertSame('psalm', $xml->getName());
+        } finally {
+            \libxml_clear_errors();
+            \libxml_use_internal_errors($previous);
+        }
+    }
+
+    #[Test]
+    public function refuses_to_overwrite_by_default_when_answered_no(): void
+    {
+        $target = $this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml';
+        \file_put_contents($target, '<existing/>');
+
+        $tester = $this->makeTester();
+        $tester->setInputs(['no']);
+
+        $exit = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertSame('<existing/>', \file_get_contents($target));
+    }
+
+    #[Test]
+    public function overwrites_when_answered_yes(): void
+    {
+        $target = $this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml';
+        \file_put_contents($target, '<existing/>');
+
+        $tester = $this->makeTester();
+        $tester->setInputs(['yes']);
+
+        $exit = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertStringContainsString('pluginClass', (string) \file_get_contents($target));
+    }
+
+    #[Test]
+    public function overwrites_without_prompt_with_force(): void
+    {
+        $target = $this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml';
+        \file_put_contents($target, '<existing/>');
+
+        $tester = $this->makeTester();
+
+        $exit = $tester->execute(['--force' => true]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertStringContainsString('pluginClass', (string) \file_get_contents($target));
+    }
+
+    /**
+     * Exercises the production code path where no workingDirectory is injected —
+     * the command must fall back to getcwd(). We chdir() into the temp dir so
+     * the fallback lands somewhere we can clean up.
+     */
+    #[Test]
+    public function falls_back_to_getcwd_when_no_working_directory_is_injected(): void
+    {
+        $originalCwd = \getcwd();
+        self::assertIsString($originalCwd);
+
+        \chdir($this->tempDir);
+
+        try {
+            $command = new InitCommand();
+            $application = new Application();
+            $application->add($command);
+            $tester = new CommandTester($application->find('init'));
+
+            $exit = $tester->execute([]);
+
+            self::assertSame(Command::SUCCESS, $exit);
+            self::assertFileExists($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        } finally {
+            \chdir($originalCwd);
+        }
+    }
+
+    private function makeTester(): CommandTester
+    {
+        $command = new InitCommand($this->tempDir);
+        $application = new Application();
+        $application->add($command);
+
+        return new CommandTester($application->find('init'));
+    }
+}

--- a/tests/Unit/Cli/InitCommandTest.php
+++ b/tests/Unit/Cli/InitCommandTest.php
@@ -140,7 +140,7 @@ final class InitCommandTest extends TestCase
         try {
             $command = new InitCommand();
             $application = new Application();
-            $application->add($command);
+            $application->addCommand($command);
             $tester = new CommandTester($application->find('init'));
 
             $exit = $tester->execute([]);
@@ -156,7 +156,7 @@ final class InitCommandTest extends TestCase
     {
         $command = new InitCommand($this->tempDir);
         $application = new Application();
-        $application->add($command);
+        $application->addCommand($command);
 
         return new CommandTester($application->find('init'));
     }

--- a/tests/Unit/Cli/InitCommandTest.php
+++ b/tests/Unit/Cli/InitCommandTest.php
@@ -20,17 +20,21 @@ final class InitCommandTest extends TestCase
     protected function setUp(): void
     {
         $this->tempDir = \sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'psalm-laravel-init-' . \uniqid('', true);
-        \mkdir($this->tempDir);
+        if (! \mkdir($this->tempDir) && ! \is_dir($this->tempDir)) {
+            throw new \RuntimeException(\sprintf('Failed to create temp directory %s', $this->tempDir));
+        }
     }
 
     protected function tearDown(): void
     {
         $target = $this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml';
-        if (\file_exists($target)) {
-            \unlink($target);
+        if (\file_exists($target) && ! @\unlink($target)) {
+            return;
         }
 
-        \rmdir($this->tempDir);
+        if (\is_dir($this->tempDir)) {
+            @\rmdir($this->tempDir);
+        }
     }
 
     #[Test]

--- a/tests/Unit/Cli/InitCommandTest.php
+++ b/tests/Unit/Cli/InitCommandTest.php
@@ -124,6 +124,30 @@ final class InitCommandTest extends TestCase
         $this->assertStringContainsString('pluginClass', (string) \file_get_contents($target));
     }
 
+    #[Test]
+    public function writes_custom_error_level(): void
+    {
+        $tester = $this->makeTester();
+
+        $exit = $tester->execute(['--level' => '1']);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $target = $this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml';
+        $this->assertStringContainsString('errorLevel="1"', (string) \file_get_contents($target));
+    }
+
+    #[Test]
+    public function rejects_invalid_error_level(): void
+    {
+        $tester = $this->makeTester();
+
+        $exit = $tester->execute(['--level' => '9']);
+
+        $this->assertSame(Command::FAILURE, $exit);
+        $this->assertFileDoesNotExist($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $this->assertStringContainsString('Invalid --level', $tester->getDisplay());
+    }
+
     /**
      * Exercises the production code path where no workingDirectory is injected —
      * the command must fall back to getcwd(). We chdir() into the temp dir so

--- a/tests/Unit/Cli/InitCommandTest.php
+++ b/tests/Unit/Cli/InitCommandTest.php
@@ -29,6 +29,7 @@ final class InitCommandTest extends TestCase
         if (\file_exists($target)) {
             \unlink($target);
         }
+
         \rmdir($this->tempDir);
     }
 
@@ -39,19 +40,19 @@ final class InitCommandTest extends TestCase
 
         $exit = $tester->execute([]);
 
-        self::assertSame(Command::SUCCESS, $exit);
+        $this->assertSame(Command::SUCCESS, $exit);
         $target = $this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml';
-        self::assertFileExists($target);
+        $this->assertFileExists($target);
 
         $contents = \file_get_contents($target);
-        self::assertIsString($contents);
-        self::assertStringContainsString('errorLevel="3"', $contents);
-        self::assertStringContainsString('findUnusedCode="false"', $contents);
-        self::assertStringContainsString('ensureOverrideAttribute="false"', $contents);
-        self::assertStringContainsString('<pluginClass class="Psalm\\LaravelPlugin\\Plugin"/>', $contents);
-        self::assertStringContainsString('<directory name="vendor"/>', $contents);
-        self::assertStringContainsString('<directory name="storage"/>', $contents);
-        self::assertStringContainsString('<directory name="bootstrap/cache"/>', $contents);
+        $this->assertIsString($contents);
+        $this->assertStringContainsString('errorLevel="3"', $contents);
+        $this->assertStringContainsString('findUnusedCode="false"', $contents);
+        $this->assertStringContainsString('ensureOverrideAttribute="false"', $contents);
+        $this->assertStringContainsString('<pluginClass class="Psalm\\LaravelPlugin\\Plugin"/>', $contents);
+        $this->assertStringContainsString('<directory name="vendor"/>', $contents);
+        $this->assertStringContainsString('<directory name="storage"/>', $contents);
+        $this->assertStringContainsString('<directory name="bootstrap/cache"/>', $contents);
     }
 
     #[Test]
@@ -62,13 +63,13 @@ final class InitCommandTest extends TestCase
 
         $target = $this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml';
         $contents = \file_get_contents($target);
-        self::assertIsString($contents);
+        $this->assertIsString($contents);
 
         $previous = \libxml_use_internal_errors(true);
         try {
             $xml = \simplexml_load_string($contents);
-            self::assertNotFalse($xml, 'Generated psalm.xml must be well-formed XML.');
-            self::assertSame('psalm', $xml->getName());
+            $this->assertNotFalse($xml, 'Generated psalm.xml must be well-formed XML.');
+            $this->assertSame('psalm', $xml->getName());
         } finally {
             \libxml_clear_errors();
             \libxml_use_internal_errors($previous);
@@ -86,8 +87,8 @@ final class InitCommandTest extends TestCase
 
         $exit = $tester->execute([]);
 
-        self::assertSame(Command::SUCCESS, $exit);
-        self::assertSame('<existing/>', \file_get_contents($target));
+        $this->assertSame(Command::SUCCESS, $exit);
+        $this->assertSame('<existing/>', \file_get_contents($target));
     }
 
     #[Test]
@@ -101,8 +102,8 @@ final class InitCommandTest extends TestCase
 
         $exit = $tester->execute([]);
 
-        self::assertSame(Command::SUCCESS, $exit);
-        self::assertStringContainsString('pluginClass', (string) \file_get_contents($target));
+        $this->assertSame(Command::SUCCESS, $exit);
+        $this->assertStringContainsString('pluginClass', (string) \file_get_contents($target));
     }
 
     #[Test]
@@ -115,8 +116,8 @@ final class InitCommandTest extends TestCase
 
         $exit = $tester->execute(['--force' => true]);
 
-        self::assertSame(Command::SUCCESS, $exit);
-        self::assertStringContainsString('pluginClass', (string) \file_get_contents($target));
+        $this->assertSame(Command::SUCCESS, $exit);
+        $this->assertStringContainsString('pluginClass', (string) \file_get_contents($target));
     }
 
     /**
@@ -128,7 +129,7 @@ final class InitCommandTest extends TestCase
     public function falls_back_to_getcwd_when_no_working_directory_is_injected(): void
     {
         $originalCwd = \getcwd();
-        self::assertIsString($originalCwd);
+        $this->assertIsString($originalCwd);
 
         \chdir($this->tempDir);
 
@@ -140,8 +141,8 @@ final class InitCommandTest extends TestCase
 
             $exit = $tester->execute([]);
 
-            self::assertSame(Command::SUCCESS, $exit);
-            self::assertFileExists($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+            $this->assertSame(Command::SUCCESS, $exit);
+            $this->assertFileExists($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
         } finally {
             \chdir($originalCwd);
         }

--- a/tests/Unit/Cli/InitCommandTest.php
+++ b/tests/Unit/Cli/InitCommandTest.php
@@ -57,6 +57,9 @@ final class InitCommandTest extends TestCase
         $this->assertStringContainsString('<directory name="vendor"/>', $contents);
         $this->assertStringContainsString('<directory name="storage"/>', $contents);
         $this->assertStringContainsString('<directory name="bootstrap/cache"/>', $contents);
+        $this->assertStringContainsString('<ClassMustBeFinal errorLevel="suppress"/>', $contents);
+        $this->assertStringContainsString('<MissingOverrideAttribute errorLevel="suppress"/>', $contents);
+        $this->assertStringContainsString('<UnnecessaryVarAnnotation errorLevel="suppress"/>', $contents);
     }
 
     #[Test]


### PR DESCRIPTION
Closes #785 (phase 1).

## Summary

Adds a dedicated Symfony Console binary at `vendor/bin/psalm-laravel`, cutting setup from six steps to one.

The binary does not boot Psalm or Laravel, so it remains safe to run when `psalm.xml` is missing or broken (the moment users need help most).

## Subcommands

### `init` — generate `psalm.xml`

Writes a Laravel-tailored config with:

* `errorLevel="3"` (configurable via `--level` / `-l`, accepts 1–8)
* `findUnusedCode="false"`, `ensureOverrideAttribute="false"`
* `<projectFiles>` scoped to `.`, excluding `vendor/`, `storage/`, `bootstrap/cache/` (with `allowMissingFiles="true"`)
* `<pluginClass class="Psalm\LaravelPlugin\Plugin"/>` pre-wired

If `psalm.xml` already exists, `init` prompts before overwriting. `--force` bypasses the prompt for CI usage.

### `analyze` — run Psalm

Thin wrapper that locates `vendor/bin/psalm` in the working directory and execs it, passing the exit code through.

### Default routing

When `psalm-laravel` is invoked with no subcommand, the binary picks one based on workspace state:

* `psalm.xml` missing → `init` (first-run setup)
* `psalm.xml` present → `analyze` (everyday use)

Explicit subcommands are unaffected.

## Scope

Phase 1 only. `doctor`, `baseline`, and AI-tooling subcommands are tracked separately under #785.

## Dependencies

Adds `symfony/console: ^7.4 || ^8.0` to `require`. Laravel 12 allows `^7.2.0` (which permits 7.4+) and Laravel 13 requires `^7.4 || ^8.0`, so this doesn't constrain plugin users beyond what Laravel itself does.

## Notes

* `src/Cli/` (not `src/Console/`) to avoid a naming clash with the existing `src/Handlers/Console/` namespace which refers to Laravel Artisan analysis.
* Flat layout (`src/Cli/InitCommand.php`, `src/Cli/AnalyzeCommand.php`); promote to `src/Cli/Command/` if more commands arrive.