### PR TITLE
Relocate `only`/`except`/`collect`/`old` to correct traits

### DIFF
--- a/stubs/common/Http/Concerns/InteractsWithFlashData.stubphp
+++ b/stubs/common/Http/Concerns/InteractsWithFlashData.stubphp
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Http\Concerns;
+
+trait InteractsWithFlashData
+{
+    /**
+     * Retrieve old input for the given key.
+     *
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @return ($key is null ? array<string, mixed> : mixed)
+     *
+     * @psalm-taint-source input
+     */
+    public function old($key = null, $default = null) {}
+}

--- a/stubs/common/Http/Concerns/InteractsWithInput.stubphp
+++ b/stubs/common/Http/Concerns/InteractsWithInput.stubphp
@@ -17,16 +17,6 @@ trait InteractsWithInput
     public function input($key = null, $default = null) {}
 
     /**
-     * Retrieve input from the request as a collection.
-     *
-     * @param  string[]|string|null  $key
-     * @return \Illuminate\Support\Collection
-     *
-     * @psalm-taint-source input
-     */
-    public function collect($key = null) {}
-
-    /**
      * Get all of the input and files for the request.
      *
      * @param  string[]|string|null  $keys
@@ -143,34 +133,9 @@ trait InteractsWithInput
     public function fluent($key = null, array $default = []) {}
 
     // Note: str(), string(), integer(), float(), boolean(), clamp(), date(),
-    // enum(), enums(), array() live on Illuminate\Support\Traits\InteractsWithData
-    // in Laravel 11+ (stubbed at stubs/common/Support/Traits/InteractsWithData.stubphp).
-
-    /**
-     * Get a subset containing the provided keys with values from the input data.
-     *
-     * Accepts an array of keys or variadic string arguments via func_get_args().
-     *
-     * @param  string[]|string  $keys
-     * @return array
-     *
-     * @psalm-taint-source input
-     * @psalm-variadic
-     */
-    public function only($keys) {}
-
-    /**
-     * Get all of the input except for a specified array of items.
-     *
-     * Accepts an array of keys or variadic string arguments via func_get_args().
-     *
-     * @param  string[]|string  $keys
-     * @return array
-     *
-     * @psalm-taint-source input
-     * @psalm-variadic
-     */
-    public function except($keys) {}
+    // enum(), enums(), array(), collect(), only(), except() live on
+    // Illuminate\Support\Traits\InteractsWithData in Laravel 11+
+    // (stubbed at stubs/common/Support/Traits/InteractsWithData.stubphp).
 
     /**
      * Dump the request input as a debug helper.

--- a/stubs/common/Http/Concerns/InteractsWithInput.stubphp
+++ b/stubs/common/Http/Concerns/InteractsWithInput.stubphp
@@ -136,6 +136,9 @@ trait InteractsWithInput
     // enum(), enums(), array(), collect(), only(), except() live on
     // Illuminate\Support\Traits\InteractsWithData in Laravel 11+
     // (stubbed at stubs/common/Support/Traits/InteractsWithData.stubphp).
+    //
+    // Note: old() lives on Illuminate\Http\Concerns\InteractsWithFlashData
+    // (stubbed at stubs/common/Http/Concerns/InteractsWithFlashData.stubphp).
 
     /**
      * Dump the request input as a debug helper.
@@ -149,15 +152,4 @@ trait InteractsWithInput
      * @psalm-variadic
      */
     public function dump($keys = []) {}
-
-    /**
-     * Retrieve old input for the given key.
-     *
-     * @param  string|null  $key
-     * @param  mixed  $default
-     * @return ($key is null ? array<string, mixed> : mixed)
-     *
-     * @psalm-taint-source input
-     */
-    public function old($key = null, $default = null) {}
 }

--- a/stubs/common/Support/Traits/InteractsWithData.stubphp
+++ b/stubs/common/Support/Traits/InteractsWithData.stubphp
@@ -131,4 +131,34 @@ trait InteractsWithData
      * @psalm-taint-source input
      */
     public function array($key = null) {}
+
+    /**
+     * Retrieve data from the instance as a collection.
+     *
+     * @param  array|string|null  $key
+     * @return \Illuminate\Support\Collection
+     *
+     * @psalm-taint-source input
+     */
+    public function collect($key = null) {}
+
+    /**
+     * Get a subset containing the provided keys with values from the instance data.
+     *
+     * @param  string[]|string  $keys
+     * @return array
+     *
+     * @psalm-taint-source input
+     */
+    public function only($keys) {}
+
+    /**
+     * Get all of the data except for a specified array of items.
+     *
+     * @param  string[]|string  $keys
+     * @return array
+     *
+     * @psalm-taint-source input
+     */
+    public function except($keys) {}
 }

--- a/stubs/common/Support/Traits/InteractsWithData.stubphp
+++ b/stubs/common/Support/Traits/InteractsWithData.stubphp
@@ -145,20 +145,26 @@ trait InteractsWithData
     /**
      * Get a subset containing the provided keys with values from the instance data.
      *
+     * Accepts an array of keys, a single key, or variadic string keys via func_get_args().
+     *
      * @param  string[]|string  $keys
      * @return array
      *
      * @psalm-taint-source input
+     * @psalm-variadic
      */
     public function only($keys) {}
 
     /**
      * Get all of the data except for a specified array of items.
      *
+     * Accepts an array of keys, a single key, or variadic string keys via func_get_args().
+     *
      * @param  string[]|string  $keys
      * @return array
      *
      * @psalm-taint-source input
+     * @psalm-variadic
      */
     public function except($keys) {}
 }

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestOnly.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestOnly.phpt
@@ -1,0 +1,34 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Positive: FormRequest::only() returns tainted input.
+ *
+ * Regression guard for the trait-composition chain on FormRequest:
+ * FormRequest extends Request, Request uses InteractsWithInput,
+ * InteractsWithInput uses InteractsWithData (where the stub lives after #823).
+ * If any link in that chain breaks, the echo below stops firing TaintedHtml.
+ */
+final class OnlyAccessorRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['body' => 'required|string'];
+    }
+}
+
+function render(OnlyAccessorRequest $request): void {
+    $data = $request->only(['body']);
+
+    echo $data['body'];
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestCollect.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestCollect.phpt
@@ -1,0 +1,18 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Positive: Request::collect() returns a Collection wrapping tainted input.
+ *
+ * Regression guard for the stub-location fix (#823): collect() lives on
+ * Illuminate\Support\Traits\InteractsWithData in Laravel 11+.
+ */
+function renderCollectRequestData(\Illuminate\Http\Request $request): void {
+    echo json_encode($request->collect('name'));
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestCollect.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestCollect.phpt
@@ -10,7 +10,7 @@
  * Illuminate\Support\Traits\InteractsWithData in Laravel 11+.
  */
 function renderCollectRequestData(\Illuminate\Http\Request $request): void {
-    echo json_encode($request->collect('name'));
+    echo $request->collect('name')->first();
 }
 ?>
 --EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestExcept.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestExcept.phpt
@@ -1,0 +1,20 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Positive: Request::except() returns a tainted array of the remaining input.
+ *
+ * Regression guard for the stub-location fix (#823): except() lives on
+ * Illuminate\Support\Traits\InteractsWithData in Laravel 11+.
+ */
+function renderExceptRequestData(\Illuminate\Http\Request $request): void {
+    $data = $request->except(['password']);
+
+    echo $data['name'];
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestOld.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestOld.phpt
@@ -1,0 +1,19 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Positive: Request::old() returns tainted flash-session input.
+ *
+ * Regression guard for the stub-location fix (#824): old() lives on
+ * Illuminate\Http\Concerns\InteractsWithFlashData, not on
+ * Illuminate\Http\Concerns\InteractsWithInput where the stub used to live.
+ */
+function renderOldRequestData(\Illuminate\Http\Request $request): void {
+    echo $request->old('name');
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestOnly.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestOnly.phpt
@@ -1,0 +1,22 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Positive: Request::only() returns a tainted array of input values.
+ *
+ * Regression guard for the stub-location fix (#823): only() lives on
+ * Illuminate\Support\Traits\InteractsWithData in Laravel 11+, not on
+ * Illuminate\Http\Concerns\InteractsWithInput. If the @psalm-taint-source
+ * annotation ends up on the wrong trait, this test stops firing.
+ */
+function renderOnlyRequestData(\Illuminate\Http\Request $request): void {
+    $data = $request->only(['name']);
+
+    echo $data['name'];
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes


### PR DESCRIPTION
## Summary

Closes #823 and #824.

Four input methods were stubbed on `Illuminate\Http\Concerns\InteractsWithInput` but in Laravel 11+ they actually live on other traits, so Psalm silently dropped their `@psalm-taint-source input` annotations at resolve time. As a result, `$req->only([...])`, `$req->except([...])`, `$req->collect('key')`, and `$req->old('key')` produced no taint on their return values.

Same bug class as #821, which already fixed `str`/`string`/`integer`/`float`/`boolean`/`clamp`/`date`/`enum`/`enums`/`array`.

## What changed

### Stub relocations

* `collect`, `only`, `except` moved from `stubs/common/Http/Concerns/InteractsWithInput.stubphp` to `stubs/common/Support/Traits/InteractsWithData.stubphp`.
* `old` moved from `stubs/common/Http/Concerns/InteractsWithInput.stubphp` to the new `stubs/common/Http/Concerns/InteractsWithFlashData.stubphp`.
* Two `// Note:` comment blocks at the old location point to the new homes, matching the convention from #821.

### Incidental fixes, all in the spirit of the PR

* `collect()`'s `@param $key` aligned to `array|string|null` (matches sibling `array()` and Laravel source).
* `@psalm-variadic` added to `only()` / `except()` on `InteractsWithData`. Laravel accepts `$req->only('a', 'b', 'c')` via `func_get_args()`; without the annotation Psalm reported `TooManyArguments` on 3+ arg calls. Follows the precedent in #806.

### Tests

Positive taint tests in `tests/Type/tests/TaintAnalysis/` asserting `TaintedHtml` / `TaintedTextWithQuotes` fire when input flows from these methods into an echo sink:

* `TaintedHtmlRequestOnly.phpt`
* `TaintedHtmlRequestExcept.phpt`
* `TaintedHtmlRequestCollect.phpt`
* `TaintedHtmlRequestOld.phpt`
* `TaintedHtmlFormRequestOnly.phpt` (extra guard for the `FormRequest → Request → InteractsWithInput → InteractsWithData` trait-composition chain, mirrors `TaintedHtmlFormRequestString.phpt` from #821)

## Behaviour callout (release notes)

User-visible. Downstream codebases that use any of `only()`, `except()`, `collect()`, `old()` on `Request` / `FormRequest` and pipe the result into HTML, SQL, shell, or other sinks will now surface taint findings they previously missed. Existing Psalm baselines should absorb the new findings, or triage case by case.

## Out of scope

The rule-based taint escape from #821 (`KEYED_ACCESSOR_METHODS`) still covers only `validated/input/string/str`. Extending it to `only/except/collect/old` is a separate follow-up.