### PR TITLE
Register custom builder pseudo-method macros

### DIFF
--- a/src/Handlers/Eloquent/ModelRegistrationHandler.php
+++ b/src/Handlers/Eloquent/ModelRegistrationHandler.php
@@ -361,7 +361,7 @@ final class ModelRegistrationHandler implements AfterCodebasePopulatedInterface
         string $modelClass,
         string $builderClass,
     ): void {
-        $traitMethods = self::extractBuilderReturningMethods($storage);
+        $traitMethods = self::extractBuilderReturningMethods($storage, $builderClass);
         if ($traitMethods === []) {
             return;
         }
@@ -396,18 +396,20 @@ final class ModelRegistrationHandler implements AfterCodebasePopulatedInterface
     }
 
     /**
-     * Extract @method static declarations that return Builder<static> from
-     * a model's pseudo_static_methods. These typically originate from traits
-     * like SoftDeletes (which register builder macros via global scopes), but
-     * may also include model-level @method annotations; this is acceptable as
-     * we only act on methods whose return type is a generic Builder.
+     * Extract @method static declarations that return Builder<static> or the model's
+     * custom builder class from a model's pseudo_static_methods. These typically
+     * originate from traits like SoftDeletes (which register builder macros via
+     * global scopes), but may also include model-level @method annotations; this
+     * is acceptable as we only act on methods whose return type is a builder.
      *
+     * @param class-string<Builder>|null $customBuilderClass
      * @return array<lowercase-string, list<FunctionLikeParameter>>
      * @psalm-mutation-free
      */
-    private static function extractBuilderReturningMethods(ClassLikeStorage $storage): array
+    private static function extractBuilderReturningMethods(ClassLikeStorage $storage, ?string $customBuilderClass = null): array
     {
         $builderClassLower = \strtolower(Builder::class);
+        $customBuilderClassLower = $customBuilderClass !== null ? \strtolower($customBuilderClass) : null;
         $result = [];
 
         foreach ($storage->pseudo_static_methods as $methodName => $methodStorage) {
@@ -417,10 +419,16 @@ final class ModelRegistrationHandler implements AfterCodebasePopulatedInterface
             }
 
             foreach ($returnType->getAtomicTypes() as $type) {
-                if (
-                    $type instanceof TGenericObject
-                    && \strtolower($type->value) === $builderClassLower
-                ) {
+                // Laravel traits such as SoftDeletes declare Builder<static>, while apps often
+                // override those macros in model PHPDoc with a concrete custom builder return.
+                // Keep the generic and named-object checks separate so we do not treat arbitrary
+                // generic classes as builder macros, but still catch non-templated custom builders.
+                if ($type instanceof TGenericObject && \strtolower($type->value) === $builderClassLower) {
+                    $result[$methodName] = $methodStorage->params;
+                    break;
+                }
+
+                if ($customBuilderClassLower !== null && $type instanceof TNamedObject && \strtolower($type->value) === $customBuilderClassLower) {
                     $result[$methodName] = $methodStorage->params;
                     break;
                 }

--- a/tests/Application/app/Builders/BuilderMacroModelBuilder.php
+++ b/tests/Application/app/Builders/BuilderMacroModelBuilder.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Builders;
+
+use App\Models\BuilderMacroModel;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Custom builder without its own @template parameters.
+ *
+ * @extends Builder<BuilderMacroModel>
+ */
+final class BuilderMacroModelBuilder extends Builder {}

--- a/tests/Application/app/Models/BuilderMacroModel.php
+++ b/tests/Application/app/Models/BuilderMacroModel.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Builders\BuilderMacroModelBuilder;
+use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * Slim fixture for model-level @method annotations that describe builder macros.
+ *
+ * @method static BuilderMacroModelBuilder activeOnly()
+ * @method static BuilderMacroModelBuilder onlyTrashed()
+ * @method static Supplier unrelatedMacro()
+ */
+#[UseEloquentBuilder(BuilderMacroModelBuilder::class)]
+final class BuilderMacroModel extends Model
+{
+    use SoftDeletes;
+
+    protected $table = 'builder_macro_models';
+}

--- a/tests/Type/tests/Builder/CustomQueryBuilderTest.phpt
+++ b/tests/Type/tests/Builder/CustomQueryBuilderTest.phpt
@@ -1,12 +1,14 @@
 --FILE--
 <?php declare(strict_types=1);
 
+use App\Builders\BuilderMacroModelBuilder;
 use App\Builders\VehicleBuilder;
 use App\Builders\InvoiceBuilder;
 use App\Builders\MechanicBuilder;
 use App\Builders\WorkOrderBuilder;
 use App\Collections\InvoiceCollection;
 use App\Collections\WorkOrderCollection;
+use App\Models\BuilderMacroModel;
 use App\Models\Vehicle;
 use App\Models\Invoice;
 use App\Models\Mechanic;
@@ -402,6 +404,40 @@ function test_non_template_builder_base_instance_call(): void
     /** @psalm-check-type-exact $_result = InvoiceBuilder */
 }
 
+/** Non-template builder: model-level @method returning the custom builder is also a builder macro. */
+function test_model_level_custom_builder_macro_static_call(): void
+{
+    $_result = BuilderMacroModel::activeOnly();
+    /** @psalm-check-type-exact $_result = BuilderMacroModelBuilder */
+}
+
+/** Model-level @method returning a custom builder preserves static-side SoftDeletes wiring. */
+function test_model_level_custom_builder_soft_deletes_static_call(): void
+{
+    $_result = BuilderMacroModel::onlyTrashed();
+    /** @psalm-check-type-exact $_result = BuilderMacroModelBuilder */
+}
+
+/** Model-level @method returning a custom builder is also a builder macro. */
+function test_model_level_custom_builder_macro_instance_call(BuilderMacroModelBuilder $query): void
+{
+    $_result = $query->activeOnly();
+    /** @psalm-check-type-exact $_result = BuilderMacroModelBuilder */
+}
+
+/** Non-template builder: base Builder method chain must keep model-level trait macros. */
+function test_model_level_custom_builder_macro_after_base_builder_method(BuilderMacroModelBuilder $query): void
+{
+    $_result = $query->where('deleted_at', '<', '2024-01-01')->onlyTrashed();
+    /** @psalm-check-type-exact $_result = BuilderMacroModelBuilder */
+}
+
+/** Negative: unrelated model-level @method returns are not registered as builder macros. */
+function test_unrelated_model_level_method_is_not_registered_on_custom_builder(BuilderMacroModelBuilder $query): void
+{
+    $_result = $query->unrelatedMacro();
+}
+
 /**
  * Non-template builder: terminal get() returns base Collection, not InvoiceCollection.
  *
@@ -433,3 +469,4 @@ function test_non_template_collection_all(): void
 InvalidStaticInvocation on line %d: Method App\Models\WorkOrder::completed is not static, but is called statically
 UndefinedMagicMethod on line %d: Magic method App\Builders\WorkOrderBuilder::completelyfakemethod does not exist
 UndefinedMagicMethod on line %d: Magic method App\Models\WorkOrder::completelyfakemethod does not exist
+UndefinedMagicMethod on line %d: Magic method App\Builders\BuilderMacroModelBuilder::unrelatedmacro does not exist


### PR DESCRIPTION
## Issue to Solve
Models can declare builder macro methods directly in their PHPDoc as returning their custom builder class, for example `@method static MemberEloquentBuilder onlyTrashed()`. The model registration pass only harvested pseudo-methods returning `Illuminate\Database\Eloquent\Builder<static>`, so those custom-builder-returning pseudo-methods were not registered on the custom builder instance. That caused calls like `$query->onlyTrashed()` and `$query->where(...)->onlyTrashed()` to be reported as `UndefinedMagicMethod`.

## Related
Follow-up to #794 / #845.

## Solution Description
`ModelRegistrationHandler` now treats pseudo-methods returning the detected custom builder class as builder-returning methods too. These methods are registered with `CustomBuilderMethodHandler`, so both direct and chained builder-instance calls resolve.

Added regression coverage using a non-template `InvoiceBuilder` fixture with a model-level `@method static InvoiceBuilder onlyTrashed()` annotation.
