### PR TITLE
Extend taint escape to first-party `Rule` objects and `Rule::*()` builders

### DIFF
--- a/docs/contributing/taint-analysis.md
+++ b/docs/contributing/taint-analysis.md
@@ -288,9 +288,28 @@ public static function of($string) {}
 
 This differs from **escape functions** like `e()`, where `@psalm-taint-specialize` is not needed because the escape annotation removes the dangerous taint kind regardless of call site. Pure flow-through functions (no escape/unescape) must always pair `@psalm-taint-specialize` with `@psalm-flow`.
 
-## Per-rule escape on custom Rule classes
+## Per-rule escape on Rule objects
 
-The plugin already escapes taint for built-in rules used as strings (e.g. `'email'` escapes `header` and `cookie`). Application code can extend that escape to **custom Rule classes** by placing `@psalm-taint-escape <kind>` on the class docblock.
+The plugin already escapes taint for built-in rules used as strings (e.g. `'email'` escapes `header` and `cookie`). The escape also applies when the same rule is expressed as a first-party Laravel rule object, and can be extended to application-defined Rule classes.
+
+### Built-in Laravel rule classes
+
+`Illuminate\Validation\Rules\*` objects and the matching `Illuminate\Validation\Rule::*()` fluent builders are recognised automatically, with escape bits that mirror the string-rule equivalents:
+
+| Usage | Escape |
+|---|---|
+| `new Rules\Email()`, `Rule::email()` | `header`, `cookie` |
+| `new Rules\Numeric()`, `Rule::numeric()` | all input |
+| `new Rules\In([...])`, `Rule::in([...])` | all input |
+| `new Rules\Date()`, `Rule::date()` | all input |
+
+Chained fluent calls (including the nullsafe form `?->`) resolve to the root class, so `Rule::email()->preventSpoofing()->rfcCompliant(strict: true)` still escapes `header` and `cookie`.
+
+Other `Rule::*()` methods (`unique`, `exists`, `dimensions`, `when`, `notIn`, `file`, `imageFile`, `enum`, …) contribute no taint escape, because the value either depends on runtime arguments (e.g. the column passed to `Rule::unique`) or is not bounded to a safe character set. The field still surfaces in the validator's inferred shape, so type narrowing on `validated()` continues to apply.
+
+### Custom Rule classes
+
+Application code can extend the escape to **custom Rule classes** by placing `@psalm-taint-escape <kind>` on the class docblock.
 
 When `ValidationRuleAnalyzer` encounters a Rule object in a `rules()` array, it resolves the class FQN, reads the class's own `@psalm-taint-escape` tags, and ORs those kinds into the field's removed-taints bitmask alongside any string rule escapes.
 
@@ -330,7 +349,7 @@ final class EmailWithDnsRule implements ValidationRule
 - Rule objects constructed via `new X()` or a static factory `X::method(...)`. Dynamic class names (`new $class()`) and runtime-built rule arrays are out of scope, matching the parser limits elsewhere in `ValidationRuleAnalyzer`.
 - **The annotation is read from the class that appears literally in `rules()`.** Subclassing an annotated rule does NOT inherit its escape. Re-declare the annotation on the subclass if you need it. This keeps the taint contract explicit and reviewable from the Rule class alone.
 
-**Static factory caveat.** For `X::make(...)` the plugin reads the docblock of `X`, not of whatever object the method returns. This is sound for the common user-authored pattern (`public static function make(): static { return new static(); }`) but NOT for Laravel's own builder `Rule::email()`, which returns a different class. Built-in Laravel rule semantics are already handled by the string-rule path (`'email'`), so the mismatch has no practical effect.
+**Static factory caveat.** For an application `X::make(...)` the plugin reads the docblock of `X`, not of whatever object the method returns. This is sound for the common user-authored pattern (`public static function make(): static { return new static(); }`) where `X` and the returned class coincide. Laravel's own `Rule::*()` fluent builders do not match this heuristic (they return a different class), so they are handled via the dedicated method map described above rather than by reading `Rule`'s docblock.
 
 **Base class agnostic.** The handler reads the docblock on whatever class you instantiate. Any of `Illuminate\Contracts\Validation\ValidationRule`, `Illuminate\Contracts\Validation\InvokableRule`, or the deprecated `Illuminate\Contracts\Validation\Rule` works. Custom base classes or community packages (e.g. Spatie's `CompositeRule`) work as well, since no `instanceof` check is performed.
 

--- a/src/Handlers/Validation/ValidationRuleAnalyzer.php
+++ b/src/Handlers/Validation/ValidationRuleAnalyzer.php
@@ -40,6 +40,68 @@ final class ValidationRuleAnalyzer
      */
     private const CLASS_SEGMENT_PREFIX = 'class:';
 
+    /**
+     * Authoritative taint-escape table for first-party Laravel rule classes
+     * whose object form carries the same safety guarantees as their string-rule
+     * equivalent in {@see ruleToRemovedTaints()}. Consulted before any class
+     * docblock lookup — Laravel's own Rule classes do not and should not carry
+     * `@psalm-taint-escape` annotations.
+     *
+     * Keys are lowercase FQNs (matching {@see classRuleRemovedTaints()}'s
+     * cache-key convention). Any class not listed here falls through to the
+     * user-authored docblock path and contributes 0 unless annotated.
+     */
+    private const FIRST_PARTY_RULE_ESCAPES = [
+        // Mirrors the 'email' string rule: Laravel's email validators reject
+        // raw whitespace and control characters, so the value is safe for
+        // header/cookie sinks. Other taints (HTML, SQL, …) are preserved.
+        'illuminate\\validation\\rules\\email'
+            => TaintKind::INPUT_HEADER | TaintKind::INPUT_COOKIE,
+        // Mirrors the 'numeric' string rule: the value contains no meta-chars.
+        'illuminate\\validation\\rules\\numeric' => TaintKind::ALL_INPUT,
+        // Mirrors the 'in:' string rule: whitelist-bounded values.
+        'illuminate\\validation\\rules\\in' => TaintKind::ALL_INPUT,
+        // Mirrors the 'date' / 'date_format' string rules: the object form
+        // always emits at least one of those via Rules\Date::__toString(),
+        // and every fluent method on Rules\Date (format, past, future,
+        // beforeToday, between, …) returns $this and only adds
+        // before/after/before_or_equal/after_or_equal constraints — all of
+        // which are themselves ALL_INPUT-escaped in ruleToRemovedTaints().
+        'illuminate\\validation\\rules\\date' => TaintKind::ALL_INPUT,
+    ];
+
+    /**
+     * Map from {@see \Illuminate\Validation\Rule} facade method name to the
+     * concrete `Illuminate\Validation\Rules\*` class it returns. Drives the
+     * fluent-builder resolution in {@see resolveRuleObjectClassName()}.
+     *
+     * Only methods whose return class is a single, stable `Rules\*` type are
+     * listed. `Rule::when()`, `Rule::unique()`, `Rule::exists()`,
+     * `Rule::dimensions()`, etc. are intentionally excluded because their
+     * output has no value-shape guarantee that would warrant taint escape.
+     *
+     * Method-name keys are lowercased (PHP method lookup is case-insensitive).
+     * Values are stored as exact-case FQNs; the lowercase form used by
+     * {@see FIRST_PARTY_RULE_ESCAPES} is derived in {@see classRuleRemovedTaints()}.
+     */
+    private const RULE_FACADE_METHOD_RETURN_CLASS = [
+        'email' => \Illuminate\Validation\Rules\Email::class,
+        'in' => \Illuminate\Validation\Rules\In::class,
+        'notin' => \Illuminate\Validation\Rules\NotIn::class,
+        'numeric' => \Illuminate\Validation\Rules\Numeric::class,
+        'date' => \Illuminate\Validation\Rules\Date::class,
+        'enum' => \Illuminate\Validation\Rules\Enum::class,
+        'file' => \Illuminate\Validation\Rules\File::class,
+        'imagefile' => \Illuminate\Validation\Rules\ImageFile::class,
+    ];
+
+    /**
+     * Lowercased FQN of the Rule facade, pre-computed to avoid calling
+     * {@see \strtolower()} on a class constant for every resolved static call.
+     * Kept as a companion to {@see RULE_FACADE_METHOD_RETURN_CLASS}.
+     */
+    private const RULE_FACADE_LOWER_FQN = 'illuminate\\validation\\rule';
+
     /** @var array<string, array<string, ResolvedRule>|null> */
     private static array $cache = [];
 
@@ -749,22 +811,48 @@ final class ValidationRuleAnalyzer
     /**
      * Resolve the class FQN of a Rule object expression in a rules() array.
      *
-     * Recognises two patterns (matching the issue's scope — #822):
+     * Recognises, in order:
      *   - `new App\Rules\X()` → `App\Rules\X`
-     *   - `App\Rules\X::make(...)` (or any other static factory) → `App\Rules\X`
+     *   - `App\Rules\X::make(...)` (user-authored static factory) → `App\Rules\X`
+     *   - `Illuminate\Validation\Rule::email()` and the other Rule-facade
+     *     fluent builders → the concrete `Rules\*` class from
+     *     {@see RULE_FACADE_METHOD_RETURN_CLASS}.
+     *   - Any chain of the form `<root>->fluent()->fluent()` (including the
+     *     nullsafe variant `?->`) where `<root>` is one of the above, by
+     *     unwrapping the outer method-call nodes. Laravel's first-party
+     *     fluent builders (`Email::preventSpoofing`, `Numeric::between`, …)
+     *     return `$this`, so the chain's top-level value is always an
+     *     instance of the root's class. User-authored `X::make()->y()`
+     *     chains remain best-effort: if `y()` returns a different class
+     *     (decorator pattern) the analyzer will read `X`'s docblock, which
+     *     is the same soundness caveat as the existing `X::make()` path.
      *
-     * For static calls we read the docblock of the **named** class (the left
-     * side of `::`), not of whatever class the method actually returns. This
-     * is sound when `X::make()` returns `new self()` / `new static()` — the
-     * common user-authored factory pattern. It is unsound for Laravel's own
-     * fluent factories like `Rule::email()` which return `Illuminate\Validation\Rules\Email`
-     * rather than `Rule`; that's acceptable because built-in rule escape
-     * behaviour is handled by the string-rule path in {@see ruleToRemovedTaints()}.
-     * Dynamic (`new $class()`) or chained expressions are out of scope, matching
-     * the parser limits elsewhere in {@see extractRulePairsFromArrayNode()}.
+     * For a user-authored `X::make(...)` we read the docblock of `X` itself,
+     * which is sound for the common `new self()` / `new static()` factory
+     * pattern. The Rule-facade special case bypasses that assumption because
+     * `Rule::email()` returns `Rules\Email`, not `Rule` itself.
+     *
+     * Unmapped Rule-facade methods (`Rule::unique()`, `Rule::exists()`, …)
+     * fall back to the `Rule` class itself: the docblock path then finds no
+     * `@psalm-taint-escape` and contributes 0 bits. This preserves the
+     * presence of the field in the rules map so downstream type inference
+     * still narrows `validated()` output for fields guarded only by these
+     * builders.
+     *
+     * Dynamic (`new $class()`) or other unhandled expressions return null,
+     * matching the parser limits elsewhere in {@see extractRulePairsFromArrayNode()}.
      */
     private static function resolveRuleObjectClassName(Node\Expr $expr): ?string
     {
+        // Unwrap outer fluent calls (standard and nullsafe): chained calls
+        // like `Rule::email()->preventSpoofing()` or `Rule::email()?->strict()`
+        // resolve to the class of the innermost receiver.
+        while ($expr instanceof Node\Expr\MethodCall
+            || $expr instanceof Node\Expr\NullsafeMethodCall
+        ) {
+            $expr = $expr->var;
+        }
+
         if ($expr instanceof Node\Expr\New_ && $expr->class instanceof Node\Name) {
             /** @var string|null $resolved */
             $resolved = $expr->class->getAttribute('resolvedName');
@@ -776,7 +864,26 @@ final class ValidationRuleAnalyzer
             /** @var string|null $resolved */
             $resolved = $expr->class->getAttribute('resolvedName');
 
-            return \is_string($resolved) ? $resolved : null;
+            if (!\is_string($resolved)) {
+                return null;
+            }
+
+            // Laravel's Rule facade: translate `Rule::email()` to the concrete
+            // `Rules\Email` class, so the escape table can match. Unmapped
+            // methods on Rule (unique, exists, dimensions, when, …) fall back
+            // to Rule itself so the field still surfaces as a rule segment;
+            // the docblock path then contributes 0 bits since Rule carries no
+            // `@psalm-taint-escape` annotation.
+            if (\strtolower($resolved) === self::RULE_FACADE_LOWER_FQN) {
+                if (!$expr->name instanceof Node\Identifier) {
+                    return $resolved;
+                }
+
+                return self::RULE_FACADE_METHOD_RETURN_CLASS[\strtolower($expr->name->name)]
+                    ?? $resolved;
+            }
+
+            return $resolved;
         }
 
         return null;
@@ -810,6 +917,17 @@ final class ValidationRuleAnalyzer
 
         if (\array_key_exists($cacheKey, self::$classTaintCache)) {
             return self::$classTaintCache[$cacheKey];
+        }
+
+        // First-party Laravel rule classes: short-circuit the docblock lookup.
+        // Laravel's own `Illuminate\Validation\Rules\*` classes carry no
+        // `@psalm-taint-escape` annotation, so without this authoritative
+        // table the object form of a built-in rule (`new Rules\Email()`,
+        // `Rule::numeric()`, …) would silently lose the taint-escape that
+        // its string equivalent ('email', 'numeric') already provides.
+        if (isset(self::FIRST_PARTY_RULE_ESCAPES[$cacheKey])) {
+            return self::$classTaintCache[$cacheKey]
+                = self::FIRST_PARTY_RULE_ESCAPES[$cacheKey];
         }
 
         try {

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestRuleDateFluentNoTaint.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestRuleDateFluentNoTaint.phpt
@@ -1,0 +1,29 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Fluent `Rule::date()` (including format/past/future chains) resolves to
+ * `Rules\Date`, whose object output always includes a 'date' or
+ * 'date_format:...' constraint. That matches the string-rule 'date' escape,
+ * which covers every input taint kind.
+ */
+final class FluentDateRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['born_on' => ['required', 'string', Rule::date()->beforeToday()]];
+    }
+}
+
+function render(FluentDateRequest $request): void {
+    echo $request->string('born_on');
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestRuleEmailChainEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestRuleEmailChainEscapesHeader.phpt
@@ -1,0 +1,37 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * The chained form `Rule::email()->preventSpoofing()->rfcCompliant(strict: true)`
+ * is the recommended idiom for modern email validation. Each fluent method
+ * returns `$this` on `Rules\Email`, so the analyzer walks the MethodCall
+ * chain down to the root StaticCall and resolves the escape from the Email
+ * class. Header and cookie taint are escaped; SSRF is not.
+ */
+final class FluentChainedEmailRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'team_email' => [
+                'required',
+                'string',
+                Rule::email()->preventSpoofing()->rfcCompliant(strict: true),
+            ],
+        ];
+    }
+}
+
+function direct(FluentChainedEmailRequest $request): \Illuminate\Http\RedirectResponse {
+    return redirect()->to($request->safe()->input('team_email'));
+}
+?>
+--EXPECTF--
+%ATaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestRuleEmailFluentEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestRuleEmailFluentEscapesHeader.phpt
@@ -1,0 +1,30 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Fluent `Rule::email()` resolves to `Rules\Email` via the Rule facade
+ * method map. The resulting class carries the same header/cookie escape
+ * as `'email'` and `new Rules\Email()`. redirect()->to() still reports
+ * TaintedSSRF because email validation does not constrain resolution.
+ */
+final class FluentEmailRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['team_email' => ['required', 'string', Rule::email()]];
+    }
+}
+
+function direct(FluentEmailRequest $request): \Illuminate\Http\RedirectResponse {
+    return redirect()->to($request->safe()->input('team_email'));
+}
+?>
+--EXPECTF--
+%ATaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestRuleInFluentNoTaint.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestRuleInFluentNoTaint.phpt
@@ -1,0 +1,27 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Fluent `Rule::in([...])` resolves to `Rules\In`, which escapes all input
+ * taint because the accepted set is bounded by the constructor whitelist.
+ */
+final class FluentInRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['role' => ['required', 'string', Rule::in(['admin', 'user', 'guest'])]];
+    }
+}
+
+function render(FluentInRequest $request): void {
+    echo $request->string('role');
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestRuleNumericFluentNoTaint.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestRuleNumericFluentNoTaint.phpt
@@ -1,0 +1,28 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Fluent `Rule::numeric()` resolves to `Rules\Numeric`, which escapes all
+ * input taint. Echoing the validated string into HTML must not report
+ * TaintedHtml.
+ */
+final class FluentNumericRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['age' => ['required', 'string', Rule::numeric()]];
+    }
+}
+
+function render(FluentNumericRequest $request): void {
+    echo $request->string('age');
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestRulesEmailInstanceEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestRulesEmailInstanceEscapesHeader.phpt
@@ -1,0 +1,30 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Email;
+
+/**
+ * `new Rules\Email()` carries the same header/cookie escape as the 'email'
+ * string rule. redirect()->to() still reports TaintedSSRF because the email
+ * validator does not prevent SSRF (a valid email domain can resolve to an
+ * internal host).
+ */
+final class ObjectEmailRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['team_email' => ['required', 'string', new Email()]];
+    }
+}
+
+function direct(ObjectEmailRequest $request): \Illuminate\Http\RedirectResponse {
+    return redirect()->to($request->safe()->input('team_email'));
+}
+?>
+--EXPECTF--
+%ATaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestRulesInInstanceNoTaint.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestRulesInInstanceNoTaint.phpt
@@ -1,0 +1,28 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\In;
+
+/**
+ * `new Rules\In([...])` is the object equivalent of the 'in:a,b,c' string
+ * rule — the value is bounded to a whitelist, so every input taint is safe
+ * to remove. Echoing into HTML is therefore untainted.
+ */
+final class ObjectInRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['role' => ['required', 'string', new In(['admin', 'user', 'guest'])]];
+    }
+}
+
+function render(ObjectInRequest $request): void {
+    echo $request->string('role');
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestRulesNumericInstanceNoTaint.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestRulesNumericInstanceNoTaint.phpt
@@ -1,0 +1,28 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Numeric;
+
+/**
+ * `new Rules\Numeric()` escapes every input taint — a numeric value cannot
+ * carry injection meta-characters. Echoing the validated string must not
+ * report TaintedHtml.
+ */
+final class ObjectNumericRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['age' => ['required', 'string', new Numeric()]];
+    }
+}
+
+function render(ObjectNumericRequest $request): void {
+    echo $request->string('age');
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestRuleNotInNoEscape.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestRuleNotInNoEscape.phpt
@@ -1,0 +1,31 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * `Rule::notIn()` maps to `Rules\NotIn`, which is deliberately absent from
+ * the first-party escape table: rejecting a blocklist of values does not
+ * constrain the accepted value to a safe shape. The taint therefore flows
+ * unchanged into echo, so TaintedHtml (and TaintedTextWithQuotes) fire.
+ */
+final class FluentNotInRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['role' => ['required', 'string', Rule::notIn(['banned'])]];
+    }
+}
+
+function render(FluentNotInRequest $request): void {
+    echo $request->string('role');
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestRuleUniqueNoEscape.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestRuleUniqueNoEscape.phpt
@@ -1,0 +1,32 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * `Rule::unique(...)` is intentionally absent from the Rule facade method
+ * map: its value is constrained by a DB lookup rather than a character
+ * shape, so it carries no taint escape. The field must still flow taint
+ * (TaintedHtml fires) and, critically, must remain present in the rules
+ * map so the 'string' rule's type inference still applies.
+ */
+final class FluentUniqueRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['email' => ['required', 'string', Rule::unique('users', 'email')]];
+    }
+}
+
+function render(FluentUniqueRequest $request): void {
+    echo $request->string('email');
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Unit/Handlers/Validation/ValidationRuleAnalyzerTest.php
+++ b/tests/Unit/Handlers/Validation/ValidationRuleAnalyzerTest.php
@@ -515,11 +515,13 @@ final class ValidationRuleAnalyzerTest extends TestCase
     }
 
     /**
-     * Defensive guard: classes in RULE_FACADE_METHOD_RETURN_CLASS whose
-     * fluent builders return value-shape-unsafe content (user-controlled
-     * file uploads, dev-chosen enum cases with runtime-defined string
-     * backing) must NOT be in FIRST_PARTY_RULE_ESCAPES. If a future refactor
-     * added them, this test would flip to a non-zero expectation and fail.
+     * Defensive guard: these classes are mapped in RULE_FACADE_METHOD_RETURN_CLASS
+     * but deliberately omitted from FIRST_PARTY_RULE_ESCAPES. File/ImageFile
+     * carry user-controlled filename/mime/contents; Enum is a plausible
+     * candidate for a future escape (backing values are developer-defined
+     * string literals) but is intentionally out of scope for the initial PR.
+     * If a future refactor added any of them, this test would flip to a
+     * non-zero expectation and fail, forcing a deliberate decision.
      *
      * @return iterable<string, array{string}>
      */

--- a/tests/Unit/Handlers/Validation/ValidationRuleAnalyzerTest.php
+++ b/tests/Unit/Handlers/Validation/ValidationRuleAnalyzerTest.php
@@ -446,4 +446,114 @@ final class ValidationRuleAnalyzerTest extends TestCase
         $this->assertTrue($rule->type->isMixed());
         $this->assertFalse($rule->required);
     }
+
+    // --- First-party Illuminate\Validation\Rules\* segments (#828) ---
+
+    #[Test]
+    public function class_segment_for_rules_email_removes_header_and_cookie_taint(): void
+    {
+        // The authoritative FIRST_PARTY_RULE_ESCAPES table short-circuits the
+        // docblock lookup, so this resolves even without a Psalm analysis
+        // context. The bits mirror the 'email' string rule.
+        $rule = ValidationRuleAnalyzer::resolveRuleSegments(
+            ['required', 'string', 'class:Illuminate\\Validation\\Rules\\Email'],
+        );
+
+        $this->assertSame(
+            TaintKind::INPUT_HEADER | TaintKind::INPUT_COOKIE,
+            $rule->removedTaints,
+        );
+        $this->assertSame('string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function class_segment_for_rules_numeric_removes_all_input_taint(): void
+    {
+        $rule = ValidationRuleAnalyzer::resolveRuleSegments(
+            ['required', 'class:Illuminate\\Validation\\Rules\\Numeric'],
+        );
+
+        $this->assertSame(TaintKind::ALL_INPUT, $rule->removedTaints);
+        $this->assertTrue($rule->required);
+    }
+
+    #[Test]
+    public function class_segment_for_rules_in_removes_all_input_taint(): void
+    {
+        $rule = ValidationRuleAnalyzer::resolveRuleSegments(
+            ['required', 'class:Illuminate\\Validation\\Rules\\In'],
+        );
+
+        $this->assertSame(TaintKind::ALL_INPUT, $rule->removedTaints);
+    }
+
+    #[Test]
+    public function class_segment_for_rules_date_removes_all_input_taint(): void
+    {
+        // The 'date' string rule escapes ALL_INPUT; the object form must be
+        // in parity since Rules\Date::__toString() always emits 'date' or
+        // 'date_format:...' as the first constraint.
+        $rule = ValidationRuleAnalyzer::resolveRuleSegments(
+            ['required', 'class:Illuminate\\Validation\\Rules\\Date'],
+        );
+
+        $this->assertSame(TaintKind::ALL_INPUT, $rule->removedTaints);
+    }
+
+    #[Test]
+    public function class_segment_for_rules_notin_removes_no_taint(): void
+    {
+        // NotIn is deliberately not in FIRST_PARTY_RULE_ESCAPES: rejecting a
+        // blocklist of values does not constrain the accepted set to a safe
+        // shape. In unit-test context ProjectAnalyzer::getInstance() throws,
+        // so the function returns 0 without touching the docblock path.
+        $rule = ValidationRuleAnalyzer::resolveRuleSegments(
+            ['required', 'class:Illuminate\\Validation\\Rules\\NotIn'],
+        );
+
+        $this->assertSame(0, $rule->removedTaints);
+    }
+
+    /**
+     * Defensive guard: classes in RULE_FACADE_METHOD_RETURN_CLASS whose
+     * fluent builders return value-shape-unsafe content (user-controlled
+     * file uploads, dev-chosen enum cases with runtime-defined string
+     * backing) must NOT be in FIRST_PARTY_RULE_ESCAPES. If a future refactor
+     * added them, this test would flip to a non-zero expectation and fail.
+     *
+     * @return iterable<string, array{string}>
+     */
+    public static function provideNonEscapingMappedRuleClasses(): iterable
+    {
+        yield 'Enum' => ['Illuminate\\Validation\\Rules\\Enum'];
+        yield 'File' => ['Illuminate\\Validation\\Rules\\File'];
+        yield 'ImageFile' => ['Illuminate\\Validation\\Rules\\ImageFile'];
+    }
+
+    #[Test]
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideNonEscapingMappedRuleClasses')]
+    public function mapped_rule_class_outside_escape_table_removes_no_taint(string $fqn): void
+    {
+        $rule = ValidationRuleAnalyzer::resolveRuleSegments(
+            ['required', 'string', 'class:' . $fqn],
+        );
+
+        $this->assertSame(0, $rule->removedTaints);
+    }
+
+    #[Test]
+    public function class_segment_for_rules_email_is_case_insensitive(): void
+    {
+        // ValidationRuleAnalyzer lower-cases the FQN for cache/table lookup,
+        // so mixed-case input (e.g. from a `resolvedName` that preserves the
+        // `use` statement's casing) must still hit the escape table.
+        $rule = ValidationRuleAnalyzer::resolveRuleSegments(
+            ['class:illuminate\\validation\\rules\\EMAIL'],
+        );
+
+        $this->assertSame(
+            TaintKind::INPUT_HEADER | TaintKind::INPUT_COOKIE,
+            $rule->removedTaints,
+        );
+    }
 }


### PR DESCRIPTION
## Issue to Solve

Today, the string form of a built-in Laravel rule and its object form have different taint semantics. `'email'` / `'numeric'` / `'in:...'` / `'date'` all escape taint through the string-rule path, but `new Rules\Email()`, `new Rules\Numeric()`, `new Rules\In([...])`, `new Rules\Date()`, and the fluent `Rule::email()` / `Rule::numeric()` / `Rule::in([...])` / `Rule::date()` builders used to contribute nothing, because PR #826's docblock lookup only matched user-annotated classes.

Modern Laravel APIs increasingly push the fluent form (e.g. `Rule::email()->preventSpoofing()->rfcCompliant(strict: true)`), so the asymmetry matters in practice.

## Related

Closes #828. Builds on #822 / #826 (custom Rule classes) and #819 / #821 (earlier rule-based taint escape).

## Solution Description

`ValidationRuleAnalyzer` now knows about first-party Rule classes directly.

**Authoritative FQN-to-bitmask table** (`FIRST_PARTY_RULE_ESCAPES`), consulted before any docblock lookup:

| Usage | Escape |
|---|---|
| `new Rules\Email()`, `Rule::email()` | `header`, `cookie` |
| `new Rules\Numeric()`, `Rule::numeric()` | all input |
| `new Rules\In([...])`, `Rule::in([...])` | all input |
| `new Rules\Date()`, `Rule::date()->past()` | all input |

Each entry mirrors the existing string-rule mapping in `ruleToRemovedTaints()`, so the object form carries the same taint-escape guarantees as the string form.

**Rule facade method map** (`RULE_FACADE_METHOD_RETURN_CLASS`) translates `Rule::email`, `Rule::in`, `Rule::notIn`, `Rule::numeric`, `Rule::date`, `Rule::enum`, `Rule::file`, `Rule::imageFile` to their concrete `Rules\*` return class. `resolveRuleObjectClassName()` unwraps chained `MethodCall` and `NullsafeMethodCall` receivers to the root expression before the lookup, so chains like `Rule::email()->preventSpoofing()->rfcCompliant(strict: true)` resolve correctly.

Unmapped methods (`Rule::unique`, `Rule::exists`, `Rule::dimensions`, `Rule::when`, …) fall back to the `Rule` FQN itself. The Rule class has no escape annotation, so zero bits are contributed, but the field still appears in the rules map so `validated()`'s type narrowing stays intact.

### Tests

- **10 new PHPT tests** in `tests/Type/tests/TaintAnalysis/`:
  - Direct instantiation for Email (header/cookie), Numeric, In
  - Fluent `Rule::email()`, `Rule::numeric()`, `Rule::in()`, `Rule::date()`
  - Chained `Rule::email()->preventSpoofing()->rfcCompliant(strict: true)`
  - Negative `Rule::notIn()` and `Rule::unique()` preserve taint
- **6 new unit tests** in `ValidationRuleAnalyzerTest`, including a data provider that guards `Enum`, `File`, `ImageFile` against accidental inclusion in the escape table.

### Docs

`docs/contributing/taint-analysis.md` now introduces "Per-rule escape on Rule objects" with two subsections: built-in Laravel rule classes (new first-party table) and custom application Rule classes (unchanged behaviour from #826). The static-factory caveat is updated to describe the dedicated Rule-facade method map.

## Checklist

- [x] Tests cover the change (10 PHPT tests + 6 unit tests)
- [x] Documentation is updated
