### PR TITLE
Fix `scopes()` chaining on builder contracts

### DIFF
--- a/src/Handlers/Eloquent/ModelBuilderMixinHandler.php
+++ b/src/Handlers/Eloquent/ModelBuilderMixinHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Handlers\Eloquent;
 
+use Illuminate\Contracts\Database\Eloquent\Builder as BuilderContract;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use PhpParser\Node\Expr\MethodCall;
@@ -13,6 +14,7 @@ use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\LaravelPlugin\Handlers\Magic\ReturnTypeResolver;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\Type\Atomic\TGenericObject;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Union;
 
@@ -74,6 +76,14 @@ final class ModelBuilderMixinHandler implements MethodReturnTypeProviderInterfac
             ? $source->getNodeTypeProvider()->getType($stmt->var)
             : null;
 
+        if (self::callerIsEloquentBuilderContract($callerType)) {
+            return new Union([
+                new TGenericObject(Builder::class, [
+                    new Union([new TNamedObject(Model::class)]),
+                ]),
+            ]);
+        }
+
         $modelClass = self::extractModelClassFromMixinCaller($event, $codebase, $callerType);
 
         if ($modelClass === null) {
@@ -81,6 +91,31 @@ final class ModelBuilderMixinHandler implements MethodReturnTypeProviderInterfac
         }
 
         return new Union([ModelMethodHandler::resolvedBuilderTypeFor($modelClass, $codebase)]);
+    }
+
+    /**
+     * Laravel's Builder contract is an empty @mixin host. When fluent methods are
+     * resolved through that mixin, returning static would bind the chain back to the
+     * empty interface and hide concrete Builder methods such as whereNull().
+     *
+     * @psalm-mutation-free
+     */
+    private static function callerIsEloquentBuilderContract(?Union $callerType): bool
+    {
+        if (!$callerType instanceof Union) {
+            return false;
+        }
+
+        foreach ($callerType->getAtomicTypes() as $atomicType) {
+            if (
+                $atomicType instanceof TNamedObject
+                && \strtolower($atomicType->value) === \strtolower(BuilderContract::class)
+            ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Type/tests/Builder/BuilderTypesTest.phpt
+++ b/tests/Type/tests/Builder/BuilderTypesTest.phpt
@@ -3,6 +3,8 @@
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Contracts\Database\Eloquent\Builder as BuilderContract;
+use Illuminate\Database\Eloquent\Model;
 use App\Models\Customer;
 use App\Models\Vehicle;
 
@@ -172,6 +174,13 @@ function test_non_eloquent_mixin_does_not_use_model_builder_forwarding(): void
 {
     $_result = (new NonEloquentBuilderMixin())->where(['id' => 1]);
     /** @psalm-check-type-exact $_result = NonEloquentBuilderMixin */
+}
+
+function test_scopes_on_builder_contract_preserves_concrete_builder_surface(BuilderContract $query): BuilderContract
+{
+    $_result = $query->scopes(['active'])->whereNull('deleted_at');
+    /** @psalm-check-type-exact $_result = Builder<Model>&static */
+    return $_result;
 }
 ?>
 --EXPECTF--


### PR DESCRIPTION
## Issue to Solve
`Illuminate\Contracts\Database\Eloquent\Builder` is an empty interface with an `@mixin` to the concrete Eloquent builder. When `scopes()` was resolved through that mixin, Psalm bound `static` back to the empty contract, so fluent follow-up calls like `whereNull()` were reported as undefined.

## Related
Follow-up to #845.

## Solution Description
When the model-builder mixin handler sees a fluent Eloquent builder method called from the builder contract, it returns the concrete `Illuminate\Database\Eloquent\Builder<Model>` surface instead of the empty contract. Added a type test for `BuilderContract $query->scopes(...)->whereNull(...)`.

Verified locally:
- `composer test:type -- --no-progress`
- `composer psalm -- --no-progress --no-suggestions --output-format=compact`
- `composer cs -- --show-progress=none --no-ansi -n`
- `composer test:unit -- --no-progress --colors=never --display-errors --display-warnings`

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)
