### PR TITLE
Bind `firstOr()` callback template across argument positions

### DIFF
--- a/stubs/common/Database/Eloquent/Builder.stubphp
+++ b/stubs/common/Database/Eloquent/Builder.stubphp
@@ -362,7 +362,7 @@ class Builder implements BuilderContract
      *
      * @template TValue
      *
-     * @param  list<string>|(\Closure(): TValue)  $columns
+     * @param  list<non-empty-string>|(\Closure(): TValue)  $columns
      * @param  (\Closure(): TValue)|null  $callback
      * @return TModel|TValue
      */

--- a/stubs/common/Database/Eloquent/Builder.stubphp
+++ b/stubs/common/Database/Eloquent/Builder.stubphp
@@ -360,13 +360,19 @@ class Builder implements BuilderContract
      * `$columns` parameter must therefore also carry `TValue` so Psalm binds
      * the template no matter where the closure lives.
      *
+     * Builder calls Query Builder's `get($columns)` (via `first()`), which
+     * accepts a bare string and wraps it with `Arr::wrap()`. The relation
+     * subclasses route through `shouldSelect(array $columns)` instead, which
+     * hard-rejects strings — so the relation stubs do not include the string
+     * branch.
+     *
      * @template TValue
      *
-     * @param  list<non-empty-string>|(\Closure(): TValue)  $columns
+     * @param  list<non-empty-string>|non-empty-string|(\Closure(): TValue)  $columns
      * @param  (\Closure(): TValue)|null  $callback
      * @return TModel|TValue
      */
-    public function firstOr($columns = ['*'], \Closure $callback = null) {}
+    public function firstOr($columns = ['*'], ?\Closure $callback = null) {}
 
     /**
      * @param  array<string, mixed>  $attributes

--- a/stubs/common/Database/Eloquent/Builder.stubphp
+++ b/stubs/common/Database/Eloquent/Builder.stubphp
@@ -355,9 +355,14 @@ class Builder implements BuilderContract
     public function firstOrFail($columns = ['*']) {}
 
     /**
+     * Laravel accepts the callback in either argument position. When given as
+     * the first argument, Laravel swaps it into `$callback` internally; the
+     * `$columns` parameter must therefore also carry `TValue` so Psalm binds
+     * the template no matter where the closure lives.
+     *
      * @template TValue
      *
-     * @param  \Closure|array  $columns
+     * @param  list<string>|(\Closure(): TValue)  $columns
      * @param  (\Closure(): TValue)|null  $callback
      * @return TModel|TValue
      */

--- a/stubs/common/Database/Eloquent/Relations/BelongsToMany.stubphp
+++ b/stubs/common/Database/Eloquent/Relations/BelongsToMany.stubphp
@@ -174,7 +174,7 @@ class BelongsToMany extends Relation
      *
      * @template TValue
      *
-     * @param  list<string>|(\Closure(): TValue)  $columns
+     * @param  list<non-empty-string>|(\Closure(): TValue)  $columns
      * @param  (\Closure(): TValue)|null  $callback
      * @return (TRelatedModel&object{pivot: TPivotModel})|TValue
      */

--- a/stubs/common/Database/Eloquent/Relations/BelongsToMany.stubphp
+++ b/stubs/common/Database/Eloquent/Relations/BelongsToMany.stubphp
@@ -167,9 +167,14 @@ class BelongsToMany extends Relation
     public function cursorPaginate($perPage = null, $columns = ['*'], $cursorName = 'cursor', $cursor = null) {}
 
     /**
+     * Laravel accepts the callback in either argument position. When given as
+     * the first argument, Laravel swaps it into `$callback` internally; the
+     * `$columns` parameter must therefore also carry `TValue` so Psalm binds
+     * the template no matter where the closure lives.
+     *
      * @template TValue
      *
-     * @param  \Closure|array  $columns
+     * @param  list<string>|(\Closure(): TValue)  $columns
      * @param  (\Closure(): TValue)|null  $callback
      * @return (TRelatedModel&object{pivot: TPivotModel})|TValue
      */

--- a/stubs/common/Database/Eloquent/Relations/BelongsToMany.stubphp
+++ b/stubs/common/Database/Eloquent/Relations/BelongsToMany.stubphp
@@ -172,13 +172,17 @@ class BelongsToMany extends Relation
      * `$columns` parameter must therefore also carry `TValue` so Psalm binds
      * the template no matter where the closure lives.
      *
+     * Unlike `Builder::firstOr()`, the relation routes columns through
+     * `shouldSelect(array $columns)`, which hard-rejects bare strings at
+     * runtime — so this stub permits only `list<non-empty-string>`.
+     *
      * @template TValue
      *
      * @param  list<non-empty-string>|(\Closure(): TValue)  $columns
      * @param  (\Closure(): TValue)|null  $callback
      * @return (TRelatedModel&object{pivot: TPivotModel})|TValue
      */
-    public function firstOr($columns = ['*'], \Closure $callback = null) {}
+    public function firstOr($columns = ['*'], ?\Closure $callback = null) {}
 
     /**
      * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column

--- a/stubs/common/Database/Eloquent/Relations/HasOneOrManyThrough.stubphp
+++ b/stubs/common/Database/Eloquent/Relations/HasOneOrManyThrough.stubphp
@@ -46,6 +46,20 @@ abstract class HasOneOrManyThrough extends Relation
     public function findOrFail($id, $columns = ['*']) {}
 
     /**
+     * Override the @mixin Builder<TRelatedModel> route so the relation enforces
+     * its own runtime constraint: like BelongsToMany, the through-relations
+     * route columns through `shouldSelect(array $columns)`, which rejects bare
+     * strings — so this stub permits only `list<non-empty-string>`.
+     *
+     * @template TValue
+     *
+     * @param  list<non-empty-string>|(\Closure(): TValue)  $columns
+     * @param  (\Closure(): TValue)|null  $callback
+     * @return TRelatedModel|TValue
+     */
+    public function firstOr($columns = ['*'], ?\Closure $callback = null) {}
+
+    /**
      * @param  int|null  $perPage
      * @param  list<non-empty-string>  $columns
      * @param  string  $pageName

--- a/tests/Type/tests/Builder/BuilderFirstOrTest.phpt
+++ b/tests/Type/tests/Builder/BuilderFirstOrTest.phpt
@@ -1,0 +1,112 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use App\Models\Invoice;
+use App\Models\Mechanic;
+use App\Models\MechanicSpecialization;
+use App\Models\SpecializationPivot;
+use App\Models\WorkOrder;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+
+/**
+ * Regression for https://github.com/psalm/psalm-plugin-laravel/issues/848
+ *
+ * Builder::firstOr() must narrow to TModel when the callback's return type is
+ * `never` (i.e. always throws). The same applies to BelongsToMany::firstOr()
+ * and HasOneOrManyThrough::firstOr().
+ */
+
+final class FirstOrNotFoundException extends \RuntimeException {}
+
+// Closure in 1st position with `never` return type → must narrow to Customer.
+function test_firstOr_closure_first_position_never_narrows(): void
+{
+    $_ = Customer::query()
+        ->where('id', 1)
+        ->firstOr(static function (): never {
+            throw new FirstOrNotFoundException();
+        });
+    /** @psalm-check-type-exact $_ = App\Models\Customer */
+}
+
+// Closure in 2nd position (named) with `never` → still narrows to Customer.
+function test_firstOr_closure_second_position_never_narrows(): void
+{
+    $_ = Customer::query()
+        ->where('id', 1)
+        ->firstOr(['*'], static function (): never {
+            throw new FirstOrNotFoundException();
+        });
+    /** @psalm-check-type-exact $_ = App\Models\Customer */
+}
+
+// Closure returning a value → return is TModel|TValue. Psalm narrows the
+// closure return to a literal here because the lambda body is constant.
+function test_firstOr_closure_returns_value(): void
+{
+    $_ = Customer::query()->firstOr(static fn (): string => 'fallback');
+    /** @psalm-check-type-exact $_ = 'fallback'|App\Models\Customer */
+}
+
+// Same as above but with the closure in the second (named) position.
+function test_firstOr_named_callback_returns_value(): void
+{
+    $_ = Customer::query()->firstOr(['*'], static fn (): int => 42);
+    /** @psalm-check-type-exact $_ = 42|App\Models\Customer */
+}
+
+/**
+ * BelongsToMany::firstOr() with `never` callback must narrow to the related
+ * model intersected with the pivot.
+ *
+ * @param BelongsToMany<MechanicSpecialization, Mechanic, SpecializationPivot, 'pivot'> $relation
+ */
+function test_belongsToMany_firstOr_never_narrows(BelongsToMany $relation): void
+{
+    $_ = $relation->firstOr(static function (): never {
+        throw new FirstOrNotFoundException();
+    });
+    /** @psalm-check-type-exact $_ = App\Models\MechanicSpecialization&object{pivot: App\Models\SpecializationPivot} */
+}
+
+/**
+ * BelongsToMany::firstOr() with a value-returning callback in 1st position
+ * must include the value type in the union.
+ *
+ * @param BelongsToMany<MechanicSpecialization, Mechanic, SpecializationPivot, 'pivot'> $relation
+ */
+function test_belongsToMany_firstOr_value_callback_first_position(BelongsToMany $relation): void
+{
+    $_ = $relation->firstOr(static fn (): string => 'fallback');
+    /** @psalm-check-type-exact $_ = 'fallback'|App\Models\MechanicSpecialization&object{pivot: App\Models\SpecializationPivot} */
+}
+
+/**
+ * HasOneOrManyThrough::firstOr() with `never` callback must narrow to TRelatedModel.
+ *
+ * @param HasManyThrough<Invoice, WorkOrder, Customer> $relation
+ */
+function test_hasManyThrough_firstOr_never_narrows(HasManyThrough $relation): void
+{
+    $_ = $relation->firstOr(static function (): never {
+        throw new FirstOrNotFoundException();
+    });
+    /** @psalm-check-type-exact $_ = App\Models\Invoice */
+}
+
+/**
+ * HasOneOrManyThrough::firstOr() with a value-returning callback in 1st position
+ * must include the value type in the union.
+ *
+ * @param HasManyThrough<Invoice, WorkOrder, Customer> $relation
+ */
+function test_hasManyThrough_firstOr_value_callback_first_position(HasManyThrough $relation): void
+{
+    $_ = $relation->firstOr(static fn (): string => 'fallback');
+    /** @psalm-check-type-exact $_ = 'fallback'|App\Models\Invoice */
+}
+
+?>
+--EXPECTF--

--- a/tests/Type/tests/Relation/FirstOrInvalidColumnsTest.phpt
+++ b/tests/Type/tests/Relation/FirstOrInvalidColumnsTest.phpt
@@ -1,0 +1,42 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use App\Models\Invoice;
+use App\Models\Mechanic;
+use App\Models\MechanicSpecialization;
+use App\Models\SpecializationPivot;
+use App\Models\WorkOrder;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+
+/**
+ * Relation `firstOr()` implementations route `$columns` through the protected
+ * `shouldSelect(array $columns)` helper, which hard-rejects bare strings at
+ * runtime. The Builder version, by contrast, lets `Arr::wrap()` widen a string
+ * into an array — which is why only the Builder stub permits the
+ * `non-empty-string` shape.
+ *
+ * @param BelongsToMany<MechanicSpecialization, Mechanic, SpecializationPivot, 'pivot'> $relation
+ */
+function test_belongsToMany_firstOr_rejects_string_columns(BelongsToMany $relation): void
+{
+    $relation->firstOr('id', static function (): never {
+        throw new \RuntimeException('Missing specialization');
+    });
+}
+
+/**
+ * @param HasManyThrough<Invoice, WorkOrder, Customer> $relation
+ */
+function test_hasManyThrough_firstOr_rejects_string_columns(HasManyThrough $relation): void
+{
+    $relation->firstOr('id', static function (): never {
+        throw new \RuntimeException('Missing invoice');
+    });
+}
+
+?>
+--EXPECTF--
+InvalidArgument on line %d: Argument 1 of Illuminate\Database\Eloquent\Relations\BelongsToMany::firstOr expects %s, but 'id' provided
+InvalidArgument on line %d: Argument 1 of Illuminate\Database\Eloquent\Relations\HasManyThrough::firstOr expects %s, but 'id' provided


### PR DESCRIPTION
Closes #848.

`Builder::firstOr()` and `BelongsToMany::firstOr()` accept the callback in either argument position; Laravel internally swaps the closure from the first slot into `\$callback`. The previous stub typed `\$columns` as `\Closure|array`, so when the closure was passed as the first argument `TValue` never bound and the return type degraded:

- value-returning closures lost their value type in the return union;
- a closure returning `never` only narrowed to `TModel` by accident (`TValue` defaulted to `never` and the union collapsed).

This PR retypes `\$columns` as `list<string>|(\Closure(): TValue)` so `TValue` binds regardless of position. The shape now matches Laravel's own docblock and Larastan.

## Changes

- `stubs/common/Database/Eloquent/Builder.stubphp` — `Builder::firstOr()`
- `stubs/common/Database/Eloquent/Relations/BelongsToMany.stubphp` — `BelongsToMany::firstOr()` (preserves the `TRelatedModel & object{pivot: TPivotModel}` intersection)
- `tests/Type/tests/Builder/BuilderFirstOrTest.phpt` — 8 PHPT assertions covering both positions, `never` and value callbacks, on `Builder`, `BelongsToMany`, and `HasManyThrough`

## Notes

- `HasOneOrManyThrough::firstOr()` does not need its own plugin stub. Its subclasses (`HasManyThrough`, `HasOneThrough`) inherit `firstOr` via `@mixin Builder<TRelatedModel>`, and Laravel's own source docblock already uses `(\Closure(): TValue)|list<string>`. Tests confirm the chain works.
- The fix is not `never`-specific. The original issue reports the `never` symptom, but the same template-binding gap also broke value-returning callbacks in the first argument position. Both are fixed.
- The conditional return type proposed in the issue (`(TValue is never ? TModel : TModel|TValue)`) is not needed: Psalm's `T|never` collapse handles it (`TypeCombiner` drops `TNever` from non-trivial unions). Larastan and the existing `findOr` family use the same pattern.