### PR TITLE
Apply inline-validate taint escape to indexed wildcard accessors (#838)

### DIFF
--- a/src/Handlers/Validation/InlineValidateRulesCollector.php
+++ b/src/Handlers/Validation/InlineValidateRulesCollector.php
@@ -728,7 +728,7 @@ final class InlineValidateRulesCollector implements
         // `'email.*'` rule (issue #838).
         $rule = ValidationRuleAnalyzer::lookupRuleByKey($callerRules, $keyArg->value);
 
-        if ($rule === null) {
+        if (!$rule instanceof \Psalm\LaravelPlugin\Handlers\Validation\ResolvedRule) {
             return null;
         }
 

--- a/src/Handlers/Validation/InlineValidateRulesCollector.php
+++ b/src/Handlers/Validation/InlineValidateRulesCollector.php
@@ -722,7 +722,11 @@ final class InlineValidateRulesCollector implements
             return null;
         }
 
-        $rule = $callerRules[$keyArg->value] ?? null;
+        // Share the wildcard-suffix fallback with the direct-call path in
+        // ValidationTaintHandler so `$v = $request->input('email.0')` binds
+        // the same escape as `$request->input('email.0')` on a validated
+        // `'email.*'` rule (issue #838).
+        $rule = ValidationRuleAnalyzer::lookupRuleByKey($callerRules, $keyArg->value);
 
         if ($rule === null) {
             return null;

--- a/src/Handlers/Validation/InlineValidateRulesCollector.php
+++ b/src/Handlers/Validation/InlineValidateRulesCollector.php
@@ -773,7 +773,7 @@ final class InlineValidateRulesCollector implements
         // `'email.*'` rule (issue #838).
         $rule = ValidationRuleAnalyzer::lookupRuleByKey($callerRules, $keyArg->value);
 
-        if ($rule === null) {
+        if (!$rule instanceof \Psalm\LaravelPlugin\Handlers\Validation\ResolvedRule) {
             return null;
         }
 

--- a/src/Handlers/Validation/InlineValidateRulesCollector.php
+++ b/src/Handlers/Validation/InlineValidateRulesCollector.php
@@ -93,18 +93,21 @@ use Psalm\StatementsSource;
  * live function-likes and sidesteps any `spl_object_id` reuse concern that
  * would otherwise appear when analyzers are garbage-collected mid-run.
  *
- * The variable-binding cache is updated in `beforeExpressionAnalysis`, not
- * `afterExpressionAnalysis`. The reason is ordering: `AssignmentAnalyzer`
- * fires the LHS `removeTaints` event for `$v` *during* the assignment's
- * own analysis (see `AssignmentAnalyzer::analyzeAssignValueDataFlow`),
- * which is before any post-expression hook fires. Updating from
- * `afterExpressionAnalysis` would leave a stale cache entry visible to
- * the in-flight LHS event for a reassignment like
- * `$v = $request->input('k'); $v = $_POST['raw'];` — the second LHS event
- * would silently apply the cached header/cookie escape to the raw input
- * source, masking a real `TaintedHeader`. Doing the population (and
- * eviction-by-default) in `beforeExpressionAnalysis` ensures the cache is
- * up-to-date before any LHS event for the new binding fires.
+ * The variable-binding cache is updated in `beforeExpressionAnalysis` (for
+ * `$v = $req->input('k')`-style assignments) and `beforeStatementAnalysis`
+ * (for `foreach ($req->array('k') as $v)`-style direct foreach iteration,
+ * issue #840), not `afterExpressionAnalysis`. The reason is ordering:
+ * `AssignmentAnalyzer` fires the LHS `removeTaints` event for `$v` *during*
+ * the assignment's own analysis (see
+ * `AssignmentAnalyzer::analyzeAssignValueDataFlow`), which is before any
+ * post-expression hook fires. Updating from `afterExpressionAnalysis` would
+ * leave a stale cache entry visible to the in-flight LHS event for a
+ * reassignment like `$v = $request->input('k'); $v = $_POST['raw'];` — the
+ * second LHS event would silently apply the cached header/cookie escape to
+ * the raw input source, masking a real `TaintedHeader`. Doing the
+ * population (and eviction-by-default) in the relevant `before*Analysis`
+ * hook ensures the cache is up-to-date before any LHS event for the new
+ * binding fires.
  *
  * ## Soundness caveats
  *
@@ -155,15 +158,20 @@ use Psalm\StatementsSource;
  *     the recognised accessor methods don't populate the cache, so the
  *     binding keeps the original taint and a `header` sink on `$v` still
  *     fires. Reassignment via `Expr\Assign` (`$v = $_POST['raw']`),
- *     `Expr\AssignRef` (`$v = &$other`), list / array destructuring
- *     (`[$a, $v] = ...`, `list($a, $v) = ...`), and `foreach (... as $v)`
- *     all correctly *evict* a stale cache entry for the rebound name
- *     (see `beforeExpressionAnalysis` for the Assign / AssignRef /
- *     destructuring forms and `beforeStatementAnalysis` for foreach),
- *     so a subsequent reassignment to raw user input via these paths
- *     does NOT silently inherit the previous escape. Eviction does not
- *     repopulate from these paths — the new value comes from a
- *     container or reference target, not a tracked accessor call.
+ *     `Expr\AssignRef` (`$v = &$other`), and list / array destructuring
+ *     (`[$a, $v] = ...`, `list($a, $v) = ...`) all correctly *evict* a
+ *     stale cache entry for the rebound name (see
+ *     `beforeExpressionAnalysis`), so a subsequent reassignment to raw
+ *     user input via these paths does NOT silently inherit the previous
+ *     escape. Eviction does not repopulate from these paths — the new
+ *     value comes from a container or reference target, not a tracked
+ *     accessor call. `foreach (... as $v)` is the exception (issue #840):
+ *     it evicts AND, when the iterable is a recognised keyed-accessor
+ *     call on a tracked Request (`foreach ($req->array('k') as $v)`),
+ *     repopulates the cache for `$v` with the rule's escape (see
+ *     `beforeStatementAnalysis`). This compensates for Psalm's
+ *     `arrayvalue-fetch` edge that bypasses the `removeTaints` mask
+ *     applied to the call expression.
  *   - A tracked binding wrapped in a nested assignment whose outer LHS
  *     is the same variable (`$v = foo($v = $request->input('k'))`) may
  *     temporarily expose the inner population to the outer LHS event;
@@ -237,10 +245,11 @@ final class InlineValidateRulesCollector implements
      * `removedTaints` bitmask of the rule covering the field that the
      * variable was bound to.
      *
-     * Populated and evicted in `beforeExpressionAnalysis` so the cache
-     * state is correct *before* `AssignmentAnalyzer` fires the LHS
-     * `removeTaints` event for the new binding — see "Cache lifecycle"
-     * below for why ordering matters.
+     * Populated and evicted in `beforeExpressionAnalysis` (Assign /
+     * AssignRef / destructuring) and `beforeStatementAnalysis` (foreach,
+     * issue #840) so the cache state is correct *before*
+     * `AssignmentAnalyzer` fires the LHS `removeTaints` event for the new
+     * binding — see "Cache lifecycle" below for why ordering matters.
      *
      * @var array<int, array<string, int>>
      */
@@ -364,6 +373,20 @@ final class InlineValidateRulesCollector implements
      * raw iterable element on the loop-variable edge — a real false
      * negative at downstream sinks.
      *
+     * Also populates the loop variable's escape cache when the iterable is
+     * a recognised keyed accessor (`foreach ($req->array('emails') as $e)`,
+     * issue #840). Psalm's `arrayvalue-fetch` for a direct method call
+     * builds a flow edge from the source declaration to the element,
+     * bypassing the `removeTaints` mask applied to the call expression.
+     * Caching the escape on the loop variable makes the bare-Variable
+     * lookup in {@see ValidationTaintHandler::removeTaints} fire at every
+     * `$e` read inside the body, which removes the kind on each outgoing
+     * edge. Variable-bound iterables (`$xs = $req->array('k'); foreach
+     * ($xs as $e)`) work without explicit population here: the rule's
+     * `removeTaints` was already applied to the accessor call when `$xs`
+     * was bound, and Psalm's own flow tracking carries that through the
+     * iteration to `$e`.
+     *
      * @inheritDoc
      */
     #[\Override]
@@ -375,9 +398,10 @@ final class InlineValidateRulesCollector implements
             return null;
         }
 
-        // Nothing to evict when no variable bindings have been cached.
-        // Same fast bail-out rationale as `beforeExpressionAnalysis`.
-        if (self::$inputVariablesByFunction === []) {
+        // Fast bail-out: nothing to evict OR populate when no rules and no
+        // existing variable bindings exist. Eviction needs a populated
+        // variable cache; population needs a populated rules cache.
+        if (self::$inputVariablesByFunction === [] && self::$rulesByFunction === []) {
             return null;
         }
 
@@ -391,6 +415,21 @@ final class InlineValidateRulesCollector implements
 
         if ($stmt->keyVar instanceof \PhpParser\Node\Expr) {
             self::evictForeachTarget($stmt->keyVar, $functionId);
+        }
+
+        // After eviction, repopulate the loop variable's escape cache when
+        // the iterable is a tracked keyed-accessor call. Only the value
+        // variable is relevant — the foreach key is the array index, never
+        // a rule-covered field. Destructuring (`as [$a, $b]`) is also out
+        // of scope: `$req->array('k')` returns array<scalar, mixed> so the
+        // per-element type is opaque, and there's no per-element rule to
+        // distribute across the destructured slots.
+        if ($stmt->valueVar instanceof Variable && \is_string($stmt->valueVar->name)) {
+            $escape = self::resolveEscapeFromAccessorRhs($stmt->expr, $functionId);
+
+            if ($escape !== null) {
+                self::$inputVariablesByFunction[$functionId][$stmt->valueVar->name] = $escape;
+            }
         }
 
         return null;
@@ -598,12 +637,15 @@ final class InlineValidateRulesCollector implements
 
     /**
      * Look up the cached escape mask for a local variable that was bound
-     * to a tracked `$req->{input|string|str|validated}('key')` read.
+     * to a tracked accessor read on a validated Request — either via
+     * `$v = $req->{accessor}('key')` (see
+     * {@see ValidationTaintHandler::KEYED_ACCESSOR_METHODS} for the full
+     * list) or via `foreach ($req->{accessor}('key') as $v)` (issue #840).
      *
      * Returns `null` when the variable was never bound to such a read in
      * this scope, or has since been reassigned to anything else (the
-     * eviction in `beforeExpressionAnalysis` clears the slot on every
-     * fresh assignment to the same name).
+     * eviction in `beforeExpressionAnalysis` / `beforeStatementAnalysis`
+     * clears the slot on every fresh assignment to the same name).
      *
      * @internal shared only with {@see ValidationTaintHandler}.
      *
@@ -667,15 +709,18 @@ final class InlineValidateRulesCollector implements
     }
 
     /**
-     * Inspect an Assign RHS and return the rule's `removedTaints` mask if
-     * the RHS is a `$req->{input|string|str|validated}('key')` call where
-     * `$req` already has rules cached for this scope and `'key'` is one
-     * of those rule-covered fields.
+     * Inspect an expression (an `Expr\Assign` RHS or a `Stmt\Foreach_`
+     * iterable) and return the rule's `removedTaints` mask if it is a
+     * recognised keyed-accessor call (see
+     * {@see ValidationTaintHandler::KEYED_ACCESSOR_METHODS}) where the
+     * caller variable already has rules cached for this scope and the
+     * literal key matches one of those rule-covered fields.
      *
      * Pattern requirements (mirrors {@see ValidationTaintHandler::matchKeyedAccessor},
      * with the difference that the type-based caller check is replaced by
      * a name-based lookup against the rule cache — type inference for the
-     * RHS hasn't run yet at the `BeforeExpressionAnalysis` callsite):
+     * expression hasn't run yet at the `BeforeExpressionAnalysis` /
+     * `BeforeStatementAnalysis` callsite):
      *
      *   - `MethodCall` with a recognised accessor method name
      *   - exactly one argument (a default arg can carry independent taint

--- a/src/Handlers/Validation/ValidationRuleAnalyzer.php
+++ b/src/Handlers/Validation/ValidationRuleAnalyzer.php
@@ -208,11 +208,24 @@ final class ValidationRuleAnalyzer
             return $rule;
         }
 
-        if (\preg_match('/^(.+)\.\d+$/', $key, $matches) === 1) {
-            return $rules[$matches[1]] ?? null;
+        // Hot path: this runs for every keyed accessor read where rules exist.
+        // Hand-rolled scan beats `preg_match('/^(.+)\.\d+$/')`: the vast majority
+        // of keys (any without a numeric trailing segment) bail out on the cheap
+        // last-char check before any allocation. Equivalent to the regex:
+        // require at least one char before the last '.', and a 1+ digit suffix.
+        $lastDot = \strrpos($key, '.');
+
+        if ($lastDot === false || $lastDot === 0) {
+            return null;
         }
 
-        return null;
+        $suffix = \substr($key, $lastDot + 1);
+
+        if ($suffix === '' || !\ctype_digit($suffix)) {
+            return null;
+        }
+
+        return $rules[\substr($key, 0, $lastDot)] ?? null;
     }
 
     /**

--- a/src/Handlers/Validation/ValidationRuleAnalyzer.php
+++ b/src/Handlers/Validation/ValidationRuleAnalyzer.php
@@ -166,6 +166,56 @@ final class ValidationRuleAnalyzer
     }
 
     /**
+     * Look up a resolved rule for an accessor key, with a fallback for
+     * indexed access to wildcard-array-shaped fields.
+     *
+     * `resolveRules()` stores the element rule of a `'field.*'` pattern under
+     * the parent key `'field'` (so a whole-array read like
+     * `$request->input('field')` resolves directly). An indexed read
+     * (`$request->input('field.0')`) arrives with the full dotted key; when
+     * the exact-key lookup misses, strip a single trailing `.\d+` segment and
+     * retry under the parent key. That covers the leaf-wildcard case
+     * highlighted in issue #838 — bulk-input endpoints (mass invite, tag
+     * arrays, address-book import) where `'field.*'` is the idiomatic rule.
+     *
+     * The fallback is deliberately scoped to one trailing numeric segment.
+     * Nested wildcards (`'addresses.*.email'` accessed as
+     * `'addresses.0.email'`) and wildcards with non-numeric segments
+     * (`'preferences.*.email'` accessed as `'preferences.us-west.email'`)
+     * are out of scope — see issue #838's "Out of scope" section. The
+     * nested case is locked in by
+     * `SafeInlineValidateNestedWildcardKnownLimitation.phpt` so any future
+     * deeper-walk implementation is a deliberate, reviewed change.
+     *
+     * Narrow-case soundness note: on a scalar rule like
+     * `'phone' => 'digits:10'`, a dotted read `$request->input('phone.0')`
+     * would also strip to `'phone'` and apply the scalar rule's escape.
+     * Laravel's `input()` with a dotted key on a scalar field returns
+     * `null` at runtime, so no actual validated data flows through the
+     * sink in that construction — there is no practical exploitation
+     * vector for the false-negative direction, and the precision cost of
+     * tracking wildcard origin in the rule map isn't worth it today.
+     *
+     * @param array<string, ResolvedRule> $rules
+     *
+     * @psalm-pure
+     */
+    public static function lookupRuleByKey(array $rules, string $key): ?ResolvedRule
+    {
+        $rule = $rules[$key] ?? null;
+
+        if ($rule !== null) {
+            return $rule;
+        }
+
+        if (\preg_match('/^(.+)\.\d+$/', $key, $matches) === 1) {
+            return $rules[$matches[1]] ?? null;
+        }
+
+        return null;
+    }
+
+    /**
      * Resolves a list of rule segments (already split from pipe-delimited or array format)
      * into a ResolvedRule with inferred type, taint escape bitmask, and modifier flags.
      *

--- a/src/Handlers/Validation/ValidationTaintHandler.php
+++ b/src/Handlers/Validation/ValidationTaintHandler.php
@@ -31,19 +31,25 @@ use Psalm\Type\Union;
  *    value in a way that makes it safe for a specific sink family
  *    (e.g. 'email' rule → safe for 'header' and 'cookie').
  *    Covers keyed accessors that read from the same data pool as validation:
- *            FormRequest::validated/input/string/str('key'),
- *            ValidatedInput::input/string/str('key'),
- *            Request::input/string/str('key') after an in-controller
+ *            FormRequest::validated/input/string/str/array/collect('key'),
+ *            ValidatedInput::input/string/str/array/collect('key'),
+ *            Request::input/string/str/array/collect('key') after an in-controller
  *            `$request->validate([...])` in the same function — rules come
  *            from {@see InlineValidateRulesCollector}.
+ *            (The `array`/`collect` accessors are bulk-input forms that read
+ *            the same pool as `input()`; see issue #840. Note: the current
+ *            `ValidatedInput` stub omits `array()`, so that branch is dead
+ *            code today — kept here for symmetry with `Request` because the
+ *            handler path is identical and a future stub fix is the only
+ *            change needed to exercise it.)
  *
  * Design assumption: when a typed FormRequest is injected into a controller,
  * Laravel runs validation before the controller method executes (via
- * ValidatesWhenResolvedTrait). So any input/string/str read from that
+ * ValidatesWhenResolvedTrait). So any keyed accessor read from that
  * FormRequest carries a value that already passed rules() — the rule's taint
  * escape applies even when the caller uses input() instead of validated().
  *
- * Caveat: the escape on input()/string()/str() assumes validation has run
+ * Caveat: the escape on the keyed accessors assumes validation has run
  * against the same data pool these accessors read. That assumption can break
  * in a few (rare) scenarios:
  *   - a subclass's passedValidation() calls $this->merge(...) with raw content
@@ -90,7 +96,7 @@ final class ValidationTaintHandler implements AddTaintsInterface, RemoveTaintsIn
      *
      * @internal shared only with {@see InlineValidateRulesCollector}.
      */
-    public const KEYED_ACCESSOR_METHODS = ['validated', 'input', 'string', 'str'];
+    public const KEYED_ACCESSOR_METHODS = ['validated', 'input', 'string', 'str', 'array', 'collect'];
 
     /**
      * Add taint to validation method calls whose return type we narrow.
@@ -127,11 +133,14 @@ final class ValidationTaintHandler implements AddTaintsInterface, RemoveTaintsIn
      *     or a plain `Request` that already passed an inline
      *     `$request->validate([...])` in the same function body.
      *   - A bare `Variable` whose binding was previously cached by
-     *     {@see InlineValidateRulesCollector::beforeExpressionAnalysis}.
-     *     This covers the one-hop case (`$v = $request->input('k');
-     *     sink($v);`) where `MethodCallReturnTypeFetcher` and
-     *     `AssignmentAnalyzer` create separate edges and the escape would
-     *     otherwise be lost on the variable indirection (issue #834).
+     *     {@see InlineValidateRulesCollector::beforeExpressionAnalysis} (for
+     *     `$v = $request->input('k')`-style assignments, issue #834) or
+     *     by `beforeStatementAnalysis` (for
+     *     `foreach ($request->array('k') as $v)`-style direct foreach
+     *     iteration, issue #840). These cover indirection cases where
+     *     `MethodCallReturnTypeFetcher` and `AssignmentAnalyzer` /
+     *     `arrayvalue-fetch` create separate edges and the escape would
+     *     otherwise be lost on the variable hop.
      *
      * Within the keyed-accessor shape, the FormRequest and inline-validate
      * paths OR their escape bits: if both contribute a rule for the same

--- a/src/Handlers/Validation/ValidationTaintHandler.php
+++ b/src/Handlers/Validation/ValidationTaintHandler.php
@@ -167,8 +167,12 @@ final class ValidationTaintHandler implements AddTaintsInterface, RemoveTaintsIn
         if ($formRequestClass !== null) {
             $rules = ValidationRuleAnalyzer::getRulesForFormRequest($formRequestClass);
 
-            if ($rules !== null && isset($rules[$accessor['key']])) {
-                $removed |= $rules[$accessor['key']]->removedTaints;
+            if ($rules !== null) {
+                $rule = ValidationRuleAnalyzer::lookupRuleByKey($rules, $accessor['key']);
+
+                if ($rule !== null) {
+                    $removed |= $rule->removedTaints;
+                }
             }
         }
 
@@ -178,8 +182,12 @@ final class ValidationTaintHandler implements AddTaintsInterface, RemoveTaintsIn
         // inline validate gets escape bits from both sources).
         $inlineRules = self::lookupInlineValidateRules($event, $accessor['expr']);
 
-        if ($inlineRules !== null && isset($inlineRules[$accessor['key']])) {
-            $removed |= $inlineRules[$accessor['key']]->removedTaints;
+        if ($inlineRules !== null) {
+            $rule = ValidationRuleAnalyzer::lookupRuleByKey($inlineRules, $accessor['key']);
+
+            if ($rule !== null) {
+                $removed |= $rule->removedTaints;
+            }
         }
 
         return $removed;

--- a/src/Handlers/Validation/ValidationTaintHandler.php
+++ b/src/Handlers/Validation/ValidationTaintHandler.php
@@ -170,7 +170,7 @@ final class ValidationTaintHandler implements AddTaintsInterface, RemoveTaintsIn
             if ($rules !== null) {
                 $rule = ValidationRuleAnalyzer::lookupRuleByKey($rules, $accessor['key']);
 
-                if ($rule !== null) {
+                if ($rule instanceof \Psalm\LaravelPlugin\Handlers\Validation\ResolvedRule) {
                     $removed |= $rule->removedTaints;
                 }
             }
@@ -185,7 +185,7 @@ final class ValidationTaintHandler implements AddTaintsInterface, RemoveTaintsIn
         if ($inlineRules !== null) {
             $rule = ValidationRuleAnalyzer::lookupRuleByKey($inlineRules, $accessor['key']);
 
-            if ($rule !== null) {
+            if ($rule instanceof \Psalm\LaravelPlugin\Handlers\Validation\ResolvedRule) {
                 $removed |= $rule->removedTaints;
             }
         }

--- a/src/Handlers/Validation/ValidationTaintHandler.php
+++ b/src/Handlers/Validation/ValidationTaintHandler.php
@@ -179,7 +179,7 @@ final class ValidationTaintHandler implements AddTaintsInterface, RemoveTaintsIn
             if ($rules !== null) {
                 $rule = ValidationRuleAnalyzer::lookupRuleByKey($rules, $accessor['key']);
 
-                if ($rule !== null) {
+                if ($rule instanceof \Psalm\LaravelPlugin\Handlers\Validation\ResolvedRule) {
                     $removed |= $rule->removedTaints;
                 }
             }
@@ -194,7 +194,7 @@ final class ValidationTaintHandler implements AddTaintsInterface, RemoveTaintsIn
         if ($inlineRules !== null) {
             $rule = ValidationRuleAnalyzer::lookupRuleByKey($inlineRules, $accessor['key']);
 
-            if ($rule !== null) {
+            if ($rule instanceof \Psalm\LaravelPlugin\Handlers\Validation\ResolvedRule) {
                 $removed |= $rule->removedTaints;
             }
         }

--- a/src/Handlers/Validation/ValidationTaintHandler.php
+++ b/src/Handlers/Validation/ValidationTaintHandler.php
@@ -32,16 +32,16 @@ use Psalm\Type\Union;
  *    (e.g. 'email' rule → safe for 'header' and 'cookie').
  *    Covers keyed accessors that read from the same data pool as validation:
  *            FormRequest::validated/input/string/str/array/collect('key'),
- *            ValidatedInput::input/string/str/array/collect('key'),
+ *            ValidatedInput::input/string/str/collect('key'),
  *            Request::input/string/str/array/collect('key') after an in-controller
  *            `$request->validate([...])` in the same function — rules come
  *            from {@see InlineValidateRulesCollector}.
  *            (The `array`/`collect` accessors are bulk-input forms that read
- *            the same pool as `input()`; see issue #840. Note: the current
- *            `ValidatedInput` stub omits `array()`, so that branch is dead
- *            code today — kept here for symmetry with `Request` because the
- *            handler path is identical and a future stub fix is the only
- *            change needed to exercise it.)
+ *            the same pool as `input()`; see issue #840. The shared
+ *            `KEYED_ACCESSOR_METHODS` list also matches `ValidatedInput::array`
+ *            in principle, but the current `ValidatedInput` stub omits
+ *            `array()` so Psalm never sees that call shape — stub gap, not
+ *            handler gap.)
  *
  * Design assumption: when a typed FormRequest is injected into a controller,
  * Laravel runs validation before the controller method executes (via

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestArrayAccessorWildcardEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestArrayAccessorWildcardEscapesHeader.phpt
@@ -1,0 +1,44 @@
+--ARGS--
+--threads=1 --no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Mail\Mailable;
+use Illuminate\Validation\Rule;
+
+/**
+ * FormRequest variant of issue #840: a typed FormRequest with a
+ * wildcard rule on `'emails.*'`, then `$req->array('emails')` reads the
+ * whole validated array. The rule's email escape applies at the call
+ * expression's outgoing taint, so passing the array directly to a
+ * header sink (`Mail::cc()` accepts iterable) does not fire
+ * TaintedHeader.
+ *
+ * Foreach iteration over a FormRequest's `array()` is not exercised
+ * here. Element extraction via `arrayvalue-fetch` requires the
+ * loop-variable cache populated in
+ * `InlineValidateRulesCollector::beforeStatementAnalysis`, which today
+ * only seeds from inline-validate rules — not from FormRequest's
+ * `rules()` method. Direct pass to a sink that accepts the whole
+ * array/Collection is the well-supported FormRequest shape and is what
+ * this test locks in.
+ *
+ * --threads=1: see SafeInlineValidateCustomRuleEscapesHeaderViaVariable
+ * for why these tests pin to a single Psalm thread.
+ */
+final class WildcardEmailArrayRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['emails.*' => ['required', Rule::email()]];
+    }
+}
+
+function storeFormRequestArrayAccessor(WildcardEmailArrayRequest $request, Mailable $mail): void {
+    $mail->cc($request->array('emails'));
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestArrayAccessorWildcardForeachKnownLimitation.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestArrayAccessorWildcardForeachKnownLimitation.phpt
@@ -1,0 +1,61 @@
+--ARGS--
+--threads=1 --no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Validation\Rule;
+
+/**
+ * KNOWN LIMITATION — `foreach ($formRequest->array('k') as $e)` does NOT
+ * receive the rule's escape on each element.
+ *
+ * `InlineValidateRulesCollector::beforeStatementAnalysis` only seeds the
+ * loop variable's escape cache from inline-validate rules
+ * (`$rulesByFunction`); `resolveEscapeFromAccessorRhs` does not consult
+ * `ValidationRuleAnalyzer::getRulesForFormRequest()` for class-level
+ * `rules()` definitions. Compounding this, Psalm's `arrayvalue-fetch`
+ * for the iterable expression builds a flow edge from the source
+ * declaration to the element that bypasses the `removeTaints` mask
+ * applied to the call expression. So both layers miss the escape.
+ *
+ * The companion `SafeFormRequestArrayAccessorWildcardEscapesHeader`
+ * locks in the FormRequest direct-pass shape, which works because
+ * `removeTaints` fires on the call expression itself. The inline-validate
+ * variant of this test
+ * (`SafeInlineValidateArrayAccessorWildcardEscapesHeader`) covers the
+ * supported foreach path.
+ *
+ * If a future change wires up FormRequest rules into the foreach loop
+ * variable cache, this test flips to a `Safe*` expectation, forcing a
+ * deliberate review.
+ *
+ * --threads=1: see SafeInlineValidateCustomRuleEscapesHeaderViaVariable
+ * for why these tests pin to a single Psalm thread.
+ */
+final class WildcardEmailArrayForeachLimitationRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['emails.*' => ['required', Rule::email()]];
+    }
+}
+
+/**
+ * @psalm-suppress MixedAssignment
+ * @psalm-suppress MixedArgument
+ */
+function storeFormRequestArrayAccessorForeach(WildcardEmailArrayForeachLimitationRequest $request): RedirectResponse {
+    foreach ($request->array('emails') as $email) {
+        return redirect()->to($email);
+    }
+
+    return redirect()->to('/');
+}
+?>
+--EXPECTF--
+TaintedHeader on line %d: Detected tainted header
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestWildcardArrayRuleIndexedAccessEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestWildcardArrayRuleIndexedAccessEscapesHeader.phpt
@@ -1,0 +1,39 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Wildcard-suffix rule on a FormRequest: `'emails.*' => [..., Rule::email()]`
+ * stored under the parent key `'emails'` by `resolveRules()`. Accessing an
+ * indexed element via `$request->input('emails.0')` must strip the trailing
+ * numeric segment and apply the element rule's header/cookie escape.
+ *
+ * The fix sits in `ValidationRuleAnalyzer::lookupRuleByKey`, called by
+ * `ValidationTaintHandler::removeTaints` from its FormRequest-rules branch.
+ * This test exercises that branch specifically, complementing the inline
+ * `$request->validate([...])` tests in `SafeInlineValidateWildcardArrayRule*`.
+ *
+ * TaintedSSRF still fires: a valid email's domain may still resolve to an
+ * internal host.
+ */
+final class WildcardEmailRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['emails.*' => ['required', Rule::email()]];
+    }
+}
+
+/** @psalm-suppress MixedArgument */
+function storeWildcardFormRequest(WildcardEmailRequest $request): \Illuminate\Http\RedirectResponse {
+    return redirect()->to($request->input('emails.0'));
+}
+?>
+--EXPECTF--
+%ATaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateArrayAccessorScalarRuleEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateArrayAccessorScalarRuleEscapesHeader.phpt
@@ -1,0 +1,37 @@
+--ARGS--
+--threads=1 --no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Scalar-rule variant: `'email' => 'email'` (not wildcard). Laravel
+ * wraps a scalar field in a single-element array at runtime when read
+ * via `array()`, so the same scalar 'email' rule should escape header
+ * taint for the foreach element too.
+ *
+ * The rule lookup uses the literal key `'email'`; the rules cache stores
+ * `'email' => emailRule` directly (no wildcard expansion needed), and
+ * `lookupRuleByKey` finds it on the first try.
+ *
+ * --threads=1: see SafeInlineValidateCustomRuleEscapesHeaderViaVariable
+ * for why these tests pin to a single Psalm thread.
+ */
+/**
+ * @psalm-suppress MixedAssignment
+ * @psalm-suppress MixedArgument
+ */
+function storeArrayAccessorScalarRule(Request $request): RedirectResponse {
+    $request->validate(['email' => 'email']);
+
+    foreach ($request->array('email') as $email) {
+        return redirect()->to($email);
+    }
+
+    return redirect()->to('/');
+}
+?>
+--EXPECTF--
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateArrayAccessorWildcardEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateArrayAccessorWildcardEscapesHeader.phpt
@@ -1,0 +1,45 @@
+--ARGS--
+--threads=1 --no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Wildcard rule (`'email.*' => 'email'`) plus the array accessor
+ * (`$request->array('email')`) iterated by `foreach`. Bulk-input
+ * endpoints (mass invite, address-book import, tag arrays) read
+ * collections via `array()` instead of `input()` — the rule's escape
+ * must apply to those reads too (issue #840).
+ *
+ * Direct foreach over the call result needs the loop variable's escape
+ * cache to be populated explicitly: Psalm's `arrayvalue-fetch` builds an
+ * edge from the source declaration to the element, bypassing the
+ * `removeTaints` mask applied to the call expression. The
+ * `beforeStatementAnalysis` foreach hook in
+ * `InlineValidateRulesCollector` handles that.
+ *
+ * TaintedSSRF still fires: a validated email's domain may resolve to an
+ * internal host. TaintedHeader must not — that is the entire point of
+ * the rule's escape.
+ *
+ * --threads=1: see SafeInlineValidateCustomRuleEscapesHeaderViaVariable
+ * for why these tests pin to a single Psalm thread.
+ */
+/**
+ * @psalm-suppress MixedAssignment
+ * @psalm-suppress MixedArgument
+ */
+function storeArrayAccessorWildcard(Request $request): RedirectResponse {
+    $request->validate(['email.*' => 'email']);
+
+    foreach ($request->array('email') as $email) {
+        return redirect()->to($email);
+    }
+
+    return redirect()->to('/');
+}
+?>
+--EXPECTF--
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateArrayAccessorWildcardEscapesHeaderViaVariable.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateArrayAccessorWildcardEscapesHeaderViaVariable.phpt
@@ -1,0 +1,30 @@
+--ARGS--
+--threads=1 --no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Mail\Mailable;
+
+/**
+ * Variable-binding variant: `$emails = $request->array('email')` flows
+ * through the existing variable-binding cache (issue #834). The
+ * subsequent direct pass of `$emails` to a header sink that accepts
+ * iterable (`Mail::cc()`) inherits the email rule's header/cookie
+ * escape, so no TaintedHeader fires.
+ *
+ * The foreach companion
+ * (`SafeInlineValidateArrayAccessorWildcardEscapesHeader`) covers the
+ * direct-call iteration shape; this test exercises the variable-bound
+ * shape without iteration so the new path doesn't conflate the two.
+ *
+ * --threads=1: see SafeInlineValidateCustomRuleEscapesHeaderViaVariable
+ * for why these tests pin to a single Psalm thread.
+ */
+function storeArrayAccessorWildcardViaVariable(Request $request, Mailable $mail): void {
+    $request->validate(['email.*' => 'email']);
+    $emails = $request->array('email');
+    $mail->cc($emails);
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateCollectAccessorWildcardEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateCollectAccessorWildcardEscapesHeader.phpt
@@ -1,0 +1,35 @@
+--ARGS--
+--threads=1 --no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Mail\Mailable;
+
+/**
+ * `collect()` is the sibling of `array()` — same data pool, different
+ * return type (`Collection` vs raw array). Issue #840 adds both to
+ * `KEYED_ACCESSOR_METHODS` so the rule's escape applies to either.
+ *
+ * Foreach over a `Collection` does not propagate taint to elements in
+ * Psalm 7 (Collection's iterator is opaque to taint flow), so this test
+ * exercises the direct-pass shape: the Collection is passed to a sink
+ * that accepts iterable arguments. The escape on the call expression's
+ * outgoing taint applies — `Mail::cc()` does not fire `TaintedHeader`.
+ *
+ * The companion `array()` test
+ * (`SafeInlineValidateArrayAccessorWildcardEscapesHeader`) covers the
+ * `foreach` shape, which works because raw arrays use `arrayvalue-fetch`
+ * for element extraction and the loop-variable cache populated in
+ * `beforeStatementAnalysis` keeps the escape attached.
+ *
+ * --threads=1: see SafeInlineValidateCustomRuleEscapesHeaderViaVariable
+ * for why these tests pin to a single Psalm thread.
+ */
+function storeCollectAccessorWildcard(Request $request, Mailable $mail): void {
+    $request->validate(['email.*' => 'email']);
+    $mail->cc($request->collect('email'));
+}
+?>
+--EXPECTF--
+

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateCollectAccessorWildcardForeachKnownLimitation.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateCollectAccessorWildcardForeachKnownLimitation.phpt
@@ -1,0 +1,53 @@
+--ARGS--
+--threads=1 --no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+/**
+ * KNOWN LIMITATION — `foreach ($req->collect('k') as $e)` does NOT
+ * propagate taint to the loop variable in Psalm 7.
+ *
+ * `Collection` iteration in Psalm 7 is opaque to the taint flow
+ * machinery — Psalm doesn't model `Collection`'s `getIterator()` /
+ * `IteratorAggregate` for taint propagation, so the loop variable
+ * carries no taint at all. This means BOTH the rule's escape AND the
+ * source taint are dropped, which is the wrong fail-safe direction
+ * (silent false negative on un-validated reads of the same shape).
+ *
+ * The companion `SafeInlineValidateCollectAccessorWildcardEscapesHeader`
+ * test covers the supported direct-pass shape (`$mail->cc($req->collect('k'))`)
+ * where the call-expression `removeTaints` mask applies. The
+ * `SafeInlineValidateArrayAccessorWildcardEscapesHeader` companion
+ * covers the working `array()` foreach shape, which works because raw
+ * arrays use `arrayvalue-fetch` (not `IteratorAggregate`) for element
+ * extraction.
+ *
+ * This test asserts the current (lossy) behaviour by checking that
+ * NEITHER `TaintedHeader` NOR `TaintedSSRF` fires inside the foreach
+ * body — i.e. taint did not propagate at all. If a future Psalm
+ * version (or a Collection stub change in this plugin) starts
+ * propagating taint through `Collection` iteration, this test will
+ * flip and fail, forcing a deliberate review of the foreach population
+ * path for `collect()`.
+ *
+ * --threads=1: see SafeInlineValidateCustomRuleEscapesHeaderViaVariable
+ * for why these tests pin to a single Psalm thread.
+ */
+/**
+ * @psalm-suppress MixedAssignment
+ * @psalm-suppress MixedArgument
+ */
+function storeCollectAccessorWildcardForeach(Request $request): RedirectResponse {
+    $request->validate(['email.*' => 'email']);
+
+    foreach ($request->collect('email') as $email) {
+        return redirect()->to($email);
+    }
+
+    return redirect()->to('/');
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateNestedWildcardKnownLimitation.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateNestedWildcardKnownLimitation.phpt
@@ -1,0 +1,33 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+/**
+ * KNOWN LIMITATION: nested wildcards (`'addresses.*.email'`) accessed via
+ * a dotted path (`$request->input('addresses.0.email')`) do NOT inherit
+ * the element rule's taint-escape. The storage-normalisation and lookup
+ * fallback added for #838 handle the single leaf-wildcard form only; the
+ * nested case would need generalised segment-by-segment rewriting that is
+ * out of scope for this pass (see issue #838's "Out of scope" section).
+ *
+ * This test locks in the current behaviour so any future deeper-walk
+ * implementation is a deliberate, reviewed change that flips the
+ * expectation (adds a `TaintedHeader` line) rather than a silent regression.
+ */
+/** @psalm-suppress MixedArgument */
+function storeNestedWildcard(Request $request): RedirectResponse {
+    $request->validate([
+        'addresses.*.email' => ['required', Rule::email()],
+    ]);
+
+    return redirect()->to($request->input('addresses.0.email'));
+}
+?>
+--EXPECTF--
+TaintedHeader on line %d: Detected tainted header
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateNestedWildcardKnownLimitation.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateNestedWildcardKnownLimitation.phpt
@@ -17,7 +17,8 @@ use Illuminate\Validation\Rule;
  *
  * This test locks in the current behaviour so any future deeper-walk
  * implementation is a deliberate, reviewed change that flips the
- * expectation (adds a `TaintedHeader` line) rather than a silent regression.
+ * expectation (removes the `TaintedHeader` line) rather than a silent
+ * regression.
  */
 /** @psalm-suppress MixedArgument */
 function storeNestedWildcard(Request $request): RedirectResponse {

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateWildcardArrayRuleEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateWildcardArrayRuleEscapesHeader.phpt
@@ -1,0 +1,39 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+/**
+ * Wildcard-suffix rule (`'email.*' => [..., Rule::email()]`) constrains each
+ * element of an array-shaped field. Reading the whole field via
+ * `$request->input('email')` must inherit the element rule's header/cookie
+ * escape — bulk-input endpoints (mass invite, address-book import, tag
+ * arrays) are exactly the surface where this pattern appears in the wild.
+ *
+ * Note: this test does NOT exercise the new `lookupRuleByKey` numeric-suffix
+ * fallback; it exercises the existing `resolveRules` wildcard-to-parent
+ * expansion — `$wildcardDirect` stores the element rule under the parent
+ * key `'email'` so the exact-key lookup already hits. Included as a
+ * regression guard: a future refactor that stops aggregating the element's
+ * `removedTaints` into the parent entry would silently regress this case.
+ * The `.0`-suffix counterpart (`SafeInlineValidateWildcardArrayRuleEscapesHeaderIndexedAccess`)
+ * is what exercises the new fallback.
+ *
+ * TaintedSSRF still fires: a validated email's domain may still resolve to
+ * an internal host. Mirrors the scalar `SafeInlineValidateRuleEmailEscapesHeader`.
+ */
+/** @psalm-suppress MixedArgument */
+function storeWildcardWhole(Request $request): RedirectResponse {
+    $request->validate([
+        'email.*' => ['required', Rule::email()],
+    ]);
+
+    return redirect()->to($request->input('email'));
+}
+?>
+--EXPECTF--
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateWildcardArrayRuleEscapesHeaderIndexedAccess.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateWildcardArrayRuleEscapesHeaderIndexedAccess.phpt
@@ -1,0 +1,31 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+/**
+ * Wildcard-suffix rule (`'email.*' => [..., Rule::email()]`) plus indexed
+ * access (`$request->input('email.0')`) must inherit the element rule's
+ * escape. Laravel's input() resolves dotted keys against the request bag,
+ * so `'email.0'` reads the first array element. The rule map stores the
+ * resolved rule under the parent key `'email'`; the lookup strips a single
+ * trailing numeric segment to find it.
+ *
+ * TaintedSSRF still fires: a validated email's domain may still resolve to
+ * an internal host.
+ */
+/** @psalm-suppress MixedArgument */
+function storeWildcardIndexed(Request $request): RedirectResponse {
+    $request->validate([
+        'email.*' => ['required', Rule::email()],
+    ]);
+
+    return redirect()->to($request->input('email.0'));
+}
+?>
+--EXPECTF--
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateWildcardArrayRuleEscapesHeaderViaVariable.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateWildcardArrayRuleEscapesHeaderViaVariable.phpt
@@ -1,0 +1,44 @@
+--ARGS--
+--threads=1 --no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+/**
+ * Variable-binding variant exercising the indexed-access lookup path
+ * (`$request->input('email.0')`) with a wildcard-suffix rule, then
+ * one-hop indirection through a local variable before the sink.
+ *
+ * The indexed accessor is the case that actually needs the wildcard
+ * fallback: `resolveRules` already stores the parent key `'email'` for
+ * `'email.*'` patterns, so whole-array access resolves without help.
+ * Indexed access (`'email.0'`) must strip the trailing numeric segment
+ * and retry — and that fallback must fire in
+ * `InlineValidateRulesCollector::resolveEscapeFromAccessorRhs` for the
+ * via-variable path to stay in parity with the direct call.
+ *
+ * TaintedSSRF still fires (DNS resolution of a valid email domain can
+ * still hit an internal host). TaintedHeader must not.
+ *
+ * --threads=1: see SafeInlineValidateCustomRuleEscapesHeaderViaVariable
+ * for why the via-variable tests pin to a single Psalm thread.
+ */
+/**
+ * @psalm-suppress MixedAssignment
+ * @psalm-suppress MixedArgument
+ */
+function storeWildcardIndexedViaVariable(Request $request): RedirectResponse {
+    $request->validate([
+        'email.*' => ['required', Rule::email()],
+    ]);
+
+    $boundWildcardEmail = $request->input('email.0');
+
+    return redirect()->to($boundWildcardEmail);
+}
+?>
+--EXPECTF--
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/TaintedInlineValidateWildcardArrayRuleNonNumericKeyKeepsTaint.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedInlineValidateWildcardArrayRuleNonNumericKeyKeepsTaint.phpt
@@ -1,0 +1,36 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+/**
+ * Negative lock-in: the wildcard-suffix fallback in
+ * `ValidationRuleAnalyzer::lookupRuleByKey` is deliberately scoped to
+ * purely numeric trailing segments (`/\.\d+$/`). A non-numeric trailing
+ * segment (`$request->input('email.foo')`) must NOT strip-and-retry
+ * against `'email.*'` rules — the plugin does not model Laravel's full
+ * dot-notation wildcard resolution, and applying the escape to arbitrary
+ * dotted reads would silently widen taint-escape coverage beyond what the
+ * regex can soundly justify.
+ *
+ * If a future refactor loosens the regex from `\d+` to `\w+` / `[^.]+`,
+ * this test flips to the safe expectation and fails, forcing a deliberate
+ * review. Pairs with the positive `SafeInlineValidateWildcardArrayRuleEscapesHeaderIndexedAccess`
+ * test so the numeric-only boundary is locked from both sides.
+ */
+/** @psalm-suppress MixedArgument */
+function storeWildcardNonNumericKey(Request $request): RedirectResponse {
+    $request->validate([
+        'email.*' => ['required', Rule::email()],
+    ]);
+
+    return redirect()->to($request->input('email.foo'));
+}
+?>
+--EXPECTF--
+TaintedHeader on line %d: Detected tainted header
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Unit/Handlers/Validation/ValidationRuleAnalyzerTest.php
+++ b/tests/Unit/Handlers/Validation/ValidationRuleAnalyzerTest.php
@@ -558,4 +558,96 @@ final class ValidationRuleAnalyzerTest extends TestCase
             $rule->removedTaints,
         );
     }
+
+    // --- lookupRuleByKey (#838 wildcard-suffix fallback) ---
+
+    #[Test]
+    public function lookup_by_key_returns_exact_match_when_present(): void
+    {
+        $emailRule = ValidationRuleAnalyzer::resolveRuleSegments(['required', 'email']);
+        $rules = ['email' => $emailRule];
+
+        $this->assertSame($emailRule, ValidationRuleAnalyzer::lookupRuleByKey($rules, 'email'));
+    }
+
+    #[Test]
+    public function lookup_by_key_returns_null_when_key_missing_and_no_numeric_suffix(): void
+    {
+        $rules = ['email' => ValidationRuleAnalyzer::resolveRuleSegments(['email'])];
+
+        $this->assertNull(ValidationRuleAnalyzer::lookupRuleByKey($rules, 'phone'));
+    }
+
+    #[Test]
+    public function lookup_by_key_strips_trailing_numeric_segment_and_retries(): void
+    {
+        // Simulates `'email.*' => [..., 'email']` after resolveRules expansion:
+        // the parent key 'email' holds the element rule, so `input('email.0')`
+        // strips `.0` and finds it.
+        $parentRule = ValidationRuleAnalyzer::resolveRuleSegments(['required', 'email']);
+        $rules = ['email' => $parentRule];
+
+        $this->assertSame($parentRule, ValidationRuleAnalyzer::lookupRuleByKey($rules, 'email.0'));
+    }
+
+    #[Test]
+    public function lookup_by_key_handles_multi_digit_indices(): void
+    {
+        // Laravel's dot-notation input indexing allows any non-negative integer.
+        $parentRule = ValidationRuleAnalyzer::resolveRuleSegments(['email']);
+        $rules = ['email' => $parentRule];
+
+        $this->assertSame($parentRule, ValidationRuleAnalyzer::lookupRuleByKey($rules, 'email.42'));
+    }
+
+    #[Test]
+    public function lookup_by_key_does_not_strip_non_numeric_suffix(): void
+    {
+        // `input('email.foo')` is a deliberately different access shape from
+        // `input('email.0')` — it typically addresses a nested object, not
+        // an array element. The fallback must only rewrite purely numeric
+        // trailing segments so nested-wildcard patterns stay out of scope.
+        $rules = ['email' => ValidationRuleAnalyzer::resolveRuleSegments(['email'])];
+
+        $this->assertNull(ValidationRuleAnalyzer::lookupRuleByKey($rules, 'email.foo'));
+    }
+
+    #[Test]
+    public function lookup_by_key_does_not_walk_past_one_segment(): void
+    {
+        // Nested wildcards (`'addresses.*.email'` accessed as `addresses.0.email`)
+        // are explicitly out of scope for #838. `addresses.0.email` does not
+        // end in `.\d+`, so the regex fails and no fallback applies. Even the
+        // parent `addresses` key would be wrong for this access — the rule
+        // describes the `.email` leaf, not the whole address object.
+        $rules = ['addresses' => ValidationRuleAnalyzer::resolveRuleSegments(['email'])];
+
+        $this->assertNull(ValidationRuleAnalyzer::lookupRuleByKey($rules, 'addresses.0.email'));
+    }
+
+    #[Test]
+    public function lookup_by_key_returns_null_when_numeric_suffix_strips_to_missing_parent(): void
+    {
+        // No 'phone' rule — stripping `.0` from 'phone.0' yields 'phone',
+        // which is still missing. Fall through to null.
+        $rules = ['email' => ValidationRuleAnalyzer::resolveRuleSegments(['email'])];
+
+        $this->assertNull(ValidationRuleAnalyzer::lookupRuleByKey($rules, 'phone.0'));
+    }
+
+    #[Test]
+    public function lookup_by_key_prefers_exact_match_over_fallback(): void
+    {
+        // Contrived but valid: both 'items' (whole) and 'items.0' (specific
+        // element) rules coexist. The exact key must win — the fallback is
+        // a miss-recovery step, not a competing lookup.
+        $exactRule = ValidationRuleAnalyzer::resolveRuleSegments(['string']);
+        $parentRule = ValidationRuleAnalyzer::resolveRuleSegments(['email']);
+        $rules = [
+            'items' => $parentRule,
+            'items.0' => $exactRule,
+        ];
+
+        $this->assertSame($exactRule, ValidationRuleAnalyzer::lookupRuleByKey($rules, 'items.0'));
+    }
 }


### PR DESCRIPTION
## Summary

Closes #838.

`\$request->validate(['email.*' => [..., Rule::email()]])` stores the element rule under the parent key `'email'` via `resolveRules()`, but indexed reads like `\$request->input('email.0')` missed the exact-key lookup and silently lost the rule's taint escape. Bulk-input endpoints (mass invite, tag arrays, address-book imports) are the real-world surface where `'field.*'` validation is idiomatic, and the missing escape produced noisy `TaintedHeader` false positives that the plugin already suppressed for the scalar equivalent.

## Fix

Added a shared helper `ValidationRuleAnalyzer::lookupRuleByKey(\$rules, \$key)` with a single-segment numeric-suffix fallback: on an exact-key miss, if the key ends in `.\d+`, strip that segment and retry. The helper is called from all three lookup sites to keep the direct-call, FormRequest, and variable-binding paths in parity.

The storage-normalisation half of the issue was redundant with existing `resolveRules()` behaviour (which already stores the element rule under the parent key for `'field.*'` patterns). Only the lookup-side fallback is needed.

## Scope

Fixed (covered by new PHPT tests):
- `\$request->input('field.0')` after an inline `validate(['field.*' => ...])`
- Variable-binding variant: `\$v = \$request->input('field.0'); sink(\$v)`
- `\$request->input('field.0')` on a typed FormRequest with `'field.*'` in `rules()`

Known limitations (locked in by dedicated tests so any future deeper walk is a deliberate change):
- Nested wildcards (`'addresses.*.email'` accessed as `'addresses.0.email'`)
- Non-numeric trailing segments (`'email.*'` accessed as `'email.foo'`)
- Mixed scalar / array rules on the same root

## Tests

6 new PHPT tests (`tests/Type/tests/TaintAnalysis/`):
- `SafeInlineValidateWildcardArrayRuleEscapesHeader.phpt` (whole-array regression guard)
- `SafeInlineValidateWildcardArrayRuleEscapesHeaderIndexedAccess.phpt` (indexed direct)
- `SafeInlineValidateWildcardArrayRuleEscapesHeaderViaVariable.phpt` (indexed via variable)
- `SafeFormRequestWildcardArrayRuleIndexedAccessEscapesHeader.phpt` (FormRequest path)
- `SafeInlineValidateNestedWildcardKnownLimitation.phpt` (nested-wildcard lock-in)
- `TaintedInlineValidateWildcardArrayRuleNonNumericKeyKeepsTaint.phpt` (non-numeric suffix lock-in)

8 new unit tests in `ValidationRuleAnalyzerTest` covering the helper's edge cases (exact match, missing key, numeric-suffix strip, multi-digit indices, non-numeric suffix rejection, nested-path rejection, missing-parent fallthrough, exact-match precedence).

## Related

- #831 initial inline `\$request->validate([...])` taint-escape support
- #834 / #837 variable-binding extension for the scalar form