### PR TITLE
Support more Laravel public methods that use variadic parameters: `LazyCollection`, `MessageBag`, `ServiceProvider`

### DIFF
--- a/stubs/common/Support/LazyCollection.stubphp
+++ b/stubs/common/Support/LazyCollection.stubphp
@@ -64,4 +64,28 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @return static<never, never>
      */
     public static function empty() {}
+
+    /**
+     * Determine if an item exists in the enumerable by key.
+     *
+     * Accepts an array of keys or variadic key arguments via func_get_args().
+     *
+     * @param  TKey|array<array-key, TKey>  $key
+     * @return bool
+     *
+     * @psalm-variadic
+     */
+    public function has($key) {}
+
+    /**
+     * Determine if any of the keys exist in the enumerable.
+     *
+     * Accepts an array of keys or variadic key arguments via func_get_args().
+     *
+     * @param  TKey|array<array-key, TKey>  $key
+     * @return bool
+     *
+     * @psalm-variadic
+     */
+    public function hasAny($key) {}
 }

--- a/stubs/common/Support/MessageBag.stubphp
+++ b/stubs/common/Support/MessageBag.stubphp
@@ -1,0 +1,55 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Contracts\Support\MessageBag as MessageBagContract;
+use Illuminate\Contracts\Support\MessageProvider;
+use JsonSerializable;
+use Stringable;
+
+/**
+ * Interface list mirrors Laravel's source declaration. Psalm wipes the reflected
+ * class_implements list when a stub declares the class, so the clause must be
+ * repeated verbatim or interface relationships (MessageBagContract, etc.) break
+ * for any caller typed on those contracts.
+ */
+class MessageBag implements Jsonable, JsonSerializable, MessageBagContract, MessageProvider, Stringable
+{
+    /**
+     * Determine if messages exist for all of the given keys.
+     *
+     * Accepts an array of keys or variadic string key arguments via func_get_args().
+     * Passing null falls through to any() (not variadic).
+     *
+     * @param  array<string>|string|null  $key
+     * @return bool
+     *
+     * @psalm-variadic
+     */
+    public function has($key) {}
+
+    /**
+     * Determine if messages exist for any of the given keys.
+     *
+     * Accepts an array of keys or variadic string key arguments via func_get_args().
+     *
+     * @param  array<string>|string|null  $keys
+     * @return bool
+     *
+     * @psalm-variadic
+     */
+    public function hasAny($keys = []) {}
+
+    /**
+     * Determine if messages don't exist for all of the given keys.
+     *
+     * Accepts an array of keys or variadic string key arguments via func_get_args().
+     *
+     * @param  array<string>|string|null  $key
+     * @return bool
+     *
+     * @psalm-variadic
+     */
+    public function missing($key) {}
+}

--- a/stubs/common/Support/ServiceProvider.stubphp
+++ b/stubs/common/Support/ServiceProvider.stubphp
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Support;
+
+abstract class ServiceProvider
+{
+    /**
+     * Register the package's custom Artisan commands.
+     *
+     * Accepts an array of commands or variadic command arguments via func_get_args().
+     * Each entry is either a Command class-string (resolved through the container)
+     * or a Command instance; the `Artisan::resolve()` call site supports both.
+     *
+     * @param  array<class-string<\Illuminate\Console\Command>|\Illuminate\Console\Command>|class-string<\Illuminate\Console\Command>|\Illuminate\Console\Command  $commands
+     * @return void
+     *
+     * @psalm-variadic
+     */
+    public function commands($commands) {}
+}

--- a/tests/Type/tests/Variadic/AuditRejectionsTest.phpt
+++ b/tests/Type/tests/Variadic/AuditRejectionsTest.phpt
@@ -1,0 +1,66 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App;
+
+use Illuminate\Support\LazyCollection;
+use Illuminate\Support\Stringable;
+
+/**
+ * Regression guard for methods that look variadic (their Laravel source uses
+ * func_get_args()) but whose extras are silently discarded by a fixed-arity
+ * downstream call. These must NOT be annotated with @psalm-variadic — the
+ * analogue to #809's rejection of Builder::find.
+ *
+ * If any of these assertions stops firing, a contributor has probably added a
+ * misleading @psalm-variadic annotation. Re-audit the method against its
+ * Laravel source before removing the guard.
+ */
+
+/** @param LazyCollection<int, string> $c */
+function audit_lazy_merge_rejected(LazyCollection $c): void
+{
+    $c->merge([], []);
+}
+
+/** @param LazyCollection<int, string> $c */
+function audit_lazy_diff_rejected(LazyCollection $c): void
+{
+    $c->diff([], []);
+}
+
+/** @param LazyCollection<int, string> $c */
+function audit_lazy_intersect_rejected(LazyCollection $c): void
+{
+    $c->intersect([], []);
+}
+
+/** @param LazyCollection<int, string> $c */
+function audit_lazy_union_rejected(LazyCollection $c): void
+{
+    $c->union([], []);
+}
+
+function audit_stringable_trim_rejected(Stringable $s): void
+{
+    $s->trim(', ', 'x', 'y');
+}
+
+function audit_stringable_ltrim_rejected(Stringable $s): void
+{
+    $s->ltrim(', ', 'x', 'y');
+}
+
+function audit_stringable_rtrim_rejected(Stringable $s): void
+{
+    $s->rtrim(', ', 'x', 'y');
+}
+?>
+--EXPECTF--
+TooManyArguments on line %d: Too many arguments for method Illuminate\Support\LazyCollection::merge - saw 2
+TooManyArguments on line %d: Too many arguments for method Illuminate\Support\LazyCollection::diff - saw 2
+TooManyArguments on line %d: Too many arguments for method Illuminate\Support\LazyCollection::intersect - saw 2
+TooManyArguments on line %d: Too many arguments for method Illuminate\Support\LazyCollection::union - saw 2
+TooManyArguments on line %d: Too many arguments for method Illuminate\Support\Stringable::trim - saw 3
+TooManyArguments on line %d: Too many arguments for method Illuminate\Support\Stringable::ltrim - saw 3
+TooManyArguments on line %d: Too many arguments for method Illuminate\Support\Stringable::rtrim - saw 3

--- a/tests/Type/tests/Variadic/LazyCollectionTest.phpt
+++ b/tests/Type/tests/Variadic/LazyCollectionTest.phpt
@@ -1,0 +1,77 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App;
+
+use Illuminate\Support\LazyCollection;
+
+/**
+ * LazyCollection::has(), hasAny(), doesntContain(), doesntContainStrict(), zip()
+ * mirror their Collection counterparts and accept variadic arguments via
+ * func_get_args(). Without @psalm-variadic the multi-arg calls would be
+ * rejected as TooManyArguments.
+ *
+ * @param LazyCollection<string, string> $c
+ */
+function lazy_collection_has_variadic(LazyCollection $c): void
+{
+    $_single = $c->has('name');
+    /** @psalm-check-type-exact $_single = bool */
+
+    $_variadic = $c->has('name', 'email', 'missing');
+    /** @psalm-check-type-exact $_variadic = bool */
+
+    $_array = $c->has(['name', 'email']);
+    /** @psalm-check-type-exact $_array = bool */
+}
+
+/** @param LazyCollection<string, string> $c */
+function lazy_collection_has_any_variadic(LazyCollection $c): void
+{
+    $_single = $c->hasAny('name');
+    /** @psalm-check-type-exact $_single = bool */
+
+    $_variadic = $c->hasAny('name', 'email', 'missing');
+    /** @psalm-check-type-exact $_variadic = bool */
+
+    $_array = $c->hasAny(['name', 'email']);
+    /** @psalm-check-type-exact $_array = bool */
+}
+
+/** @param LazyCollection<int, string> $c */
+function lazy_collection_doesnt_contain_variadic(LazyCollection $c): void
+{
+    $_single = $c->doesntContain('needle');
+    /** @psalm-check-type-exact $_single = bool */
+
+    $_triple = $c->doesntContain('status', '=', 'active');
+    /** @psalm-check-type-exact $_triple = bool */
+}
+
+/** @param LazyCollection<int, string> $c */
+function lazy_collection_doesnt_contain_strict_variadic(LazyCollection $c): void
+{
+    $_single = $c->doesntContainStrict('needle');
+    /** @psalm-check-type-exact $_single = bool */
+
+    $_triple = $c->doesntContainStrict('status', '=', 'active');
+    /** @psalm-check-type-exact $_triple = bool */
+}
+
+/**
+ * @param LazyCollection<int, string> $c
+ * @param LazyCollection<int, string> $other
+ */
+function lazy_collection_zip_variadic(LazyCollection $c, LazyCollection $other): void
+{
+    $_one = $c->zip($other);
+    /** @psalm-check-type-exact $_one = LazyCollection<int, LazyCollection<int, string>&static>&static */
+
+    $_two = $c->zip($other, ['x', 'y']);
+    /** @psalm-check-type-exact $_two = LazyCollection<int, LazyCollection<int, string>&static>&static */
+
+    $_three = $c->zip($other, ['x', 'y'], ['a', 'b']);
+    /** @psalm-check-type-exact $_three = LazyCollection<int, LazyCollection<int, string>&static>&static */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Variadic/MessageBagTest.phpt
+++ b/tests/Type/tests/Variadic/MessageBagTest.phpt
@@ -1,0 +1,49 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App;
+
+use Illuminate\Support\MessageBag;
+
+/**
+ * MessageBag::has(), hasAny(), missing() accept variadic string keys via
+ * func_get_args(). Without @psalm-variadic the multi-arg calls would be
+ * rejected as TooManyArguments.
+ */
+function message_bag_has_variadic(MessageBag $bag): void
+{
+    $_single = $bag->has('name');
+    /** @psalm-check-type-exact $_single = bool */
+
+    $_variadic = $bag->has('name', 'email', 'missing');
+    /** @psalm-check-type-exact $_variadic = bool */
+
+    $_array = $bag->has(['name', 'email']);
+    /** @psalm-check-type-exact $_array = bool */
+}
+
+function message_bag_has_any_variadic(MessageBag $bag): void
+{
+    $_single = $bag->hasAny('name');
+    /** @psalm-check-type-exact $_single = bool */
+
+    $_variadic = $bag->hasAny('name', 'email');
+    /** @psalm-check-type-exact $_variadic = bool */
+
+    $_array = $bag->hasAny(['name', 'email']);
+    /** @psalm-check-type-exact $_array = bool */
+}
+
+function message_bag_missing_variadic(MessageBag $bag): void
+{
+    $_single = $bag->missing('name');
+    /** @psalm-check-type-exact $_single = bool */
+
+    $_variadic = $bag->missing('name', 'email', 'missing');
+    /** @psalm-check-type-exact $_variadic = bool */
+
+    $_array = $bag->missing(['name', 'email']);
+    /** @psalm-check-type-exact $_array = bool */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Variadic/NegativeTest.phpt
+++ b/tests/Type/tests/Variadic/NegativeTest.phpt
@@ -12,6 +12,9 @@ use Illuminate\Routing\ControllerMiddlewareOptions;
 use Illuminate\Routing\PendingResourceRegistration;
 use Illuminate\Session\Store as SessionStore;
 use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
+use Illuminate\Support\MessageBag;
+use Illuminate\Support\ServiceProvider;
 
 /**
  * @psalm-variadic must not swallow arity checks. The annotation allows extra
@@ -103,6 +106,51 @@ function request_except_too_few(Request $r): void
 {
     $r->except();
 }
+
+/** @param LazyCollection<array-key, mixed> $c */
+function lazy_collection_has_too_few(LazyCollection $c): void
+{
+    $c->has();
+}
+
+/** @param LazyCollection<array-key, mixed> $c */
+function lazy_collection_has_any_too_few(LazyCollection $c): void
+{
+    $c->hasAny();
+}
+
+/** @param LazyCollection<array-key, mixed> $c */
+function lazy_collection_doesnt_contain_too_few(LazyCollection $c): void
+{
+    $c->doesntContain();
+}
+
+/** @param LazyCollection<array-key, mixed> $c */
+function lazy_collection_doesnt_contain_strict_too_few(LazyCollection $c): void
+{
+    $c->doesntContainStrict();
+}
+
+/** @param LazyCollection<array-key, mixed> $c */
+function lazy_collection_zip_too_few(LazyCollection $c): void
+{
+    $c->zip();
+}
+
+function message_bag_has_too_few(MessageBag $bag): void
+{
+    $bag->has();
+}
+
+function message_bag_missing_too_few(MessageBag $bag): void
+{
+    $bag->missing();
+}
+
+function service_provider_commands_too_few(ServiceProvider $sp): void
+{
+    $sp->commands();
+}
 ?>
 --EXPECTF--
 TooFewArguments on line %d: Too few arguments for Illuminate\Container\Container::tag - expecting tags to be passed
@@ -137,3 +185,19 @@ TooFewArguments on line %d: Too few arguments for Illuminate\Http\Request::only 
 TooFewArguments on line %d: Too few arguments for method Illuminate\Support\Traits\InteractsWithData::only saw 0
 TooFewArguments on line %d: Too few arguments for Illuminate\Http\Request::except - expecting keys to be passed
 TooFewArguments on line %d: Too few arguments for method Illuminate\Support\Traits\InteractsWithData::except saw 0
+TooFewArguments on line %d: Too few arguments for Illuminate\Support\LazyCollection::has - expecting key to be passed
+TooFewArguments on line %d: Too few arguments for method Illuminate\Support\LazyCollection::has saw 0
+TooFewArguments on line %d: Too few arguments for Illuminate\Support\LazyCollection::hasAny - expecting key to be passed
+TooFewArguments on line %d: Too few arguments for method Illuminate\Support\LazyCollection::hasany saw 0
+TooFewArguments on line %d: Too few arguments for Illuminate\Support\LazyCollection::doesntContain - expecting key to be passed
+TooFewArguments on line %d: Too few arguments for method Illuminate\Support\LazyCollection::doesntcontain saw 0
+TooFewArguments on line %d: Too few arguments for Illuminate\Support\LazyCollection::doesntContainStrict - expecting key to be passed
+TooFewArguments on line %d: Too few arguments for method Illuminate\Support\LazyCollection::doesntcontainstrict saw 0
+TooFewArguments on line %d: Too few arguments for Illuminate\Support\LazyCollection::zip - expecting items to be passed
+TooFewArguments on line %d: Too few arguments for method Illuminate\Support\LazyCollection::zip saw 0
+TooFewArguments on line %d: Too few arguments for Illuminate\Support\MessageBag::has - expecting key to be passed
+TooFewArguments on line %d: Too few arguments for method Illuminate\Support\MessageBag::has saw 0
+TooFewArguments on line %d: Too few arguments for Illuminate\Support\MessageBag::missing - expecting key to be passed
+TooFewArguments on line %d: Too few arguments for method Illuminate\Support\MessageBag::missing saw 0
+TooFewArguments on line %d: Too few arguments for Illuminate\Support\ServiceProvider::commands - expecting commands to be passed
+TooFewArguments on line %d: Too few arguments for method Illuminate\Support\ServiceProvider::commands saw 0

--- a/tests/Type/tests/Variadic/ServiceProviderTest.phpt
+++ b/tests/Type/tests/Variadic/ServiceProviderTest.phpt
@@ -1,0 +1,39 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\ServiceProvider;
+
+class InspectCommand extends Command {}
+class ReportCommand extends Command {}
+
+/**
+ * ServiceProvider::commands() accepts an array of class-strings or variadic
+ * class-string arguments via func_get_args(). Without @psalm-variadic the
+ * multi-arg calls would be rejected as TooManyArguments.
+ */
+function service_provider_commands_variadic(ServiceProvider $provider): void
+{
+    $provider->commands(InspectCommand::class);
+
+    $provider->commands(InspectCommand::class, ReportCommand::class);
+
+    $provider->commands([InspectCommand::class, ReportCommand::class]);
+}
+
+/**
+ * Concrete service providers are the typical call site: `$this->commands(...)`
+ * inside `boot()` or `register()`. Verify the variadic annotation propagates
+ * through subclassing — Psalm resolves the method on the declaring class.
+ */
+final class ExampleServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $this->commands(InspectCommand::class, ReportCommand::class);
+    }
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

Many Laravel public methods accept an array OR variadic arguments via `func_get_args()`, but their declared signatures only carry the first named parameter. Calls with multiple positional args (the documented alternative) are rejected by Psalm as `TooManyArguments`.

## Related

Closes #813. Follows the `@psalm-variadic` pattern established in #0 and extended in #809 (HIGH and MEDIUM buckets). This PR covers the **LOW priority** bucket documented in `.alies/docs/variadic-stubs.md`.

## Solution Description

Bare `@psalm-variadic` tag added to each method whose Laravel source uses `func_get_args()`. Every placement was verified against Laravel 13.x source and re-checked against the Laravel 12.x branch.

**Stubs updated:**

- `Support/LazyCollection`: `has`, `hasAny`
- `Support/MessageBag` (new stub): `has`, `hasAny`, `missing`. The `implements` clause mirrors Laravel source verbatim (`Jsonable, JsonSerializable, MessageBagContract, MessageProvider, Stringable`) so Psalm does not wipe the reflected interface list when the class is re-declared.
- `Support/ServiceProvider` (new stub): `commands`. Parameter typed as `class-string<Command>|Command` (or array of same) to match the runtime contract of `Artisan::resolve()`, which accepts both class strings and instances.

**Explicitly audited and rejected** (same principle used for `Builder::find` in #809):

- `Stringable::trim`, `ltrim`, `rtrim`. Forward to `Str::trim(...array_merge([$this->value], func_get_args()))`, but `Str::trim($value, $charlist)` is 2-arg fixed. Extras are silently ignored.
- `FailoverStore::*` (`add`, `put`, `get`, `forget`, `lock`, `restoreLock`, etc.). All forward via `attemptOnAllStores(__FUNCTION__, func_get_args())` to the fixed-arity `Store` / `LockProvider` contracts. Extras are silently ignored.
- `LazyCollection::merge`, `intersect`, `union`, `diff`. Delegate via `passthru(__FUNCTION__, func_get_args())` to their `Collection` counterparts, which take a single `$items` parameter and never inspect `func_get_args()`.

**Tests:** 4 new PHPT files under `tests/Type/tests/Variadic/` and an extended `NegativeTest.phpt`. Each positive test exercises single-arg, variadic, and array-form call shapes with `@psalm-check-type-exact` assertions. `NegativeTest.phpt` gains `TooFewArguments` coverage for the newly-annotated mandatory-first-param methods. `AuditRejectionsTest.phpt` guards against future drift by asserting the rejected methods still emit `TooManyArguments` when called with extras; if someone adds a misleading `@psalm-variadic` to one of them, the regression guard fails.

Full test suite green: `composer psalm`, `composer test:type` (322 tests), `composer test:unit` (549 tests), `composer cs:check`.

## Checklist

- [x] Tests cover the change (5 files under `tests/Type/tests/Variadic/`)
