### PR TITLE
Restate implements/extends in 4 stubs that were wiping metadata

### DIFF
--- a/stubs/common/Cache/Repository.stubphp
+++ b/stubs/common/Cache/Repository.stubphp
@@ -2,7 +2,15 @@
 
 namespace Illuminate\Cache;
 
-class Repository
+use ArrayAccess;
+use Illuminate\Contracts\Cache\Repository as CacheContract;
+
+/**
+ * Class declaration mirrors Laravel's source. Psalm wipes the reflected
+ * class_implements list when a stub re-declares the class, so the clause
+ * must be repeated verbatim or callers typed on the contracts break.
+ */
+class Repository implements ArrayAccess, CacheContract
 {
     /**
      * Begin executing a new tags operation if the store supports it.

--- a/stubs/common/Container/Container.stubphp
+++ b/stubs/common/Container/Container.stubphp
@@ -2,7 +2,15 @@
 
 namespace Illuminate\Container;
 
-class Container
+use ArrayAccess;
+use Illuminate\Contracts\Container\Container as ContainerContract;
+
+/**
+ * Class declaration mirrors Laravel's source. Psalm wipes the reflected
+ * class_implements list when a stub re-declares the class, so the clause
+ * must be repeated verbatim or callers typed on the contracts break.
+ */
+class Container implements ArrayAccess, ContainerContract
 {
     /**
      * Assign a set of tags to a given binding.

--- a/stubs/common/Http/RedirectResponse.stubphp
+++ b/stubs/common/Http/RedirectResponse.stubphp
@@ -2,7 +2,14 @@
 
 namespace Illuminate\Http;
 
-class RedirectResponse
+use Symfony\Component\HttpFoundation\RedirectResponse as BaseRedirectResponse;
+
+/**
+ * Class declaration mirrors Laravel's source. Psalm resets inheritance
+ * metadata when a stub re-declares the class, so the `extends` clause must
+ * be repeated verbatim or callers typed on the Symfony parent break.
+ */
+class RedirectResponse extends BaseRedirectResponse
 {
     /**
      * Flash an array of input to the session.

--- a/stubs/common/Pipeline/Pipeline.stubphp
+++ b/stubs/common/Pipeline/Pipeline.stubphp
@@ -2,7 +2,14 @@
 
 namespace Illuminate\Pipeline;
 
-class Pipeline
+use Illuminate\Contracts\Pipeline\Pipeline as PipelineContract;
+
+/**
+ * Class declaration mirrors Laravel's source. Psalm wipes the reflected
+ * class_implements list when a stub re-declares the class, so the clause
+ * must be repeated verbatim or callers typed on the contract break.
+ */
+class Pipeline implements PipelineContract
 {
     /**
      * Set the array of pipes.

--- a/tests/Type/tests/StubInterfaceTest.phpt
+++ b/tests/Type/tests/StubInterfaceTest.phpt
@@ -4,17 +4,21 @@
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Contracts\Auth\SupportsBasicAuth;
+use Illuminate\Contracts\Cache\Repository as CacheContract;
 use Illuminate\Contracts\Console\Kernel as KernelContract;
+use Illuminate\Contracts\Container\Container as ContainerContract;
 use Illuminate\Contracts\Database\Query\Builder as BuilderContract;
 use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
 use Illuminate\Contracts\Encryption\StringEncrypter;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Filesystem\Cloud as CloudFilesystemContract;
 use Illuminate\Contracts\Mail\Mailable as MailableContract;
+use Illuminate\Contracts\Pipeline\Pipeline as PipelineContract;
 use Illuminate\Contracts\Routing\ResponseFactory as FactoryContract;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\Support\ValidatedData;
 use Illuminate\Database\ConnectionInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse as BaseRedirectResponse;
 
 /**
  * Stubs must declare the same `implements` clauses as the real Laravel classes.
@@ -121,6 +125,38 @@ final class StubInterfaceTest
     public function stringableImplementsBaseStringable(\Illuminate\Support\Stringable $s): \Stringable
     {
         return $s;
+    }
+
+    public function cacheRepositoryImplementsContract(\Illuminate\Cache\Repository $r): CacheContract
+    {
+        return $r;
+    }
+
+    /** @param \Illuminate\Cache\Repository $r */
+    public function cacheRepositoryImplementsArrayAccess($r): \ArrayAccess
+    {
+        return $r;
+    }
+
+    public function containerImplementsContract(\Illuminate\Container\Container $c): ContainerContract
+    {
+        return $c;
+    }
+
+    /** @param \Illuminate\Container\Container $c */
+    public function containerImplementsArrayAccess($c): \ArrayAccess
+    {
+        return $c;
+    }
+
+    public function pipelineImplementsContract(\Illuminate\Pipeline\Pipeline $p): PipelineContract
+    {
+        return $p;
+    }
+
+    public function redirectResponseExtendsSymfony(\Illuminate\Http\RedirectResponse $r): BaseRedirectResponse
+    {
+        return $r;
     }
 }
 ?>


### PR DESCRIPTION
## Summary

Four stubs (`Container`, `Pipeline`, `Cache/Repository`, `Http/RedirectResponse`) redeclared their Laravel classes without the `implements` or `extends` clause. Psalm's `ClassLikeNodeScanner` resets `class_implements` and `parent_interfaces` on stub redeclaration and repopulates them only from the stub's own clauses (verified at `vendor/vimeo/psalm/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php:210-212` and `:344-351`). Callers typed on `ContainerContract`, `PipelineContract`, `CacheContract`, or Symfony's `RedirectResponse` parent were silently losing those relationships.

The CLAUDE.md rule covering this ("Class declarations wipe reflected metadata") and the `MessageBag.stubphp` / `Collection.stubphp` precedents already document the fix: restate the clause verbatim.

## Changes

Restated the verbatim `implements`/`extends` clauses plus the corresponding `use` imports:

| File | Added |
| --- | --- |
| `stubs/common/Container/Container.stubphp` | `implements ArrayAccess, ContainerContract` |
| `stubs/common/Pipeline/Pipeline.stubphp` | `implements PipelineContract` |
| `stubs/common/Cache/Repository.stubphp` | `implements ArrayAccess, CacheContract` |
| `stubs/common/Http/RedirectResponse.stubphp` | `extends BaseRedirectResponse` |

Trait `use` inside the class body was intentionally not mirrored (following `Collection.stubphp` precedent, which omits `Macroable`, `TransformsToResourceCollection`). The metadata wipe only affects `class_implements` / `parent_interfaces`.

## Regression coverage

Added 6 cases to `tests/Type/tests/StubInterfaceTest.phpt` (the canonical home for this bug class). Empirically verified: reverting the `implements PipelineContract` clause makes the new test fail with `InvalidReturnType` / `InvalidReturnStatement`, so these are true regression tests.

## Out of scope

`Config/Repository`, `Http/Response`, `Filesystem/Filesystem`, and `Hashing/HashManager` have the same pattern but are not covered here. Worth a follow-up audit of every `class X` redeclared in `stubs/common/` against Laravel source.