### PR TITLE
Suggest companion Psalm plugins in `init`

### DIFF
--- a/src/Cli/CompanionPlugin.php
+++ b/src/Cli/CompanionPlugin.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Cli;
+
+/**
+ * Psalm plugins that meaningfully improve analysis when a sibling Composer
+ * dependency is in use. `init` detects these and either auto-wires them into
+ * the generated psalm.xml (when already installed) or prompts/hints the user
+ * to install them.
+ *
+ * Adding a new case here is the only change needed to teach `init` about
+ * another companion plugin.
+ */
+enum CompanionPlugin: string
+{
+    case PhpUnit = 'phpunit';
+    case Mockery = 'mockery';
+
+    /**
+     * The Composer package whose presence triggers this companion. The
+     * companion is only suggested when this package is declared in the
+     * project's composer.json (require or require-dev).
+     *
+     * @psalm-mutation-free
+     */
+    public function dependency(): string
+    {
+        return match ($this) {
+            self::PhpUnit => 'phpunit/phpunit',
+            self::Mockery => 'mockery/mockery',
+        };
+    }
+
+    /**
+     * The Psalm companion plugin package to install.
+     *
+     * @psalm-mutation-free
+     */
+    public function pluginPackage(): string
+    {
+        return match ($this) {
+            self::PhpUnit => 'psalm/phpunit-plugin',
+            self::Mockery => 'psalm/mockery-plugin',
+        };
+    }
+
+    /**
+     * The FQCN registered as a <pluginClass> in psalm.xml.
+     *
+     * @psalm-mutation-free
+     */
+    public function pluginClass(): string
+    {
+        return match ($this) {
+            self::PhpUnit => 'Psalm\\PhpUnitPlugin\\Plugin',
+            self::Mockery => 'Psalm\\MockeryPlugin\\Plugin',
+        };
+    }
+
+    /**
+     * Display name used in CLI output.
+     *
+     * @psalm-mutation-free
+     */
+    public function friendlyName(): string
+    {
+        return match ($this) {
+            self::PhpUnit => 'PHPUnit',
+            self::Mockery => 'Mockery',
+        };
+    }
+}

--- a/src/Cli/CompanionPluginDecisions.php
+++ b/src/Cli/CompanionPluginDecisions.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Cli;
+
+/**
+ * Output of `InitCommand::resolveCompanionPlugins`: what to splice into
+ * psalm.xml, what to print after a successful write, and what hints to emit
+ * for missing companion plugins.
+ *
+ * A flat list of fields is clearer than a positional tuple at the call site
+ * and lets the "nothing detected" case use a named constructor instead of
+ * the sentinel `['', [], []]`.
+ *
+ * @psalm-immutable
+ */
+final readonly class CompanionPluginDecisions
+{
+    /**
+     * @param list<string> $confirmations one-liners describing plugins that
+     *                                    were auto-enabled (Case A)
+     * @param list<string> $hints         multi-line blocks suggesting plugins
+     *                                    the user hasn't installed (Case B)
+     *
+     * @psalm-mutation-free
+     */
+    public function __construct(
+        public string $xmlFragment,
+        public array $confirmations,
+        public array $hints,
+    ) {}
+
+    /** @psalm-pure */
+    public static function none(): self
+    {
+        return new self('', [], []);
+    }
+}

--- a/src/Cli/ComposerInspector.php
+++ b/src/Cli/ComposerInspector.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Cli;
+
+/**
+ * Reads the project's composer.json and vendor/ layout to answer two narrow
+ * questions used by `init`:
+ *
+ *   - Is a given package declared as a dependency (require / require-dev)?
+ *   - Is a given package physically installed under vendor/?
+ *
+ * Tolerant by design: a missing composer.json degrades to "no dependencies"
+ * because users may legitimately run `init` in a fresh directory. But a
+ * composer.json that *exists and is unreadable/malformed* is a user problem
+ * worth surfacing — we record it in $parseWarning so the caller can display
+ * it without blocking config generation.
+ */
+final class ComposerInspector
+{
+    private readonly string $cwd;
+
+    /**
+     * Declared dependency names read once at construction.
+     *
+     * `array<string, true>` is a set-of-strings: keys are package names
+     * ("phpunit/phpunit") and values are an unused sentinel so callers can
+     * query with a single `isset()`.
+     *
+     * @var array<string, true>
+     */
+    private readonly array $declaredDependencies;
+
+    /**
+     * Non-null when composer.json existed but could not be parsed (bad JSON,
+     * wrong root type, read error). Null means either "absent" or "loaded OK".
+     */
+    public readonly ?string $parseWarning;
+
+    public function __construct(string $cwd)
+    {
+        // Normalize so `cwd` ending in a separator doesn't produce `//vendor/…`.
+        $this->cwd = \rtrim($cwd, \DIRECTORY_SEPARATOR);
+        [$this->declaredDependencies, $this->parseWarning] = $this->loadDeclaredDependencies();
+    }
+
+    /**
+     * True if the package is listed in require or require-dev.
+     *
+     * @psalm-mutation-free
+     */
+    public function hasDependency(string $package): bool
+    {
+        return isset($this->declaredDependencies[$package]);
+    }
+
+    /**
+     * True if the package is installed under vendor/. Checks for the package's
+     * own composer.json, which Composer always writes when it installs a
+     * package. More reliable than checking for a directory alone (directories
+     * can linger after incomplete removals).
+     *
+     * Reads the filesystem on every call by design: callers may invoke this
+     * after running `composer require`, so the answer must reflect live state
+     * rather than a snapshot from construction.
+     */
+    public function hasInstalledPackage(string $package): bool
+    {
+        $path = $this->cwd
+            . \DIRECTORY_SEPARATOR . 'vendor'
+            . \DIRECTORY_SEPARATOR . \str_replace('/', \DIRECTORY_SEPARATOR, $package)
+            . \DIRECTORY_SEPARATOR . 'composer.json';
+
+        return \is_file($path);
+    }
+
+    /**
+     * @return array{0: array<string, true>, 1: ?string}
+     */
+    private function loadDeclaredDependencies(): array
+    {
+        $path = $this->cwd . \DIRECTORY_SEPARATOR . 'composer.json';
+        if (! \is_file($path)) {
+            // No composer.json is a legitimate state for a fresh project.
+            return [[], null];
+        }
+
+        $contents = @\file_get_contents($path);
+        if (! \is_string($contents)) {
+            return [[], \sprintf('Could not read %s.', $path)];
+        }
+
+        try {
+            /** @var mixed $data */
+            $data = \json_decode($contents, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $exception) {
+            return [[], \sprintf('%s is not valid JSON: %s', $path, $exception->getMessage())];
+        }
+
+        if (! \is_array($data)) {
+            return [[], \sprintf('%s root must be a JSON object.', $path)];
+        }
+
+        $declared = [];
+        foreach (['require', 'require-dev'] as $section) {
+            $packages = $data[$section] ?? null;
+            if (! \is_array($packages)) {
+                continue;
+            }
+            foreach (\array_keys($packages) as $package) {
+                if (\is_string($package)) {
+                    $declared[$package] = true;
+                }
+            }
+        }
+
+        return [$declared, null];
+    }
+}

--- a/src/Cli/ComposerInspector.php
+++ b/src/Cli/ComposerInspector.php
@@ -94,8 +94,8 @@ final class ComposerInspector
         try {
             /** @var mixed $data */
             $data = \json_decode($contents, true, 512, \JSON_THROW_ON_ERROR);
-        } catch (\JsonException $exception) {
-            return [[], \sprintf('%s is not valid JSON: %s', $path, $exception->getMessage())];
+        } catch (\JsonException $jsonException) {
+            return [[], \sprintf('%s is not valid JSON: %s', $path, $jsonException->getMessage())];
         }
 
         if (! \is_array($data)) {
@@ -108,6 +108,7 @@ final class ComposerInspector
             if (! \is_array($packages)) {
                 continue;
             }
+
             foreach (\array_keys($packages) as $package) {
                 if (\is_string($package)) {
                     $declared[$package] = true;

--- a/src/Cli/InitCommand.php
+++ b/src/Cli/InitCommand.php
@@ -196,6 +196,7 @@ final class InitCommand extends Command
         foreach ($decisions->confirmations as $note) {
             $io->writeln(\sprintf('  [+] %s', $note));
         }
+
         foreach ($decisions->hints as $hint) {
             $io->writeln($hint);
         }

--- a/src/Cli/InitCommand.php
+++ b/src/Cli/InitCommand.php
@@ -15,7 +15,9 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  * Writes a Laravel-tailored psalm.xml into the current working directory.
  *
  * Intentionally does NOT boot Psalm or Laravel so it remains safe to run when
- * psalm.xml is broken or missing — the exact moment a user needs it.
+ * psalm.xml is broken or missing — the exact moment a user needs it. Does,
+ * however, run `composer require` on explicit user confirmation when the
+ * project has phpunit/mockery without the matching Psalm companion plugins.
  */
 #[AsCommand(
     name: 'init',
@@ -24,6 +26,20 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 final class InitCommand extends Command
 {
     private const DEFAULT_ERROR_LEVEL = '3';
+
+    /**
+     * Placeholder for a future preset system (see #785). Today only "auto"
+     * is accepted — it means "infer sensible defaults from project context"
+     * (the current behavior, including companion-plugin detection).
+     *
+     * Values like "ci", "dev", "audit" may be added later; keeping the option
+     * now lets callers pin `--preset=auto` today without a breaking change
+     * when real presets ship.
+     */
+    private const DEFAULT_PRESET = 'auto';
+
+    /** @var list<string> */
+    private const SUPPORTED_PRESETS = ['auto'];
 
     private const PSALM_XML_TEMPLATE = <<<'XML'
         <?xml version="1.0"?>
@@ -45,7 +61,7 @@ final class InitCommand extends Command
             </projectFiles>
 
             <plugins>
-                <pluginClass class="Psalm\LaravelPlugin\Plugin"/>
+                <pluginClass class="Psalm\LaravelPlugin\Plugin"/>{{COMPANION_PLUGINS}}
             </plugins>
 
             <issueHandlers>
@@ -89,6 +105,28 @@ final class InitCommand extends Command
             'Psalm errorLevel (1 = strictest, 8 = most lenient).',
             self::DEFAULT_ERROR_LEVEL,
         );
+        $this->addOption(
+            'no-suggest',
+            null,
+            InputOption::VALUE_NONE,
+            \sprintf(
+                'Do not detect or suggest companion Psalm plugins (%s).',
+                \implode(', ', \array_map(
+                    static fn(CompanionPlugin $p): string => $p->pluginPackage(),
+                    CompanionPlugin::cases(),
+                )),
+            ),
+        );
+        $this->addOption(
+            'preset',
+            'p',
+            InputOption::VALUE_REQUIRED,
+            \sprintf(
+                'Configuration preset. Supported values: %s. More presets (ci, dev, audit) may be added later.',
+                \implode(', ', self::SUPPORTED_PRESETS),
+            ),
+            self::DEFAULT_PRESET,
+        );
     }
 
     #[\Override]
@@ -101,6 +139,16 @@ final class InitCommand extends Command
             $io->error(\sprintf(
                 'Invalid --level value %s. Must be an integer between 1 (strictest) and 8 (most lenient).',
                 \is_string($levelOption) ? "'{$levelOption}'" : 'of unexpected type',
+            ));
+            return Command::FAILURE;
+        }
+
+        $presetOption = $input->getOption('preset');
+        if (! \is_string($presetOption) || ! \in_array($presetOption, self::SUPPORTED_PRESETS, true)) {
+            $io->error(\sprintf(
+                'Invalid --preset value %s. Supported: %s.',
+                \is_string($presetOption) ? "'{$presetOption}'" : 'of unexpected type',
+                \implode(', ', self::SUPPORTED_PRESETS),
             ));
             return Command::FAILURE;
         }
@@ -125,7 +173,13 @@ final class InitCommand extends Command
             }
         }
 
-        $contents = \str_replace('{{LEVEL}}', $levelOption, self::PSALM_XML_TEMPLATE);
+        $decisions = $this->resolveCompanionPlugins($input, $io, $cwd);
+
+        $contents = \str_replace(
+            ['{{LEVEL}}', '{{COMPANION_PLUGINS}}'],
+            [$levelOption, $decisions->xmlFragment],
+            self::PSALM_XML_TEMPLATE,
+        );
 
         // Suppress the warning so we can surface error_get_last() ourselves —
         // blind "failed to write" messages send users hunting for the real cause.
@@ -138,8 +192,182 @@ final class InitCommand extends Command
         }
 
         $io->success(\sprintf('Wrote %s.', $targetPath));
+
+        foreach ($decisions->confirmations as $note) {
+            $io->writeln(\sprintf('  [+] %s', $note));
+        }
+        foreach ($decisions->hints as $hint) {
+            $io->writeln($hint);
+        }
+
         $io->writeln('Next step: run <info>vendor/bin/psalm</info>.');
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * Decide what to do about companion plugins (phpunit, mockery).
+     *
+     * Flow per companion (skipped entirely when --no-suggest):
+     *   - dep absent                       → nothing
+     *   - dep present + plugin installed   → auto-include + confirmation note
+     *   - dep present + plugin missing:
+     *       · interactive → prompt; on yes run composer require, then include if install succeeded
+     *       · non-interactive → print a static hint so CI logs are informative
+     */
+    private function resolveCompanionPlugins(
+        InputInterface $input,
+        SymfonyStyle $io,
+        string $cwd,
+    ): CompanionPluginDecisions {
+        if ($input->getOption('no-suggest') === true) {
+            return CompanionPluginDecisions::none();
+        }
+
+        $inspector = new ComposerInspector($cwd);
+        if ($inspector->parseWarning !== null) {
+            // composer.json exists but is unreadable or malformed. Surface the
+            // reason so the user can fix it — otherwise a broken composer.json
+            // silently degrades to "no companion plugins detected", leading
+            // users to file bugs about missing detection.
+            $io->warning(\sprintf(
+                'Skipping companion-plugin detection: %s',
+                $inspector->parseWarning,
+            ));
+            return CompanionPluginDecisions::none();
+        }
+
+        $pluginEntries = '';
+        /** @var list<string> $confirmations */
+        $confirmations = [];
+        /** @var list<string> $hints */
+        $hints = [];
+
+        foreach (CompanionPlugin::cases() as $plugin) {
+            if (! $inspector->hasDependency($plugin->dependency())) {
+                continue;
+            }
+
+            if ($inspector->hasInstalledPackage($plugin->pluginPackage())) {
+                $pluginEntries .= $this->pluginClassEntry($plugin);
+                $confirmations[] = $this->enabledMessage($plugin, 'already installed');
+                continue;
+            }
+
+            if ($input->isInteractive() && $this->promptAndInstall($io, $plugin, $inspector, $cwd)) {
+                $pluginEntries .= $this->pluginClassEntry($plugin);
+                $confirmations[] = $this->enabledMessage($plugin, 'now installed');
+                continue;
+            }
+
+            // Either non-interactive, or the user declined / install failed.
+            // Print a hint so users (and CI logs) know about the companion.
+            $hints[] = \sprintf(
+                '  [i] %1$s detected. Install the Psalm %1$s plugin for type-aware analysis:',
+                $plugin->friendlyName(),
+            );
+            $hints[] = \sprintf('      composer require --dev %s', $plugin->pluginPackage());
+        }
+
+        return new CompanionPluginDecisions($pluginEntries, $confirmations, $hints);
+    }
+
+    /** @psalm-mutation-free */
+    private function enabledMessage(CompanionPlugin $plugin, string $status): string
+    {
+        return \sprintf(
+            '%s detected and %s %s -> enabled',
+            $plugin->friendlyName(),
+            $plugin->pluginPackage(),
+            $status,
+        );
+    }
+
+    /**
+     * Leading newline + 8-space indent so the entry slots neatly after the
+     * Laravel pluginClass line in the template's `<plugins>` block.
+     *
+     * @psalm-mutation-free
+     */
+    private function pluginClassEntry(CompanionPlugin $plugin): string
+    {
+        return "\n        <pluginClass class=\"{$plugin->pluginClass()}\"/>";
+    }
+
+    /**
+     * Ask the user whether to install the companion plugin and, on yes, run
+     * `composer require --dev <package>` with pass-through I/O so the user
+     * sees composer's prompts and output directly.
+     *
+     * Returns true only when, after composer exits, the package is actually
+     * installed under vendor/. A non-zero composer exit, or a successful exit
+     * that somehow didn't install the package, both return false and emit a
+     * distinct warning so users know why the hint reappears.
+     */
+    private function promptAndInstall(
+        SymfonyStyle $io,
+        CompanionPlugin $plugin,
+        ComposerInspector $inspector,
+        string $cwd,
+    ): bool {
+        $confirmed = $io->confirm(
+            \sprintf(
+                '%s detected. Install %s for type-aware analysis?',
+                $plugin->friendlyName(),
+                $plugin->pluginPackage(),
+            ),
+            false,
+        );
+
+        if (! $confirmed) {
+            return false;
+        }
+
+        $manualCommand = \sprintf('composer require --dev %s', $plugin->pluginPackage());
+        $command = ['composer', 'require', '--dev', $plugin->pluginPackage()];
+        $io->writeln(\sprintf('Running: <info>%s</info>', \implode(' ', $command)));
+
+        // Pass-through descriptors: composer inherits our STDIN/OUT/ERR and
+        // writes directly to the user's terminal. $pipes stays empty; if
+        // anyone switches to captured pipes (e.g. ['pipe', 'w']), they must
+        // fclose them before proc_close or the call will deadlock.
+        $descriptors = [0 => \STDIN, 1 => \STDOUT, 2 => \STDERR];
+        $process = \proc_open($command, $descriptors, $pipes, $cwd);
+        if (! \is_resource($process)) {
+            $error = \error_get_last();
+            $reason = isset($error['message']) ? ': ' . $error['message'] : '';
+            $io->warning(\sprintf(
+                'Failed to launch composer%s. Install manually: %s',
+                $reason,
+                $manualCommand,
+            ));
+            return false;
+        }
+
+        $exitCode = \proc_close($process);
+        if ($exitCode !== 0) {
+            $io->warning(\sprintf(
+                'composer require exited with code %d. The package was not installed — '
+                . 'check composer output above for the cause (version conflict, auth, network). '
+                . 'Retry manually once resolved: %s',
+                $exitCode,
+                $manualCommand,
+            ));
+            return false;
+        }
+
+        if (! $inspector->hasInstalledPackage($plugin->pluginPackage())) {
+            // Composer reported success but the package isn't on disk. Rare
+            // but possible (e.g., a plugin rewriting the install path). Call
+            // it out distinctly so the user doesn't assume "retry" will help.
+            $io->warning(\sprintf(
+                'composer reported success but %s is not under vendor/. Install manually: %s',
+                $plugin->pluginPackage(),
+                $manualCommand,
+            ));
+            return false;
+        }
+
+        return true;
     }
 }

--- a/tests/Unit/Cli/ComposerInspectorTest.php
+++ b/tests/Unit/Cli/ComposerInspectorTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Cli;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Cli\ComposerInspector;
+
+#[CoversClass(ComposerInspector::class)]
+final class ComposerInspectorTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = \sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'psalm-laravel-inspector-' . \uniqid('', true);
+        if (! \mkdir($this->tempDir, 0777, true) && ! \is_dir($this->tempDir)) {
+            throw new \RuntimeException(\sprintf('Failed to create temp directory %s', $this->tempDir));
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->tempDir);
+    }
+
+    #[Test]
+    public function reports_no_dependencies_when_composer_json_is_missing(): void
+    {
+        $inspector = new ComposerInspector($this->tempDir);
+
+        $this->assertFalse($inspector->hasDependency('phpunit/phpunit'));
+        // Missing composer.json is a legitimate state (fresh project): no warning.
+        $this->assertNull($inspector->parseWarning);
+    }
+
+    #[Test]
+    public function reads_require_and_require_dev(): void
+    {
+        $this->writeComposerJson([
+            'require' => ['illuminate/support' => '^12.0'],
+            'require-dev' => ['phpunit/phpunit' => '^11.0'],
+        ]);
+
+        $inspector = new ComposerInspector($this->tempDir);
+
+        $this->assertTrue($inspector->hasDependency('illuminate/support'));
+        $this->assertTrue($inspector->hasDependency('phpunit/phpunit'));
+        $this->assertFalse($inspector->hasDependency('mockery/mockery'));
+        $this->assertNull($inspector->parseWarning);
+    }
+
+    #[Test]
+    public function surfaces_parse_warning_for_malformed_json(): void
+    {
+        \file_put_contents($this->tempDir . '/composer.json', '{ not valid json');
+
+        $inspector = new ComposerInspector($this->tempDir);
+
+        $this->assertFalse($inspector->hasDependency('phpunit/phpunit'));
+        $this->assertNotNull($inspector->parseWarning);
+        $this->assertStringContainsString('not valid JSON', $inspector->parseWarning);
+    }
+
+    #[Test]
+    public function surfaces_parse_warning_for_non_object_json(): void
+    {
+        \file_put_contents($this->tempDir . '/composer.json', '"just a string"');
+
+        $inspector = new ComposerInspector($this->tempDir);
+
+        $this->assertFalse($inspector->hasDependency('phpunit/phpunit'));
+        $this->assertNotNull($inspector->parseWarning);
+        $this->assertStringContainsString('must be a JSON object', $inspector->parseWarning);
+    }
+
+    #[Test]
+    public function tolerates_non_array_require_sections(): void
+    {
+        // Not treated as a parse error: malformed sub-sections degrade to
+        // "no packages in that section" since that's what composer would do.
+        $this->writeComposerJson([
+            'require' => 'should-be-object',
+            'require-dev' => ['phpunit/phpunit' => '^11.0'],
+        ]);
+
+        $inspector = new ComposerInspector($this->tempDir);
+
+        $this->assertTrue($inspector->hasDependency('phpunit/phpunit'));
+        $this->assertNull($inspector->parseWarning);
+    }
+
+    #[Test]
+    public function detects_installed_package_via_vendor_composer_json(): void
+    {
+        $this->writeVendorPackage('psalm/phpunit-plugin');
+
+        $inspector = new ComposerInspector($this->tempDir);
+
+        $this->assertTrue($inspector->hasInstalledPackage('psalm/phpunit-plugin'));
+        $this->assertFalse($inspector->hasInstalledPackage('psalm/mockery-plugin'));
+    }
+
+    #[Test]
+    public function installed_check_requires_composer_json_not_just_directory(): void
+    {
+        // A bare directory without composer.json does not count as installed
+        // (matches Composer's own view — installed packages always carry a
+        // composer.json).
+        \mkdir($this->tempDir . '/vendor/psalm/phpunit-plugin', 0777, true);
+
+        $inspector = new ComposerInspector($this->tempDir);
+
+        $this->assertFalse($inspector->hasInstalledPackage('psalm/phpunit-plugin'));
+    }
+
+    #[Test]
+    public function installed_check_reflects_live_vendor_state(): void
+    {
+        // Unlike dependency metadata (read once at construction), vendor/
+        // probes always hit disk: callers may call this after running
+        // `composer require` and need the fresh answer.
+        $inspector = new ComposerInspector($this->tempDir);
+        $this->assertFalse($inspector->hasInstalledPackage('psalm/phpunit-plugin'));
+
+        $this->writeVendorPackage('psalm/phpunit-plugin');
+
+        $this->assertTrue($inspector->hasInstalledPackage('psalm/phpunit-plugin'));
+    }
+
+    #[Test]
+    public function normalizes_trailing_separator_in_cwd(): void
+    {
+        $this->writeComposerJson(['require' => ['phpunit/phpunit' => '^11.0']]);
+
+        $inspector = new ComposerInspector($this->tempDir . \DIRECTORY_SEPARATOR);
+
+        $this->assertTrue($inspector->hasDependency('phpunit/phpunit'));
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function writeComposerJson(array $data): void
+    {
+        $json = \json_encode($data, \JSON_THROW_ON_ERROR);
+        \file_put_contents($this->tempDir . '/composer.json', $json);
+    }
+
+    private function writeVendorPackage(string $package): void
+    {
+        $dir = $this->tempDir . '/vendor/' . $package;
+        \mkdir($dir, 0777, true);
+        \file_put_contents($dir . '/composer.json', \json_encode(['name' => $package], \JSON_THROW_ON_ERROR));
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (! \is_dir($path)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($iterator as $fileInfo) {
+            \assert($fileInfo instanceof \SplFileInfo);
+            if ($fileInfo->isDir()) {
+                @\rmdir($fileInfo->getPathname());
+            } else {
+                @\unlink($fileInfo->getPathname());
+            }
+        }
+
+        @\rmdir($path);
+    }
+}

--- a/tests/Unit/Cli/ComposerInspectorTest.php
+++ b/tests/Unit/Cli/ComposerInspectorTest.php
@@ -169,7 +169,7 @@ final class ComposerInspectorTest extends TestCase
         );
 
         foreach ($iterator as $fileInfo) {
-            \assert($fileInfo instanceof \SplFileInfo);
+            $this->assertInstanceOf(\SplFileInfo::class, $fileInfo);
             if ($fileInfo->isDir()) {
                 @\rmdir($fileInfo->getPathname());
             } else {

--- a/tests/Unit/Cli/InitCommandTest.php
+++ b/tests/Unit/Cli/InitCommandTest.php
@@ -338,6 +338,7 @@ final class InitCommandTest extends TestCase
             foreach ($xml->plugins->pluginClass as $entry) {
                 $classes[] = (string) $entry['class'];
             }
+
             $this->assertEqualsCanonicalizing(
                 [
                     'Psalm\\LaravelPlugin\\Plugin',
@@ -450,7 +451,7 @@ final class InitCommandTest extends TestCase
         );
 
         foreach ($iterator as $fileInfo) {
-            \assert($fileInfo instanceof \SplFileInfo);
+            $this->assertInstanceOf(\SplFileInfo::class, $fileInfo);
             if ($fileInfo->isDir()) {
                 @\rmdir($fileInfo->getPathname());
             } else {

--- a/tests/Unit/Cli/InitCommandTest.php
+++ b/tests/Unit/Cli/InitCommandTest.php
@@ -20,21 +20,14 @@ final class InitCommandTest extends TestCase
     protected function setUp(): void
     {
         $this->tempDir = \sys_get_temp_dir() . \DIRECTORY_SEPARATOR . 'psalm-laravel-init-' . \uniqid('', true);
-        if (! \mkdir($this->tempDir) && ! \is_dir($this->tempDir)) {
+        if (! \mkdir($this->tempDir, 0777, true) && ! \is_dir($this->tempDir)) {
             throw new \RuntimeException(\sprintf('Failed to create temp directory %s', $this->tempDir));
         }
     }
 
     protected function tearDown(): void
     {
-        $target = $this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml';
-        if (\file_exists($target) && ! @\unlink($target)) {
-            return;
-        }
-
-        if (\is_dir($this->tempDir)) {
-            @\rmdir($this->tempDir);
-        }
+        $this->removeDirectory($this->tempDir);
     }
 
     #[Test]
@@ -151,6 +144,40 @@ final class InitCommandTest extends TestCase
         $this->assertStringContainsString('Invalid --level', $tester->getDisplay());
     }
 
+    #[Test]
+    public function accepts_preset_auto(): void
+    {
+        $tester = $this->makeTester();
+
+        $exit = $tester->execute(['--preset' => 'auto']);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $this->assertFileExists($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+    }
+
+    #[Test]
+    public function auto_is_the_default_preset(): void
+    {
+        $tester = $this->makeTester();
+
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $this->assertFileExists($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+    }
+
+    #[Test]
+    public function rejects_unknown_preset(): void
+    {
+        $tester = $this->makeTester();
+
+        $exit = $tester->execute(['--preset' => 'ci']);
+
+        $this->assertSame(Command::FAILURE, $exit);
+        $this->assertFileDoesNotExist($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $this->assertStringContainsString("Invalid --preset value 'ci'", $tester->getDisplay());
+    }
+
     /**
      * Exercises the production code path where no workingDirectory is injected —
      * the command must fall back to getcwd(). We chdir() into the temp dir so
@@ -179,6 +206,207 @@ final class InitCommandTest extends TestCase
         }
     }
 
+    #[Test]
+    public function includes_phpunit_plugin_when_dependency_and_plugin_both_installed(): void
+    {
+        $this->writeComposerJson(['require-dev' => ['phpunit/phpunit' => '^11.0']]);
+        $this->writeVendorPackage('psalm/phpunit-plugin');
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $this->assertStringContainsString('<pluginClass class="Psalm\\PhpUnitPlugin\\Plugin"/>', $contents);
+        $this->assertStringContainsString('PHPUnit detected and psalm/phpunit-plugin already installed', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function includes_both_companion_plugins_when_both_present(): void
+    {
+        $this->writeComposerJson([
+            'require-dev' => [
+                'phpunit/phpunit' => '^11.0',
+                'mockery/mockery' => '^1.6',
+            ],
+        ]);
+        $this->writeVendorPackage('psalm/phpunit-plugin');
+        $this->writeVendorPackage('psalm/mockery-plugin');
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $this->assertStringContainsString('<pluginClass class="Psalm\\PhpUnitPlugin\\Plugin"/>', $contents);
+        $this->assertStringContainsString('<pluginClass class="Psalm\\MockeryPlugin\\Plugin"/>', $contents);
+    }
+
+    #[Test]
+    public function omits_companion_plugin_when_dependency_missing(): void
+    {
+        // Plugin installed but dep not declared → do not enable
+        // (avoids enabling a plugin for a framework the project isn't using).
+        $this->writeComposerJson(['require' => ['illuminate/support' => '^12.0']]);
+        $this->writeVendorPackage('psalm/phpunit-plugin');
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $this->assertStringNotContainsString('PhpUnitPlugin', $contents);
+    }
+
+    #[Test]
+    public function prints_hint_in_non_interactive_mode_when_plugin_missing(): void
+    {
+        $this->writeComposerJson(['require-dev' => ['phpunit/phpunit' => '^11.0']]);
+        // Intentionally: no vendor/psalm/phpunit-plugin/ — Case B.
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([], ['interactive' => false]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $this->assertStringNotContainsString('PhpUnitPlugin', $contents);
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('PHPUnit detected', $display);
+        $this->assertStringContainsString('composer require --dev psalm/phpunit-plugin', $display);
+    }
+
+    #[Test]
+    public function declined_interactive_prompt_falls_back_to_hint(): void
+    {
+        $this->writeComposerJson(['require-dev' => ['phpunit/phpunit' => '^11.0']]);
+
+        $tester = $this->makeTester();
+        // Decline the companion prompt. No composer invocation, no XML change.
+        $tester->setInputs(['no']);
+
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $this->assertStringNotContainsString('PhpUnitPlugin', $contents);
+        $this->assertStringContainsString('composer require --dev psalm/phpunit-plugin', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function no_suggest_skips_all_companion_detection(): void
+    {
+        // Even when both dep and plugin are installed, --no-suggest must not
+        // auto-enable or even detect. The output stays clean.
+        $this->writeComposerJson(['require-dev' => ['phpunit/phpunit' => '^11.0']]);
+        $this->writeVendorPackage('psalm/phpunit-plugin');
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute(['--no-suggest' => true]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $this->assertStringNotContainsString('PhpUnitPlugin', $contents);
+        $this->assertStringNotContainsString('PHPUnit detected', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function companion_xml_remains_well_formed_with_all_plugin_entries(): void
+    {
+        $this->writeComposerJson([
+            'require-dev' => [
+                'phpunit/phpunit' => '^11.0',
+                'mockery/mockery' => '^1.6',
+            ],
+        ]);
+        $this->writeVendorPackage('psalm/phpunit-plugin');
+        $this->writeVendorPackage('psalm/mockery-plugin');
+
+        $tester = $this->makeTester();
+        $tester->execute([]);
+
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+
+        $previous = \libxml_use_internal_errors(true);
+        try {
+            $xml = \simplexml_load_string($contents);
+            $this->assertNotFalse($xml, 'psalm.xml with companion plugins must remain well-formed.');
+
+            // All three pluginClass entries must live directly under <plugins>.
+            // Use canonicalizing equality so the assertion survives any future
+            // reordering of CompanionPlugin::cases().
+            $classes = [];
+            foreach ($xml->plugins->pluginClass as $entry) {
+                $classes[] = (string) $entry['class'];
+            }
+            $this->assertEqualsCanonicalizing(
+                [
+                    'Psalm\\LaravelPlugin\\Plugin',
+                    'Psalm\\PhpUnitPlugin\\Plugin',
+                    'Psalm\\MockeryPlugin\\Plugin',
+                ],
+                $classes,
+            );
+            // The Laravel plugin itself always comes first (the template puts
+            // it before the companion placeholder).
+            $this->assertSame('Psalm\\LaravelPlugin\\Plugin', $classes[0]);
+        } finally {
+            \libxml_clear_errors();
+            \libxml_use_internal_errors($previous);
+        }
+    }
+
+    #[Test]
+    public function includes_mockery_plugin_in_isolation(): void
+    {
+        $this->writeComposerJson(['require-dev' => ['mockery/mockery' => '^1.6']]);
+        $this->writeVendorPackage('psalm/mockery-plugin');
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $this->assertStringContainsString('<pluginClass class="Psalm\\MockeryPlugin\\Plugin"/>', $contents);
+        $this->assertStringNotContainsString('PhpUnitPlugin', $contents);
+        $this->assertStringContainsString('Mockery detected and psalm/mockery-plugin already installed', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function no_suggest_also_suppresses_hints_when_plugin_missing(): void
+    {
+        // Complements no_suggest_skips_all_companion_detection: here the
+        // companion plugin is NOT installed, so without --no-suggest we'd
+        // print a hint. The flag must silence that too.
+        $this->writeComposerJson(['require-dev' => ['phpunit/phpunit' => '^11.0']]);
+        // Intentionally no vendor/psalm/phpunit-plugin/.
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute(['--no-suggest' => true], ['interactive' => false]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $display = $tester->getDisplay();
+        $this->assertStringNotContainsString('PHPUnit detected', $display);
+        $this->assertStringNotContainsString('composer require --dev', $display);
+    }
+
+    #[Test]
+    public function surfaces_malformed_composer_json_and_skips_detection(): void
+    {
+        \file_put_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'composer.json', '{ broken json');
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([], ['interactive' => false]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        // psalm.xml is still written, so a broken composer.json doesn't block init.
+        $this->assertFileExists($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        // But the user is told why no companion detection ran.
+        $this->assertStringContainsString(
+            'Skipping companion-plugin detection',
+            $tester->getDisplay(),
+        );
+    }
+
     private function makeTester(): CommandTester
     {
         $command = new InitCommand($this->tempDir);
@@ -186,5 +414,50 @@ final class InitCommandTest extends TestCase
         $application->addCommand($command);
 
         return new CommandTester($application->find('init'));
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function writeComposerJson(array $data): void
+    {
+        \file_put_contents(
+            $this->tempDir . \DIRECTORY_SEPARATOR . 'composer.json',
+            \json_encode($data, \JSON_THROW_ON_ERROR),
+        );
+    }
+
+    private function writeVendorPackage(string $package): void
+    {
+        $dir = $this->tempDir . \DIRECTORY_SEPARATOR . 'vendor'
+            . \DIRECTORY_SEPARATOR . \str_replace('/', \DIRECTORY_SEPARATOR, $package);
+        \mkdir($dir, 0777, true);
+        \file_put_contents(
+            $dir . \DIRECTORY_SEPARATOR . 'composer.json',
+            \json_encode(['name' => $package], \JSON_THROW_ON_ERROR),
+        );
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (! \is_dir($path)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($iterator as $fileInfo) {
+            \assert($fileInfo instanceof \SplFileInfo);
+            if ($fileInfo->isDir()) {
+                @\rmdir($fileInfo->getPathname());
+            } else {
+                @\unlink($fileInfo->getPathname());
+            }
+        }
+
+        @\rmdir($path);
     }
 }


### PR DESCRIPTION
Closes #788.

## Summary

`psalm-laravel init` now inspects `composer.json` for `phpunit/phpunit` and `mockery/mockery`, and wires up the matching official Psalm plugins (`psalm/phpunit-plugin`, `psalm/mockery-plugin`) when present. Discovery used to be accidental; now it's one of three explicit flows.

## Behavior

### Case A — companion plugin already installed

Auto-includes the `<pluginClass>` in the generated `psalm.xml`. Prints:

```
[+] PHPUnit detected and psalm/phpunit-plugin already installed -> enabled
```

### Case B — companion plugin missing, interactive

Prompts:

```
PHPUnit detected. Install psalm/phpunit-plugin for type-aware analysis? (yes/no)
```

On yes, runs `composer require --dev psalm/phpunit-plugin` with pass-through I/O so the user sees composer's output directly. After a successful install, the pluginClass entry is added and a confirmation is printed. On failure (launch error, non-zero exit, or zero exit but package not on disk), a distinct warning explains the cause so users aren't told to "retry manually" when the command they just ran failed.

### Case B — companion plugin missing, non-interactive (CI)

Prints the hint without prompting:

```
[i] PHPUnit detected. Install the Psalm PHPUnit plugin for type-aware analysis:
    composer require --dev psalm/phpunit-plugin
```

## New options

- `--no-suggest`: Skip all companion detection (for projects using Pest or hand-rolled test doubles).
- `--preset=auto`: Forward-looking placeholder for the preset system tracked in #785. Only `auto` is accepted today; rejects unknown values with a clear error. Lets callers pin `--preset=auto` now without a breaking change later.

## Malformed composer.json

`ComposerInspector` surfaces a `$parseWarning` when `composer.json` exists but is unreadable / invalid JSON / wrong root type. `init` prints it via `$io->warning()` and proceeds with psalm.xml generation (it must never block config creation). This replaces the original silent-degrade-to-no-deps behavior that led to "init doesn't detect my phpunit" bug reports.

## Structure

- `src/Cli/CompanionPlugin.php` — enum with one case per companion; four `@psalm-mutation-free` accessors. Adding a new companion is a single-case change, and `match` exhaustiveness keeps every accessor in sync.
- `src/Cli/ComposerInspector.php` — fully immutable (eager-loads in ctor). `hasDependency` is mutation-free; `hasInstalledPackage` deliberately hits the filesystem per call so it reflects live state after `composer require`.
- `src/Cli/CompanionPluginDecisions.php` — immutable DTO carrying the XML fragment, confirmation lines, and hints.
- `src/Cli/InitCommand.php` — orchestrates detection, prompting, and template splicing.

## Dependencies

None. Uses the existing `symfony/console` dependency added in #786.