### PR TITLE
Preserve custom Eloquent builder fluent returns

### DIFF
--- a/src/Handlers/Eloquent/ModelBuilderMixinHandler.php
+++ b/src/Handlers/Eloquent/ModelBuilderMixinHandler.php
@@ -33,7 +33,7 @@ final class ModelBuilderMixinHandler implements MethodReturnTypeProviderInterfac
     /**
      * Cache: class name → whether it is an Eloquent model.
      *
-     * @var array<string, bool>
+     * @var array<lowercase-string, bool>
      */
     private static array $modelClassCache = [];
 

--- a/src/Handlers/Eloquent/ModelBuilderMixinHandler.php
+++ b/src/Handlers/Eloquent/ModelBuilderMixinHandler.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Eloquent;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use Psalm\Codebase;
+use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\LaravelPlugin\Handlers\Magic\ReturnTypeResolver;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Union;
+
+/**
+ * Intercepts Model's @mixin Builder<static> fluent calls after Builder stubs use $this/static.
+ *
+ * Psalm binds $this/static in mixin-reached methods to the mixin host, so without this
+ * Customer::where() and (new Customer())->where() would be typed as Customer&static.
+ *
+ * If another non-Eloquent forwarding domain is added later, this logic could move behind a
+ * ForwardingRule callback instead. Keeping it here is the smaller step while Eloquent is the
+ * only model-builder host with this behavior.
+ */
+final class ModelBuilderMixinHandler implements MethodReturnTypeProviderInterface
+{
+    private const MODEL_FQN_LOWER = 'illuminate\\database\\eloquent\\model';
+
+    /**
+     * Cache: class name → whether it is an Eloquent model.
+     *
+     * @var array<string, bool>
+     */
+    private static array $modelClassCache = [];
+
+    /** @psalm-external-mutation-free */
+    public static function init(): void
+    {
+        self::$modelClassCache = [];
+    }
+
+    /**
+     * @return list<string>
+     * @psalm-pure
+     */
+    #[\Override]
+    public static function getClassLikeNames(): array
+    {
+        return [Builder::class];
+    }
+
+    #[\Override]
+    public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        $source = $event->getSource();
+
+        if (!$source instanceof StatementsAnalyzer) {
+            return null;
+        }
+
+        $codebase = $source->getCodebase();
+        $methodName = $event->getMethodNameLowercase();
+
+        if (!ReturnTypeResolver::targetClassMethodReturnsSelf($codebase, Builder::class, $methodName)) {
+            return null;
+        }
+
+        $stmt = $event->getStmt();
+        $callerType = $stmt instanceof MethodCall
+            ? $source->getNodeTypeProvider()->getType($stmt->var)
+            : null;
+
+        $modelClass = self::extractModelClassFromMixinCaller($event, $codebase, $callerType);
+
+        if ($modelClass === null) {
+            return null;
+        }
+
+        return new Union([ModelMethodHandler::resolvedBuilderTypeFor($modelClass, $codebase)]);
+    }
+
+    /**
+     * @return class-string<Model>|null
+     * @psalm-external-mutation-free
+     */
+    private static function extractModelClassFromMixinCaller(
+        MethodReturnTypeProviderEvent $event,
+        Codebase $codebase,
+        ?Union $callerType,
+    ): ?string {
+        $stmt = $event->getStmt();
+
+        if ($stmt instanceof StaticCall) {
+            $calledClass = $event->getCalledFqClasslikeName();
+
+            if (\is_string($calledClass) && self::isModelClass($codebase, $calledClass)) {
+                return $calledClass;
+            }
+
+            return null;
+        }
+
+        if (!$callerType instanceof Union) {
+            return null;
+        }
+
+        foreach ($callerType->getAtomicTypes() as $atomicType) {
+            if ($atomicType instanceof TNamedObject && self::isModelClass($codebase, $atomicType->value)) {
+                return $atomicType->value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @psalm-assert-if-true class-string<Model> $className
+     * @psalm-external-mutation-free
+     */
+    private static function isModelClass(Codebase $codebase, string $className): bool
+    {
+        $classNameLower = \strtolower($className);
+
+        if (\array_key_exists($classNameLower, self::$modelClassCache)) {
+            return self::$modelClassCache[$classNameLower];
+        }
+
+        if ($classNameLower === self::MODEL_FQN_LOWER) {
+            return self::$modelClassCache[$classNameLower] = true;
+        }
+
+        try {
+            return self::$modelClassCache[$classNameLower] = $codebase->classOrInterfaceExists($className)
+                && $codebase->classExtends($className, Model::class);
+        } catch (\Psalm\Exception\UnpopulatedClasslikeException|\InvalidArgumentException) {
+            return self::$modelClassCache[$classNameLower] = false;
+        }
+    }
+}

--- a/src/Handlers/Eloquent/ModelMethodHandler.php
+++ b/src/Handlers/Eloquent/ModelMethodHandler.php
@@ -90,6 +90,17 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
     }
 
     /**
+     * Build the Psalm type for the builder used by a model.
+     *
+     * @internal Used by magic forwarding handlers that intercept Model's @mixin path
+     * @psalm-external-mutation-free
+     */
+    public static function builderTypeForModel(string $modelClass, Codebase $codebase): Type\Atomic\TNamedObject
+    {
+        return self::builderType(self::getBuilderClassForModel($modelClass), $modelClass, $codebase);
+    }
+
+    /**
      * Build the Psalm type for Builder<Model> (or CustomBuilder<Model>).
      *
      * If the custom builder has template parameters, returns TGenericObject (e.g. PostBuilder<Post>).

--- a/src/Handlers/Eloquent/ModelMethodHandler.php
+++ b/src/Handlers/Eloquent/ModelMethodHandler.php
@@ -95,7 +95,7 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
      * @internal Used by magic forwarding handlers that intercept Model's @mixin path
      * @psalm-external-mutation-free
      */
-    public static function builderTypeForModel(string $modelClass, Codebase $codebase): Type\Atomic\TNamedObject
+    public static function resolvedBuilderTypeFor(string $modelClass, Codebase $codebase): Type\Atomic\TNamedObject
     {
         return self::builderType(self::getBuilderClassForModel($modelClass), $modelClass, $codebase);
     }

--- a/src/Handlers/Magic/MethodForwardingHandler.php
+++ b/src/Handlers/Magic/MethodForwardingHandler.php
@@ -467,14 +467,9 @@ final class MethodForwardingHandler implements
             $calledClass = $event->getCalledFqClasslikeName();
 
             if (\is_string($calledClass) && self::isModelClass($codebase, $calledClass)) {
-                /** @var class-string<\Illuminate\Database\Eloquent\Model> */
                 return $calledClass;
             }
 
-            return null;
-        }
-
-        if (!$stmt instanceof MethodCall) {
             return null;
         }
 
@@ -494,7 +489,6 @@ final class MethodForwardingHandler implements
             }
 
             if (self::isModelClass($codebase, $atomicType->value)) {
-                /** @var class-string<\Illuminate\Database\Eloquent\Model> */
                 return $atomicType->value;
             }
         }

--- a/src/Handlers/Magic/MethodForwardingHandler.php
+++ b/src/Handlers/Magic/MethodForwardingHandler.php
@@ -50,6 +50,14 @@ final class MethodForwardingHandler implements
     MethodReturnTypeProviderInterface,
     MethodParamsProviderInterface
 {
+    private const BUILDER_FQN = \Illuminate\Database\Eloquent\Builder::class;
+
+    private const BUILDER_FQN_LOWER = 'illuminate\\database\\eloquent\\builder';
+
+    private const MODEL_FQN = \Illuminate\Database\Eloquent\Model::class;
+
+    private const MODEL_FQN_LOWER = 'illuminate\\database\\eloquent\\model';
+
     private static ?ForwardingRule $rule = null;
 
     /** @var array<lowercase-string, bool> Indexed source classes for O(1) lookup */
@@ -332,13 +340,16 @@ final class MethodForwardingHandler implements
         }
 
         $stmt = $event->getStmt();
+        $callerType = $stmt instanceof MethodCall
+            ? $source->getNodeTypeProvider()->getType($stmt->var)
+            : null;
 
         $modelBuilderResult = self::resolveModelBuilderMixinInterception(
-            $source,
             $event,
             $mixinTargetClass,
             $methodName,
             $codebase,
+            $callerType,
         );
 
         if ($modelBuilderResult instanceof Union) {
@@ -352,8 +363,6 @@ final class MethodForwardingHandler implements
         // Get the ORIGINAL caller's type from the node type provider.
         // $stmt->var type is set BEFORE mixin resolution
         // (confirmed in MethodCallAnalyzer.php lines 67-69).
-        $callerType = $source->getNodeTypeProvider()->getType($stmt->var);
-
         if (!$callerType instanceof \Psalm\Type\Union) {
             return null;
         }
@@ -428,38 +437,41 @@ final class MethodForwardingHandler implements
      *
      * Psalm binds $this/static in mixin-reached methods to the mixin host, so without this
      * Customer::where() and (new Customer())->where() would be typed as Customer&static.
+     *
+     * @psalm-external-mutation-free
      */
     private static function resolveModelBuilderMixinInterception(
-        StatementsAnalyzer $source,
         MethodReturnTypeProviderEvent $event,
         string $mixinTargetClass,
         string $methodName,
         Codebase $codebase,
+        ?Union $callerType,
     ): ?Union {
-        if (\strtolower($mixinTargetClass) !== \strtolower(\Illuminate\Database\Eloquent\Builder::class)) {
+        if (\strtolower($mixinTargetClass) !== self::BUILDER_FQN_LOWER) {
             return null;
         }
 
-        $modelClass = self::extractModelClassFromMixinCaller($source, $event, $codebase);
+        if (!ReturnTypeResolver::targetClassMethodReturnsSelf($codebase, self::BUILDER_FQN, $methodName)) {
+            return null;
+        }
+
+        $modelClass = self::extractModelClassFromMixinCaller($event, $codebase, $callerType);
 
         if ($modelClass === null) {
             return null;
         }
 
-        if (!ReturnTypeResolver::targetClassMethodReturnsSelf($codebase, \Illuminate\Database\Eloquent\Builder::class, $methodName)) {
-            return null;
-        }
-
-        return new Union([ModelMethodHandler::builderTypeForModel($modelClass, $codebase)]);
+        return new Union([ModelMethodHandler::resolvedBuilderTypeFor($modelClass, $codebase)]);
     }
 
     /**
      * @return class-string<\Illuminate\Database\Eloquent\Model>|null
+     * @psalm-external-mutation-free
      */
     private static function extractModelClassFromMixinCaller(
-        StatementsAnalyzer $source,
         MethodReturnTypeProviderEvent $event,
         Codebase $codebase,
+        ?Union $callerType,
     ): ?string {
         $stmt = $event->getStmt();
 
@@ -472,8 +484,6 @@ final class MethodForwardingHandler implements
 
             return null;
         }
-
-        $callerType = $source->getNodeTypeProvider()->getType($stmt->var);
 
         if (!$callerType instanceof Union) {
             return null;
@@ -508,13 +518,13 @@ final class MethodForwardingHandler implements
             return self::$modelClassCache[$classNameLower];
         }
 
-        if ($classNameLower === \strtolower(\Illuminate\Database\Eloquent\Model::class)) {
+        if ($classNameLower === self::MODEL_FQN_LOWER) {
             return self::$modelClassCache[$classNameLower] = true;
         }
 
         try {
             return self::$modelClassCache[$classNameLower] = $codebase->classOrInterfaceExists($className)
-                && $codebase->classExtends($className, \Illuminate\Database\Eloquent\Model::class);
+                && $codebase->classExtends($className, self::MODEL_FQN);
         } catch (\Psalm\Exception\UnpopulatedClasslikeException|\InvalidArgumentException) {
             return self::$modelClassCache[$classNameLower] = false;
         }

--- a/src/Handlers/Magic/MethodForwardingHandler.php
+++ b/src/Handlers/Magic/MethodForwardingHandler.php
@@ -496,7 +496,10 @@ final class MethodForwardingHandler implements
         return null;
     }
 
-    /** @psalm-external-mutation-free */
+    /**
+     * @psalm-assert-if-true class-string<\Illuminate\Database\Eloquent\Model> $className
+     * @psalm-external-mutation-free
+     */
     private static function isModelClass(Codebase $codebase, string $className): bool
     {
         $classNameLower = \strtolower($className);
@@ -505,12 +508,16 @@ final class MethodForwardingHandler implements
             return self::$modelClassCache[$classNameLower];
         }
 
-        if (\strtolower($className) === \strtolower(\Illuminate\Database\Eloquent\Model::class)) {
+        if ($classNameLower === \strtolower(\Illuminate\Database\Eloquent\Model::class)) {
             return self::$modelClassCache[$classNameLower] = true;
         }
 
-        return self::$modelClassCache[$classNameLower] = $codebase->classOrInterfaceExists($className)
-            && $codebase->classExtends($className, \Illuminate\Database\Eloquent\Model::class);
+        try {
+            return self::$modelClassCache[$classNameLower] = $codebase->classOrInterfaceExists($className)
+                && $codebase->classExtends($className, \Illuminate\Database\Eloquent\Model::class);
+        } catch (\Psalm\Exception\UnpopulatedClasslikeException|\InvalidArgumentException) {
+            return self::$modelClassCache[$classNameLower] = false;
+        }
     }
 
     /**

--- a/src/Handlers/Magic/MethodForwardingHandler.php
+++ b/src/Handlers/Magic/MethodForwardingHandler.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Psalm\LaravelPlugin\Handlers\Magic;
 
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\StaticCall;
 use Psalm\Codebase;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\LaravelPlugin\Handlers\Eloquent\BuilderScopeHandler;
@@ -18,7 +17,6 @@ use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
 use Psalm\Storage\FunctionLikeParameter;
 use Psalm\Type;
 use Psalm\Type\Atomic\TGenericObject;
-use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Union;
 
 /**
@@ -50,14 +48,6 @@ final class MethodForwardingHandler implements
     MethodReturnTypeProviderInterface,
     MethodParamsProviderInterface
 {
-    private const BUILDER_FQN = \Illuminate\Database\Eloquent\Builder::class;
-
-    private const BUILDER_FQN_LOWER = 'illuminate\\database\\eloquent\\builder';
-
-    private const MODEL_FQN = \Illuminate\Database\Eloquent\Model::class;
-
-    private const MODEL_FQN_LOWER = 'illuminate\\database\\eloquent\\model';
-
     private static ?ForwardingRule $rule = null;
 
     /** @var array<lowercase-string, bool> Indexed source classes for O(1) lookup */
@@ -100,13 +90,6 @@ final class MethodForwardingHandler implements
      */
     private static array $scopeParamsCache = [];
 
-    /**
-     * Cache: class name → whether it is an Eloquent model.
-     *
-     * @var array<string, bool>
-     */
-    private static array $modelClassCache = [];
-
     /** @psalm-external-mutation-free */
     public static function init(ForwardingRule $rule): void
     {
@@ -114,7 +97,6 @@ final class MethodForwardingHandler implements
         self::$sourceClassIndex = [];
         self::$searchClassIndex = [];
         self::$scopeParamsCache = [];
-        self::$modelClassCache = [];
 
         foreach ($rule->allSourceClasses() as $class) {
             self::$sourceClassIndex[\strtolower($class)] = true;
@@ -344,18 +326,6 @@ final class MethodForwardingHandler implements
             ? $source->getNodeTypeProvider()->getType($stmt->var)
             : null;
 
-        $modelBuilderResult = self::resolveModelBuilderMixinInterception(
-            $event,
-            $mixinTargetClass,
-            $methodName,
-            $codebase,
-            $callerType,
-        );
-
-        if ($modelBuilderResult instanceof Union) {
-            return $modelBuilderResult;
-        }
-
         if (!$stmt instanceof MethodCall) {
             return null;
         }
@@ -430,104 +400,6 @@ final class MethodForwardingHandler implements
         }
 
         return null;
-    }
-
-    /**
-     * Intercept Model's @mixin Builder<static> fluent calls after Builder stubs use $this/static.
-     *
-     * Psalm binds $this/static in mixin-reached methods to the mixin host, so without this
-     * Customer::where() and (new Customer())->where() would be typed as Customer&static.
-     *
-     * @psalm-external-mutation-free
-     */
-    private static function resolveModelBuilderMixinInterception(
-        MethodReturnTypeProviderEvent $event,
-        string $mixinTargetClass,
-        string $methodName,
-        Codebase $codebase,
-        ?Union $callerType,
-    ): ?Union {
-        if (\strtolower($mixinTargetClass) !== self::BUILDER_FQN_LOWER) {
-            return null;
-        }
-
-        if (!ReturnTypeResolver::targetClassMethodReturnsSelf($codebase, self::BUILDER_FQN, $methodName)) {
-            return null;
-        }
-
-        $modelClass = self::extractModelClassFromMixinCaller($event, $codebase, $callerType);
-
-        if ($modelClass === null) {
-            return null;
-        }
-
-        return new Union([ModelMethodHandler::resolvedBuilderTypeFor($modelClass, $codebase)]);
-    }
-
-    /**
-     * @return class-string<\Illuminate\Database\Eloquent\Model>|null
-     * @psalm-external-mutation-free
-     */
-    private static function extractModelClassFromMixinCaller(
-        MethodReturnTypeProviderEvent $event,
-        Codebase $codebase,
-        ?Union $callerType,
-    ): ?string {
-        $stmt = $event->getStmt();
-
-        if ($stmt instanceof StaticCall) {
-            $calledClass = $event->getCalledFqClasslikeName();
-
-            if (\is_string($calledClass) && self::isModelClass($codebase, $calledClass)) {
-                return $calledClass;
-            }
-
-            return null;
-        }
-
-        if (!$callerType instanceof Union) {
-            return null;
-        }
-
-        foreach ($callerType->getAtomicTypes() as $atomicType) {
-            if (!$atomicType instanceof TNamedObject) {
-                continue;
-            }
-
-            if (isset(self::$sourceClassIndex[\strtolower($atomicType->value)])) {
-                continue;
-            }
-
-            if (self::isModelClass($codebase, $atomicType->value)) {
-                return $atomicType->value;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * @psalm-assert-if-true class-string<\Illuminate\Database\Eloquent\Model> $className
-     * @psalm-external-mutation-free
-     */
-    private static function isModelClass(Codebase $codebase, string $className): bool
-    {
-        $classNameLower = \strtolower($className);
-
-        if (\array_key_exists($classNameLower, self::$modelClassCache)) {
-            return self::$modelClassCache[$classNameLower];
-        }
-
-        if ($classNameLower === self::MODEL_FQN_LOWER) {
-            return self::$modelClassCache[$classNameLower] = true;
-        }
-
-        try {
-            return self::$modelClassCache[$classNameLower] = $codebase->classOrInterfaceExists($className)
-                && $codebase->classExtends($className, self::MODEL_FQN);
-        } catch (\Psalm\Exception\UnpopulatedClasslikeException|\InvalidArgumentException) {
-            return self::$modelClassCache[$classNameLower] = false;
-        }
     }
 
     /**

--- a/src/Handlers/Magic/MethodForwardingHandler.php
+++ b/src/Handlers/Magic/MethodForwardingHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Psalm\LaravelPlugin\Handlers\Magic;
 
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
 use Psalm\Codebase;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\LaravelPlugin\Handlers\Eloquent\BuilderScopeHandler;
@@ -17,6 +18,7 @@ use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
 use Psalm\Storage\FunctionLikeParameter;
 use Psalm\Type;
 use Psalm\Type\Atomic\TGenericObject;
+use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Union;
 
 /**
@@ -90,6 +92,13 @@ final class MethodForwardingHandler implements
      */
     private static array $scopeParamsCache = [];
 
+    /**
+     * Cache: class name → whether it is an Eloquent model.
+     *
+     * @var array<string, bool>
+     */
+    private static array $modelClassCache = [];
+
     /** @psalm-external-mutation-free */
     public static function init(ForwardingRule $rule): void
     {
@@ -97,6 +106,7 @@ final class MethodForwardingHandler implements
         self::$sourceClassIndex = [];
         self::$searchClassIndex = [];
         self::$scopeParamsCache = [];
+        self::$modelClassCache = [];
 
         foreach ($rule->allSourceClasses() as $class) {
             self::$sourceClassIndex[\strtolower($class)] = true;
@@ -323,6 +333,18 @@ final class MethodForwardingHandler implements
 
         $stmt = $event->getStmt();
 
+        $modelBuilderResult = self::resolveModelBuilderMixinInterception(
+            $source,
+            $event,
+            $mixinTargetClass,
+            $methodName,
+            $codebase,
+        );
+
+        if ($modelBuilderResult instanceof Union) {
+            return $modelBuilderResult;
+        }
+
         if (!$stmt instanceof MethodCall) {
             return null;
         }
@@ -399,6 +421,102 @@ final class MethodForwardingHandler implements
         }
 
         return null;
+    }
+
+    /**
+     * Intercept Model's @mixin Builder<static> fluent calls after Builder stubs use $this/static.
+     *
+     * Psalm binds $this/static in mixin-reached methods to the mixin host, so without this
+     * Customer::where() and (new Customer())->where() would be typed as Customer&static.
+     */
+    private static function resolveModelBuilderMixinInterception(
+        StatementsAnalyzer $source,
+        MethodReturnTypeProviderEvent $event,
+        string $mixinTargetClass,
+        string $methodName,
+        Codebase $codebase,
+    ): ?Union {
+        if (\strtolower($mixinTargetClass) !== \strtolower(\Illuminate\Database\Eloquent\Builder::class)) {
+            return null;
+        }
+
+        $modelClass = self::extractModelClassFromMixinCaller($source, $event, $codebase);
+
+        if ($modelClass === null) {
+            return null;
+        }
+
+        if (!ReturnTypeResolver::targetClassMethodReturnsSelf($codebase, \Illuminate\Database\Eloquent\Builder::class, $methodName)) {
+            return null;
+        }
+
+        return new Union([ModelMethodHandler::builderTypeForModel($modelClass, $codebase)]);
+    }
+
+    /**
+     * @return class-string<\Illuminate\Database\Eloquent\Model>|null
+     */
+    private static function extractModelClassFromMixinCaller(
+        StatementsAnalyzer $source,
+        MethodReturnTypeProviderEvent $event,
+        Codebase $codebase,
+    ): ?string {
+        $stmt = $event->getStmt();
+
+        if ($stmt instanceof StaticCall) {
+            $calledClass = $event->getCalledFqClasslikeName();
+
+            if (\is_string($calledClass) && self::isModelClass($codebase, $calledClass)) {
+                /** @var class-string<\Illuminate\Database\Eloquent\Model> */
+                return $calledClass;
+            }
+
+            return null;
+        }
+
+        if (!$stmt instanceof MethodCall) {
+            return null;
+        }
+
+        $callerType = $source->getNodeTypeProvider()->getType($stmt->var);
+
+        if (!$callerType instanceof Union) {
+            return null;
+        }
+
+        foreach ($callerType->getAtomicTypes() as $atomicType) {
+            if (!$atomicType instanceof TNamedObject) {
+                continue;
+            }
+
+            if (isset(self::$sourceClassIndex[\strtolower($atomicType->value)])) {
+                continue;
+            }
+
+            if (self::isModelClass($codebase, $atomicType->value)) {
+                /** @var class-string<\Illuminate\Database\Eloquent\Model> */
+                return $atomicType->value;
+            }
+        }
+
+        return null;
+    }
+
+    /** @psalm-external-mutation-free */
+    private static function isModelClass(Codebase $codebase, string $className): bool
+    {
+        $classNameLower = \strtolower($className);
+
+        if (\array_key_exists($classNameLower, self::$modelClassCache)) {
+            return self::$modelClassCache[$classNameLower];
+        }
+
+        if (\strtolower($className) === \strtolower(\Illuminate\Database\Eloquent\Model::class)) {
+            return self::$modelClassCache[$classNameLower] = true;
+        }
+
+        return self::$modelClassCache[$classNameLower] = $codebase->classOrInterfaceExists($className)
+            && $codebase->classExtends($className, \Illuminate\Database\Eloquent\Model::class);
     }
 
     /**

--- a/src/Handlers/Magic/ReturnTypeResolver.php
+++ b/src/Handlers/Magic/ReturnTypeResolver.php
@@ -81,7 +81,7 @@ final class ReturnTypeResolver
             return null;
         }
 
-        if (self::targetMethodReturnsSelf($codebase, $methodNameLowercase)) {
+        if (self::anyTargetClassMethodReturnsSelf($codebase, $methodNameLowercase)) {
             return new Union([
                 new TGenericObject($sourceClass, $sourceTemplateParams),
             ]);
@@ -105,7 +105,7 @@ final class ReturnTypeResolver
      *
      * @psalm-external-mutation-free
      */
-    private static function targetMethodReturnsSelf(
+    private static function anyTargetClassMethodReturnsSelf(
         Codebase $codebase,
         string $methodNameLowercase,
     ): bool {
@@ -115,7 +115,7 @@ final class ReturnTypeResolver
         }
 
         $rule = self::$rule;
-        \assert($rule instanceof \Psalm\LaravelPlugin\Handlers\Magic\ForwardingRule, 'initForRule() must be called before targetMethodReturnsSelf()');
+        \assert($rule instanceof \Psalm\LaravelPlugin\Handlers\Magic\ForwardingRule, 'initForRule() must be called before anyTargetClassMethodReturnsSelf()');
 
         $result = false;
 

--- a/src/Handlers/Magic/ReturnTypeResolver.php
+++ b/src/Handlers/Magic/ReturnTypeResolver.php
@@ -31,6 +31,13 @@ final class ReturnTypeResolver
      */
     private static array $selfReturnCache = [];
 
+    /**
+     * Cache: "target class::method name" -> returns self?
+     *
+     * @var array<string, bool>
+     */
+    private static array $targetSelfReturnCache = [];
+
     private static ?ForwardingRule $rule = null;
 
     /** @var array<lowercase-string, true> Pre-lowered selfReturnIndicators as a lookup set, set via initForRule() */
@@ -47,6 +54,7 @@ final class ReturnTypeResolver
     public static function initForRule(ForwardingRule $rule): void
     {
         self::$selfReturnCache = [];
+        self::$targetSelfReturnCache = [];
         self::$rule = $rule;
         self::$indicatorsLower = \array_fill_keys(
             \array_map(static fn(string $s): string => \strtolower($s), $rule->selfReturnIndicators),
@@ -97,7 +105,7 @@ final class ReturnTypeResolver
      *
      * @psalm-external-mutation-free
      */
-    private static function targetMethodReturnsSelf(
+    public static function targetMethodReturnsSelf(
         Codebase $codebase,
         string $methodNameLowercase,
     ): bool {
@@ -114,34 +122,72 @@ final class ReturnTypeResolver
         foreach ($rule->searchClasses as $searchClass) {
             $returnType = self::getDeclaredReturnType($codebase, $searchClass, $methodNameLowercase);
 
-            if (!$returnType instanceof Union) {
-                continue;
-            }
-
-            foreach ($returnType->getAtomicTypes() as $atomicType) {
-                if (!$atomicType instanceof TNamedObject) {
-                    continue;
-                }
-
-                // Check 1: @return $this / @return static
-                // Psalm stores these as TNamedObject(value="static", is_static=false),
-                // NOT as is_static=true. Match the literal "static" value.
-                if ($atomicType->value === 'static' || $atomicType->is_static) {
-                    $result = true;
-                    break 2;
-                }
-
-                // Check 2: class name matches selfReturnIndicators (e.g., Builder)
-                if (isset(self::$indicatorsLower[\strtolower($atomicType->value)])) {
-                    $result = true;
-                    break 2;
-                }
+            if ($returnType instanceof Union && self::returnTypeIndicatesSelf($returnType)) {
+                $result = true;
+                break;
             }
         }
 
         self::$selfReturnCache[$methodNameLowercase] = $result;
 
         return $result;
+    }
+
+    /**
+     * Check one target class instead of all search classes in the active forwarding rule.
+     *
+     * @psalm-external-mutation-free
+     */
+    public static function targetClassMethodReturnsSelf(
+        Codebase $codebase,
+        string $targetClass,
+        string $methodNameLowercase,
+    ): bool {
+        $key = \strtolower($targetClass) . '::' . $methodNameLowercase;
+
+        if (\array_key_exists($key, self::$targetSelfReturnCache)) {
+            return self::$targetSelfReturnCache[$key];
+        }
+
+        $returnType = self::getDeclaredReturnType($codebase, $targetClass, $methodNameLowercase);
+
+        if (!$returnType instanceof Union) {
+            return self::$targetSelfReturnCache[$key] = false;
+        }
+
+        return self::$targetSelfReturnCache[$key] = self::returnTypeIndicatesSelf($returnType);
+    }
+
+    /**
+     * @psalm-external-mutation-free
+     */
+    private static function returnTypeIndicatesSelf(Union $returnType): bool
+    {
+        $indicatesSelf = false;
+
+        foreach ($returnType->getAtomicTypes() as $atomicType) {
+            if (!$atomicType instanceof TNamedObject) {
+                return false;
+            }
+
+            // Check 1: @return $this / @return static
+            // Psalm stores these as TNamedObject(value="static", is_static=false),
+            // NOT as is_static=true. Match the literal "static" value.
+            if ($atomicType->value === 'static' || $atomicType->is_static) {
+                $indicatesSelf = true;
+                continue;
+            }
+
+            // Check 2: class name matches selfReturnIndicators (e.g., Builder)
+            if (isset(self::$indicatorsLower[\strtolower($atomicType->value)])) {
+                $indicatesSelf = true;
+                continue;
+            }
+
+            return false;
+        }
+
+        return $indicatesSelf;
     }
 
     /**

--- a/src/Handlers/Magic/ReturnTypeResolver.php
+++ b/src/Handlers/Magic/ReturnTypeResolver.php
@@ -105,7 +105,7 @@ final class ReturnTypeResolver
      *
      * @psalm-external-mutation-free
      */
-    public static function targetMethodReturnsSelf(
+    private static function targetMethodReturnsSelf(
         Codebase $codebase,
         string $methodNameLowercase,
     ): bool {
@@ -163,31 +163,25 @@ final class ReturnTypeResolver
      */
     private static function returnTypeIndicatesSelf(Union $returnType): bool
     {
-        $indicatesSelf = false;
-
         foreach ($returnType->getAtomicTypes() as $atomicType) {
             if (!$atomicType instanceof TNamedObject) {
-                return false;
+                continue;
             }
 
             // Check 1: @return $this / @return static
             // Psalm stores these as TNamedObject(value="static", is_static=false),
             // NOT as is_static=true. Match the literal "static" value.
             if ($atomicType->value === 'static' || $atomicType->is_static) {
-                $indicatesSelf = true;
-                continue;
+                return true;
             }
 
             // Check 2: class name matches selfReturnIndicators (e.g., Builder)
             if (isset(self::$indicatorsLower[\strtolower($atomicType->value)])) {
-                $indicatesSelf = true;
-                continue;
+                return true;
             }
-
-            return false;
         }
 
-        return $indicatesSelf;
+        return false;
     }
 
     /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -233,6 +233,8 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Magic/ForwardingRule.php';
         require_once __DIR__ . '/Handlers/Magic/ReturnTypeResolver.php';
         require_once __DIR__ . '/Handlers/Magic/MethodForwardingHandler.php';
+        require_once __DIR__ . '/Handlers/Eloquent/ModelMethodHandler.php';
+        require_once __DIR__ . '/Handlers/Eloquent/ModelBuilderMixinHandler.php';
         Handlers\Magic\MethodForwardingHandler::init(new Handlers\Magic\ForwardingRule(
             sourceClass: \Illuminate\Database\Eloquent\Relations\Relation::class,
             searchClasses: [
@@ -264,9 +266,13 @@ final class Plugin implements PluginEntryPointInterface
             Handlers\Magic\MethodForwardingHandler::enableDynamicWhere();
         }
 
+        // Eloquent's Model -> Builder @mixin host correction is intentionally separate
+        // from the rule-driven forwarding handler. If another forwarding domain needs
+        // the same hook, this could become an optional ForwardingRule callback instead.
+        Handlers\Eloquent\ModelBuilderMixinHandler::init();
+        $registration->registerHooksFromClass(Handlers\Eloquent\ModelBuilderMixinHandler::class);
         $registration->registerHooksFromClass(Handlers\Magic\MethodForwardingHandler::class);
 
-        require_once __DIR__ . '/Handlers/Eloquent/ModelMethodHandler.php';
         $registration->registerHooksFromClass(Handlers\Eloquent\ModelMethodHandler::class);
         require_once __DIR__ . '/Util/ModelPropertyResolver.php';
         require_once __DIR__ . '/Handlers/Eloquent/BuilderScopeHandler.php';

--- a/stubs/common/Database/Eloquent/Builder.stubphp
+++ b/stubs/common/Database/Eloquent/Builder.stubphp
@@ -32,13 +32,13 @@ class Builder implements BuilderContract
     /**
      * @param  string  $identifier
      * @param  \Illuminate\Database\Eloquent\Scope|\Closure  $scope
-     * @return self<TModel>
+     * @return $this
      */
     public function withGlobalScope($identifier, $scope) {}
 
     /**
      * @param  \Illuminate\Database\Eloquent\Scope|string  $scope
-     * @return self<TModel>
+     * @return $this
      */
     public function withoutGlobalScope($scope) {}
 
@@ -55,7 +55,7 @@ class Builder implements BuilderContract
 
     /**
      * @param  array|null  $scopes
-     * @return self<TModel>
+     * @return $this
      */
     public function withoutGlobalScopes(array $scopes = null) {}
 
@@ -68,13 +68,13 @@ class Builder implements BuilderContract
 
     /**
      * @param  mixed  $id
-     * @return self<TModel>
+     * @return $this
      */
     public function whereKey($id) {}
 
     /**
      * @param  mixed  $id
-     * @return self<TModel>
+     * @return $this
      */
     public function whereKeyNot($id) {}
 
@@ -85,7 +85,7 @@ class Builder implements BuilderContract
      * @param  mixed   $operator
      * @param  mixed   $value
      * @param  string  $boolean
-     * @return self<TModel>
+     * @return $this
      *
      * @psalm-taint-sink sql $column
      * @psalm-taint-escape sql
@@ -98,7 +98,7 @@ class Builder implements BuilderContract
      * @param  string  $operator
      * @param  \DateTimeInterface|string|null  $value
      * @param  string  $boolean
-     * @return self<TModel>
+     * @return $this
      */
     public function whereDate($column, $operator, $value = null, $boolean = 'and') {}
 
@@ -106,7 +106,7 @@ class Builder implements BuilderContract
      * @param  \Closure|array|string  $column
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return self<TModel>
+     * @return $this
      *
      * @psalm-taint-sink sql $column
      * @psalm-taint-escape sql
@@ -119,7 +119,7 @@ class Builder implements BuilderContract
      * @param  \Closure|null  $callback
      * @param  string  $operator
      * @param  int  $count
-     * @return self<TModel>
+     * @return $this
      */
     public function whereHas($relation, \Closure $callback = null, $operator = '>=', $count = 1) {}
 
@@ -128,7 +128,7 @@ class Builder implements BuilderContract
      * @param  \Closure|string|array<mixed>|\Illuminate\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return self<TModel>
+     * @return $this
      */
     public function whereRelation($relation, $column, $operator = null, $value = null) {}
 
@@ -144,7 +144,7 @@ class Builder implements BuilderContract
      * @param  \Closure|string|array<int, string>|\Illuminate\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return self<TModel>
+     * @return $this
      */
     public function orWhereRelation($relation, $column, $operator = null, $value = null) {}
 
@@ -153,7 +153,7 @@ class Builder implements BuilderContract
      * @param  \Closure|null  $callback
      * @param  string  $operator
      * @param  int  $count
-     * @return self<TModel>
+     * @return $this
      */
     public function orWhereHas($relation, \Closure $callback = null, $operator = '>=', $count = 1) {}
 
@@ -166,7 +166,7 @@ class Builder implements BuilderContract
      * @param  int  $count
      * @param  string  $boolean
      * @param  \Closure|null  $callback
-     * @return self<TModel>
+     * @return $this
      */
     public function hasMorph($relation, $types, $operator = '>=', $count = 1, $boolean = 'and', \Closure $callback = null) {}
 
@@ -177,7 +177,7 @@ class Builder implements BuilderContract
      * @param  string|array<string>  $types
      * @param  string  $operator
      * @param  int  $count
-     * @return self<TModel>
+     * @return $this
      */
     public function orHasMorph($relation, $types, $operator = '>=', $count = 1) {}
 
@@ -188,7 +188,7 @@ class Builder implements BuilderContract
      * @param  string|array<string>  $types
      * @param  string  $boolean
      * @param  \Closure|null  $callback
-     * @return self<TModel>
+     * @return $this
      */
     public function doesntHaveMorph($relation, $types, $boolean = 'and', \Closure $callback = null) {}
 
@@ -197,7 +197,7 @@ class Builder implements BuilderContract
      * @template TChildModel of Model
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TChildModel>|string  $relation
      * @param  string|array<string>  $types
-     * @return self<TModel>
+     * @return $this
      */
     public function orDoesntHaveMorph($relation, $types) {}
 
@@ -209,7 +209,7 @@ class Builder implements BuilderContract
      * @param  \Closure|null  $callback
      * @param  string  $operator
      * @param  int  $count
-     * @return self<TModel>
+     * @return $this
      */
     public function whereHasMorph($relation, $types, \Closure $callback = null, $operator = '>=', $count = 1) {}
 
@@ -221,7 +221,7 @@ class Builder implements BuilderContract
      * @param  \Closure|null  $callback
      * @param  string  $operator
      * @param  int  $count
-     * @return self<TModel>
+     * @return $this
      */
     public function orWhereHasMorph($relation, $types, \Closure $callback = null, $operator = '>=', $count = 1) {}
 
@@ -231,7 +231,7 @@ class Builder implements BuilderContract
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TChildModel>|string  $relation
      * @param  string|array<string>  $types
      * @param  \Closure|null  $callback
-     * @return self<TModel>
+     * @return $this
      */
     public function whereDoesntHaveMorph($relation, $types, \Closure $callback = null) {}
 
@@ -241,39 +241,39 @@ class Builder implements BuilderContract
      * @param  \Illuminate\Database\Eloquent\Relations\MorphTo<TRelatedModel, TChildModel>|string  $relation
      * @param  string|array<string>  $types
      * @param  \Closure|null  $callback
-     * @return self<TModel>
+     * @return $this
      */
     public function orWhereDoesntHaveMorph($relation, $types, \Closure $callback = null) {}
 
     /**
      * @param  \Illuminate\Database\Eloquent\Builder<TModel>  $from
-     * @return self<TModel>
+     * @return $this
      */
     public function mergeConstraintsFrom(\Illuminate\Database\Eloquent\Builder $from) {}
 
     /**
      * @param  string  $relation
      * @param  \Closure|null  $callback
-     * @return self<TModel>
+     * @return $this
      */
     public function orWhereDoesntHave($relation, \Closure $callback = null) {}
 
     /**
      * @param  string  $relation
      * @param  \Closure|null  $callback
-     * @return self<TModel>
+     * @return $this
      */
     public function whereDoesntHave($relation, \Closure $callback = null) {}
 
     /**
      * @param  string  $column
-     * @return self<TModel>
+     * @return $this
      */
     public function latest($column = null) {}
 
     /**
      * @param  string  $column
-     * @return self<TModel>
+     * @return $this
      */
     public function oldest($column = null) {}
 
@@ -432,7 +432,7 @@ class Builder implements BuilderContract
      * @param  int  $count
      * @param  string  $boolean
      * @param  \Closure|null  $callback
-     * @return self<TModel>
+     * @return $this
      *
      * @throws \RuntimeException
      */
@@ -442,7 +442,7 @@ class Builder implements BuilderContract
      * @param  string  $relation
      * @param  string  $operator
      * @param  int  $count
-     * @return self<TModel>
+     * @return $this
      */
     public function orHas($relation, $operator = '>=', $count = 1) {}
 
@@ -450,13 +450,13 @@ class Builder implements BuilderContract
      * @param  string  $relation
      * @param  string  $boolean
      * @param  \Closure|null  $callback
-     * @return self<TModel>
+     * @return $this
      */
     public function doesntHave($relation, $boolean = 'and', \Closure $callback = null) {}
 
     /**
      * @param  string  $relation
-     * @return self<TModel>
+     * @return $this
      */
     public function orDoesntHave($relation) {}
 
@@ -607,19 +607,19 @@ class Builder implements BuilderContract
      * Call the given local model scopes.
      *
      * @param  array|non-empty-string  $scopes
-     * @return self<TModel>
+     * @return static|mixed
      */
     public function scopes($scopes) {}
 
     /**
-     * @return self<TModel>
+     * @return static
      */
     public function applyScopes() {}
 
     /**
      * @param  mixed  $relations
      * @param  \Closure|string|null  $callback
-     * @return self<TModel>
+     * @return $this
      *
      * @psalm-variadic
      */
@@ -627,7 +627,7 @@ class Builder implements BuilderContract
 
     /**
      * @param  mixed  $relations
-     * @return self<TModel>
+     * @return $this
      *
      * @psalm-variadic
      */
@@ -646,19 +646,20 @@ class Builder implements BuilderContract
 
     /**
      * @param  \Illuminate\Database\Query\Builder  $query
-     * @return self<TModel>
+     * @return $this
      */
     public function setQuery($query) {}
 
     /**
      * @param array $eagerLoad
-     * @return self<TModel>
+     * @return $this
      */
     public function setEagerLoads(array $eagerLoad) {}
 
     /**
-     * @param TModel $model
-     * @return self<TModel>
+     * @template TNewModel of \Illuminate\Database\Eloquent\Model
+     * @param TNewModel $model
+     * @return static<TNewModel>
      */
     public function setModel(Model $model) {}
 
@@ -675,7 +676,7 @@ class Builder implements BuilderContract
      * @param  mixed  $operator
      * @param  mixed  $value
      * @param  string  $boolean
-     * @return self<TModel>
+     * @return $this
      *
      * @psalm-taint-sink sql $column
      * @psalm-taint-escape sql
@@ -689,7 +690,7 @@ class Builder implements BuilderContract
      * @param  (\Closure(self<TModel>): mixed)|array|string|\Illuminate\Contracts\Database\Query\Expression  $column
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return self<TModel>
+     * @return $this
      *
      * @psalm-taint-sink sql $column
      * @psalm-taint-escape sql

--- a/tests/Type/tests/Builder/BuilderTypesTest.phpt
+++ b/tests/Type/tests/Builder/BuilderTypesTest.phpt
@@ -53,7 +53,9 @@ final class EloquentBuilderCustomerRepository
 
     /** @return Builder<Customer> */
     public function getWhereBuilderViaInstance(array $attributes): Builder {
-        return (new Customer())->where($attributes);
+        $query = (new Customer())->where($attributes);
+        /** @psalm-check-type-exact $query = Builder<Customer> */
+        return $query;
     }
 
     public function chunkReturnsTemplatedCollection(): void
@@ -86,7 +88,9 @@ final class EloquentBuilderCustomerRepository
     /** @return Builder<Customer> */
     public function getWhereBuilderViaStatic(array $attributes): Builder
     {
-      return Customer::where($attributes);
+      $query = Customer::where($attributes);
+      /** @psalm-check-type-exact $query = Builder<Customer> */
+      return $query;
     }
 
 //    /** @return Collection<int, Customer> */

--- a/tests/Type/tests/Builder/BuilderTypesTest.phpt
+++ b/tests/Type/tests/Builder/BuilderTypesTest.phpt
@@ -4,6 +4,7 @@
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use App\Models\Customer;
+use App\Models\Vehicle;
 
 final class EloquentBuilderCustomerRepository
 {
@@ -91,6 +92,12 @@ final class EloquentBuilderCustomerRepository
       $query = Customer::where($attributes);
       /** @psalm-check-type-exact $query = Builder<Customer> */
       return $query;
+    }
+
+    public function setModelChangesBuilderTemplate(): void
+    {
+        $_result = Customer::query()->setModel(new Vehicle());
+        /** @psalm-check-type-exact $_result = Builder<Vehicle>&static */
     }
 
 //    /** @return Collection<int, Customer> */

--- a/tests/Type/tests/Builder/BuilderTypesTest.phpt
+++ b/tests/Type/tests/Builder/BuilderTypesTest.phpt
@@ -6,6 +6,11 @@ use Illuminate\Database\Eloquent\Collection;
 use App\Models\Customer;
 use App\Models\Vehicle;
 
+/**
+ * @mixin Builder<Customer>
+ */
+final class NonEloquentBuilderMixin {}
+
 final class EloquentBuilderCustomerRepository
 {
     /** @return Builder<Customer> */
@@ -161,6 +166,12 @@ function test_where_long_form_closure(): Builder
 function test_firstWhere_arrow_closure(): ?Customer
 {
     return Customer::query()->firstWhere(fn ($q) => $q->where('email', 'x'));
+}
+
+function test_non_eloquent_mixin_does_not_use_model_builder_forwarding(): void
+{
+    $_result = (new NonEloquentBuilderMixin())->where(['id' => 1]);
+    /** @psalm-check-type-exact $_result = NonEloquentBuilderMixin */
 }
 ?>
 --EXPECTF--

--- a/tests/Type/tests/Builder/CustomQueryBuilderTest.phpt
+++ b/tests/Type/tests/Builder/CustomQueryBuilderTest.phpt
@@ -57,14 +57,26 @@ function test_chain_multiple_custom_methods(): void
 /**
  * Base Builder methods still work on the custom builder.
  *
- * Returns Builder<WorkOrder> rather than WorkOrderBuilder<WorkOrder> because the Builder stub's
- * where() uses @return self<TModel> and self resolves to Builder (the declaring class).
- * Custom builder methods that explicitly return self<TModel> preserve the WorkOrderBuilder type.
+ * Fluent Builder methods preserve the concrete custom builder type.
  */
-function test_base_builder_methods_still_work(): void
+function test_base_builder_methods_preserve_custom_builder(): void
 {
     $_result = WorkOrder::query()->where('title', 'Hello');
-    /** @psalm-check-type-exact $_result = Builder<WorkOrder> */
+    /** @psalm-check-type-exact $_result = WorkOrderBuilder<WorkOrder>&static */
+}
+
+/** Base Builder methods preserve custom builder type via static model forwarding. */
+function test_base_builder_static_methods_preserve_custom_builder(): void
+{
+    $_result = WorkOrder::where('title', 'Hello');
+    /** @psalm-check-type-exact $_result = WorkOrderBuilder<WorkOrder> */
+}
+
+/** Base Builder methods preserve custom builder type via instance model forwarding. */
+function test_base_builder_instance_methods_preserve_custom_builder(): void
+{
+    $_result = (new WorkOrder())->where('title', 'Hello');
+    /** @psalm-check-type-exact $_result = WorkOrderBuilder<WorkOrder> */
 }
 
 /** Custom builder methods accessible via static call on the model. */
@@ -366,6 +378,20 @@ function test_non_template_builder_custom_method(): void
 function test_non_template_builder_static_call(): void
 {
     $_result = Invoice::wherePaid();
+    /** @psalm-check-type-exact $_result = InvoiceBuilder */
+}
+
+/** Non-template builder: base Builder method via static call preserves plain InvoiceBuilder. */
+function test_non_template_builder_base_static_call(): void
+{
+    $_result = Invoice::where('status', 'paid');
+    /** @psalm-check-type-exact $_result = InvoiceBuilder */
+}
+
+/** Non-template builder: base Builder method via instance call preserves plain InvoiceBuilder. */
+function test_non_template_builder_base_instance_call(): void
+{
+    $_result = (new Invoice())->where('status', 'paid');
     /** @psalm-check-type-exact $_result = InvoiceBuilder */
 }
 

--- a/tests/Type/tests/Builder/CustomQueryBuilderTest.phpt
+++ b/tests/Type/tests/Builder/CustomQueryBuilderTest.phpt
@@ -54,6 +54,13 @@ function test_chain_multiple_custom_methods(): void
     /** @psalm-check-type-exact $_result = WorkOrderBuilder<WorkOrder> */
 }
 
+/** Custom builder method chained into a base Builder method preserves the custom builder. */
+function test_custom_method_chain_to_base_builder_method(): void
+{
+    $_result = WorkOrder::query()->whereCompleted()->where('priority', 1);
+    /** @psalm-check-type-exact $_result = WorkOrderBuilder<WorkOrder>&static */
+}
+
 /**
  * Base Builder methods still work on the custom builder.
  *

--- a/tests/Type/tests/Relation/ForwardingHandlerTest.phpt
+++ b/tests/Type/tests/Relation/ForwardingHandlerTest.phpt
@@ -57,6 +57,15 @@ function test_mixin_only_preserves_relation_type(): void {
     /** @psalm-check-type-exact $_ = HasOne<Invoice, WorkOrder> */
 }
 
+// Builder::scopes() returns static|mixed. The fluent detector must match any
+// self-like atomic in the union, not fail on the mixed branch.
+function test_scopes_preserves_relation_type(): void {
+    /** @var HasOne<Invoice, WorkOrder> $r */
+    $r = (new WorkOrder())->invoice();
+    $_ = $r->scopes('urgent');
+    /** @psalm-check-type-exact $_ = HasOne<Invoice, WorkOrder> */
+}
+
 // Different Relation subclass: BelongsToMany (verifies template params work beyond HasOne)
 function test_belongsToMany_where_preserves_relation_type(): void {
     /** @var BelongsToMany<Part, WorkOrder, Pivot, 'pivot'> $r */


### PR DESCRIPTION
## Issue to Solve

Custom Eloquent builder methods that return chains of base `Builder` fluent methods were inferred as base `Builder<TModel>` instead of the concrete custom builder. This produced `MoreSpecificReturnType` and `LessSpecificReturnStatement` errors in builders that declare methods returning `self`.

## Related

Fixes #794

## Solution Description

- Change fluent Eloquent `Builder` stub returns from `self<TModel>` to `$this` where Laravel returns the same builder instance.
- Keep broader Laravel contracts for `scopes()`, `applyScopes()`, and `setModel()` so clone/mixed/template-changing returns are not over-narrowed.
- Intercept model `@mixin Builder<static>` fluent calls so `Model::where(...)` and `(new Model())->where(...)` still return the model builder instead of the model type after the `$this` stub change.
- Add type coverage for custom builder static, instance, non-template, and normal model forwarding paths.

Verification:

- `composer test:type -- --no-progress`
- `composer psalm -- --no-progress --no-suggestions --output-format=compact`
- `composer cs -- --show-progress=none --no-ansi -n`
- `composer test:unit -- --no-progress --colors=never --display-errors --display-warnings`
- `composer test:app`

## Checklist

- [x] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)
