### PR TITLE
Extend rule-based taint escape to `FormRequest` input/string/str accessors

### DIFF
--- a/src/Handlers/Validation/ValidationTaintHandler.php
+++ b/src/Handlers/Validation/ValidationTaintHandler.php
@@ -118,11 +118,17 @@ final class ValidationTaintHandler implements AddTaintsInterface, RemoveTaintsIn
 
         $rules = ValidationRuleAnalyzer::getRulesForFormRequest($match['class']);
 
-        if ($rules === null || !isset($rules[$match['key']])) {
+        if ($rules === null) {
             return 0;
         }
 
-        return $rules[$match['key']]->removedTaints;
+        $rule = $rules[$match['key']] ?? null;
+
+        if ($rule === null) {
+            return 0;
+        }
+
+        return $rule->removedTaints;
     }
 
     /**

--- a/src/Handlers/Validation/ValidationTaintHandler.php
+++ b/src/Handlers/Validation/ValidationTaintHandler.php
@@ -118,11 +118,11 @@ final class ValidationTaintHandler implements AddTaintsInterface, RemoveTaintsIn
 
         $rules = ValidationRuleAnalyzer::getRulesForFormRequest($match['class']);
 
-        if ($rules === null) {
+        if ($rules === null || !isset($rules[$match['key']])) {
             return 0;
         }
 
-        return $rules[$match['key']]->removedTaints ?? 0;
+        return $rules[$match['key']]->removedTaints;
     }
 
     /**

--- a/src/Handlers/Validation/ValidationTaintHandler.php
+++ b/src/Handlers/Validation/ValidationTaintHandler.php
@@ -10,43 +10,91 @@ use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Plugin\EventHandler\AddTaintsInterface;
 use Psalm\Plugin\EventHandler\Event\AddRemoveTaintsEvent;
 use Psalm\Plugin\EventHandler\RemoveTaintsInterface;
+use Psalm\Type\Atomic\TGenericObject;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\TaintKind;
 use Psalm\Type\Union;
 
 /**
- * Manages taint for validated data from FormRequest and Request.
+ * Manages taint for validated data read from FormRequest, Request, and ValidatedInput.
  *
- * When a MethodReturnTypeProvider overrides the return type of validated() or validate(),
- * Psalm skips the stub's @psalm-taint-source annotation. This handler compensates by
- * explicitly adding taint (via AddTaintsInterface) and then selectively removing it
- * for fields with safe rules (via RemoveTaintsInterface).
+ * Two responsibilities, split across the two interfaces:
  *
- * Upstream workaround: https://github.com/vimeo/psalm/issues/11765
- * Remove this handler when Psalm calls taintMethodCallResult() even with a type provider.
+ * 1. Add taint where {@see ValidatedTypeHandler} narrows the return type.
+ *    A type-provider override causes Psalm to drop the stub's
+ *    @psalm-taint-source annotation, so we must re-introduce it.
+ *    Covers: FormRequest::validated()/safe()/validate(),
+ *            ValidatedInput::input('key').
  *
- * Handles:
- *   $request->validated('field')    — FormRequest, per-field add+remove
- *   $request->safe()                — FormRequest, add taint
- *   $request->validate([...])       — Request, add taint to return value
+ * 2. Remove taint per field when the declared validation rule constrains the
+ *    value in a way that makes it safe for a specific sink family
+ *    (e.g. 'email' rule → safe for 'header' and 'cookie').
+ *    Covers keyed accessors that read from the same data pool as validation:
+ *            FormRequest::validated/input/string/str('key'),
+ *            ValidatedInput::input/string/str('key').
+ *
+ * Design assumption: when a typed FormRequest is injected into a controller,
+ * Laravel runs validation before the controller method executes (via
+ * ValidatesWhenResolvedTrait). So any input/string/str read from that
+ * FormRequest carries a value that already passed rules() — the rule's taint
+ * escape applies even when the caller uses input() instead of validated().
+ *
+ * Caveat: the escape on input()/string()/str() assumes validation has run
+ * against the same data pool these accessors read. That assumption can break
+ * in a few (rare) scenarios:
+ *   - a subclass's passedValidation() calls $this->merge(...) with raw content
+ *     on a rule-covered key;
+ *   - a subclass overrides validationData() to validate a different source
+ *     (e.g. $this->json()->all()) than input() reads;
+ *   - input() is called before validation runs (e.g. inside prepareForValidation,
+ *     rules(), or authorize()) — the static analyzer cannot see call ordering;
+ *   - precognition mode strips rules from the live validator while the static
+ *     rules() still parses the full set.
+ * In all of these, validated() and safe()->input() still reflect the validated
+ * snapshot. Prefer them in security-sensitive paths.
+ *
+ * NOT handled here (deliberate):
+ *   - query(), post(), json(), cookie(), server(), header(), file():
+ *     these read from a specific transport rather than the validated merge,
+ *     so a rule on 'team_email' does not necessarily describe $req->query('team_email').
+ *   - integer/float/boolean/date/enum:
+ *     cast methods are not taint sources (see InteractsWithInput.stubphp).
+ *
+ * Upstream workaround for Psalm dropping the stub source on override:
+ *   https://github.com/vimeo/psalm/issues/11765
  *
  * Architecture follows {@see \Psalm\Internal\Provider\AddRemoveTaints\HtmlFunctionTainter}.
  *
- * Performance: fires on every expression. Bail-out chain rejects non-matching
- * expressions fast (instanceof checks first, then method name, then class type).
+ * Performance: fires on every expression. The bail-out chain rejects non-matching
+ * expressions fast (instanceof, then method name, then caller-class check).
  */
 final class ValidationTaintHandler implements AddTaintsInterface, RemoveTaintsInterface
 {
     /**
-     * Add taint to validated()/validate()/safe() calls.
+     * Accessor methods whose single-key form selects a rule-covered field.
      *
-     * This replaces the @psalm-taint-source annotation from stubs, which
-     * gets skipped when ValidatedTypeHandler provides a return type.
+     * Listed explicitly (not derived) so reviewers can audit the set.
+     */
+    private const KEYED_ACCESSOR_METHODS = ['validated', 'input', 'string', 'str'];
+
+    /**
+     * Add taint to validation method calls whose return type we narrow.
+     *
+     * Without this, the override in {@see ValidatedTypeHandler} would cause
+     * Psalm to silently drop the stub's @psalm-taint-source annotation,
+     * producing false negatives on sinks that consume the narrowed value.
      */
     #[\Override]
     public static function addTaints(AddRemoveTaintsEvent $event): int
     {
-        if (self::isValidationMethodCall($event) !== null) {
+        if (self::isValidationMethodCall($event)) {
+            return TaintKind::ALL_INPUT;
+        }
+
+        // ValidatedInput::input('key') also has its return type narrowed
+        // (see ValidatedTypeHandler::resolveValidatedInputMethod), so the
+        // stub source is dropped there as well.
+        if (self::isValidatedInputAccessor($event)) {
             return TaintKind::ALL_INPUT;
         }
 
@@ -54,81 +102,105 @@ final class ValidationTaintHandler implements AddTaintsInterface, RemoveTaintsIn
     }
 
     /**
-     * Remove taint from validated('field') calls where the field's validation
-     * rules guarantee safe content (e.g. integer, uuid, alpha_num).
-     *
-     * Only applies to FormRequest::validated('field') with a literal key —
-     * validate()/safe() return full arrays where per-field taint removal is not possible.
+     * Remove taint kinds that the declared rule guarantees cannot occur in
+     * the validated value. Applies to all keyed accessors in
+     * KEYED_ACCESSOR_METHODS whose caller resolves to either a FormRequest
+     * subclass or ValidatedInput<FormRequest>.
      */
     #[\Override]
     public static function removeTaints(AddRemoveTaintsEvent $event): int
     {
-        $expr = $event->getExpr();
+        $match = self::matchKeyedAccess($event);
 
-        if (!$expr instanceof MethodCall || !$expr->name instanceof Identifier) {
+        if ($match === null) {
             return 0;
         }
 
-        if ($expr->name->toLowerString() !== 'validated') {
+        $rules = ValidationRuleAnalyzer::getRulesForFormRequest($match['class']);
+
+        if ($rules === null) {
             return 0;
         }
 
-        $args = $expr->getArgs();
-
-        if ($args === []) {
-            return 0;
-        }
-
-        $statementsAnalyzer = $event->getStatementsSource();
-
-        if (!$statementsAnalyzer instanceof StatementsAnalyzer) {
-            return 0;
-        }
-
-        $firstArgType = $statementsAnalyzer->node_data->getType($args[0]->value);
-
-        if (!$firstArgType instanceof Union || !$firstArgType->isSingleStringLiteral()) {
-            return 0;
-        }
-
-        $fieldKey = $firstArgType->getSingleStringLiteral()->value;
-
-        $className = self::resolveCallerClass($event, \Illuminate\Foundation\Http\FormRequest::class);
-
-        if ($className === null) {
-            return 0;
-        }
-
-        $rules = ValidationRuleAnalyzer::getRulesForFormRequest($className);
-
-        if ($rules === null || !isset($rules[$fieldKey])) {
-            return 0;
-        }
-
-        return $rules[$fieldKey]->removedTaints;
+        return $rules[$match['key']]->removedTaints ?? 0;
     }
 
     /**
-     * Check if the expression is a validated()/validate()/safe() call on Request/FormRequest.
+     * Match a keyed accessor call and resolve the backing FormRequest class,
+     * whether the call is on the FormRequest itself or on ValidatedInput<FormRequest>.
      *
-     * @return 'validated'|'validate'|'safe'|null  The matched method name, or null
+     * @return array{class: class-string, key: string}|null
      */
-    private static function isValidationMethodCall(AddRemoveTaintsEvent $event): ?string
+    private static function matchKeyedAccess(AddRemoveTaintsEvent $event): ?array
     {
         $expr = $event->getExpr();
 
-        if (!$expr instanceof MethodCall) {
-            return null;
-        }
-
-        if (!$expr->name instanceof Identifier) {
+        if (!$expr instanceof MethodCall || !$expr->name instanceof Identifier) {
             return null;
         }
 
         $methodName = $expr->name->toLowerString();
 
-        if (!\in_array($methodName, ['validated', 'validate', 'safe'], true)) {
+        if (!\in_array($methodName, self::KEYED_ACCESSOR_METHODS, true)) {
             return null;
+        }
+
+        $args = $expr->getArgs();
+
+        if ($args === []) {
+            return null;
+        }
+
+        $statementsAnalyzer = $event->getStatementsSource();
+
+        if (!$statementsAnalyzer instanceof StatementsAnalyzer) {
+            return null;
+        }
+
+        $firstArgType = $statementsAnalyzer->node_data->getType($args[0]->value);
+
+        if (!$firstArgType instanceof Union || !$firstArgType->isSingleStringLiteral()) {
+            return null;
+        }
+
+        $fieldKey = $firstArgType->getSingleStringLiteral()->value;
+
+        // Direct FormRequest caller: $req->validated|input|string|str('key')
+        $formRequestClass = self::resolveCallerClass($event, \Illuminate\Foundation\Http\FormRequest::class);
+
+        if ($formRequestClass !== null) {
+            return ['class' => $formRequestClass, 'key' => $fieldKey];
+        }
+
+        // ValidatedInput<FormRequest> caller: $req->safe()->input|string|str('key').
+        // validated() does not exist on ValidatedInput, so this branch applies
+        // only to input/string/str.
+        if ($methodName !== 'validated') {
+            $formRequestClass = self::extractFormRequestFromValidatedInput($event);
+
+            if ($formRequestClass !== null) {
+                return ['class' => $formRequestClass, 'key' => $fieldKey];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Whether the expression is validated()/validate()/safe() on Request/FormRequest.
+     */
+    private static function isValidationMethodCall(AddRemoveTaintsEvent $event): bool
+    {
+        $expr = $event->getExpr();
+
+        if (!$expr instanceof MethodCall || !$expr->name instanceof Identifier) {
+            return false;
+        }
+
+        $methodName = $expr->name->toLowerString();
+
+        if (!\in_array($methodName, ['validated', 'validate', 'safe'], true)) {
+            return false;
         }
 
         // validated() and safe() are FormRequest methods, validate() is on Request
@@ -136,8 +208,95 @@ final class ValidationTaintHandler implements AddTaintsInterface, RemoveTaintsIn
             ? \Illuminate\Foundation\Http\FormRequest::class
             : \Illuminate\Http\Request::class;
 
-        if (self::resolveCallerClass($event, $baseClass) !== null) {
-            return $methodName;
+        return self::resolveCallerClass($event, $baseClass) !== null;
+    }
+
+    /**
+     * Check for ValidatedInput::input(…) — any first argument, literal or not.
+     *
+     * addTaints compensates for the type-provider override; the per-field
+     * rule lookup in removeTaints additionally requires a literal key.
+     */
+    private static function isValidatedInputAccessor(AddRemoveTaintsEvent $event): bool
+    {
+        $expr = $event->getExpr();
+
+        if (!$expr instanceof MethodCall || !$expr->name instanceof Identifier) {
+            return false;
+        }
+
+        if ($expr->name->toLowerString() !== 'input') {
+            return false;
+        }
+
+        if ($expr->getArgs() === []) {
+            return false;
+        }
+
+        return self::extractFormRequestFromValidatedInput($event) !== null;
+    }
+
+    /**
+     * Extract the FormRequest class from a ValidatedInput<FormRequest> caller type.
+     *
+     * The template parameter is populated when FormRequest::safe() returns
+     * ValidatedInput<static> — so every safe() on a typed FormRequest is resolvable.
+     *
+     * @return class-string|null
+     */
+    private static function extractFormRequestFromValidatedInput(AddRemoveTaintsEvent $event): ?string
+    {
+        $expr = $event->getExpr();
+
+        if (!$expr instanceof MethodCall) {
+            return null;
+        }
+
+        $statementsAnalyzer = $event->getStatementsSource();
+
+        if (!$statementsAnalyzer instanceof StatementsAnalyzer) {
+            return null;
+        }
+
+        $callerType = $statementsAnalyzer->node_data->getType($expr->var);
+
+        if (!$callerType instanceof Union) {
+            return null;
+        }
+
+        $codebase = $event->getCodebase();
+
+        foreach ($callerType->getAtomicTypes() as $atomic) {
+            if (!$atomic instanceof TGenericObject) {
+                continue;
+            }
+
+            if ($atomic->value !== \Illuminate\Support\ValidatedInput::class) {
+                continue;
+            }
+
+            if (!isset($atomic->type_params[0])) {
+                continue;
+            }
+
+            foreach ($atomic->type_params[0]->getAtomicTypes() as $paramAtomic) {
+                if (!$paramAtomic instanceof TNamedObject) {
+                    continue;
+                }
+
+                /** @var class-string $className */
+                $className = $paramAtomic->value;
+
+                try {
+                    if ($className === \Illuminate\Foundation\Http\FormRequest::class
+                        || $codebase->classExtends($className, \Illuminate\Foundation\Http\FormRequest::class)
+                    ) {
+                        return $className;
+                    }
+                } catch (\Psalm\Exception\UnpopulatedClasslikeException|\InvalidArgumentException) {
+                    continue;
+                }
+            }
         }
 
         return null;
@@ -146,8 +305,8 @@ final class ValidationTaintHandler implements AddTaintsInterface, RemoveTaintsIn
     /**
      * Resolve a class from the method call's caller type that matches or extends the given base class.
      *
-     * Shared by addTaints (via isValidationMethodCall) and removeTaints to avoid
-     * duplicating the classExtends resolution logic.
+     * Shared by addTaints (via isValidationMethodCall) and matchKeyedAccess
+     * to avoid duplicating the classExtends resolution logic.
      *
      * @param class-string $baseClass
      * @return class-string|null

--- a/src/Handlers/Validation/ValidationTaintHandler.php
+++ b/src/Handlers/Validation/ValidationTaintHandler.php
@@ -58,7 +58,7 @@ use Psalm\Type\Union;
  *     these read from a specific transport rather than the validated merge,
  *     so a rule on 'team_email' does not necessarily describe $req->query('team_email').
  *   - integer/float/boolean/date/enum:
- *     cast methods are not taint sources (see InteractsWithInput.stubphp).
+ *     cast methods are not taint sources (see InteractsWithData.stubphp).
  *
  * Upstream workaround for Psalm dropping the stub source on override:
  *   https://github.com/vimeo/psalm/issues/11765
@@ -154,6 +154,14 @@ final class ValidationTaintHandler implements AddTaintsInterface, RemoveTaintsIn
         $args = $expr->getArgs();
 
         if ($args === []) {
+            return null;
+        }
+
+        // A default argument (input('key', $default)) can carry its own taint.
+        // The rule for 'key' describes the validated value, not the default,
+        // so applying the rule's escape would wrongly clean taint that comes
+        // from the default expression. Bail out — taint is preserved.
+        if (isset($args[1])) {
             return null;
         }
 

--- a/stubs/common/Http/Concerns/InteractsWithInput.stubphp
+++ b/stubs/common/Http/Concerns/InteractsWithInput.stubphp
@@ -132,28 +132,6 @@ trait InteractsWithInput
     public function bearerToken() {}
 
     /**
-     * Retrieve input from the request as a Stringable instance.
-     *
-     * @param  string  $key
-     * @param  mixed  $default
-     * @return \Illuminate\Support\Stringable
-     *
-     * @psalm-taint-source input
-     */
-    public function str($key, $default = null) {}
-
-    /**
-     * Retrieve input from the request as a Stringable instance.
-     *
-     * @param  string  $key
-     * @param  mixed  $default
-     * @return \Illuminate\Support\Stringable
-     *
-     * @psalm-taint-source input
-     */
-    public function string($key, $default = null) {}
-
-    /**
      * Retrieve input from the request as a Fluent object instance.
      *
      * @param  array|string|null  $key
@@ -164,72 +142,9 @@ trait InteractsWithInput
      */
     public function fluent($key = null, array $default = []) {}
 
-    /**
-     * Retrieve input as an integer value.
-     *
-     * Not a taint source: (int) cast cannot produce an injection payload.
-     * e.g. (int) "1; DROP TABLE users" → 1
-     *
-     * @param  string  $key
-     * @param  int  $default
-     * @return int
-     */
-    public function integer($key, $default = 0) {}
-
-    /**
-     * Retrieve input as a float value.
-     *
-     * Not a taint source: (float) cast cannot produce an injection payload.
-     * e.g. (float) "<script>alert(1)</script>" → 0.0
-     *
-     * @param  string  $key
-     * @param  float  $default
-     * @return float
-     */
-    public function float($key, $default = 0.0) {}
-
-    /**
-     * Retrieve input from the request as a boolean value.
-     *
-     * Returns strict true/false via filter_var(FILTER_VALIDATE_BOOLEAN).
-     * Not a taint source: a boolean cannot carry injectable content.
-     *
-     * @param  string|null  $key
-     * @param  bool  $default
-     * @return bool
-     */
-    public function boolean($key = null, $default = false) {}
-
-    /**
-     * Retrieve input from the request as a Carbon instance.
-     *
-     * Not a taint source: Date::parse()/createFromFormat() validates input
-     * into a structured Carbon object. The string representation is a
-     * formatted date, not raw user input.
-     *
-     * @param  string  $key
-     * @param  string|null  $format
-     * @param  \UnitEnum|string|null  $tz
-     * @return \Illuminate\Support\Carbon|null
-     */
-    public function date($key, $format = null, $tz = null) {}
-
-    /**
-     * Retrieve input from the request as an enum.
-     *
-     * Not a taint source: BackedEnum::tryFrom() is a strict whitelist —
-     * the return value can only be one of the developer-defined enum cases
-     * (or the $default).
-     *
-     * @template TEnum of \BackedEnum
-     * @template TDefault of TEnum|null
-     *
-     * @param  string  $key
-     * @param  class-string<TEnum>  $enumClass
-     * @param  TDefault  $default
-     * @return TEnum|TDefault
-     */
-    public function enum($key, $enumClass, $default = null) {}
+    // Note: str(), string(), integer(), float(), boolean(), clamp(), date(),
+    // enum(), enums(), array() live on Illuminate\Support\Traits\InteractsWithData
+    // in Laravel 11+ (stubbed at stubs/common/Support/Traits/InteractsWithData.stubphp).
 
     /**
      * Get a subset containing the provided keys with values from the input data.

--- a/stubs/common/Support/Traits/InteractsWithData.stubphp
+++ b/stubs/common/Support/Traits/InteractsWithData.stubphp
@@ -5,6 +5,110 @@ namespace Illuminate\Support\Traits;
 trait InteractsWithData
 {
     /**
+     * Retrieve data from the instance as a Stringable instance.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return \Illuminate\Support\Stringable
+     *
+     * @psalm-taint-source input
+     */
+    public function str($key, $default = null) {}
+
+    /**
+     * Retrieve data from the instance as a Stringable instance.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return \Illuminate\Support\Stringable
+     *
+     * @psalm-taint-source input
+     */
+    public function string($key, $default = null) {}
+
+    /**
+     * Retrieve data as an integer value.
+     *
+     * Not a taint source: (int) cast cannot produce an injection payload.
+     * e.g. (int) "1; DROP TABLE users" → 1
+     *
+     * @param  string  $key
+     * @param  int  $default
+     * @return int
+     */
+    public function integer($key, $default = 0) {}
+
+    /**
+     * Retrieve data as a float value.
+     *
+     * Not a taint source: (float) cast cannot produce an injection payload.
+     * e.g. (float) "<script>alert(1)</script>" → 0.0
+     *
+     * @param  string  $key
+     * @param  float  $default
+     * @return float
+     */
+    public function float($key, $default = 0.0) {}
+
+    /**
+     * Retrieve data from the instance as a boolean value.
+     *
+     * Returns strict true/false via filter_var(FILTER_VALIDATE_BOOLEAN).
+     * Not a taint source: a boolean cannot carry injectable content.
+     *
+     * @param  string|null  $key
+     * @param  bool  $default
+     * @return bool
+     */
+    public function boolean($key = null, $default = false) {}
+
+    /**
+     * Retrieve data clamped between min and max values.
+     *
+     * Not a taint source: returns a numeric value constrained by min()
+     * and max(). Like integer()/float(), a number cannot carry an
+     * injection payload.
+     *
+     * @param  string  $key
+     * @param  int|float  $min
+     * @param  int|float  $max
+     * @param  int|float  $default
+     * @return int|float
+     */
+    public function clamp($key, $min, $max, $default = 0) {}
+
+    /**
+     * Retrieve data from the instance as a Carbon instance.
+     *
+     * Not a taint source: Date::parse()/createFromFormat() validates input
+     * into a structured Carbon object. The string representation is a
+     * formatted date, not raw user input.
+     *
+     * @param  string  $key
+     * @param  string|null  $format
+     * @param  \UnitEnum|string|null  $tz
+     * @return \Illuminate\Support\Carbon|null
+     */
+    public function date($key, $format = null, $tz = null) {}
+
+    /**
+     * Retrieve data from the instance as an enum.
+     *
+     * Not a taint source: BackedEnum::tryFrom() is a strict whitelist —
+     * the return value can only be one of the developer-defined enum cases
+     * (or the $default).
+     *
+     * @template TEnum of \BackedEnum
+     * @template TDefault of TEnum|null
+     *
+     * @param  string  $key
+     * @param  class-string<TEnum>  $enumClass
+     * @param  TDefault  $default
+     * @return TEnum|TDefault
+     */
+    public function enum($key, $enumClass, $default = null) {}
+
+    /**
      * Retrieve data from the instance as an array of enums.
      *
      * Not a taint source: BackedEnum::tryFrom() is a strict whitelist.
@@ -27,19 +131,4 @@ trait InteractsWithData
      * @psalm-taint-source input
      */
     public function array($key = null) {}
-
-    /**
-     * Retrieve data clamped between min and max values.
-     *
-     * Not a taint source: returns a numeric value constrained by min()
-     * and max(). Like integer()/float(), a number cannot carry an
-     * injection payload.
-     *
-     * @param  string  $key
-     * @param  int|float  $min
-     * @param  int|float  $max
-     * @param  int|float  $default
-     * @return int|float
-     */
-    public function clamp($key, $min, $max, $default = 0) {}
 }

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestInputIntegerNoTaint.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestInputIntegerNoTaint.phpt
@@ -1,0 +1,32 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Regression guard: $req->input('key') on a typed FormRequest goes through
+ * the direct-FormRequest resolution path (distinct from safe()->input()).
+ * With 'integer' rule the escape clears all input taint.
+ *
+ * The MixedArgument suppression is for the echo — input() returns mixed.
+ * The asserted behavior is taint: when the rule is 'integer', no Tainted*
+ * error must fire even though echo is an html/quotes sink.
+ */
+final class DirectInputAgeRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['age' => 'required|integer'];
+    }
+}
+
+function render(DirectInputAgeRequest $request): void {
+    /** @psalm-suppress MixedArgument */
+    echo $request->input('age');
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestIntegerNoTaint.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestIntegerNoTaint.phpt
@@ -1,0 +1,27 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * string('age') with 'integer' rule removes all input taint —
+ * an integer value cannot carry an injection payload. Escape applies
+ * to FormRequest accessor methods, not just validated().
+ */
+final class InputAgeRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['age' => 'required|integer'];
+    }
+}
+
+function render(InputAgeRequest $request): void {
+    echo $request->string('age');
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestStrIntegerNoTaint.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestStrIntegerNoTaint.phpt
@@ -1,0 +1,26 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Regression guard: str() (alias of string()) participates in KEYED_ACCESSOR_METHODS.
+ * With 'integer' rule the escape clears all input taint.
+ */
+final class StrIntegerRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['age' => 'required|integer'];
+    }
+}
+
+function render(StrIntegerRequest $request): void {
+    echo $request->str('age');
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestStringEmailNoTaintedHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestStringEmailNoTaintedHeader.phpt
@@ -1,0 +1,28 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Rule-based escape extends beyond validated() to safe()->input().
+ * The 'email' rule escapes header/cookie taint kinds, so redirect()->to()
+ * only fires TaintedSSRF — TaintedHeader is suppressed.
+ */
+final class EmailContactRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['team_email' => 'required|email'];
+    }
+}
+
+function direct(EmailContactRequest $request): \Illuminate\Http\RedirectResponse {
+    return redirect()->to($request->safe()->input('team_email'));
+}
+?>
+--EXPECTF--
+%ATaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeInputViaSafeAccessorIntegerNoTaint.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInputViaSafeAccessorIntegerNoTaint.phpt
@@ -1,0 +1,29 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * safe()->input('age') respects the rule-based taint escape the same as
+ * validated('age'): ValidatedInput<TRequest> carries the FormRequest class
+ * in its generic parameter. The 'integer' rule escapes all input taint.
+ */
+final class SafeInputAgeRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['age' => 'required|integer'];
+    }
+}
+
+function render(SafeInputAgeRequest $request): void {
+    // input('age') is narrowed to int|numeric-string by ValidatedTypeHandler,
+    // so no MixedArgument — the echo is straight int/string.
+    echo $request->safe()->input('age');
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestString.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestString.phpt
@@ -1,0 +1,33 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Positive: string('body') with 'string' rule retains HTML taint.
+ * The 'string' rule only constrains the value to be a string — arbitrary
+ * content can still carry an injection payload, so no taint kind is escaped.
+ *
+ * Regression guard for the stub-location fix: proves taint actually flows
+ * from InteractsWithData::string() through to the echo sink (complements
+ * SafeFormRequestIntegerNoTaint.phpt, which asserts the 'integer' rule escape).
+ */
+final class BodyStringRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['body' => 'required|string'];
+    }
+}
+
+function render(BodyStringRequest $request): void {
+    echo $request->string('body');
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlInputWithTaintedDefault.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlInputWithTaintedDefault.phpt
@@ -1,0 +1,34 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Negative: input('key', $default) with a default expression must NOT apply
+ * the rule's escape. The rule describes the validated value; the default is
+ * an independent expression that can carry its own taint.
+ *
+ * Here 'age' is constrained to integer (would normally escape ALL_INPUT), but
+ * the tainted $default comes from an unvalidated source ('fallback'), so the
+ * echo sink must still fire TaintedHtml.
+ */
+final class InputWithDefaultRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['age' => 'required|integer'];
+    }
+}
+
+function render(InputWithDefaultRequest $request): void {
+    /** @psalm-suppress MixedArgument */
+    echo $request->input('age', $request->input('fallback'));
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSafeInput.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSafeInput.phpt
@@ -8,11 +8,9 @@ namespace App\Http\Requests;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
- * Known limitation: safe()->input('body') does not propagate taint.
- * The ValidatedTypeHandler provides a return type for input(), which causes
- * Psalm to skip the stub's @psalm-taint-source annotation on ValidatedInput::input().
- * Same root cause as the validated() variable assignment limitation.
- * TODO: if https://github.com/vimeo/psalm/issues/11765 is fixed, this test should expect TaintedHtml.
+ * safe()->input('body') — rule is 'string', so no per-kind taint is escaped.
+ * ValidationTaintHandler compensates for the type-provider override by re-adding
+ * the taint source, so the echo sink still fires.
  */
 class SafeRequest extends FormRequest
 {
@@ -23,7 +21,9 @@ class SafeRequest extends FormRequest
 }
 
 function renderSafeInput(SafeRequest $request): void {
-    echo $request->safe()->input('body'); // No taint reported — known limitation
+    echo $request->safe()->input('body');
 }
 ?>
 --EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes


### PR DESCRIPTION
## Summary

Before this PR, rule-based taint escape only applied to `$req->validated('key')`. After this PR, it also applies to the accessor methods that read from the same data pool as validation:

- `$req->input('key')`, `->string('key')`, `->str('key')` on a `FormRequest`.
- `$req->safe()->input('key')`, `->string('key')`, `->str('key')` on `ValidatedInput<TRequest of FormRequest>`.

Motivation: when a typed `FormRequest` is injected into a controller, `$req->input('team_email')` returns the same validated content as `$req->validated('team_email')`. Having different taint semantics between the two forces users to rewrite code for the analyzer rather than for clarity.

## Behavior changes

- `safe()->input('key')` previously lost its taint entirely (because `ValidatedTypeHandler` narrows the return type, which drops the stub's `@psalm-taint-source`). This PR re-introduces the source via `addTaints`, then applies the rule-based escape. The previously-documented "known limitation" test (`TaintedHtmlSafeInput.phpt`) is flipped from expecting zero taint to expecting the correct `TaintedHtml` on a `string` rule.
- `input/string/str('key')` on a `FormRequest` with a rule-matched key now escape the same taint kinds that `validated('key')` does.

## What is NOT covered

- `query/post/json/cookie/server/header/file` — these read a specific transport that validation does not necessarily cover.
- `integer/float/boolean/date/enum` — already not taint sources.
- The upstream limitation on variable-assigned expressions (vimeo/psalm#11765) is unchanged. `validated()` via variable remains silent, per the existing `TaintedHtmlValidatedStringViaVariable.phpt` lock-in.

## Caveat documented in the handler

The escape assumes validation ran against the same pool the accessor reads. This can fail to hold if a subclass overrides `passedValidation()` + `merge(...)`, overrides `validationData()`, runs in precognition mode, or calls `input()` before validation (inside `prepareForValidation`, `rules()`, `authorize()`). In those cases `validated()` / `safe()->input()` still reflect the validated snapshot, so prefer those for security-sensitive paths. The class docblock lists all of these.

## Related

- Follows up on PR #819.
- Files vimeo/psalm#11820 for a separate docs/suppression-UX issue discovered during review (`@psalm-suppress TaintedHeader` silently does nothing; only `TaintedInput` works).

## Test coverage

- `SafeFormRequestIntegerNoTaint.phpt`: `string('age')` with integer rule → no taint.
- `SafeFormRequestStringEmailNoTaintedHeader.phpt`: `safe()->input('team_email')` with email rule → `TaintedSSRF` only (header escaped).
- `SafeInputViaSafeAccessorIntegerNoTaint.phpt`: `safe()->input('age')` with integer rule → no taint.
- `TaintedHtmlSafeInput.phpt`: flipped to expect `TaintedHtml` now that taint propagates through `safe()->input('body')`.