### PR TITLE
Add StatsHandler to report plugin-level counts under --stats

### DIFF
--- a/src/Handlers/Eloquent/ModelRegistrationHandler.php
+++ b/src/Handlers/Eloquent/ModelRegistrationHandler.php
@@ -98,8 +98,10 @@ final class ModelRegistrationHandler implements AfterCodebasePopulatedInterface
      *
      * @see \Psalm\Internal\Analyzer\ClassAnalyzer::getAnonymousClassName()
      * @psalm-pure
+     *
+     * @internal exposed for reuse by other plugin handlers (e.g. StatsHandler)
      */
-    private static function isSyntheticAnonymousClassName(string $fqcn, string $filePath): bool
+    public static function isSyntheticAnonymousClassName(string $fqcn, string $filePath): bool
     {
         if ($filePath === '') {
             return false;

--- a/src/Handlers/StatsHandler.php
+++ b/src/Handlers/StatsHandler.php
@@ -43,7 +43,7 @@ final class StatsHandler implements AfterAnalysisInterface
         $modelCount = self::countModels($codebase);
 
         $schema = SchemaStateProvider::getSchema();
-        $tables = $schema === null ? 'N/A' : (string) \count($schema->tables);
+        $tables = $schema instanceof \Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaAggregator ? (string) \count($schema->tables) : 'N/A';
 
         $progress->write("Laravel plugin stats:\n");
         $progress->write("  Models discovered: {$modelCount}\n");

--- a/src/Handlers/StatsHandler.php
+++ b/src/Handlers/StatsHandler.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers;
+
+use Illuminate\Database\Eloquent\Model;
+use Psalm\Codebase;
+use Psalm\LaravelPlugin\Handlers\Eloquent\ModelRegistrationHandler;
+use Psalm\LaravelPlugin\Providers\SchemaStateProvider;
+use Psalm\Plugin\EventHandler\AfterAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterAnalysisEvent;
+
+/**
+ * Emits plugin-related counts when Psalm runs with --stats.
+ *
+ * Psalm does not expose the --stats flag to plugins via Config/Codebase,
+ * so we sniff $_SERVER['argv'] directly.
+ *
+ * The AfterAnalysis hook dispatches from IssueBuffer::finish() before Psalm's
+ * own --stats block, so on a merged terminal the plugin stats appear after
+ * the issue list and just before the 'N errors found' separator.
+ *
+ * Output goes through Psalm's progress stream (typically STDERR). This keeps
+ * machine-readable stdout report output clean. Under --no-progress the
+ * underlying VoidProgress is a no-op, matching the user's intent to suppress
+ * progress-like output.
+ *
+ * @internal
+ */
+final class StatsHandler implements AfterAnalysisInterface
+{
+    #[\Override]
+    public static function afterAnalysis(AfterAnalysisEvent $event): void
+    {
+        if (!self::statsRequested()) {
+            return;
+        }
+
+        $codebase = $event->getCodebase();
+        $progress = $codebase->progress;
+
+        $modelCount = self::countModels($codebase);
+
+        $schema = SchemaStateProvider::getSchema();
+        $tables = $schema === null ? 'N/A' : (string) \count($schema->tables);
+
+        $progress->write("Laravel plugin stats:\n");
+        $progress->write("  Models discovered: {$modelCount}\n");
+        $progress->write("  Tables in schema: {$tables}\n");
+    }
+
+    /**
+     * Counts concrete Model subclasses using the same filter as
+     * {@see ModelRegistrationHandler::afterCodebasePopulated()} so the stat
+     * mirrors the set the plugin actually registers handlers for.
+     *
+     * The class_exists() gate from ModelRegistrationHandler is deliberately
+     * skipped here: init-time already warned on unloadable classes, and
+     * re-invoking the autoloader post-analysis would duplicate warnings.
+     * The small drift (unloadable Model subclasses are counted but not
+     * registered) is acceptable for a discovery metric.
+     *
+     * @psalm-external-mutation-free
+     */
+    private static function countModels(Codebase $codebase): int
+    {
+        $count = 0;
+        // parent_classes is keyed by lowercase FQN without a leading backslash
+        // (the same convention every other handler in this plugin relies on;
+        // see e.g. ModelRegistrationHandler, SuppressHandler).
+        $modelFqcn = \strtolower(Model::class);
+
+        foreach ($codebase->classlike_storage_provider::getAll() as $storage) {
+            if ($storage->abstract) {
+                continue;
+            }
+
+            if (!isset($storage->parent_classes[$modelFqcn])) {
+                continue;
+            }
+
+            if (
+                $storage->stmt_location !== null
+                && ModelRegistrationHandler::isSyntheticAnonymousClassName($storage->name, $storage->stmt_location->file_path)
+            ) {
+                continue;
+            }
+
+            $count++;
+        }
+
+        return $count;
+    }
+
+    /**
+     * Psalm's CLI defines --stats as a boolean long option (no `=value` form),
+     * so presence in argv is sufficient. Returns false for non-CLI invocations
+     * (language server, programmatic use) where argv is not set.
+     */
+    private static function statsRequested(): bool
+    {
+        $argv = $_SERVER['argv'] ?? null;
+
+        return \is_array($argv) && \in_array('--stats', $argv, true);
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -304,6 +304,9 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/SuppressHandler.php';
         $registration->registerHooksFromClass(Handlers\SuppressHandler::class);
 
+        require_once __DIR__ . '/Handlers/StatsHandler.php';
+        $registration->registerHooksFromClass(Handlers\StatsHandler::class);
+
         require_once __DIR__ . '/Handlers/Jobs/DispatchableHandler.php';
         $registration->registerHooksFromClass(Handlers\Jobs\DispatchableHandler::class);
 

--- a/tests/Unit/Handlers/StatsHandlerTest.php
+++ b/tests/Unit/Handlers/StatsHandlerTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psalm\LaravelPlugin\Handlers\StatsHandler;
-use ReflectionMethod;
 
 #[CoversClass(StatsHandler::class)]
 final class StatsHandlerTest extends TestCase
@@ -61,7 +60,7 @@ final class StatsHandlerTest extends TestCase
             $_SERVER['argv'] = $argv;
         }
 
-        $method = new ReflectionMethod(StatsHandler::class, 'statsRequested');
+        $method = new \ReflectionMethod(StatsHandler::class, 'statsRequested');
 
         $this->assertSame($expected, $method->invoke(null));
     }

--- a/tests/Unit/Handlers/StatsHandlerTest.php
+++ b/tests/Unit/Handlers/StatsHandlerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Handlers\StatsHandler;
+use ReflectionMethod;
+
+#[CoversClass(StatsHandler::class)]
+final class StatsHandlerTest extends TestCase
+{
+    // Typed `mixed` because $_SERVER['argv'] is not guaranteed to be an array —
+    // the test suite itself exercises non-array argv cases (via $this->argvProvider),
+    // and a previous test could leave a non-array value behind. A narrower type
+    // would TypeError in setUp() in that scenario.
+    private mixed $originalArgv = null;
+
+    private bool $argvWasSet = false;
+
+    protected function setUp(): void
+    {
+        $this->argvWasSet = \array_key_exists('argv', $_SERVER);
+        $this->originalArgv = $this->argvWasSet ? $_SERVER['argv'] : null;
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->argvWasSet) {
+            $_SERVER['argv'] = $this->originalArgv;
+        } else {
+            unset($_SERVER['argv']);
+        }
+    }
+
+    /** @return iterable<string, array{mixed, bool}> */
+    public static function argvProvider(): iterable
+    {
+        yield 'stats flag present' => [['psalm', '--stats'], true];
+        yield 'stats flag present among other flags' => [['psalm', '--no-cache', '--stats', '--threads=4'], true];
+        yield 'no stats flag' => [['psalm', '--no-cache'], false];
+        yield 'empty argv' => [[], false];
+        yield 'argv not set' => [null, false];
+        yield 'argv is non-array' => ['--stats', false];
+        // Psalm defines --stats as a boolean longopt with no `=value` form,
+        // so `--stats=1` is not a valid invocation and must not match.
+        yield 'stats with value is not a match' => [['psalm', '--stats=1'], false];
+    }
+
+    #[Test]
+    #[DataProvider('argvProvider')]
+    public function stats_requested_reflects_argv(mixed $argv, bool $expected): void
+    {
+        if ($argv === null) {
+            unset($_SERVER['argv']);
+        } else {
+            $_SERVER['argv'] = $argv;
+        }
+
+        $method = new ReflectionMethod(StatsHandler::class, 'statsRequested');
+
+        $this->assertSame($expected, $method->invoke(null));
+    }
+}


### PR DESCRIPTION
## Issue to Solve
Psalm exposes a `--stats` flag that prints a type-inference summary at the end of analysis, but the plugin itself has no way to surface Laravel-specific counts (models found, schema tables parsed) in that same output. Users running the plugin on large codebases have no built-in signal of how much Laravel surface it's actually modelling.

## Related
No linked issue.

## Solution Description
Adds `StatsHandler` (an `AfterAnalysisInterface` hook) that, when Psalm is invoked with `--stats`, emits two lines through the progress stream:

```
Laravel plugin stats:
  Models discovered: 6
  Tables in schema: 8
```

Implementation notes:

- `--stats` is not exposed to plugins via `Config` or `Codebase`, so the handler sniffs `$_SERVER['argv']` directly. Unit-tested against 7 argv permutations (flag present, flag among others, absent, empty, null, non-array, `--stats=1` rejected).
- Model count re-walks `classlike_storage_provider::getAll()` and applies the same filter as `ModelRegistrationHandler::afterCodebasePopulated` (non-abstract, `parent_classes[Model]`, synthetic-anonymous-class guard) so the stat mirrors the set the plugin actually registers handlers for. The `class_exists()` gate is intentionally skipped to avoid duplicate autoload warnings post-analysis.
- `ModelRegistrationHandler::isSyntheticAnonymousClassName` is promoted from `private` to `public static` (annotated `@internal`) so `StatsHandler` can reuse it without copy/paste drift.
- Table count comes from `SchemaStateProvider::getSchema()?->tables`; prints `N/A` when schema is null (covers migrations disabled, missing migrations dir, empty dir, aggregation failure). Plugin init already emits a `$progress->warning()` for the failure case, so users see both signals.
- Output goes through `$codebase->progress->write()` (typically STDERR, `VoidProgress` no-op under `--no-progress`). This keeps STDOUT clean for JSON / SARIF report consumers and respects user intent when they opt into quiet runs.
- `AfterAnalysis` dispatches from `IssueBuffer::finish()` before Psalm's own `--stats` block, so on a merged terminal the plugin stats appear right after the issue list and just before the `N errors found` separator.

Verification:

- Psalm self-analysis clean (100% type coverage).
- 538 unit tests pass (531 existing + 7 new).
- End-to-end verified via `./tests/Application/laravel-test.sh`, which already runs Psalm with `--stats`.

## Checklist
- [x] Tests cover the change (unit test in `tests/Unit/Handlers/StatsHandlerTest.php`)
