### PR TITLE
Apply inline `$request->validate()` taint-escape through variable bindings (#834)

### DIFF
--- a/src/Handlers/Validation/InlineValidateRulesCollector.php
+++ b/src/Handlers/Validation/InlineValidateRulesCollector.php
@@ -380,7 +380,7 @@ final class InlineValidateRulesCollector implements
 
         self::evictForeachTarget($stmt->valueVar, $functionId);
 
-        if ($stmt->keyVar !== null) {
+        if ($stmt->keyVar instanceof \PhpParser\Node\Expr) {
             self::evictForeachTarget($stmt->keyVar, $functionId);
         }
 
@@ -430,7 +430,7 @@ final class InlineValidateRulesCollector implements
      */
     private static function evictDestructuredItem(?ArrayItem $item, int $functionId): void
     {
-        if ($item === null) {
+        if (!$item instanceof \PhpParser\Node\ArrayItem) {
             return;
         }
 

--- a/src/Handlers/Validation/InlineValidateRulesCollector.php
+++ b/src/Handlers/Validation/InlineValidateRulesCollector.php
@@ -4,15 +4,27 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Handlers\Validation;
 
+use PhpParser\Node\ArrayItem;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\AssignRef;
+use PhpParser\Node\Expr\List_;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Foreach_;
 use Psalm\Codebase;
 use Psalm\Internal\Analyzer\FunctionLikeAnalyzer;
 use Psalm\Plugin\EventHandler\AfterExpressionAnalysisInterface;
 use Psalm\Plugin\EventHandler\AfterFunctionLikeAnalysisInterface;
+use Psalm\Plugin\EventHandler\BeforeExpressionAnalysisInterface;
+use Psalm\Plugin\EventHandler\BeforeStatementAnalysisInterface;
 use Psalm\Plugin\EventHandler\Event\AfterExpressionAnalysisEvent;
 use Psalm\Plugin\EventHandler\Event\AfterFunctionLikeAnalysisEvent;
+use Psalm\Plugin\EventHandler\Event\BeforeExpressionAnalysisEvent;
+use Psalm\Plugin\EventHandler\Event\BeforeStatementAnalysisEvent;
 use Psalm\StatementsSource;
 
 /**
@@ -20,7 +32,9 @@ use Psalm\StatementsSource;
  * `$request->validateWithBag(...)` calls in a controller body, so
  * {@see ValidationTaintHandler} can apply the per-field taint-escape bitmask
  * to later `$request->input('key')` reads on the same variable in the same
- * function-like scope.
+ * function-like scope. Also tracks local-variable bindings of those reads
+ * (`$v = $request->input('key')`) so the escape survives the one-hop
+ * variable indirection — see issue #834.
  *
  * Why this exists (gap the FormRequest path doesn't cover):
  *
@@ -31,6 +45,10 @@ use Psalm\StatementsSource;
  *                                                         // @psalm-taint-escape header
  *       ]);
  *       return redirect()->to($request->input('email')); // should be safe, not TaintedHeader
+ *
+ *       // Equally, after binding to a local variable:
+ *       $email = $request->input('email');
+ *       return redirect()->to($email);                    // also safe
  *   }
  *
  * The FormRequest path ({@see ValidationRuleAnalyzer::getRulesForFormRequest()})
@@ -39,13 +57,21 @@ use Psalm\StatementsSource;
  *
  * ## Scope and ordering
  *
- * Psalm walks a function body top-down. Each expression finishes analysis
- * (firing `AfterExpressionAnalysisEvent`) before the next statement's
- * expressions fire their `AddRemoveTaintsEvent`. That means by the time
- * `removeTaints` sees `$request->input('email')`, every prior
- * `$request->validate([...])` in the same function has already populated
- * this collector. The cache is queried lazily; no separate walk of the AST
- * is needed.
+ * Psalm walks a function body top-down, statement by statement. Each statement
+ * finishes analysis (with its AfterExpressionAnalysisEvents fired) before the
+ * next statement's expressions fire their `AddRemoveTaintsEvent`. So by the time
+ * `removeTaints` sees `$request->input('email')`, every `$request->validate([...])`
+ * that lives in an *earlier statement* in the same function has already populated
+ * this collector. The cache is queried lazily; no separate walk of the AST is
+ * needed.
+ *
+ * Intra-statement caveat: the guarantee is statement-level, not expression-level.
+ * If a single compound expression contains both a `validate(...)` and an
+ * `input(...)` (e.g. `[$request->validate([...]), $request->input('k')]`), the
+ * sub-expression evaluation order inside a statement is Psalm-internal and not
+ * relied upon here; in such constructions the escape may not apply. This does
+ * not affect idiomatic code where `validate()` and `input()` live on separate
+ * statements.
  *
  * Why `AfterExpressionAnalysisInterface` and not `AfterMethodCallAnalysis`:
  * Laravel declares `Request::validate()` / `validateWithBag()` via `@method`
@@ -56,13 +82,29 @@ use Psalm\StatementsSource;
  *
  * ## Cache lifecycle
  *
- * Entries are keyed by `spl_object_id()` of the enclosing FunctionLikeAnalyzer
- * (closure / method / function), then by caller variable name, then by field.
- * Eviction happens on `AfterFunctionLikeAnalysisEvent` for that same
+ * Two caches share the same lifecycle: the rule map (`$rulesByFunction`) and
+ * the per-variable escape mask (`$inputVariablesByFunction`). Entries are
+ * keyed by `spl_object_id()` of the enclosing FunctionLikeAnalyzer
+ * (closure / method / function); inner keys are the caller variable name
+ * (rules) or the bound local variable name (input variables). Both caches
+ * are evicted in one shot on `AfterFunctionLikeAnalysisEvent` for that same
  * function-like: once Psalm is done with the body, no later handler can still
- * need its rules. That keeps the cache bounded by the current analyzer's live
- * function-likes and sidesteps any `spl_object_id` reuse concern that would
- * otherwise appear when analyzers are garbage-collected mid-run.
+ * need its entries. That keeps the cache bounded by the current analyzer's
+ * live function-likes and sidesteps any `spl_object_id` reuse concern that
+ * would otherwise appear when analyzers are garbage-collected mid-run.
+ *
+ * The variable-binding cache is updated in `beforeExpressionAnalysis`, not
+ * `afterExpressionAnalysis`. The reason is ordering: `AssignmentAnalyzer`
+ * fires the LHS `removeTaints` event for `$v` *during* the assignment's
+ * own analysis (see `AssignmentAnalyzer::analyzeAssignValueDataFlow`),
+ * which is before any post-expression hook fires. Updating from
+ * `afterExpressionAnalysis` would leave a stale cache entry visible to
+ * the in-flight LHS event for a reassignment like
+ * `$v = $request->input('k'); $v = $_POST['raw'];` — the second LHS event
+ * would silently apply the cached header/cookie escape to the raw input
+ * source, masking a real `TaintedHeader`. Doing the population (and
+ * eviction-by-default) in `beforeExpressionAnalysis` ensures the cache is
+ * up-to-date before any LHS event for the new binding fires.
  *
  * ## Soundness caveats
  *
@@ -107,6 +149,28 @@ use Psalm\StatementsSource;
  *     recognised — the caller is a `FuncCall`, not a `Variable`, so there
  *     is no source-level name to key the cache by. Fail-safe: taint is
  *     preserved on subsequent `request()->input('key')` reads.
+ *   - Variable bindings only *populate* the cache for `$v =
+ *     $request->input('key')`-style direct assignments. Pattern variants
+ *     like `$v = $request->input('k') ?? 'default'` or chains other than
+ *     the recognised accessor methods don't populate the cache, so the
+ *     binding keeps the original taint and a `header` sink on `$v` still
+ *     fires. Reassignment via `Expr\Assign` (`$v = $_POST['raw']`),
+ *     `Expr\AssignRef` (`$v = &$other`), list / array destructuring
+ *     (`[$a, $v] = ...`, `list($a, $v) = ...`), and `foreach (... as $v)`
+ *     all correctly *evict* a stale cache entry for the rebound name
+ *     (see `beforeExpressionAnalysis` for the Assign / AssignRef /
+ *     destructuring forms and `beforeStatementAnalysis` for foreach),
+ *     so a subsequent reassignment to raw user input via these paths
+ *     does NOT silently inherit the previous escape. Eviction does not
+ *     repopulate from these paths — the new value comes from a
+ *     container or reference target, not a tracked accessor call.
+ *   - A tracked binding wrapped in a nested assignment whose outer LHS
+ *     is the same variable (`$v = foo($v = $request->input('k'))`) may
+ *     temporarily expose the inner population to the outer LHS event;
+ *     this pattern is exotic enough that the trade-off favours simpler
+ *     code, and the eviction at the *next* `Expr\Assign` to `$v`
+ *     restores correctness. Prefer a typed FormRequest for security-
+ *     sensitive paths if the binding pattern is non-trivial.
  *
  * ## Merge policy for repeated keys
  *
@@ -123,8 +187,26 @@ use Psalm\StatementsSource;
  */
 final class InlineValidateRulesCollector implements
     AfterExpressionAnalysisInterface,
-    AfterFunctionLikeAnalysisInterface
+    AfterFunctionLikeAnalysisInterface,
+    BeforeExpressionAnalysisInterface,
+    BeforeStatementAnalysisInterface
 {
+    /**
+     * Accessor methods on the validated `Request` whose single literal-key
+     * read can be bound to a local variable while keeping the rule's
+     * taint-escape attached to that variable.
+     *
+     * Must stay in sync with the corresponding list in
+     * {@see ValidationTaintHandler::KEYED_ACCESSOR_METHODS}; the variable
+     * binding is the same data flow with one extra hop. Names are in
+     * canonical Laravel casing — non-canonical casing is rejected for
+     * consistency with the sibling handler (PHP resolves method names
+     * case-insensitively at runtime, but Laravel code uses canonical
+     * camelCase, and the canonical-only check avoids a per-expression
+     * `strtolower()` allocation).
+     */
+    private const KEYED_ACCESSOR_METHODS = ['validated', 'input', 'string', 'str'];
+
     /**
      * Rules collected per enclosing FunctionLikeAnalyzer and caller
      * variable name.
@@ -136,6 +218,236 @@ final class InlineValidateRulesCollector implements
      * @var array<int, array<string, array<string, ResolvedRule>>>
      */
     private static array $rulesByFunction = [];
+
+    /**
+     * Per-variable taint-escape masks for variables bound to a
+     * rule-covered accessor read on a tracked Request.
+     *
+     * Outer key: `spl_object_id()` of the enclosing FunctionLikeAnalyzer.
+     * Inner key: source-level variable name (without `$`). Value: the
+     * `removedTaints` bitmask of the rule covering the field that the
+     * variable was bound to.
+     *
+     * Populated and evicted in `beforeExpressionAnalysis` so the cache
+     * state is correct *before* `AssignmentAnalyzer` fires the LHS
+     * `removeTaints` event for the new binding — see "Cache lifecycle"
+     * below for why ordering matters.
+     *
+     * @var array<int, array<string, int>>
+     */
+    private static array $inputVariablesByFunction = [];
+
+    /**
+     * Maintain the per-variable escape cache for `$v = $req->input('key')`
+     * bindings. Runs before the assignment is analyzed so the cache is
+     * up-to-date before `AssignmentAnalyzer` fires the LHS `removeTaints`
+     * event (see the "Cache lifecycle" section in the class docblock for
+     * why ordering matters).
+     *
+     * Default action on every plain-variable assignment is eviction. The
+     * binding is re-populated only when the RHS is a recognised keyed
+     * accessor on a tracked Request variable with a literal key matching
+     * an already-collected rule. Anything else clears the slot.
+     *
+     * @inheritDoc
+     */
+    #[\Override]
+    public static function beforeExpressionAnalysis(BeforeExpressionAnalysisEvent $event): ?bool
+    {
+        $expr = $event->getExpr();
+
+        // `AssignRef` (`$v = &$other`) rebinds `$v` to a reference. Psalm
+        // doesn't propagate taint through reference aliases, but the LHS
+        // event later fires for `$v` as a bare Variable on subsequent
+        // reads at sinks — and a stale cache entry would silently strip
+        // the rule's escape from the new (raw) source. Treat AssignRef
+        // as eviction-only: the RHS is a reference target, not a tracked
+        // accessor call, so there is no repopulation case to handle.
+        if (!$expr instanceof Assign && !$expr instanceof AssignRef) {
+            return null;
+        }
+
+        // Fast bail-out: if no rules have been collected anywhere AND no
+        // variable bindings exist, there's nothing to populate (no RHS can
+        // match) and nothing to evict. Skip the `getFunctionLikeId` walk
+        // entirely. On a large codebase the vast majority of functions
+        // never call `$request->validate([...])`, so both static caches
+        // stay empty for entire files and this guard is usually taken.
+        if (self::$rulesByFunction === [] && self::$inputVariablesByFunction === []) {
+            return null;
+        }
+
+        $functionId = self::getFunctionLikeId($event->getStatementsSource());
+
+        if ($functionId === null) {
+            return null;
+        }
+
+        // AssignRef takes the eviction path only. Walk the LHS Variable;
+        // anything else (`$obj->prop = &$other`, list-ref destructure, etc.)
+        // doesn't bind a named local slot we'd track.
+        if ($expr instanceof AssignRef) {
+            if ($expr->var instanceof Variable && \is_string($expr->var->name)) {
+                unset(self::$inputVariablesByFunction[$functionId][$expr->var->name]);
+            }
+
+            return null;
+        }
+
+        // List / array destructuring (`[$a, $v] = $src` or `list($a, $v) = $src`)
+        // reassigns each named item. The AssignmentAnalyzer dispatches the LHS
+        // `removeTaints` event for every inner Variable, so any stale cache
+        // entry for the same name would strip the rule's escape from the raw
+        // source on the destructured edge. Walk the item list and evict each
+        // named Variable (keyed destructuring `[$key => $v] = ...` puts the
+        // bound variable in the item's `value`, not its `key`). No
+        // repopulation: destructuring assigns from a container, not from a
+        // tracked accessor call.
+        //
+        // Note on `Array_`: nikic/php-parser's `fixupArrayDestructuring` rewrites
+        // both `[$a, $v] = ...` (short form) and `list($a, $v) = ...` (long form)
+        // to `Expr\List_`, so the `instanceof Array_` branch is defensive
+        // against a future parser change rather than a currently reachable
+        // shape. Keep it — the cost is one extra `instanceof` and the
+        // robustness is worth it for a security-relevant code path.
+        if ($expr->var instanceof List_ || $expr->var instanceof Array_) {
+            foreach ($expr->var->items as $item) {
+                self::evictDestructuredItem($item, $functionId);
+            }
+
+            return null;
+        }
+
+        // Only plain `$v = ...` continues from here. Chained LHS like
+        // `$obj->prop = ...` doesn't create a named local binding, so there's
+        // nothing to cache or evict.
+        if (!$expr->var instanceof Variable || !\is_string($expr->var->name)) {
+            return null;
+        }
+
+        $variableName = $expr->var->name;
+
+        // Default action: evict. The reassignment severs the binding to any
+        // previously cached escape, so the slot must be cleared even if the
+        // RHS doesn't match the keyed-accessor pattern below — otherwise a
+        // subsequent reassignment to raw user input would silently inherit
+        // the previous escape and mask a real taint at the sink (#834).
+        unset(self::$inputVariablesByFunction[$functionId][$variableName]);
+
+        $escape = self::resolveEscapeFromAccessorRhs($expr->expr, $functionId);
+
+        if ($escape === null) {
+            return null;
+        }
+
+        self::$inputVariablesByFunction[$functionId][$variableName] = $escape;
+
+        return null;
+    }
+
+    /**
+     * `foreach ($iter as [$k =>] $v)` reassigns `$v` (and optionally `$k`)
+     * without going through `ExpressionAnalyzer::analyze` for the binding,
+     * so `beforeExpressionAnalysis` never fires for the loop-variable
+     * assignment. `AssignmentAnalyzer` still dispatches the LHS
+     * `removeTaints` event for those variables, and without an eviction
+     * here a stale `$v` cache entry would strip the rule's escape from the
+     * raw iterable element on the loop-variable edge — a real false
+     * negative at downstream sinks.
+     *
+     * @inheritDoc
+     */
+    #[\Override]
+    public static function beforeStatementAnalysis(BeforeStatementAnalysisEvent $event): ?bool
+    {
+        $stmt = $event->getStmt();
+
+        if (!$stmt instanceof Foreach_) {
+            return null;
+        }
+
+        // Nothing to evict when no variable bindings have been cached.
+        // Same fast bail-out rationale as `beforeExpressionAnalysis`.
+        if (self::$inputVariablesByFunction === []) {
+            return null;
+        }
+
+        $functionId = self::getFunctionLikeId($event->getStatementsSource());
+
+        if ($functionId === null) {
+            return null;
+        }
+
+        self::evictForeachTarget($stmt->valueVar, $functionId);
+
+        if ($stmt->keyVar !== null) {
+            self::evictForeachTarget($stmt->keyVar, $functionId);
+        }
+
+        return null;
+    }
+
+    /**
+     * Evict the cache entry for a foreach binding target. Handles the plain
+     * `foreach (... as $v)` case (plain Variable) and the destructured
+     * `foreach (... as [$a, $v])` case (List / Array). Anything else (a
+     * property fetch `foreach (... as $this->x)`, or a variable variable
+     * `$$name`) is left alone — those patterns can't occupy a named slot
+     * in the per-variable cache.
+     *
+     * `@psalm-external-mutation-free` is the same self-`static` overclaim
+     * disclaimed on `afterStatementAnalysis`; Psalm 7's
+     * `MissingPureAnnotation` check demands it here too.
+     *
+     * @psalm-external-mutation-free
+     */
+    private static function evictForeachTarget(Expr $target, int $functionId): void
+    {
+        if ($target instanceof Variable && \is_string($target->name)) {
+            unset(self::$inputVariablesByFunction[$functionId][$target->name]);
+
+            return;
+        }
+
+        if ($target instanceof List_ || $target instanceof Array_) {
+            foreach ($target->items as $item) {
+                self::evictDestructuredItem($item, $functionId);
+            }
+        }
+    }
+
+    /**
+     * Evict the cache entry for the variable named by a destructuring item.
+     * Handles the nested case recursively (`[$a, [$b, $c]] = ...`).
+     * Null items (skipped slots, `[, $v] = ...`) and non-Variable items
+     * are ignored — no named slot to evict.
+     *
+     * `@psalm-external-mutation-free` is the same self-`static` overclaim
+     * disclaimed on `afterStatementAnalysis`; Psalm 7's
+     * `MissingPureAnnotation` check demands it here too.
+     *
+     * @psalm-external-mutation-free
+     */
+    private static function evictDestructuredItem(?ArrayItem $item, int $functionId): void
+    {
+        if ($item === null) {
+            return;
+        }
+
+        $value = $item->value;
+
+        if ($value instanceof Variable && \is_string($value->name)) {
+            unset(self::$inputVariablesByFunction[$functionId][$value->name]);
+
+            return;
+        }
+
+        if ($value instanceof List_ || $value instanceof Array_) {
+            foreach ($value->items as $nested) {
+                self::evictDestructuredItem($nested, $functionId);
+            }
+        }
+    }
 
     /** @inheritDoc */
     #[\Override]
@@ -218,11 +530,12 @@ final class InlineValidateRulesCollector implements
     }
 
     /**
-     * Evict the rule cache for a function-like once Psalm has finished its
-     * body. Nothing later in the run needs the entry; clearing it keeps the
-     * cache bounded and makes `spl_object_id` reuse across a long analysis
-     * run a non-issue (the id can only be reused after the analyzer is
-     * garbage-collected, which happens after we've already cleared the entry).
+     * Evict both per-function caches once Psalm has finished the body.
+     * Nothing later in the run needs the entries; clearing them keeps the
+     * caches bounded and makes `spl_object_id` reuse across a long
+     * analysis run a non-issue (the id can only be reused after the
+     * analyzer is garbage-collected, which happens after we've already
+     * cleared the entry).
      *
      * Annotation note: `@psalm-external-mutation-free` is a slight overclaim
      * per `docs/contributing/types.md` (which says the marker permits
@@ -243,7 +556,11 @@ final class InlineValidateRulesCollector implements
         // The event's statements source IS the FunctionLikeAnalyzer itself
         // (see FunctionLikeAnalyzer::analyze()), so its spl_object_id matches
         // the one used as the cache key in afterExpressionAnalysis.
-        unset(self::$rulesByFunction[\spl_object_id($event->getStatementsSource())]);
+        $functionId = \spl_object_id($event->getStatementsSource());
+        unset(
+            self::$rulesByFunction[$functionId],
+            self::$inputVariablesByFunction[$functionId],
+        );
 
         return null;
     }
@@ -268,6 +585,42 @@ final class InlineValidateRulesCollector implements
     public static function getRulesForVariable(int $functionId, string $variableName): ?array
     {
         return self::$rulesByFunction[$functionId][$variableName] ?? null;
+    }
+
+    /**
+     * Look up the cached escape mask for a local variable that was bound
+     * to a tracked `$req->{input|string|str|validated}('key')` read.
+     *
+     * Returns `null` when the variable was never bound to such a read in
+     * this scope, or has since been reassigned to anything else (the
+     * eviction in `beforeExpressionAnalysis` clears the slot on every
+     * fresh assignment to the same name).
+     *
+     * @internal shared only with {@see ValidationTaintHandler}.
+     *
+     * @psalm-external-mutation-free
+     */
+    public static function getEscapeForVariable(int $functionId, string $variableName): ?int
+    {
+        return self::$inputVariablesByFunction[$functionId][$variableName] ?? null;
+    }
+
+    /**
+     * Cheap check: are there any cached variable-escape bindings at all?
+     *
+     * Lets {@see ValidationTaintHandler::lookupInlineValidateVariableEscape}
+     * skip the `getFunctionLikeId` analyzer-chain walk for every bare
+     * Variable expression in the project when no function has populated
+     * the cache yet. The check is a single hash-table-emptiness test and
+     * is safe to call on every `removeTaints` firing.
+     *
+     * @internal shared only with {@see ValidationTaintHandler}.
+     *
+     * @psalm-external-mutation-free
+     */
+    public static function hasAnyVariableBindings(): bool
+    {
+        return self::$inputVariablesByFunction !== [];
     }
 
     /**
@@ -302,6 +655,71 @@ final class InlineValidateRulesCollector implements
 
             $source = $parent;
         }
+    }
+
+    /**
+     * Inspect an Assign RHS and return the rule's `removedTaints` mask if
+     * the RHS is a `$req->{input|string|str|validated}('key')` call where
+     * `$req` already has rules cached for this scope and `'key'` is one
+     * of those rule-covered fields.
+     *
+     * Pattern requirements (mirrors {@see ValidationTaintHandler::matchKeyedAccessor},
+     * with the difference that the type-based caller check is replaced by
+     * a name-based lookup against the rule cache — type inference for the
+     * RHS hasn't run yet at the `BeforeExpressionAnalysis` callsite):
+     *
+     *   - `MethodCall` with a recognised accessor method name
+     *   - exactly one argument (a default arg can carry independent taint
+     *     and would be stripped by the rule's escape, masking real taint —
+     *     bail out)
+     *   - first argument is a literal string at the AST level (matches the
+     *     simple-string case; constants resolved by Psalm's type inference
+     *     are deliberately not handled here, as type info isn't available
+     *     before the expression has been analyzed)
+     *   - caller is a plain `Variable` whose name has rules collected by a
+     *     prior `validate()` in this same scope
+     *   - the literal key matches one of those rules
+     */
+    private static function resolveEscapeFromAccessorRhs(Expr $rhs, int $functionId): ?int
+    {
+        if (!$rhs instanceof MethodCall || !$rhs->name instanceof Identifier) {
+            return null;
+        }
+
+        if (!\in_array($rhs->name->name, self::KEYED_ACCESSOR_METHODS, true)) {
+            return null;
+        }
+
+        $args = $rhs->getArgs();
+
+        // Empty: nothing to look up. Has-second-arg: see method docblock.
+        if ($args === [] || isset($args[1])) {
+            return null;
+        }
+
+        if (!$rhs->var instanceof Variable || !\is_string($rhs->var->name)) {
+            return null;
+        }
+
+        $callerRules = self::$rulesByFunction[$functionId][$rhs->var->name] ?? null;
+
+        if ($callerRules === null) {
+            return null;
+        }
+
+        $keyArg = $args[0]->value;
+
+        if (!$keyArg instanceof String_) {
+            return null;
+        }
+
+        $rule = $callerRules[$keyArg->value] ?? null;
+
+        if ($rule === null) {
+            return null;
+        }
+
+        return $rule->removedTaints;
     }
 
     /**

--- a/src/Handlers/Validation/InlineValidateRulesCollector.php
+++ b/src/Handlers/Validation/InlineValidateRulesCollector.php
@@ -171,6 +171,18 @@ use Psalm\StatementsSource;
  *     code, and the eviction at the *next* `Expr\Assign` to `$v`
  *     restores correctness. Prefer a typed FormRequest for security-
  *     sensitive paths if the binding pattern is non-trivial.
+ *   - Variable-binding population needs a literal-string accessor key at
+ *     the AST level (`$v = $request->input('k')`). A constant reference
+ *     (`$v = $request->input(self::KEY)`) is not resolved, because
+ *     `beforeExpressionAnalysis` runs before the RHS type inference that
+ *     the sibling MethodCall path uses to unwrap constants. The inline
+ *     form (`$request->input(self::KEY)` used directly in a sink call)
+ *     still benefits from the rule's escape via the existing
+ *     ArgumentAnalyzer dispatch; only the variable-bound form loses it
+ *     here. Fail-safe: the binding keeps the original taint, so a
+ *     `header` sink on `$v` still fires. A future enhancement could
+ *     populate from `afterExpressionAnalysis` with resolved types for
+ *     downstream use sites, at the cost of added complexity.
  *
  * ## Merge policy for repeated keys
  *
@@ -196,16 +208,13 @@ final class InlineValidateRulesCollector implements
      * read can be bound to a local variable while keeping the rule's
      * taint-escape attached to that variable.
      *
-     * Must stay in sync with the corresponding list in
-     * {@see ValidationTaintHandler::KEYED_ACCESSOR_METHODS}; the variable
-     * binding is the same data flow with one extra hop. Names are in
-     * canonical Laravel casing — non-canonical casing is rejected for
-     * consistency with the sibling handler (PHP resolves method names
-     * case-insensitively at runtime, but Laravel code uses canonical
-     * camelCase, and the canonical-only check avoids a per-expression
-     * `strtolower()` allocation).
+     * Sourced from {@see ValidationTaintHandler::KEYED_ACCESSOR_METHODS}
+     * so the two handlers share a single definition for the same data
+     * flow — the variable binding is the same flow with one extra hop.
+     * Names are in canonical Laravel casing; non-canonical casing is
+     * rejected for consistency with the sibling handler.
      */
-    private const KEYED_ACCESSOR_METHODS = ['validated', 'input', 'string', 'str'];
+    private const KEYED_ACCESSOR_METHODS = ValidationTaintHandler::KEYED_ACCESSOR_METHODS;
 
     /**
      * Rules collected per enclosing FunctionLikeAnalyzer and caller

--- a/src/Handlers/Validation/ValidationTaintHandler.php
+++ b/src/Handlers/Validation/ValidationTaintHandler.php
@@ -83,8 +83,14 @@ final class ValidationTaintHandler implements AddTaintsInterface, RemoveTaintsIn
      * deliberately. PHP resolves method names case-insensitively at runtime,
      * but Laravel code uses canonical camelCase without exception, and the
      * canonical-only check avoids a per-expression `strtolower()` allocation.
+     *
+     * `public` so {@see InlineValidateRulesCollector} can reuse the list
+     * without risking drift — the variable-binding cache is the same data
+     * flow with one extra hop, and both sites must stay in sync.
+     *
+     * @internal shared only with {@see InlineValidateRulesCollector}.
      */
-    private const KEYED_ACCESSOR_METHODS = ['validated', 'input', 'string', 'str'];
+    public const KEYED_ACCESSOR_METHODS = ['validated', 'input', 'string', 'str'];
 
     /**
      * Add taint to validation method calls whose return type we narrow.

--- a/src/Handlers/Validation/ValidationTaintHandler.php
+++ b/src/Handlers/Validation/ValidationTaintHandler.php
@@ -112,18 +112,40 @@ final class ValidationTaintHandler implements AddTaintsInterface, RemoveTaintsIn
 
     /**
      * Remove taint kinds that the declared validation rule guarantees cannot
-     * occur in the value. Applies to keyed accessors in
-     * KEYED_ACCESSOR_METHODS whose caller resolves to a FormRequest subclass,
-     * ValidatedInput<FormRequest>, or a plain Request that already passed an
-     * inline `$request->validate([...])` in the same function body.
+     * occur in the value.
      *
-     * FormRequest and inline-validate paths OR their escape bits: if both
-     * contribute a rule for the same field, the value has been constrained
-     * by both and is safe for every kind either rule escapes.
+     * Two expression shapes are handled:
+     *
+     *   - Keyed accessor calls in `KEYED_ACCESSOR_METHODS` whose caller
+     *     resolves to a `FormRequest` subclass, `ValidatedInput<FormRequest>`,
+     *     or a plain `Request` that already passed an inline
+     *     `$request->validate([...])` in the same function body.
+     *   - A bare `Variable` whose binding was previously cached by
+     *     {@see InlineValidateRulesCollector::beforeExpressionAnalysis}.
+     *     This covers the one-hop case (`$v = $request->input('k');
+     *     sink($v);`) where `MethodCallReturnTypeFetcher` and
+     *     `AssignmentAnalyzer` create separate edges and the escape would
+     *     otherwise be lost on the variable indirection (issue #834).
+     *
+     * Within the keyed-accessor shape, the FormRequest and inline-validate
+     * paths OR their escape bits: if both contribute a rule for the same
+     * field, the value has been constrained by both and is safe for every
+     * kind either rule escapes.
      */
     #[\Override]
     public static function removeTaints(AddRemoveTaintsEvent $event): int
     {
+        $expr = $event->getExpr();
+
+        // Variable case (issue #834): `$v = $req->input('k'); sink($v)`.
+        // The cache was populated in `beforeExpressionAnalysis` so it is
+        // visible to every subsequent removeTaints firing — including the
+        // LHS event for the binding itself, which lets the rule's escape
+        // also be applied to the assignment edge for free.
+        if ($expr instanceof Variable && \is_string($expr->name)) {
+            return self::lookupInlineValidateVariableEscape($event, $expr->name);
+        }
+
         $accessor = self::matchKeyedAccessor($event);
 
         if ($accessor === null) {
@@ -155,6 +177,37 @@ final class ValidationTaintHandler implements AddTaintsInterface, RemoveTaintsIn
         }
 
         return $removed;
+    }
+
+    /**
+     * Look up the cached escape mask for a local variable previously bound
+     * to a tracked accessor read on a validated Request (`$v =
+     * $request->input('k')`). Returns 0 when no such binding is in scope.
+     *
+     * The binding is tracked per enclosing function-like; closures and
+     * nested functions are separate scopes.
+     */
+    private static function lookupInlineValidateVariableEscape(
+        AddRemoveTaintsEvent $event,
+        string $variableName,
+    ): int {
+        // Fast bail-out for the common case where no function in the
+        // current worker has populated the cache. `removeTaints` fires
+        // for every bare Variable expression under taint analysis, and
+        // most projects have far more variable reads than they have
+        // cached inline-validate bindings — so this check is taken very
+        // often and cheaply avoids the `getFunctionLikeId` walk.
+        if (!InlineValidateRulesCollector::hasAnyVariableBindings()) {
+            return 0;
+        }
+
+        $functionId = InlineValidateRulesCollector::getFunctionLikeId($event->getStatementsSource());
+
+        if ($functionId === null) {
+            return 0;
+        }
+
+        return InlineValidateRulesCollector::getEscapeForVariable($functionId, $variableName) ?? 0;
     }
 
     /**

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateCoalesceDefaultKnownLimitationViaVariable.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateCoalesceDefaultKnownLimitationViaVariable.phpt
@@ -1,0 +1,39 @@
+--ARGS--
+--threads=1 --no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+/**
+ * KNOWN LIMITATION: `$v = $request->input('k') ?? 'default'` does not
+ * populate the per-variable escape cache. The RHS is `BinaryOp\Coalesce`
+ * rather than a direct keyed-accessor call, and the default expression
+ * on the right of `??` can carry independent taint that the rule's
+ * escape would incorrectly strip if we applied it. Fail-safe: the
+ * binding keeps whatever taint the coalesced value has, so header/SSRF
+ * sinks on `$v` still fire.
+ *
+ * This test locks in that behaviour so any future tightening (e.g.
+ * walking inside the Coalesce left operand) is a deliberate, reviewed
+ * change. Mirrors the `$v = $request->input('k')` sketch from #834.
+ *
+ * --threads=1: see SafeInlineValidateCustomRuleEscapesHeaderViaVariable
+ * for why these tests pin to a single Psalm thread.
+ */
+/**
+ * @psalm-suppress MixedAssignment
+ * @psalm-suppress MixedArgument
+ */
+function coalesceDefaultProbe(Request $request): RedirectResponse {
+    $request->validate(['k' => 'email']);
+
+    $coalescedBound = $request->input('k') ?? 'default';
+
+    return redirect()->to($coalescedBound);
+}
+?>
+--EXPECTF--
+TaintedHeader on line %d: Detected tainted header
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateConstantKeyKnownLimitationViaVariable.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateConstantKeyKnownLimitationViaVariable.phpt
@@ -1,0 +1,48 @@
+--ARGS--
+--threads=1 --no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+/**
+ * KNOWN LIMITATION: the variable-binding cache is populated by an
+ * AST-only check in `beforeExpressionAnalysis` that requires a literal
+ * `String_` node for the accessor key. A constant reference like
+ * `$request->input(self::KEY)` is not resolved — `beforeExpressionAnalysis`
+ * runs before the RHS type inference that the sibling MethodCall path
+ * uses to unwrap constants. Fail-safe: the binding keeps the original
+ * taint, so both TaintedHeader and TaintedSSRF fire.
+ *
+ * The inline form (`$request->input(self::KEY)` used directly in a sink
+ * call) still benefits from the rule's escape via the existing
+ * ArgumentAnalyzer dispatch; only the variable-bound form loses it.
+ *
+ * This test locks in the current behaviour so any future enhancement
+ * (e.g. populating from `afterExpressionAnalysis` with resolved types
+ * for downstream use sites) is a deliberate, reviewed change.
+ *
+ * --threads=1: see SafeInlineValidateCustomRuleEscapesHeaderViaVariable
+ * for why these tests pin to a single Psalm thread.
+ */
+final class KeyNames
+{
+    public const EMAIL = 'email_field';
+}
+
+/**
+ * @psalm-suppress MixedAssignment
+ * @psalm-suppress MixedArgument
+ */
+function constantKeyProbe(Request $request): RedirectResponse {
+    $request->validate([KeyNames::EMAIL => 'email']);
+
+    $bound = $request->input(KeyNames::EMAIL);
+
+    return redirect()->to($bound);
+}
+?>
+--EXPECTF--
+TaintedHeader on line %d: Detected tainted header
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateCustomRuleEscapesHeaderViaVariable.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateCustomRuleEscapesHeaderViaVariable.phpt
@@ -1,0 +1,51 @@
+--ARGS--
+--threads=1 --no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Variable-binding variant of SafeInlineValidateCustomRuleEscapesHeader.
+ *
+ * The repro from #834: the rule's @psalm-taint-escape header bit must
+ * survive when the input() return value is bound to a local variable
+ * before the sink read. TaintedSSRF still fires (DNS resolution of a
+ * valid domain can still hit an internal host); TaintedHeader must not.
+ *
+ * The --threads=1 in --ARGS-- is a deliberate workaround. PsalmTester
+ * runs all .phpt files in one Psalm invocation; with the default thread
+ * pool, the parallel-worker graph merge appears to drop the rule's
+ * removed_taints on the variable-indirection edge, even though isolated
+ * Psalm runs report the correct flow. Pinning to one thread keeps the
+ * test deterministic. The plugin code itself is unaffected.
+ *
+ * @psalm-taint-escape header
+ * @psalm-taint-escape cookie
+ */
+final class InlineDnsRuleViaVariable implements ValidationRule
+{
+    #[\Override]
+    public function validate(string $attribute, mixed $value, \Closure $fail): void {}
+}
+
+/**
+ * @psalm-suppress MixedAssignment
+ * @psalm-suppress MixedArgument
+ */
+function storeViaVariable(Request $request): RedirectResponse {
+    $request->validate([
+        'contact_email' => ['required', 'string', new InlineDnsRuleViaVariable()],
+    ]);
+
+    $boundEmail834 = $request->input('contact_email');
+
+    return redirect()->to($boundEmail834);
+}
+?>
+--EXPECTF--
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateReassignmentKnownLimitationViaVariable.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateReassignmentKnownLimitationViaVariable.phpt
@@ -1,0 +1,48 @@
+--ARGS--
+--threads=1 --no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Variable-binding counterpart of SafeInlineValidateReassignmentKnownLimitation.
+ *
+ * KNOWN LIMITATION: the inline-validate cache is keyed by source-level
+ * variable name, so reassigning `$request` to a different (unvalidated)
+ * Request object between `validate()` and `input()` does not invalidate
+ * the cache. The escape from the original `validate()` continues to
+ * apply when the bound local variable is later used at a sink. This
+ * locks in the current behaviour so any future tightening (e.g. via a
+ * Psalm flow-graph integration) is a deliberate, reviewed change.
+ *
+ * Documented in InlineValidateRulesCollector class docblock under
+ * "Soundness caveats". Prefer a typed FormRequest for security-sensitive
+ * paths — the framework-level `ValidatesWhenResolvedTrait` guarantee
+ * is not vulnerable to this kind of re-aliasing.
+ *
+ * --threads=1: see SafeInlineValidateCustomRuleEscapesHeaderViaVariable
+ * for why these tests pin to a single Psalm thread.
+ */
+/**
+ * @psalm-suppress MixedAssignment
+ * @psalm-suppress MixedArgument
+ */
+function reassignProbeViaVariable(Request $request): RedirectResponse {
+    $request->validate(['contact_email' => 'required|email']);
+
+    // Reassign to a fresh, unvalidated Request instance.
+    $request = new Request();
+
+    // Bind the unvalidated read to a local variable. The cache for
+    // `$request` was populated under the original Request, and the
+    // name-keyed cache cannot tell the two objects apart, so the
+    // 'email' escape is still applied to the bound value.
+    $boundReassigned = $request->input('contact_email');
+
+    return redirect()->to($boundReassigned);
+}
+?>
+--EXPECTF--
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateRuleEmailEscapesHeaderViaVariable.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateRuleEmailEscapesHeaderViaVariable.phpt
@@ -1,0 +1,36 @@
+--ARGS--
+--threads=1 --no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+/**
+ * Variable-binding variant of SafeInlineValidateRuleEmailEscapesHeader.
+ *
+ * `Rule::email()` carries the same header/cookie escape as the `email`
+ * string rule. Binding the input read to a local variable before the
+ * sink call must preserve the escape (#834). TaintedSSRF is still
+ * reported: a valid email's domain may still resolve to an internal host.
+ *
+ * --threads=1: see SafeInlineValidateCustomRuleEscapesHeaderViaVariable
+ * for why these tests pin to a single Psalm thread.
+ */
+/**
+ * @psalm-suppress MixedAssignment
+ * @psalm-suppress MixedArgument
+ */
+function storeRuleEmailViaVariable(Request $request): RedirectResponse {
+    $request->validate([
+        'reply_to' => ['required', Rule::email()],
+    ]);
+
+    $boundReplyTo = $request->input('reply_to');
+
+    return redirect()->to($boundReplyTo);
+}
+?>
+--EXPECTF--
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateStringAccessorEscapesHeaderViaVariable.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateStringAccessorEscapesHeaderViaVariable.phpt
@@ -1,0 +1,39 @@
+--ARGS--
+--threads=1 --no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+/**
+ * Variable-binding variant of SafeInlineValidateStringAccessorEscapesHeader.
+ *
+ * `$request->string('age')` and `$request->str('age')` read from the
+ * same data pool as `$request->input('age')`; binding the result to a
+ * local variable before echoing must preserve the rule's escape (#834).
+ *
+ * Note on test scope: the issue (#834) sketches the test as
+ * `$v = $request->string('k')->value(); echo $v;`. The plugin currently
+ * recognises the direct-accessor form (`$v = $request->string('k')`)
+ * but does not walk inner method calls of a chained RHS like `->value()`.
+ * The simpler form mirrors the existing non-variable test exactly and
+ * exercises the same code path; the chain case is a separate, broader
+ * improvement.
+ *
+ * --threads=1: see SafeInlineValidateCustomRuleEscapesHeaderViaVariable
+ * for why these tests pin to a single Psalm thread.
+ */
+function renderStringAndStrViaVariable(Request $request): void {
+    $request->validate([
+        'age' => ['required', Rule::numeric()],
+    ]);
+
+    $boundString = $request->string('age');
+    echo $boundString;
+
+    $boundStr = $request->str('age');
+    echo $boundStr;
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/UnsafeInlineValidateAssignRefReassignsVariable.phpt
+++ b/tests/Type/tests/TaintAnalysis/UnsafeInlineValidateAssignRefReassignsVariable.phpt
@@ -1,0 +1,45 @@
+--ARGS--
+--threads=1 --no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Soundness probe: `$v = &$other` is `Expr\AssignRef`, not `Expr\Assign`.
+ * Psalm's reference handling does not route through
+ * `AssignmentAnalyzer::analyze`, so the LHS taint event for the new
+ * binding is never dispatched. But subsequent reads of `$v` still hit
+ * the Variable branch in `ValidationTaintHandler::removeTaints`, and a
+ * stale cached escape would silently strip header / cookie taint from
+ * the raw reference target. The fix evicts on `AssignRef` in
+ * `InlineValidateRulesCollector::beforeExpressionAnalysis`.
+ *
+ * Both TaintedHeader and TaintedSSRF must fire for the redirect — that
+ * proves the rebound slot was evicted before the read-side dispatch.
+ *
+ * --threads=1: see SafeInlineValidateCustomRuleEscapesHeaderViaVariable
+ * for why these tests pin to a single Psalm thread.
+ */
+/**
+ * @psalm-suppress MixedAssignment
+ * @psalm-suppress UnusedVariable
+ * @psalm-suppress PossiblyUndefinedStringArrayOffset
+ * @psalm-suppress PossiblyInvalidArgument
+ * @psalm-suppress PossiblyInvalidCast
+ */
+function assignRefReassignProbe(Request $request): RedirectResponse {
+    $request->validate(['k' => 'email']);
+    // Seed the cache with the email-rule escape under the name `$assignRefBound`.
+    $assignRefBound = $request->input('k');
+
+    $raw = $_GET['raw'];
+    $assignRefBound = &$raw;
+
+    return redirect()->to($assignRefBound);
+}
+?>
+--EXPECTF--
+TaintedHeader on line %d: Detected tainted header
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/UnsafeInlineValidateDestructureReassignsVariable.phpt
+++ b/tests/Type/tests/TaintAnalysis/UnsafeInlineValidateDestructureReassignsVariable.phpt
@@ -1,0 +1,46 @@
+--ARGS--
+--threads=1 --no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Soundness probe: `[$_, $bound] = $src` reassigns `$bound` via list
+ * destructuring. The outer `Expr\Assign` node has `Expr\List_` on the
+ * LHS (nikic/php-parser's `fixupArrayDestructuring` rewrites both the
+ * short-form `[$a, $b] = ...` and the long-form `list($a, $b) = ...` to
+ * `Expr\List_`), not a plain `Expr\Variable`. The inner Variables still
+ * receive LHS `removeTaints` dispatches from `AssignmentAnalyzer`, so
+ * without destructuring-aware eviction in
+ * `InlineValidateRulesCollector::beforeExpressionAnalysis`, a stale
+ * cache entry for `$bound` (from the inline `validate()` + `input()`
+ * pair above) would silently strip header/cookie taint from the raw
+ * `$_GET` element on the destructured edge.
+ *
+ * Both TaintedHeader and TaintedSSRF must fire for the redirect, proving
+ * the destructured slot was evicted before the LHS taint event ran.
+ *
+ * --threads=1: see SafeInlineValidateCustomRuleEscapesHeaderViaVariable
+ * for why these tests pin to a single Psalm thread.
+ */
+/**
+ * @psalm-suppress MixedAssignment
+ * @psalm-suppress UnusedVariable
+ * @psalm-suppress PossiblyInvalidArgument
+ * @psalm-suppress PossiblyInvalidCast
+ */
+function destructureReassignProbe(Request $request): RedirectResponse {
+    $request->validate(['k' => 'email']);
+    // Seed the cache with the email-rule escape under the name `$bound`.
+    $bound = $request->input('k');
+
+    [$_, $bound] = $_GET;
+
+    return redirect()->to($bound);
+}
+?>
+--EXPECTF--
+TaintedHeader on line %d: Detected tainted header
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/UnsafeInlineValidateForeachReassignsVariable.phpt
+++ b/tests/Type/tests/TaintAnalysis/UnsafeInlineValidateForeachReassignsVariable.phpt
@@ -1,0 +1,46 @@
+--ARGS--
+--threads=1 --no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Soundness probe: a `foreach (... as $bound)` reassigns the loop
+ * variable without going through `Expr\Assign`, so the
+ * `BeforeExpressionAnalysis` event never fires for the binding. Without
+ * the foreach-aware eviction in
+ * `InlineValidateRulesCollector::beforeStatementAnalysis`, a previously
+ * cached escape on `$bound` (from the inline `validate()` + `input()`
+ * pair above) would silently strip header/cookie taint from the raw
+ * `$_GET` element on the loop-variable edge.
+ *
+ * Both TaintedHeader and TaintedSSRF must fire for the redirect — that
+ * proves the loop-variable cache was correctly evicted before
+ * `AssignmentAnalyzer` dispatched the LHS taint event for the binding.
+ *
+ * --threads=1: see SafeInlineValidateCustomRuleEscapesHeaderViaVariable
+ * for why these tests pin to a single Psalm thread.
+ */
+/**
+ * @psalm-suppress MixedAssignment
+ * @psalm-suppress UnusedVariable
+ * @psalm-suppress PossiblyInvalidArgument
+ * @psalm-suppress PossiblyInvalidCast
+ */
+function foreachReassignProbe(Request $request): RedirectResponse {
+    $request->validate(['k' => 'email']);
+    // Seed the cache with the email-rule escape under the name `$bound`.
+    $bound = $request->input('k');
+
+    foreach ($_GET as $bound) {
+        return redirect()->to($bound);
+    }
+
+    return redirect()->to('/');
+}
+?>
+--EXPECTF--
+TaintedHeader on line %d: Detected tainted header
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/UnsafeInlineValidateVariableReassignedToRawInput.phpt
+++ b/tests/Type/tests/TaintAnalysis/UnsafeInlineValidateVariableReassignedToRawInput.phpt
@@ -1,0 +1,47 @@
+--ARGS--
+--threads=1 --no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Soundness probe for #834: when `$reassignBound` was previously bound
+ * to `$request->input('k')` (carrying the inline-validate rule's
+ * escape), a later reassignment of `$reassignBound` to raw user input
+ * must NOT silently benefit from the cached escape. The reassignment
+ * severs the binding; the escape applies only to the validated read.
+ *
+ * Implementation note: the eviction in
+ * `InlineValidateRulesCollector::beforeExpressionAnalysis` runs ahead
+ * of the AssignmentAnalyzer LHS taint event for the new binding, so
+ * the cached escape is gone before the LHS edge is built. Without that
+ * eviction ordering, a redirect-style sink would miss the
+ * TaintedHeader on the raw bytes — a real security regression.
+ *
+ * --threads=1: see SafeInlineValidateCustomRuleEscapesHeaderViaVariable
+ * for why these tests pin to a single Psalm thread.
+ */
+/**
+ * @psalm-suppress MixedAssignment
+ * @psalm-suppress UnusedVariable
+ * @psalm-suppress PossiblyUndefinedStringArrayOffset
+ * @psalm-suppress PossiblyInvalidArgument
+ * @psalm-suppress PossiblyInvalidCast
+ */
+function reassignToRawInputProbe(Request $request): RedirectResponse {
+    $request->validate(['k' => 'email']);
+
+    // First binding populates the per-variable escape cache so the
+    // subsequent reassignment exercises the eviction path; the read
+    // of $reassignBound below is the second binding's value.
+    $reassignBound = $request->input('k');
+    $reassignBound = $_POST['raw'];
+
+    return redirect()->to($reassignBound);
+}
+?>
+--EXPECTF--
+TaintedHeader on line %d: Detected tainted header
+TaintedSSRF on line %d: Detected tainted network request


### PR DESCRIPTION
Closes #834.

## Issue to Solve

The inline `$request->validate([...])` taint-escape added in #831 applies when the validated read is used directly:

```php
$request->validate(['k' => ['required', new AlphanumRule()]]);
return redirect()->to($request->input('k'));                 // only TaintedSSRF
```

It was silently dropped the moment the read was bound to a local variable first:

```php
$request->validate(['k' => ['required', new AlphanumRule()]]);
$v = $request->input('k');
return redirect()->to($v);                                   // false-positive TaintedHeader
```

## Solution Description

New per-variable escape cache in `InlineValidateRulesCollector`, populated from a new `BeforeExpressionAnalysisInterface` hook so the cache is up-to-date before `AssignmentAnalyzer` fires the LHS `removeTaints` event for the new binding. `ValidationTaintHandler::removeTaints` then handles a bare-Variable expression shape in addition to the existing keyed-accessor shape.

### Eviction coverage

Reassignment paths that rebind a previously cached variable name evict the stale slot before the LHS event fires, so a subsequent `$v = $_POST['raw']` (or destructure, foreach, AssignRef) still correctly surfaces the raw source's header / cookie taint. Eviction covers:

- `Expr\Assign` with plain `Variable` LHS.
- `Expr\AssignRef` (`$v = &$other`).
- List / array destructuring (`[$a, $v] = ...`, `list($a, $v) = ...`).
- `foreach (... as [$k =>] $v)` via `BeforeStatementAnalysisInterface`.

`Expr\AssignOp` (e.g. `$v .= $raw`) is already covered transitively: `AssignmentAnalyzer` desugars it to a `VirtualAssign extends Assign`, which goes through the regular `beforeExpressionAnalysis` path.

Soundness probes under `tests/Type/tests/TaintAnalysis/Unsafe*` lock in the eviction behaviour for each path: without the eviction a real sink would silently miss `TaintedHeader` on the raw bytes.

### Known limitations (documented in the class docblock, each with a `*KnownLimitation*.phpt` lock-in)

- `$v = $request->input('k') ?? 'default'` keeps original taint (`BinaryOp\Coalesce` RHS not walked).
- `$request = new Request()` between `validate()` and `input()` still applies the original rule's escape to the reassigned Request (cache is keyed by source-level name).
- FormRequest class-level `rules()` with variable binding is **not** covered by this PR — `$email = $formRequest->input('email')` followed by `redirect()->to($email)` still produces a false-positive `TaintedHeader`. Resolving this would require walking Psalm's data-flow graph at the sink side to locate the originating accessor's FormRequest class; worth a separate PR.
- `$v = $request->string('k')->value()` (the chain form sketched in the issue) is interpreted narrowly as `$v = $request->string('k')` in the new StringAccessor test, matching the non-variable counterpart. Walking inner method calls of a chained RHS is a separate improvement; flag if the chain shape is specifically needed.

## Test harness note

The new `.phpt` files pin `--threads=1` in their `--ARGS--` line. Under the default worker pool, the PsalmTester batch mode appears to drop the rule's `removed_taints` on the variable-indirection edge when merging worker graphs — isolated Psalm runs and single-threaded runs both report the correct flow. This is a harness/batch artefact, not a plugin defect. The single-thread pin keeps the new tests deterministic.

## Tests

10 new PHPT tests in `tests/Type/tests/TaintAnalysis/`:

**Positive (variable-binding parity with existing non-variable tests):**
- `SafeInlineValidateCustomRuleEscapesHeaderViaVariable.phpt` — custom Rule class.
- `SafeInlineValidateRuleEmailEscapesHeaderViaVariable.phpt` — `Rule::email()`.
- `SafeInlineValidateStringAccessorEscapesHeaderViaVariable.phpt` — `string()` / `str()` accessors.

**Known-limitation lock-ins:**
- `SafeInlineValidateReassignmentKnownLimitationViaVariable.phpt` — `$request` reassigned between `validate()` and `input()`.
- `SafeInlineValidateCoalesceDefaultKnownLimitationViaVariable.phpt` — `$v = $req->input('k') ?? 'default'` keeps taint.

**Soundness probes (eviction must fire):**
- `UnsafeInlineValidateVariableReassignedToRawInput.phpt` — plain `Expr\Assign` reassignment to raw input.
- `UnsafeInlineValidateAssignRefReassignsVariable.phpt` — `$v = &$other`.
- `UnsafeInlineValidateDestructureReassignsVariable.phpt` — `[$_, $v] = ...`.
- `UnsafeInlineValidateForeachReassignsVariable.phpt` — `foreach (... as $v)`.

All 351 type tests, 549 unit tests, self-psalm, and php-cs-fixer pass.

## Checklist

- [x] Tests cover the change.
- [x] No new `psalm-baseline.xml` entries.
- [x] No `@psalm-suppress` in production code (only test fixtures, per project convention).
- [x] Documented limitations and their lock-in tests.