### PR TITLE
Fix `Model::query()` override shadowed by trait `@method` pseudos (#795)

### DIFF
--- a/src/Handlers/Eloquent/ModelMethodHandler.php
+++ b/src/Handlers/Eloquent/ModelMethodHandler.php
@@ -9,13 +9,10 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Stmt\Class_;
 use Psalm\Codebase;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Internal\MethodIdentifier;
 use Psalm\LaravelPlugin\Util\ProxyMethodReturnTypeProvider;
-use Psalm\Plugin\EventHandler\AfterClassLikeVisitInterface;
-use Psalm\Plugin\EventHandler\Event\AfterClassLikeVisitEvent;
 use Psalm\Plugin\EventHandler\Event\MethodExistenceProviderEvent;
 use Psalm\Plugin\EventHandler\Event\MethodParamsProviderEvent;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
@@ -34,7 +31,6 @@ use Psalm\Type\Union;
  * 2. Method visibility — confirms magic methods are public
  * 3. Method params — provides parameter definitions for argument checking
  * 4. Return types — proxies calls to Builder<TModel> for type inference
- * 5. afterClassLikeVisit — removes pseudo static methods so the plugin can handle them
  *
  * Existence, visibility, params, and return type providers for concrete Model subclasses are
  * registered dynamically per-model by {@see ModelRegistrationHandler} because Psalm's
@@ -47,7 +43,7 @@ use Psalm\Type\Union;
  * Builder-instance handlers (trait methods and scopes on custom builders) are in
  * {@see CustomBuilderMethodHandler}.
  */
-final class ModelMethodHandler implements MethodReturnTypeProviderInterface, AfterClassLikeVisitInterface
+final class ModelMethodHandler implements MethodReturnTypeProviderInterface
 {
     /**
      * Cache for isUnresolvedBuilderMethod results.
@@ -481,21 +477,4 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface, Aft
         return $params;
     }
 
-    /** @inheritDoc */
-    #[\Override]
-    public static function afterClassLikeVisit(AfterClassLikeVisitEvent $event): void
-    {
-        $storage = $event->getStorage();
-        if (
-            $event->getStmt() instanceof Class_
-            && !$storage->abstract
-            && isset($storage->parent_classes[\strtolower(Model::class)])
-        ) {
-            unset(
-                $storage->pseudo_static_methods['newmodelquery'],
-                $storage->pseudo_static_methods['newquery'],
-                $storage->pseudo_static_methods['query'],
-            );
-        }
-    }
 }

--- a/src/Handlers/Eloquent/ModelRegistrationHandler.php
+++ b/src/Handlers/Eloquent/ModelRegistrationHandler.php
@@ -127,6 +127,28 @@ final class ModelRegistrationHandler implements AfterCodebasePopulatedInterface
         $properties = $codebase->properties;
         $methods = $codebase->methods;
 
+        // Drop pseudo_static_methods that shadow real method declarations. Traits can declare
+        // `@method static Builder query()` (e.g. Koel's SupportsDeleteWhereValueNotIn); this
+        // injects a zero-param pseudo into every model that uses the trait. Psalm's static
+        // call analyzer checks pseudo_static_methods first for argument validation, so the
+        // pseudo rejects Song::query(type: $t, user: $u) with TooManyArguments even though
+        // Song declares `public static function query(?PlayableType $t, ?User $u)`. The same
+        // shadowing applies to Model's other static helpers (on, onWriteConnection, with, ...),
+        // so drop any pseudo whose name also corresponds to a real declaration on the class
+        // (declared here, inherited from Model, or imported via another trait); declaring_method_ids
+        // lists every such real declaration.
+        //
+        // Runs here (post-populator) rather than in an AfterClassLikeVisit hook because
+        // Populator::populateDataFromTrait() merges trait pseudo_static_methods into the
+        // model's storage AFTER the scan phase, so earlier removal is a no-op.
+        //
+        // Issue: https://github.com/psalm/psalm-plugin-laravel/issues/795
+        foreach ($storage->pseudo_static_methods as $methodName => $_) {
+            if (isset($storage->declaring_method_ids[$methodName])) {
+                unset($storage->pseudo_static_methods[$methodName]);
+            }
+        }
+
         // Detect custom builder class via attribute, method override, or $builder property.
         // Class is already loaded by autoloader above.
         /** @var class-string<Model> $className — verified by parent_classes check in caller */

--- a/src/Handlers/Eloquent/ModelRegistrationHandler.php
+++ b/src/Handlers/Eloquent/ModelRegistrationHandler.php
@@ -143,7 +143,7 @@ final class ModelRegistrationHandler implements AfterCodebasePopulatedInterface
         // model's storage AFTER the scan phase, so earlier removal is a no-op.
         //
         // Issue: https://github.com/psalm/psalm-plugin-laravel/issues/795
-        foreach ($storage->pseudo_static_methods as $methodName => $_) {
+        foreach (array_keys($storage->pseudo_static_methods) as $methodName) {
             if (isset($storage->declaring_method_ids[$methodName])) {
                 unset($storage->pseudo_static_methods[$methodName]);
             }

--- a/src/Handlers/Eloquent/ModelRegistrationHandler.php
+++ b/src/Handlers/Eloquent/ModelRegistrationHandler.php
@@ -143,7 +143,7 @@ final class ModelRegistrationHandler implements AfterCodebasePopulatedInterface
         // model's storage AFTER the scan phase, so earlier removal is a no-op.
         //
         // Issue: https://github.com/psalm/psalm-plugin-laravel/issues/795
-        foreach (array_keys($storage->pseudo_static_methods) as $methodName) {
+        foreach (\array_keys($storage->pseudo_static_methods) as $methodName) {
             if (isset($storage->declaring_method_ids[$methodName])) {
                 unset($storage->pseudo_static_methods[$methodName]);
             }

--- a/tests/Application/app/Builders/ScopedSongBuilder.php
+++ b/tests/Application/app/Builders/ScopedSongBuilder.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Builders;
+
+use App\Models\ScopedSong;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Custom builder without @template parameters, mirroring Koel's SongBuilder shape.
+ *
+ * @extends Builder<ScopedSong>
+ */
+final class ScopedSongBuilder extends Builder {}

--- a/tests/Application/app/Models/Concerns/DeclaresQueryPseudoMethod.php
+++ b/tests/Application/app/Models/Concerns/DeclaresQueryPseudoMethod.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Concerns;
+
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Reproduces the trait-shaped trigger from Koel's SupportsDeleteWhereValueNotIn:
+ * a zero-param @method static pseudo for query() shadows a model's overriding
+ * signature unless the plugin removes the entry post-populator.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/795
+ *
+ * @method static Builder query()
+ */
+trait DeclaresQueryPseudoMethod {}

--- a/tests/Application/app/Models/Concerns/DeclaresQueryPseudoMethod.php
+++ b/tests/Application/app/Models/Concerns/DeclaresQueryPseudoMethod.php
@@ -9,10 +9,13 @@ use Illuminate\Database\Eloquent\Builder;
 /**
  * Reproduces the trait-shaped trigger from Koel's SupportsDeleteWhereValueNotIn:
  * a zero-param @method static pseudo for query() shadows a model's overriding
- * signature unless the plugin removes the entry post-populator.
+ * signature unless the plugin removes the entry post-populator. The trait also
+ * declares @method static Builder traitOnlyHelper() to guard the preservation
+ * path — pseudos without a real-method counterpart must not be dropped.
  *
  * @see https://github.com/psalm/psalm-plugin-laravel/issues/795
  *
  * @method static Builder query()
+ * @method static Builder traitOnlyHelper()
  */
 trait DeclaresQueryPseudoMethod {}

--- a/tests/Application/app/Models/ScopedSong.php
+++ b/tests/Application/app/Models/ScopedSong.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Builders\ScopedSongBuilder;
+use App\Models\Concerns\DeclaresQueryPseudoMethod;
+use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Mimics Koel's Song: a trait declares @method static Builder query(), and the model
+ * overrides query() with extra parameters + a custom builder via #[UseEloquentBuilder].
+ * The plugin must keep the override's signature authoritative so callers can pass
+ * those parameters.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/795
+ */
+#[UseEloquentBuilder(ScopedSongBuilder::class)]
+final class ScopedSong extends Model
+{
+    use DeclaresQueryPseudoMethod;
+
+    protected $table = 'scoped_songs';
+
+    #[\Override]
+    public static function query(?string $type = null, ?Admin $user = null): ScopedSongBuilder
+    {
+        /** @var ScopedSongBuilder */
+        return parent::query();
+    }
+}

--- a/tests/Type/tests/Builder/QueryOverrideTest.phpt
+++ b/tests/Type/tests/Builder/QueryOverrideTest.phpt
@@ -44,5 +44,17 @@ function test_query_override_no_args(): void
     $_result = ScopedSong::query();
     /** @psalm-check-type-exact $_result = ScopedSongBuilder */
 }
+
+/**
+ * Pseudos without a real-method counterpart must survive the shadow sweep.
+ * The trait declares `@method static Builder traitOnlyHelper()` which has no
+ * matching declaring_method_ids entry, so Psalm should still resolve the call
+ * via the pseudo rather than reporting UndefinedMagicMethod.
+ */
+function test_unshadowed_pseudo_preserved(): void
+{
+    $_result = ScopedSong::traitOnlyHelper();
+    /** @psalm-check-type-exact $_result = \Illuminate\Database\Eloquent\Builder */
+}
 ?>
 --EXPECT--

--- a/tests/Type/tests/Builder/QueryOverrideTest.phpt
+++ b/tests/Type/tests/Builder/QueryOverrideTest.phpt
@@ -1,0 +1,48 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Builders\ScopedSongBuilder;
+use App\Models\Admin;
+use App\Models\ScopedSong;
+
+/**
+ * Regression test for https://github.com/psalm/psalm-plugin-laravel/issues/795
+ *
+ * Traits that declare `@method static Builder query()` (e.g. Koel's
+ * SupportsDeleteWhereValueNotIn) inject a zero-param pseudo into every model
+ * that uses them. Before the fix, Psalm's static call analyzer validated
+ * argument lists against that pseudo rather than the overriding signature on
+ * the model, emitting TooManyArguments and InvalidNamedArgument for every
+ * call like `Song::query(type: $t, user: $u)`.
+ *
+ * ScopedSong mirrors the Koel shape exactly: custom builder via
+ * #[UseEloquentBuilder], trait with @method static Builder query(), and an
+ * overriding static query() with extra parameters.
+ *
+ * The fix drops shadowing pseudo_static_methods from Model subclasses during
+ * AfterCodebasePopulated, after the populator has merged trait pseudos into
+ * the model's storage.
+ */
+
+/** Overriding query() accepts named args without shadowing from the trait's pseudo. */
+function test_query_override_named_args(): void
+{
+    $_result = ScopedSong::query(type: 'song', user: new Admin());
+    /** @psalm-check-type-exact $_result = ScopedSongBuilder */
+}
+
+/** Same signature accepts positional args too. */
+function test_query_override_positional_args(): void
+{
+    $_result = ScopedSong::query('song', new Admin());
+    /** @psalm-check-type-exact $_result = ScopedSongBuilder */
+}
+
+/** Zero-arg call still works (all params optional). */
+function test_query_override_no_args(): void
+{
+    $_result = ScopedSong::query();
+    /** @psalm-check-type-exact $_result = ScopedSongBuilder */
+}
+?>
+--EXPECT--


### PR DESCRIPTION
## Summary

Laravel models can override `Model::query()` with additional parameters (e.g., Koel's `Song` narrows by `type` and `user`). Before this fix, Psalm would reject call sites with `TooManyArguments` and `InvalidNamedArgument` when the model also used a trait that declared `@method static Builder query()` (as Koel's `SupportsDeleteWhereValueNotIn` does).

**Root cause**: `Populator::populateDataFromTrait()` merges trait `pseudo_static_methods` into the model's storage after the scan phase. `AtomicStaticCallAnalyzer` checks `pseudo_static_methods` first for argument validation, so the trait's zero-param pseudo shadowed the model's real overriding signature. The old `ModelMethodHandler::afterClassLikeVisit` tried to unset the pseudo but ran too early (pre-populator), making it a no-op.

**Fix**: Move the removal into `ModelRegistrationHandler::registerHandlersForModel` (runs during `AfterCodebasePopulated`). Generalize from three hard-coded names to any pseudo whose key matches a real declaration in `declaring_method_ids`, which also covers `on()`, `onWriteConnection()`, `with()`, and other static helpers on `Model`.

Verified against Koel — all 15 occurrences of `TooManyArguments`/`InvalidNamedArgument` on `Song::query()` are gone.

## Changes

- `src/Handlers/Eloquent/ModelRegistrationHandler.php` — post-populator loop dropping shadowing pseudo_static_methods.
- `src/Handlers/Eloquent/ModelMethodHandler.php` — removed the dead `afterClassLikeVisit` hook (was a no-op).
- `tests/Application/app/Models/Concerns/DeclaresQueryPseudoMethod.php` — trait fixture with the `@method static Builder query()` trigger.
- `tests/Application/app/Models/ScopedSong.php` — model fixture mirroring Koel's shape: trait + `#[UseEloquentBuilder]` + overriding `query()`.
- `tests/Application/app/Builders/ScopedSongBuilder.php` — non-template custom builder (like Koel's `SongBuilder`).
- `tests/Type/tests/Builder/QueryOverrideTest.phpt` — regression test with named, positional, and zero-arg cases.

Fixes #795.