### PR TITLE
Apply inline-validate taint escape to array() and collect() accessors (#840)

### DIFF
--- a/src/Handlers/Validation/InlineValidateRulesCollector.php
+++ b/src/Handlers/Validation/InlineValidateRulesCollector.php
@@ -773,7 +773,7 @@ final class InlineValidateRulesCollector implements
         // `'email.*'` rule (issue #838).
         $rule = ValidationRuleAnalyzer::lookupRuleByKey($callerRules, $keyArg->value);
 
-        if ($rule === null) {
+        if (!$rule instanceof \Psalm\LaravelPlugin\Handlers\Validation\ResolvedRule) {
             return null;
         }
 

--- a/src/Handlers/Validation/InlineValidateRulesCollector.php
+++ b/src/Handlers/Validation/InlineValidateRulesCollector.php
@@ -93,18 +93,21 @@ use Psalm\StatementsSource;
  * live function-likes and sidesteps any `spl_object_id` reuse concern that
  * would otherwise appear when analyzers are garbage-collected mid-run.
  *
- * The variable-binding cache is updated in `beforeExpressionAnalysis`, not
- * `afterExpressionAnalysis`. The reason is ordering: `AssignmentAnalyzer`
- * fires the LHS `removeTaints` event for `$v` *during* the assignment's
- * own analysis (see `AssignmentAnalyzer::analyzeAssignValueDataFlow`),
- * which is before any post-expression hook fires. Updating from
- * `afterExpressionAnalysis` would leave a stale cache entry visible to
- * the in-flight LHS event for a reassignment like
- * `$v = $request->input('k'); $v = $_POST['raw'];` — the second LHS event
- * would silently apply the cached header/cookie escape to the raw input
- * source, masking a real `TaintedHeader`. Doing the population (and
- * eviction-by-default) in `beforeExpressionAnalysis` ensures the cache is
- * up-to-date before any LHS event for the new binding fires.
+ * The variable-binding cache is updated in `beforeExpressionAnalysis` (for
+ * `$v = $req->input('k')`-style assignments) and `beforeStatementAnalysis`
+ * (for `foreach ($req->array('k') as $v)`-style direct foreach iteration,
+ * issue #840), not `afterExpressionAnalysis`. The reason is ordering:
+ * `AssignmentAnalyzer` fires the LHS `removeTaints` event for `$v` *during*
+ * the assignment's own analysis (see
+ * `AssignmentAnalyzer::analyzeAssignValueDataFlow`), which is before any
+ * post-expression hook fires. Updating from `afterExpressionAnalysis` would
+ * leave a stale cache entry visible to the in-flight LHS event for a
+ * reassignment like `$v = $request->input('k'); $v = $_POST['raw'];` — the
+ * second LHS event would silently apply the cached header/cookie escape to
+ * the raw input source, masking a real `TaintedHeader`. Doing the
+ * population (and eviction-by-default) in the relevant `before*Analysis`
+ * hook ensures the cache is up-to-date before any LHS event for the new
+ * binding fires.
  *
  * ## Soundness caveats
  *
@@ -155,15 +158,20 @@ use Psalm\StatementsSource;
  *     the recognised accessor methods don't populate the cache, so the
  *     binding keeps the original taint and a `header` sink on `$v` still
  *     fires. Reassignment via `Expr\Assign` (`$v = $_POST['raw']`),
- *     `Expr\AssignRef` (`$v = &$other`), list / array destructuring
- *     (`[$a, $v] = ...`, `list($a, $v) = ...`), and `foreach (... as $v)`
- *     all correctly *evict* a stale cache entry for the rebound name
- *     (see `beforeExpressionAnalysis` for the Assign / AssignRef /
- *     destructuring forms and `beforeStatementAnalysis` for foreach),
- *     so a subsequent reassignment to raw user input via these paths
- *     does NOT silently inherit the previous escape. Eviction does not
- *     repopulate from these paths — the new value comes from a
- *     container or reference target, not a tracked accessor call.
+ *     `Expr\AssignRef` (`$v = &$other`), and list / array destructuring
+ *     (`[$a, $v] = ...`, `list($a, $v) = ...`) all correctly *evict* a
+ *     stale cache entry for the rebound name (see
+ *     `beforeExpressionAnalysis`), so a subsequent reassignment to raw
+ *     user input via these paths does NOT silently inherit the previous
+ *     escape. Eviction does not repopulate from these paths — the new
+ *     value comes from a container or reference target, not a tracked
+ *     accessor call. `foreach (... as $v)` is the exception (issue #840):
+ *     it evicts AND, when the iterable is a recognised keyed-accessor
+ *     call on a tracked Request (`foreach ($req->array('k') as $v)`),
+ *     repopulates the cache for `$v` with the rule's escape (see
+ *     `beforeStatementAnalysis`). This compensates for Psalm's
+ *     `arrayvalue-fetch` edge that bypasses the `removeTaints` mask
+ *     applied to the call expression.
  *   - A tracked binding wrapped in a nested assignment whose outer LHS
  *     is the same variable (`$v = foo($v = $request->input('k'))`) may
  *     temporarily expose the inner population to the outer LHS event;
@@ -237,10 +245,11 @@ final class InlineValidateRulesCollector implements
      * `removedTaints` bitmask of the rule covering the field that the
      * variable was bound to.
      *
-     * Populated and evicted in `beforeExpressionAnalysis` so the cache
-     * state is correct *before* `AssignmentAnalyzer` fires the LHS
-     * `removeTaints` event for the new binding — see "Cache lifecycle"
-     * below for why ordering matters.
+     * Populated and evicted in `beforeExpressionAnalysis` (Assign /
+     * AssignRef / destructuring) and `beforeStatementAnalysis` (foreach,
+     * issue #840) so the cache state is correct *before*
+     * `AssignmentAnalyzer` fires the LHS `removeTaints` event for the new
+     * binding — see "Cache lifecycle" below for why ordering matters.
      *
      * @var array<int, array<string, int>>
      */
@@ -364,6 +373,20 @@ final class InlineValidateRulesCollector implements
      * raw iterable element on the loop-variable edge — a real false
      * negative at downstream sinks.
      *
+     * Also populates the loop variable's escape cache when the iterable is
+     * a recognised keyed accessor (`foreach ($req->array('emails') as $e)`,
+     * issue #840). Psalm's `arrayvalue-fetch` for a direct method call
+     * builds a flow edge from the source declaration to the element,
+     * bypassing the `removeTaints` mask applied to the call expression.
+     * Caching the escape on the loop variable makes the bare-Variable
+     * lookup in {@see ValidationTaintHandler::removeTaints} fire at every
+     * `$e` read inside the body, which removes the kind on each outgoing
+     * edge. Variable-bound iterables (`$xs = $req->array('k'); foreach
+     * ($xs as $e)`) work without explicit population here: the rule's
+     * `removeTaints` was already applied to the accessor call when `$xs`
+     * was bound, and Psalm's own flow tracking carries that through the
+     * iteration to `$e`.
+     *
      * @inheritDoc
      */
     #[\Override]
@@ -375,9 +398,10 @@ final class InlineValidateRulesCollector implements
             return null;
         }
 
-        // Nothing to evict when no variable bindings have been cached.
-        // Same fast bail-out rationale as `beforeExpressionAnalysis`.
-        if (self::$inputVariablesByFunction === []) {
+        // Fast bail-out: nothing to evict OR populate when no rules and no
+        // existing variable bindings exist. Eviction needs a populated
+        // variable cache; population needs a populated rules cache.
+        if (self::$inputVariablesByFunction === [] && self::$rulesByFunction === []) {
             return null;
         }
 
@@ -391,6 +415,21 @@ final class InlineValidateRulesCollector implements
 
         if ($stmt->keyVar instanceof \PhpParser\Node\Expr) {
             self::evictForeachTarget($stmt->keyVar, $functionId);
+        }
+
+        // After eviction, repopulate the loop variable's escape cache when
+        // the iterable is a tracked keyed-accessor call. Only the value
+        // variable is relevant — the foreach key is the array index, never
+        // a rule-covered field. Destructuring (`as [$a, $b]`) is also out
+        // of scope: `$req->array('k')` returns array<scalar, mixed> so the
+        // per-element type is opaque, and there's no per-element rule to
+        // distribute across the destructured slots.
+        if ($stmt->valueVar instanceof Variable && \is_string($stmt->valueVar->name)) {
+            $escape = self::resolveEscapeFromAccessorRhs($stmt->expr, $functionId);
+
+            if ($escape !== null) {
+                self::$inputVariablesByFunction[$functionId][$stmt->valueVar->name] = $escape;
+            }
         }
 
         return null;
@@ -598,12 +637,15 @@ final class InlineValidateRulesCollector implements
 
     /**
      * Look up the cached escape mask for a local variable that was bound
-     * to a tracked `$req->{input|string|str|validated}('key')` read.
+     * to a tracked accessor read on a validated Request — either via
+     * `$v = $req->{accessor}('key')` (see
+     * {@see ValidationTaintHandler::KEYED_ACCESSOR_METHODS} for the full
+     * list) or via `foreach ($req->{accessor}('key') as $v)` (issue #840).
      *
      * Returns `null` when the variable was never bound to such a read in
      * this scope, or has since been reassigned to anything else (the
-     * eviction in `beforeExpressionAnalysis` clears the slot on every
-     * fresh assignment to the same name).
+     * eviction in `beforeExpressionAnalysis` / `beforeStatementAnalysis`
+     * clears the slot on every fresh assignment to the same name).
      *
      * @internal shared only with {@see ValidationTaintHandler}.
      *
@@ -667,15 +709,18 @@ final class InlineValidateRulesCollector implements
     }
 
     /**
-     * Inspect an Assign RHS and return the rule's `removedTaints` mask if
-     * the RHS is a `$req->{input|string|str|validated}('key')` call where
-     * `$req` already has rules cached for this scope and `'key'` is one
-     * of those rule-covered fields.
+     * Inspect an expression (an `Expr\Assign` RHS or a `Stmt\Foreach_`
+     * iterable) and return the rule's `removedTaints` mask if it is a
+     * recognised keyed-accessor call (see
+     * {@see ValidationTaintHandler::KEYED_ACCESSOR_METHODS}) where the
+     * caller variable already has rules cached for this scope and the
+     * literal key matches one of those rule-covered fields.
      *
      * Pattern requirements (mirrors {@see ValidationTaintHandler::matchKeyedAccessor},
      * with the difference that the type-based caller check is replaced by
      * a name-based lookup against the rule cache — type inference for the
-     * RHS hasn't run yet at the `BeforeExpressionAnalysis` callsite):
+     * expression hasn't run yet at the `BeforeExpressionAnalysis` /
+     * `BeforeStatementAnalysis` callsite):
      *
      *   - `MethodCall` with a recognised accessor method name
      *   - exactly one argument (a default arg can carry independent taint

--- a/src/Handlers/Validation/ValidationTaintHandler.php
+++ b/src/Handlers/Validation/ValidationTaintHandler.php
@@ -31,19 +31,25 @@ use Psalm\Type\Union;
  *    value in a way that makes it safe for a specific sink family
  *    (e.g. 'email' rule → safe for 'header' and 'cookie').
  *    Covers keyed accessors that read from the same data pool as validation:
- *            FormRequest::validated/input/string/str('key'),
- *            ValidatedInput::input/string/str('key'),
- *            Request::input/string/str('key') after an in-controller
+ *            FormRequest::validated/input/string/str/array/collect('key'),
+ *            ValidatedInput::input/string/str/array/collect('key'),
+ *            Request::input/string/str/array/collect('key') after an in-controller
  *            `$request->validate([...])` in the same function — rules come
  *            from {@see InlineValidateRulesCollector}.
+ *            (The `array`/`collect` accessors are bulk-input forms that read
+ *            the same pool as `input()`; see issue #840. Note: the current
+ *            `ValidatedInput` stub omits `array()`, so that branch is dead
+ *            code today — kept here for symmetry with `Request` because the
+ *            handler path is identical and a future stub fix is the only
+ *            change needed to exercise it.)
  *
  * Design assumption: when a typed FormRequest is injected into a controller,
  * Laravel runs validation before the controller method executes (via
- * ValidatesWhenResolvedTrait). So any input/string/str read from that
+ * ValidatesWhenResolvedTrait). So any keyed accessor read from that
  * FormRequest carries a value that already passed rules() — the rule's taint
  * escape applies even when the caller uses input() instead of validated().
  *
- * Caveat: the escape on input()/string()/str() assumes validation has run
+ * Caveat: the escape on the keyed accessors assumes validation has run
  * against the same data pool these accessors read. That assumption can break
  * in a few (rare) scenarios:
  *   - a subclass's passedValidation() calls $this->merge(...) with raw content
@@ -90,7 +96,7 @@ final class ValidationTaintHandler implements AddTaintsInterface, RemoveTaintsIn
      *
      * @internal shared only with {@see InlineValidateRulesCollector}.
      */
-    public const KEYED_ACCESSOR_METHODS = ['validated', 'input', 'string', 'str'];
+    public const KEYED_ACCESSOR_METHODS = ['validated', 'input', 'string', 'str', 'array', 'collect'];
 
     /**
      * Add taint to validation method calls whose return type we narrow.
@@ -127,11 +133,14 @@ final class ValidationTaintHandler implements AddTaintsInterface, RemoveTaintsIn
      *     or a plain `Request` that already passed an inline
      *     `$request->validate([...])` in the same function body.
      *   - A bare `Variable` whose binding was previously cached by
-     *     {@see InlineValidateRulesCollector::beforeExpressionAnalysis}.
-     *     This covers the one-hop case (`$v = $request->input('k');
-     *     sink($v);`) where `MethodCallReturnTypeFetcher` and
-     *     `AssignmentAnalyzer` create separate edges and the escape would
-     *     otherwise be lost on the variable indirection (issue #834).
+     *     {@see InlineValidateRulesCollector::beforeExpressionAnalysis} (for
+     *     `$v = $request->input('k')`-style assignments, issue #834) or
+     *     by `beforeStatementAnalysis` (for
+     *     `foreach ($request->array('k') as $v)`-style direct foreach
+     *     iteration, issue #840). These cover indirection cases where
+     *     `MethodCallReturnTypeFetcher` and `AssignmentAnalyzer` /
+     *     `arrayvalue-fetch` create separate edges and the escape would
+     *     otherwise be lost on the variable hop.
      *
      * Within the keyed-accessor shape, the FormRequest and inline-validate
      * paths OR their escape bits: if both contribute a rule for the same

--- a/src/Handlers/Validation/ValidationTaintHandler.php
+++ b/src/Handlers/Validation/ValidationTaintHandler.php
@@ -179,7 +179,7 @@ final class ValidationTaintHandler implements AddTaintsInterface, RemoveTaintsIn
             if ($rules !== null) {
                 $rule = ValidationRuleAnalyzer::lookupRuleByKey($rules, $accessor['key']);
 
-                if ($rule !== null) {
+                if ($rule instanceof \Psalm\LaravelPlugin\Handlers\Validation\ResolvedRule) {
                     $removed |= $rule->removedTaints;
                 }
             }
@@ -194,7 +194,7 @@ final class ValidationTaintHandler implements AddTaintsInterface, RemoveTaintsIn
         if ($inlineRules !== null) {
             $rule = ValidationRuleAnalyzer::lookupRuleByKey($inlineRules, $accessor['key']);
 
-            if ($rule !== null) {
+            if ($rule instanceof \Psalm\LaravelPlugin\Handlers\Validation\ResolvedRule) {
                 $removed |= $rule->removedTaints;
             }
         }

--- a/src/Handlers/Validation/ValidationTaintHandler.php
+++ b/src/Handlers/Validation/ValidationTaintHandler.php
@@ -32,16 +32,16 @@ use Psalm\Type\Union;
  *    (e.g. 'email' rule → safe for 'header' and 'cookie').
  *    Covers keyed accessors that read from the same data pool as validation:
  *            FormRequest::validated/input/string/str/array/collect('key'),
- *            ValidatedInput::input/string/str/array/collect('key'),
+ *            ValidatedInput::input/string/str/collect('key'),
  *            Request::input/string/str/array/collect('key') after an in-controller
  *            `$request->validate([...])` in the same function — rules come
  *            from {@see InlineValidateRulesCollector}.
  *            (The `array`/`collect` accessors are bulk-input forms that read
- *            the same pool as `input()`; see issue #840. Note: the current
- *            `ValidatedInput` stub omits `array()`, so that branch is dead
- *            code today — kept here for symmetry with `Request` because the
- *            handler path is identical and a future stub fix is the only
- *            change needed to exercise it.)
+ *            the same pool as `input()`; see issue #840. The shared
+ *            `KEYED_ACCESSOR_METHODS` list also matches `ValidatedInput::array`
+ *            in principle, but the current `ValidatedInput` stub omits
+ *            `array()` so Psalm never sees that call shape — stub gap, not
+ *            handler gap.)
  *
  * Design assumption: when a typed FormRequest is injected into a controller,
  * Laravel runs validation before the controller method executes (via

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestArrayAccessorWildcardEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestArrayAccessorWildcardEscapesHeader.phpt
@@ -1,0 +1,44 @@
+--ARGS--
+--threads=1 --no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Mail\Mailable;
+use Illuminate\Validation\Rule;
+
+/**
+ * FormRequest variant of issue #840: a typed FormRequest with a
+ * wildcard rule on `'emails.*'`, then `$req->array('emails')` reads the
+ * whole validated array. The rule's email escape applies at the call
+ * expression's outgoing taint, so passing the array directly to a
+ * header sink (`Mail::cc()` accepts iterable) does not fire
+ * TaintedHeader.
+ *
+ * Foreach iteration over a FormRequest's `array()` is not exercised
+ * here. Element extraction via `arrayvalue-fetch` requires the
+ * loop-variable cache populated in
+ * `InlineValidateRulesCollector::beforeStatementAnalysis`, which today
+ * only seeds from inline-validate rules — not from FormRequest's
+ * `rules()` method. Direct pass to a sink that accepts the whole
+ * array/Collection is the well-supported FormRequest shape and is what
+ * this test locks in.
+ *
+ * --threads=1: see SafeInlineValidateCustomRuleEscapesHeaderViaVariable
+ * for why these tests pin to a single Psalm thread.
+ */
+final class WildcardEmailArrayRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['emails.*' => ['required', Rule::email()]];
+    }
+}
+
+function storeFormRequestArrayAccessor(WildcardEmailArrayRequest $request, Mailable $mail): void {
+    $mail->cc($request->array('emails'));
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestArrayAccessorWildcardForeachKnownLimitation.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestArrayAccessorWildcardForeachKnownLimitation.phpt
@@ -1,0 +1,61 @@
+--ARGS--
+--threads=1 --no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Validation\Rule;
+
+/**
+ * KNOWN LIMITATION — `foreach ($formRequest->array('k') as $e)` does NOT
+ * receive the rule's escape on each element.
+ *
+ * `InlineValidateRulesCollector::beforeStatementAnalysis` only seeds the
+ * loop variable's escape cache from inline-validate rules
+ * (`$rulesByFunction`); `resolveEscapeFromAccessorRhs` does not consult
+ * `ValidationRuleAnalyzer::getRulesForFormRequest()` for class-level
+ * `rules()` definitions. Compounding this, Psalm's `arrayvalue-fetch`
+ * for the iterable expression builds a flow edge from the source
+ * declaration to the element that bypasses the `removeTaints` mask
+ * applied to the call expression. So both layers miss the escape.
+ *
+ * The companion `SafeFormRequestArrayAccessorWildcardEscapesHeader`
+ * locks in the FormRequest direct-pass shape, which works because
+ * `removeTaints` fires on the call expression itself. The inline-validate
+ * variant of this test
+ * (`SafeInlineValidateArrayAccessorWildcardEscapesHeader`) covers the
+ * supported foreach path.
+ *
+ * If a future change wires up FormRequest rules into the foreach loop
+ * variable cache, this test flips to a `Safe*` expectation, forcing a
+ * deliberate review.
+ *
+ * --threads=1: see SafeInlineValidateCustomRuleEscapesHeaderViaVariable
+ * for why these tests pin to a single Psalm thread.
+ */
+final class WildcardEmailArrayForeachLimitationRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['emails.*' => ['required', Rule::email()]];
+    }
+}
+
+/**
+ * @psalm-suppress MixedAssignment
+ * @psalm-suppress MixedArgument
+ */
+function storeFormRequestArrayAccessorForeach(WildcardEmailArrayForeachLimitationRequest $request): RedirectResponse {
+    foreach ($request->array('emails') as $email) {
+        return redirect()->to($email);
+    }
+
+    return redirect()->to('/');
+}
+?>
+--EXPECTF--
+TaintedHeader on line %d: Detected tainted header
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateArrayAccessorScalarRuleEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateArrayAccessorScalarRuleEscapesHeader.phpt
@@ -1,0 +1,37 @@
+--ARGS--
+--threads=1 --no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Scalar-rule variant: `'email' => 'email'` (not wildcard). Laravel
+ * wraps a scalar field in a single-element array at runtime when read
+ * via `array()`, so the same scalar 'email' rule should escape header
+ * taint for the foreach element too.
+ *
+ * The rule lookup uses the literal key `'email'`; the rules cache stores
+ * `'email' => emailRule` directly (no wildcard expansion needed), and
+ * `lookupRuleByKey` finds it on the first try.
+ *
+ * --threads=1: see SafeInlineValidateCustomRuleEscapesHeaderViaVariable
+ * for why these tests pin to a single Psalm thread.
+ */
+/**
+ * @psalm-suppress MixedAssignment
+ * @psalm-suppress MixedArgument
+ */
+function storeArrayAccessorScalarRule(Request $request): RedirectResponse {
+    $request->validate(['email' => 'email']);
+
+    foreach ($request->array('email') as $email) {
+        return redirect()->to($email);
+    }
+
+    return redirect()->to('/');
+}
+?>
+--EXPECTF--
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateArrayAccessorWildcardEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateArrayAccessorWildcardEscapesHeader.phpt
@@ -1,0 +1,45 @@
+--ARGS--
+--threads=1 --no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Wildcard rule (`'email.*' => 'email'`) plus the array accessor
+ * (`$request->array('email')`) iterated by `foreach`. Bulk-input
+ * endpoints (mass invite, address-book import, tag arrays) read
+ * collections via `array()` instead of `input()` — the rule's escape
+ * must apply to those reads too (issue #840).
+ *
+ * Direct foreach over the call result needs the loop variable's escape
+ * cache to be populated explicitly: Psalm's `arrayvalue-fetch` builds an
+ * edge from the source declaration to the element, bypassing the
+ * `removeTaints` mask applied to the call expression. The
+ * `beforeStatementAnalysis` foreach hook in
+ * `InlineValidateRulesCollector` handles that.
+ *
+ * TaintedSSRF still fires: a validated email's domain may resolve to an
+ * internal host. TaintedHeader must not — that is the entire point of
+ * the rule's escape.
+ *
+ * --threads=1: see SafeInlineValidateCustomRuleEscapesHeaderViaVariable
+ * for why these tests pin to a single Psalm thread.
+ */
+/**
+ * @psalm-suppress MixedAssignment
+ * @psalm-suppress MixedArgument
+ */
+function storeArrayAccessorWildcard(Request $request): RedirectResponse {
+    $request->validate(['email.*' => 'email']);
+
+    foreach ($request->array('email') as $email) {
+        return redirect()->to($email);
+    }
+
+    return redirect()->to('/');
+}
+?>
+--EXPECTF--
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateArrayAccessorWildcardEscapesHeaderViaVariable.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateArrayAccessorWildcardEscapesHeaderViaVariable.phpt
@@ -1,0 +1,30 @@
+--ARGS--
+--threads=1 --no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Mail\Mailable;
+
+/**
+ * Variable-binding variant: `$emails = $request->array('email')` flows
+ * through the existing variable-binding cache (issue #834). The
+ * subsequent direct pass of `$emails` to a header sink that accepts
+ * iterable (`Mail::cc()`) inherits the email rule's header/cookie
+ * escape, so no TaintedHeader fires.
+ *
+ * The foreach companion
+ * (`SafeInlineValidateArrayAccessorWildcardEscapesHeader`) covers the
+ * direct-call iteration shape; this test exercises the variable-bound
+ * shape without iteration so the new path doesn't conflate the two.
+ *
+ * --threads=1: see SafeInlineValidateCustomRuleEscapesHeaderViaVariable
+ * for why these tests pin to a single Psalm thread.
+ */
+function storeArrayAccessorWildcardViaVariable(Request $request, Mailable $mail): void {
+    $request->validate(['email.*' => 'email']);
+    $emails = $request->array('email');
+    $mail->cc($emails);
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateCollectAccessorWildcardEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateCollectAccessorWildcardEscapesHeader.phpt
@@ -1,0 +1,35 @@
+--ARGS--
+--threads=1 --no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Mail\Mailable;
+
+/**
+ * `collect()` is the sibling of `array()` — same data pool, different
+ * return type (`Collection` vs raw array). Issue #840 adds both to
+ * `KEYED_ACCESSOR_METHODS` so the rule's escape applies to either.
+ *
+ * Foreach over a `Collection` does not propagate taint to elements in
+ * Psalm 7 (Collection's iterator is opaque to taint flow), so this test
+ * exercises the direct-pass shape: the Collection is passed to a sink
+ * that accepts iterable arguments. The escape on the call expression's
+ * outgoing taint applies — `Mail::cc()` does not fire `TaintedHeader`.
+ *
+ * The companion `array()` test
+ * (`SafeInlineValidateArrayAccessorWildcardEscapesHeader`) covers the
+ * `foreach` shape, which works because raw arrays use `arrayvalue-fetch`
+ * for element extraction and the loop-variable cache populated in
+ * `beforeStatementAnalysis` keeps the escape attached.
+ *
+ * --threads=1: see SafeInlineValidateCustomRuleEscapesHeaderViaVariable
+ * for why these tests pin to a single Psalm thread.
+ */
+function storeCollectAccessorWildcard(Request $request, Mailable $mail): void {
+    $request->validate(['email.*' => 'email']);
+    $mail->cc($request->collect('email'));
+}
+?>
+--EXPECTF--
+

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateCollectAccessorWildcardForeachKnownLimitation.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateCollectAccessorWildcardForeachKnownLimitation.phpt
@@ -1,0 +1,53 @@
+--ARGS--
+--threads=1 --no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+/**
+ * KNOWN LIMITATION — `foreach ($req->collect('k') as $e)` does NOT
+ * propagate taint to the loop variable in Psalm 7.
+ *
+ * `Collection` iteration in Psalm 7 is opaque to the taint flow
+ * machinery — Psalm doesn't model `Collection`'s `getIterator()` /
+ * `IteratorAggregate` for taint propagation, so the loop variable
+ * carries no taint at all. This means BOTH the rule's escape AND the
+ * source taint are dropped, which is the wrong fail-safe direction
+ * (silent false negative on un-validated reads of the same shape).
+ *
+ * The companion `SafeInlineValidateCollectAccessorWildcardEscapesHeader`
+ * test covers the supported direct-pass shape (`$mail->cc($req->collect('k'))`)
+ * where the call-expression `removeTaints` mask applies. The
+ * `SafeInlineValidateArrayAccessorWildcardEscapesHeader` companion
+ * covers the working `array()` foreach shape, which works because raw
+ * arrays use `arrayvalue-fetch` (not `IteratorAggregate`) for element
+ * extraction.
+ *
+ * This test asserts the current (lossy) behaviour by checking that
+ * NEITHER `TaintedHeader` NOR `TaintedSSRF` fires inside the foreach
+ * body — i.e. taint did not propagate at all. If a future Psalm
+ * version (or a Collection stub change in this plugin) starts
+ * propagating taint through `Collection` iteration, this test will
+ * flip and fail, forcing a deliberate review of the foreach population
+ * path for `collect()`.
+ *
+ * --threads=1: see SafeInlineValidateCustomRuleEscapesHeaderViaVariable
+ * for why these tests pin to a single Psalm thread.
+ */
+/**
+ * @psalm-suppress MixedAssignment
+ * @psalm-suppress MixedArgument
+ */
+function storeCollectAccessorWildcardForeach(Request $request): RedirectResponse {
+    $request->validate(['email.*' => 'email']);
+
+    foreach ($request->collect('email') as $email) {
+        return redirect()->to($email);
+    }
+
+    return redirect()->to('/');
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
Closes #840.

## Summary

Extends the inline-validate rule taint-escape (added in #831, #834, #837, #839) to two more sibling accessor methods: `Request::array($key)` and `Request::collect($key)`. Both are stubbed with `@psalm-taint-source input` and read from the same data pool as `input/string/str`, so a per-field rule should escape downstream sinks the same way.

Two-part fix:

1. **`KEYED_ACCESSOR_METHODS` extension** — adds `'array'` and `'collect'` to the list shared by `ValidationTaintHandler` and `InlineValidateRulesCollector`. Both handlers see the new methods automatically because the const is the single source of truth.

2. **Foreach loop variable cache population** — extends `InlineValidateRulesCollector::beforeStatementAnalysis` to populate the loop variable's escape cache when the iterable is a recognised keyed-accessor call. Without this, Psalm's `arrayvalue-fetch` builds a flow edge from the source declaration to each element that bypasses the `removeTaints` mask applied to the call expression, so `foreach ($req->array('emails') as $e)` would lose the rule's escape on each element. Reuses the existing `resolveEscapeFromAccessorRhs` helper.

## Tests

5 new positive tests:
- `SafeInlineValidateArrayAccessorWildcardEscapesHeader` — direct foreach with `'email.*' => 'email'`
- `SafeInlineValidateArrayAccessorScalarRuleEscapesHeader` — scalar `'email' => 'email'` rule + foreach
- `SafeInlineValidateArrayAccessorWildcardEscapesHeaderViaVariable` — variable-bound direct pass to `Mail::cc()`
- `SafeInlineValidateCollectAccessorWildcardEscapesHeader` — `collect()` direct pass
- `SafeFormRequestArrayAccessorWildcardEscapesHeader` — typed FormRequest direct pass

2 new known-limitation tests:
- `SafeFormRequestArrayAccessorWildcardForeachKnownLimitation` — FormRequest+foreach not yet wired into the loop variable cache (rules come from `getRulesForFormRequest`, which `resolveEscapeFromAccessorRhs` doesn't consult)
- `SafeInlineValidateCollectAccessorWildcardForeachKnownLimitation` — Psalm's `Collection` iteration is opaque to taint flow

## Stacking

Built on top of #839 to share the wildcard-suffix `lookupRuleByKey` fallback. Rebases cleanly onto master once #839 lands.