### PR TITLE
Honour class-level `@psalm-taint-escape` on custom Rule classes

### DIFF
--- a/docs/contributing/taint-analysis.md
+++ b/docs/contributing/taint-analysis.md
@@ -292,7 +292,7 @@ This differs from **escape functions** like `e()`, where `@psalm-taint-specializ
 
 The plugin already escapes taint for built-in rules used as strings (e.g. `'email'` escapes `header` and `cookie`). Application code can extend that escape to **custom Rule classes** by placing `@psalm-taint-escape <kind>` on the class docblock.
 
-When `ValidationRuleAnalyzer` encounters a Rule object in a `rules()` array, it resolves the class FQN, reads the class's own `@psalm-taint-escape` tags, and OR's those kinds into the field's removed-taints bitmask alongside any string rule escapes.
+When `ValidationRuleAnalyzer` encounters a Rule object in a `rules()` array, it resolves the class FQN, reads the class's own `@psalm-taint-escape` tags, and ORs those kinds into the field's removed-taints bitmask alongside any string rule escapes.
 
 ```php
 use Closure;

--- a/docs/contributing/taint-analysis.md
+++ b/docs/contributing/taint-analysis.md
@@ -288,6 +288,56 @@ public static function of($string) {}
 
 This differs from **escape functions** like `e()`, where `@psalm-taint-specialize` is not needed because the escape annotation removes the dangerous taint kind regardless of call site. Pure flow-through functions (no escape/unescape) must always pair `@psalm-taint-specialize` with `@psalm-flow`.
 
+## Per-rule escape on custom Rule classes
+
+The plugin already escapes taint for built-in rules used as strings (e.g. `'email'` escapes `header` and `cookie`). Application code can extend that escape to **custom Rule classes** by placing `@psalm-taint-escape <kind>` on the class docblock.
+
+When `ValidationRuleAnalyzer` encounters a Rule object in a `rules()` array, it resolves the class FQN, reads the class's own `@psalm-taint-escape` tags, and OR's those kinds into the field's removed-taints bitmask alongside any string rule escapes.
+
+```php
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Validation\Rule;
+
+/**
+ * @psalm-taint-escape header
+ * @psalm-taint-escape cookie
+ */
+final class EmailWithDnsRule implements ValidationRule
+{
+    public static function make(): self
+    {
+        return new self();
+    }
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        (Rule::email()->preventSpoofing()->rfcCompliant(strict: true))
+            ->validate($attribute, $value, $fail);
+    }
+}
+
+// ['required', new EmailWithDnsRule()]      : escape unioned in.
+// ['required', EmailWithDnsRule::make()]    : same (static factory accepted, see caveat below).
+// ['required', 'email', new EmailWithDnsRule()] : email's escape unioned with class's escape.
+```
+
+**What is honoured:**
+
+- Only `@psalm-taint-escape` at class level. `@psalm-taint-source`, `@psalm-taint-sink`, and `@psalm-flow` are ignored on a class (they have no meaning outside a function-like scope).
+- The bare form (`@psalm-taint-escape header`). The conditional form (`@psalm-taint-escape (...)`) is parameter-scoped and ignored on a class.
+- Any `TaintKind` name from the [All available kinds](#all-available-kinds) table (including `input` as a shortcut for all input taints).
+- Rule objects constructed via `new X()` or a static factory `X::method(...)`. Dynamic class names (`new $class()`) and runtime-built rule arrays are out of scope, matching the parser limits elsewhere in `ValidationRuleAnalyzer`.
+- **The annotation is read from the class that appears literally in `rules()`.** Subclassing an annotated rule does NOT inherit its escape. Re-declare the annotation on the subclass if you need it. This keeps the taint contract explicit and reviewable from the Rule class alone.
+
+**Static factory caveat.** For `X::make(...)` the plugin reads the docblock of `X`, not of whatever object the method returns. This is sound for the common user-authored pattern (`public static function make(): static { return new static(); }`) but NOT for Laravel's own builder `Rule::email()`, which returns a different class. Built-in Laravel rule semantics are already handled by the string-rule path (`'email'`), so the mismatch has no practical effect.
+
+**Base class agnostic.** The handler reads the docblock on whatever class you instantiate. Any of `Illuminate\Contracts\Validation\ValidationRule`, `Illuminate\Contracts\Validation\InvokableRule`, or the deprecated `Illuminate\Contracts\Validation\Rule` works. Custom base classes or community packages (e.g. Spatie's `CompositeRule`) work as well, since no `instanceof` check is performed.
+
+**No `@psalm-flow` needed.** Unlike function-level escapes, the class-level annotation does not live on a return value: it applies to the Rule's contribution to a single validated field. The "always pair with `@psalm-flow`" rule does not apply here.
+
+**Trust model.** The plugin trusts the developer's assertion, just like any `@psalm-taint-escape`. A mis-annotated rule becomes a **false negative**: the escape removes taint kinds the value still actually carries. Only annotate kinds the rule genuinely prevents, and prefer narrow escapes (such as `header`, `cookie`) over the broad `input` alias unless the rule truly constrains the value to a digit-like or date-like form.
+
 ## Stub authoring checklist
 
 1. **Verify the function's actual behavior** against Laravel source in `vendor/laravel/framework/`

--- a/src/Handlers/Validation/ValidationRuleAnalyzer.php
+++ b/src/Handlers/Validation/ValidationRuleAnalyzer.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Psalm\LaravelPlugin\Handlers\Validation;
 
 use PhpParser\Node;
+use Psalm\DocComment;
+use Psalm\Exception\DocblockParseException;
 use Psalm\Internal\Analyzer\ProjectAnalyzer;
 use Psalm\Type;
 use Psalm\Type\Atomic\TArray;
@@ -29,8 +31,25 @@ use Psalm\Type\Union;
  */
 final class ValidationRuleAnalyzer
 {
+    /**
+     * Synthetic segment prefix used by extractRulePairsFromArrayNode to encode
+     * a custom Rule object (e.g. `new EmailWithDnsRule()` or `X::make(...)`)
+     * as a string segment consumable by resolveRuleSegments. Rule names in
+     * Laravel cannot contain a colon followed by a backslash-separated FQN,
+     * so there is no collision risk with real rule names.
+     */
+    private const CLASS_SEGMENT_PREFIX = 'class:';
+
     /** @var array<string, array<string, ResolvedRule>|null> */
     private static array $cache = [];
+
+    /**
+     * Per-class cache of the OR-ed `@psalm-taint-escape` bitmask read from a
+     * Rule class's own docblock. Keyed by lowercase FQN.
+     *
+     * @var array<string, int>
+     */
+    private static array $classTaintCache = [];
 
     /**
      * Get resolved rules for a FormRequest subclass by reading its rules() method from AST.
@@ -102,6 +121,17 @@ final class ValidationRuleAnalyzer
             $segment = \trim($segment);
 
             if ($segment === '') {
+                continue;
+            }
+
+            // Synthetic segment for a custom Rule object. Contributes only to
+            // the taint escape bitmask — the rule's runtime behavior (type,
+            // nullable, required) is opaque to the plugin.
+            if (\str_starts_with($segment, self::CLASS_SEGMENT_PREFIX)) {
+                $removedTaints |= self::classRuleRemovedTaints(
+                    \substr($segment, \strlen(self::CLASS_SEGMENT_PREFIX)),
+                );
+
                 continue;
             }
 
@@ -651,8 +681,10 @@ final class ValidationRuleAnalyzer
      *   'field' => 'required|string'       → ['field' => ['required', 'string']]
      *   'field' => ['required', 'string']  → ['field' => ['required', 'string']]
      *
+     * Not `@psalm-mutation-free` because resolving a Rule object's class name
+     * reads `resolvedName` attributes via PhpParser's impure `getAttribute()`.
+     *
      * @return array<string, list<string>>|null
-     * @psalm-mutation-free
      */
     private static function extractRulePairsFromArrayNode(Node\Expr\Array_ $array): ?array
     {
@@ -686,9 +718,18 @@ final class ValidationRuleAnalyzer
                         continue;
                     }
 
-                    // Only handle string literal rule segments (skip Rule objects)
                     if ($ruleItem->value instanceof Node\Scalar\String_) {
                         $segments[] = $ruleItem->value->value;
+
+                        continue;
+                    }
+
+                    // Custom Rule object — capture the class FQN so resolveRuleSegments
+                    // can OR the class's own @psalm-taint-escape bits into removedTaints.
+                    $ruleClassFqn = self::resolveRuleObjectClassName($ruleItem->value);
+
+                    if ($ruleClassFqn !== null) {
+                        $segments[] = self::CLASS_SEGMENT_PREFIX . $ruleClassFqn;
                     }
                 }
 
@@ -699,9 +740,170 @@ final class ValidationRuleAnalyzer
                 continue;
             }
 
-            // Value is a variable, function call, or Rule object — cannot resolve statically
+            // Value is a variable, function call, or unsupported Rule expression — cannot resolve statically
         }
 
         return $rules !== [] ? $rules : null;
+    }
+
+    /**
+     * Resolve the class FQN of a Rule object expression in a rules() array.
+     *
+     * Recognises two patterns (matching the issue's scope — #822):
+     *   - `new App\Rules\X()` → `App\Rules\X`
+     *   - `App\Rules\X::make(...)` (or any other static factory) → `App\Rules\X`
+     *
+     * For static calls we read the docblock of the **named** class (the left
+     * side of `::`), not of whatever class the method actually returns. This
+     * is sound when `X::make()` returns `new self()` / `new static()` — the
+     * common user-authored factory pattern. It is unsound for Laravel's own
+     * fluent factories like `Rule::email()` which return `Illuminate\Validation\Rules\Email`
+     * rather than `Rule`; that's acceptable because built-in rule escape
+     * behaviour is handled by the string-rule path in {@see ruleToRemovedTaints()}.
+     * Dynamic (`new $class()`) or chained expressions are out of scope, matching
+     * the parser limits elsewhere in {@see extractRulePairsFromArrayNode()}.
+     */
+    private static function resolveRuleObjectClassName(Node\Expr $expr): ?string
+    {
+        if ($expr instanceof Node\Expr\New_ && $expr->class instanceof Node\Name) {
+            /** @var mixed $resolved */
+            $resolved = $expr->class->getAttribute('resolvedName');
+
+            return \is_string($resolved) ? $resolved : null;
+        }
+
+        if ($expr instanceof Node\Expr\StaticCall && $expr->class instanceof Node\Name) {
+            /** @var mixed $resolved */
+            $resolved = $expr->class->getAttribute('resolvedName');
+
+            return \is_string($resolved) ? $resolved : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Read `@psalm-taint-escape <kind>` annotations from a Rule class's own
+     * docblock and return the OR-ed bitmask of TaintKind bits they cover.
+     *
+     * Psalm stores `removed_taints` on FunctionLikeStorage only — class-level
+     * escapes are not part of ClassLikeStorage — so we parse the class's raw
+     * docblock here. Only the bare form (`@psalm-taint-escape header`) is
+     * honoured; the conditional form (`@psalm-taint-escape (...)`) is ignored
+     * because it is defined per-parameter and has no meaning at class scope.
+     *
+     * Unknown kinds map to 0 and are silently dropped. Unlike Psalm's own
+     * `Codebase::getOrRegisterTaint()` (used in FunctionLikeDocblockScanner),
+     * which registers unfamiliar names as custom taint kinds, this lookup
+     * honours only the built-in `TaintKind::TAINT_NAMES` set. A mistyped kind
+     * (e.g. `heder` instead of `header`) contributes no escape, which is a
+     * false-negative direction — double-check spellings against the kind
+     * table in `docs/contributing/taint-analysis.md`.
+     *
+     * The FQN is treated as an opaque string — if the class does not exist in
+     * the codebase, the storage lookup below fails and we return 0.
+     */
+    private static function classRuleRemovedTaints(string $classFqn): int
+    {
+        $cacheKey = \strtolower($classFqn);
+
+        if (\array_key_exists($cacheKey, self::$classTaintCache)) {
+            return self::$classTaintCache[$cacheKey];
+        }
+
+        try {
+            $codebase = ProjectAnalyzer::getInstance()->getCodebase();
+        } catch (\RuntimeException|\Error) {
+            return self::$classTaintCache[$cacheKey] = 0;
+        }
+
+        try {
+            $storage = $codebase->classlike_storage_provider->get($cacheKey);
+        } catch (\InvalidArgumentException) {
+            return self::$classTaintCache[$cacheKey] = 0;
+        }
+
+        $filePath = $storage->location?->file_path;
+
+        if ($filePath === null) {
+            return self::$classTaintCache[$cacheKey] = 0;
+        }
+
+        try {
+            $statements = $codebase->getStatementsForFile($filePath);
+        } catch (\InvalidArgumentException|\UnexpectedValueException) {
+            return self::$classTaintCache[$cacheKey] = 0;
+        }
+
+        $classNode = self::findClassNode($statements, $storage->name);
+
+        if ($classNode === null) {
+            return self::$classTaintCache[$cacheKey] = 0;
+        }
+
+        $docComment = $classNode->getDocComment();
+
+        if ($docComment === null) {
+            return self::$classTaintCache[$cacheKey] = 0;
+        }
+
+        try {
+            $parsed = DocComment::parsePreservingLength($docComment, true);
+        } catch (DocblockParseException) {
+            return self::$classTaintCache[$cacheKey] = 0;
+        }
+
+        $escapeTags = $parsed->tags['psalm-taint-escape'] ?? [];
+
+        $bits = 0;
+
+        foreach ($escapeTags as $tagLine) {
+            $kind = \trim($tagLine);
+
+            if ($kind === '' || $kind[0] === '(') {
+                // Conditional form is parameter-scoped; has no meaning on a class.
+                continue;
+            }
+
+            // Psalm's parser keeps only the first whitespace-separated token.
+            $kind = \explode(' ', $kind)[0];
+
+            $bits |= TaintKind::TAINT_NAMES[$kind] ?? 0;
+        }
+
+        return self::$classTaintCache[$cacheKey] = $bits;
+    }
+
+    /**
+     * Locate the class AST node for a known FQN inside the given file's statements.
+     *
+     * @param list<Node\Stmt> $statements
+     * @psalm-mutation-free
+     */
+    private static function findClassNode(array $statements, string $className): ?Node\Stmt\Class_
+    {
+        foreach ($statements as $stmt) {
+            if ($stmt instanceof Node\Stmt\Namespace_) {
+                $namespaceName = $stmt->name?->toString() ?? '';
+
+                foreach ($stmt->stmts as $nsStmt) {
+                    if ($nsStmt instanceof Node\Stmt\Class_
+                        && self::classNameMatches($nsStmt, $className, $namespaceName)
+                    ) {
+                        return $nsStmt;
+                    }
+                }
+
+                continue;
+            }
+
+            if ($stmt instanceof Node\Stmt\Class_
+                && self::classNameMatches($stmt, $className, '')
+            ) {
+                return $stmt;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Handlers/Validation/ValidationRuleAnalyzer.php
+++ b/src/Handlers/Validation/ValidationRuleAnalyzer.php
@@ -766,12 +766,14 @@ final class ValidationRuleAnalyzer
     private static function resolveRuleObjectClassName(Node\Expr $expr): ?string
     {
         if ($expr instanceof Node\Expr\New_ && $expr->class instanceof Node\Name) {
+            /** @var string|null $resolved */
             $resolved = $expr->class->getAttribute('resolvedName');
 
             return \is_string($resolved) ? $resolved : null;
         }
 
         if ($expr instanceof Node\Expr\StaticCall && $expr->class instanceof Node\Name) {
+            /** @var string|null $resolved */
             $resolved = $expr->class->getAttribute('resolvedName');
 
             return \is_string($resolved) ? $resolved : null;

--- a/src/Handlers/Validation/ValidationRuleAnalyzer.php
+++ b/src/Handlers/Validation/ValidationRuleAnalyzer.php
@@ -766,14 +766,12 @@ final class ValidationRuleAnalyzer
     private static function resolveRuleObjectClassName(Node\Expr $expr): ?string
     {
         if ($expr instanceof Node\Expr\New_ && $expr->class instanceof Node\Name) {
-            /** @var mixed $resolved */
             $resolved = $expr->class->getAttribute('resolvedName');
 
             return \is_string($resolved) ? $resolved : null;
         }
 
         if ($expr instanceof Node\Expr\StaticCall && $expr->class instanceof Node\Name) {
-            /** @var mixed $resolved */
             $resolved = $expr->class->getAttribute('resolvedName');
 
             return \is_string($resolved) ? $resolved : null;
@@ -837,13 +835,13 @@ final class ValidationRuleAnalyzer
 
         $classNode = self::findClassNode($statements, $storage->name);
 
-        if ($classNode === null) {
+        if (!$classNode instanceof \PhpParser\Node\Stmt\Class_) {
             return self::$classTaintCache[$cacheKey] = 0;
         }
 
         $docComment = $classNode->getDocComment();
 
-        if ($docComment === null) {
+        if (!$docComment instanceof \PhpParser\Comment\Doc) {
             return self::$classTaintCache[$cacheKey] = 0;
         }
 

--- a/src/Handlers/Validation/ValidationRuleAnalyzer.php
+++ b/src/Handlers/Validation/ValidationRuleAnalyzer.php
@@ -796,9 +796,10 @@ final class ValidationRuleAnalyzer
      * `Codebase::getOrRegisterTaint()` (used in FunctionLikeDocblockScanner),
      * which registers unfamiliar names as custom taint kinds, this lookup
      * honours only the built-in `TaintKind::TAINT_NAMES` set. A mistyped kind
-     * (e.g. `heder` instead of `header`) contributes no escape, which is a
-     * false-negative direction — double-check spellings against the kind
-     * table in `docs/contributing/taint-analysis.md`.
+     * (e.g. `heder` instead of `header`) contributes no escape and therefore
+     * leaves taint intact, which produces extra reports (the false-positive
+     * direction) — double-check spellings against the kind table in
+     * `docs/contributing/taint-analysis.md`.
      *
      * The FQN is treated as an opaque string — if the class does not exist in
      * the codebase, the storage lookup below fails and we return 0.

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestCustomRuleEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestCustomRuleEscapesHeader.phpt
@@ -1,0 +1,42 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Custom Rule class with a class-level @psalm-taint-escape. When used via
+ * `new DnsEmailRule()` in a rules() array, the class-level escape is
+ * OR-ed into the field's removedTaints, so redirect()->to() only fires
+ * TaintedSSRF — TaintedHeader is suppressed.
+ *
+ * The 'string' rule pins the type (so Redirector::to() doesn't see `mixed`)
+ * but removes no taint, isolating the escape to the class-level annotation.
+ *
+ * @psalm-taint-escape header
+ * @psalm-taint-escape cookie
+ */
+final class DnsEmailRule implements ValidationRule
+{
+    #[\Override]
+    public function validate(string $attribute, mixed $value, \Closure $fail): void {}
+}
+
+final class ContactRequestNew extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['team_email' => ['required', 'string', new DnsEmailRule()]];
+    }
+}
+
+function direct(ContactRequestNew $request): \Illuminate\Http\RedirectResponse {
+    return redirect()->to($request->safe()->input('team_email'));
+}
+?>
+--EXPECTF--
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestCustomRuleInputAliasEscapesAll.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestCustomRuleInputAliasEscapesAll.phpt
@@ -1,0 +1,37 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * The `input` alias in TaintKind::TAINT_NAMES maps to ALL_INPUT. A class-level
+ * `@psalm-taint-escape input` must cover every input-family taint kind,
+ * including `html` — so echoing the validated value into HTML is safe.
+ *
+ * @psalm-taint-escape input
+ */
+final class AllInputRule implements ValidationRule
+{
+    #[\Override]
+    public function validate(string $attribute, mixed $value, \Closure $fail): void {}
+}
+
+final class AllInputRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['field' => ['required', 'string', new AllInputRule()]];
+    }
+}
+
+function render(AllInputRequest $request): void {
+    echo $request->string('field');
+}
+?>
+--EXPECTF--
+

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestCustomRuleStaticFactoryEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestCustomRuleStaticFactoryEscapesHeader.phpt
@@ -1,0 +1,44 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Same as SafeFormRequestCustomRuleEscapesHeader, but built via a static
+ * factory `FactoryDnsEmailRule::make()` instead of `new`. The class-level
+ * @psalm-taint-escape still applies — the synthetic `class:...` segment is
+ * captured from StaticCall nodes too.
+ *
+ * @psalm-taint-escape header
+ * @psalm-taint-escape cookie
+ */
+final class FactoryDnsEmailRule implements ValidationRule
+{
+    public static function make(): self
+    {
+        return new self();
+    }
+
+    #[\Override]
+    public function validate(string $attribute, mixed $value, \Closure $fail): void {}
+}
+
+final class ContactRequestFactory extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['team_email' => ['required', 'string', FactoryDnsEmailRule::make()]];
+    }
+}
+
+function direct(ContactRequestFactory $request): \Illuminate\Http\RedirectResponse {
+    return redirect()->to($request->safe()->input('team_email'));
+}
+?>
+--EXPECTF--
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestCustomRuleConditionalIgnored.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestCustomRuleConditionalIgnored.phpt
@@ -1,0 +1,44 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Behavior contract: the conditional form of @psalm-taint-escape (e.g.
+ * `(header)`) is parameter-scoped and has no meaning on a class. This rule
+ * must contribute zero escape bits, so HTML taint from the validated value
+ * still flows through the echo sink.
+ *
+ * Note: this locks in observable behavior, not a specific code branch — the
+ * `$kind[0] === '('` early-continue and the `TAINT_NAMES[$kind] ?? 0`
+ * fallback both produce the same outcome here, and the test doesn't
+ * distinguish between them.
+ *
+ * @psalm-taint-escape (header)
+ */
+final class ConditionalEscapeRule implements ValidationRule
+{
+    #[\Override]
+    public function validate(string $attribute, mixed $value, \Closure $fail): void {}
+}
+
+final class ConditionalRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['field' => ['required', 'string', new ConditionalEscapeRule()]];
+    }
+}
+
+function render(ConditionalRequest $request): void {
+    echo $request->string('field');
+}
+?>
+--EXPECTF--
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestCustomRulePreservesHtml.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestCustomRulePreservesHtml.phpt
@@ -1,0 +1,39 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * The class-level @psalm-taint-escape only escapes the kinds declared.
+ * Echoing the value into HTML must still report TaintedHtml — escaping
+ * `header`/`cookie` does not imply safety for other sinks.
+ *
+ * @psalm-taint-escape header
+ * @psalm-taint-escape cookie
+ */
+final class PartialEscapeRule implements ValidationRule
+{
+    #[\Override]
+    public function validate(string $attribute, mixed $value, \Closure $fail): void {}
+}
+
+final class ContactRequestHtml extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['team_email' => ['required', 'string', new PartialEscapeRule()]];
+    }
+}
+
+function render(ContactRequestHtml $request): void {
+    echo $request->string('team_email');
+}
+?>
+--EXPECTF--
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Unit/Handlers/Validation/ValidationRuleAnalyzerTest.php
+++ b/tests/Unit/Handlers/Validation/ValidationRuleAnalyzerTest.php
@@ -414,4 +414,36 @@ final class ValidationRuleAnalyzerTest extends TestCase
 
         $this->assertSame('string', $rule->type->getId());
     }
+
+    // --- Custom Rule class segments (#822) ---
+
+    #[Test]
+    public function class_segment_for_unknown_class_removes_no_taint(): void
+    {
+        // Without a Psalm analysis context, the class storage lookup in
+        // classRuleRemovedTaints fails and the segment contributes 0. The
+        // segment must still be tolerated (no crash) and must not affect
+        // the type or presence flags derived from the other segments.
+        $rule = ValidationRuleAnalyzer::resolveRuleSegments(
+            ['required', 'string', 'class:App\\Rules\\NonExistent'],
+        );
+
+        $this->assertSame('string', $rule->type->getId());
+        $this->assertSame(0, $rule->removedTaints);
+        $this->assertTrue($rule->required);
+    }
+
+    #[Test]
+    public function class_segment_is_not_a_type_bearing_rule(): void
+    {
+        // A `class:` segment alone never narrows the type — the handler
+        // cannot introspect the Rule's runtime output, only its declared
+        // taint escape set.
+        $rule = ValidationRuleAnalyzer::resolveRuleSegments(
+            ['class:App\\Rules\\NonExistent'],
+        );
+
+        $this->assertTrue($rule->type->isMixed());
+        $this->assertFalse($rule->required);
+    }
 }


### PR DESCRIPTION
## Issue to Solve

Custom Rule objects in FormRequest `rules()` arrays (e.g. `new EmailWithDnsRule()`) were skipped by `ValidationRuleAnalyzer::extractRulePairsFromArrayNode()` (only string literals were recognised), so fields validated by a project's own rule classes did not benefit from rule-based taint escape — even when the developer knew exactly which taint kinds the rule prevents.

## Related

Fixes #822.
Follows up on #819 and #821.

## Solution Description

When a `rules()` array contains a custom Rule object (via `new X()` or `X::make(...)`), `ValidationRuleAnalyzer` now resolves the class FQN, reads the class's own `@psalm-taint-escape` tags, and unions those kinds into the field's removed-taints bitmask alongside any string rule escapes:

```php
/**
 * @psalm-taint-escape header
 * @psalm-taint-escape cookie
 */
final class EmailWithDnsRule implements ValidationRule { ... }

// In the FormRequest:
return ['team_email' => ['required', 'string', new EmailWithDnsRule()]];

// redirect()->to($request->safe()->input('team_email')) now reports
// TaintedSSRF only; TaintedHeader is suppressed.
```

Implementation notes:

- A synthetic `class:<FQN>` rule segment funnels object-form rules through the existing `resolveRuleSegments()` pipeline. The FQN comes from `Node\Name::getAttribute('resolvedName')`.
- `classRuleRemovedTaints()` loads `ClassLikeStorage`, reads the class node's raw docblock, parses it via `Psalm\DocComment::parsePreservingLength`, and maps each `@psalm-taint-escape` kind through `TaintKind::TAINT_NAMES`.
- A per-class cache keyed by lowercase FQN keeps the hot path (per-expression taint dispatch in `ValidationTaintHandler`) off the AST walk.
- Only `@psalm-taint-escape` at class level is honoured. The conditional form `(kind)` is parameter-scoped and ignored. Annotations are NOT inherited from parents; re-declare on subclasses if needed.
- For `X::make(...)` the plugin reads the docblock of `X` itself, not the method's return type. Sound for the common user-authored `new static()` pattern; irrelevant for Laravel's builder `Rule::email()` since built-in rule semantics are already covered by the string-rule path.

### Tests

- **5 new PHPT tests** in `tests/Type/tests/TaintAnalysis/`:
  - `SafeFormRequestCustomRuleEscapesHeader.phpt` — `new X()` pattern, TaintedSSRF only.
  - `SafeFormRequestCustomRuleStaticFactoryEscapesHeader.phpt` — `X::make()` pattern.
  - `SafeFormRequestCustomRuleInputAliasEscapesAll.phpt` — `@psalm-taint-escape input` alias escapes HTML too.
  - `TaintedHtmlFormRequestCustomRulePreservesHtml.phpt` — only declared kinds are escaped, HTML taint still flows.
  - `TaintedHtmlFormRequestCustomRuleConditionalIgnored.phpt` — conditional form contributes zero bits.
- **2 new unit tests** in `ValidationRuleAnalyzerTest` covering the `class:` segment fallback (unknown class, not-type-bearing).

### Docs

New "Per-rule escape on custom Rule classes" section in `docs/contributing/taint-analysis.md` covering scope, the static-factory caveat, no-inheritance semantics, the absence of `@psalm-flow` pairing at class level, and the trust model (mis-annotation produces a false negative).

## Checklist

- [x] Tests cover the change (5 PHPT + 2 unit tests)
- [x] Documentation is updated
