### PR TITLE
Bind firstOr() callback template across argument positions

### DIFF
--- a/stubs/common/Database/Eloquent/Builder.stubphp
+++ b/stubs/common/Database/Eloquent/Builder.stubphp
@@ -357,11 +357,11 @@ class Builder implements BuilderContract
     /**
      * @template TValue
      *
-     * @param  \Closure|array  $columns
+     * @param  (\Closure(): TValue)|list<non-empty-string>|non-empty-string  $columns
      * @param  (\Closure(): TValue)|null  $callback
-     * @return TModel|TValue
+     * @return (TValue is never ? TModel : TModel|TValue)
      */
-    public function firstOr($columns = ['*'], \Closure $callback = null) {}
+    public function firstOr($columns = ['*'], ?\Closure $callback = null) {}
 
     /**
      * @param  array<string, mixed>  $attributes

--- a/stubs/common/Database/Eloquent/Relations/BelongsToMany.stubphp
+++ b/stubs/common/Database/Eloquent/Relations/BelongsToMany.stubphp
@@ -169,11 +169,11 @@ class BelongsToMany extends Relation
     /**
      * @template TValue
      *
-     * @param  \Closure|array  $columns
+     * @param  (\Closure(): TValue)|list<non-empty-string>  $columns
      * @param  (\Closure(): TValue)|null  $callback
-     * @return (TRelatedModel&object{pivot: TPivotModel})|TValue
+     * @return (TValue is never ? TRelatedModel&object{pivot: TPivotModel} : (TRelatedModel&object{pivot: TPivotModel})|TValue)
      */
-    public function firstOr($columns = ['*'], \Closure $callback = null) {}
+    public function firstOr($columns = ['*'], ?\Closure $callback = null) {}
 
     /**
      * @param  (\Closure(\Illuminate\Database\Eloquent\Builder<TRelatedModel>): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression  $column

--- a/stubs/common/Database/Eloquent/Relations/HasOneOrManyThrough.stubphp
+++ b/stubs/common/Database/Eloquent/Relations/HasOneOrManyThrough.stubphp
@@ -46,6 +46,15 @@ abstract class HasOneOrManyThrough extends Relation
     public function findOrFail($id, $columns = ['*']) {}
 
     /**
+     * @template TValue
+     *
+     * @param  (\Closure(): TValue)|list<non-empty-string>  $columns
+     * @param  (\Closure(): TValue)|null  $callback
+     * @return (TValue is never ? TRelatedModel : TRelatedModel|TValue)
+     */
+    public function firstOr($columns = ['*'], ?\Closure $callback = null) {}
+
+    /**
      * @param  int|null  $perPage
      * @param  list<non-empty-string>  $columns
      * @param  string  $pageName

--- a/tests/Type/tests/Builder/BuilderTypesTest.phpt
+++ b/tests/Type/tests/Builder/BuilderTypesTest.phpt
@@ -41,6 +41,26 @@ final class EloquentBuilderCustomerRepository
         return $builder->findOrFail(1);
     }
 
+    /** @param Builder<Customer> $builder */
+    public function firstOrWithNeverCallbackFromBuilderInstance(Builder $builder): Customer {
+        $_result = $builder->firstOr(static function (): never {
+            throw new \RuntimeException('Missing customer');
+        });
+        /** @psalm-check-type-exact $_result = Customer */
+
+        return $_result;
+    }
+
+    /** @param Builder<Customer> $builder */
+    public function firstOrWithNeverCallbackAndColumnsFromBuilderInstance(Builder $builder): Customer {
+        $_result = $builder->firstOr(['*'], static function (): never {
+            throw new \RuntimeException('Missing customer');
+        });
+        /** @psalm-check-type-exact $_result = Customer */
+
+        return $_result;
+    }
+
     /**
     * @param Builder<Customer> $builder
     * @return Collection<int, Customer>

--- a/tests/Type/tests/Relation/BelongsToManyPivotTest.phpt
+++ b/tests/Type/tests/Relation/BelongsToManyPivotTest.phpt
@@ -54,6 +54,35 @@ function test_firstOrFail_infers_pivot_intersection(BelongsToMany $relation): vo
 }
 
 /**
+ * firstOr() with a never-returning fallback must narrow to the related model
+ * and keep the pivot intersection.
+ *
+ * @param BelongsToMany<MechanicSpecialization, Mechanic, SpecializationPivot, 'pivot'> $relation
+ */
+function test_firstOr_with_never_callback_infers_pivot_intersection(BelongsToMany $relation): MechanicSpecialization
+{
+    $_ = $relation->firstOr(static function (): never {
+        throw new \RuntimeException('Missing specialization');
+    });
+    /** @psalm-check-type-exact $_ = MechanicSpecialization&object{pivot: SpecializationPivot} */
+
+    return $_;
+}
+
+/**
+ * @param BelongsToMany<MechanicSpecialization, Mechanic, SpecializationPivot, 'pivot'> $relation
+ */
+function test_firstOr_with_columns_and_never_callback_infers_pivot_intersection(BelongsToMany $relation): MechanicSpecialization
+{
+    $_ = $relation->firstOr(['*'], static function (): never {
+        throw new \RuntimeException('Missing specialization');
+    });
+    /** @psalm-check-type-exact $_ = MechanicSpecialization&object{pivot: SpecializationPivot} */
+
+    return $_;
+}
+
+/**
  * create() return type must include the pivot intersection.
  *
  * @param BelongsToMany<MechanicSpecialization, Mechanic, SpecializationPivot, 'pivot'> $relation

--- a/tests/Type/tests/Relation/FirstOrInvalidColumnsTest.phpt
+++ b/tests/Type/tests/Relation/FirstOrInvalidColumnsTest.phpt
@@ -1,0 +1,37 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use App\Models\Mechanic;
+use App\Models\MechanicSpecialization;
+use App\Models\SpecializationPivot;
+use App\Models\Vehicle;
+use App\Models\WorkOrder;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+
+/**
+ * Relation firstOr() implementations pass selected columns through helpers
+ * that require arrays, unlike the base Eloquent builder.
+ *
+ * @param BelongsToMany<MechanicSpecialization, Mechanic, SpecializationPivot, 'pivot'> $relation
+ */
+function test_belongsToMany_firstOr_rejects_string_columns(BelongsToMany $relation): void
+{
+    $relation->firstOr('id', static function (): never {
+        throw new \RuntimeException('Missing specialization');
+    });
+}
+
+function test_hasManyThrough_firstOr_rejects_string_columns(): void
+{
+    /** @var HasManyThrough<WorkOrder, Vehicle, Customer> $relation */
+    $relation = (new Customer())->workOrders();
+    $relation->firstOr('id', static function (): never {
+        throw new \RuntimeException('Missing work order');
+    });
+}
+?>
+--EXPECTF--
+InvalidArgument on line %d: Argument 1 of Illuminate\Database\Eloquent\Relations\BelongsToMany::firstOr expects %s, but 'id' provided
+InvalidArgument on line %d: Argument 1 of Illuminate\Database\Eloquent\Relations\HasManyThrough::firstOr expects %s, but 'id' provided

--- a/tests/Type/tests/Relation/ForwardingHandlerTest.phpt
+++ b/tests/Type/tests/Relation/ForwardingHandlerTest.phpt
@@ -105,6 +105,28 @@ function test_firstOrFail_returns_model(): void {
     /** @psalm-check-type-exact $_ = Invoice */
 }
 
+function test_hasManyThrough_firstOr_with_never_callback_returns_model(): WorkOrder {
+    /** @var HasManyThrough<WorkOrder, Vehicle, Customer> $r */
+    $r = (new Customer())->workOrders();
+    $_ = $r->firstOr(static function (): never {
+        throw new \RuntimeException('Missing work order');
+    });
+    /** @psalm-check-type-exact $_ = WorkOrder */
+
+    return $_;
+}
+
+function test_hasManyThrough_firstOr_with_columns_and_never_callback_returns_model(): WorkOrder {
+    /** @var HasManyThrough<WorkOrder, Vehicle, Customer> $r */
+    $r = (new Customer())->workOrders();
+    $_ = $r->firstOr(['*'], static function (): never {
+        throw new \RuntimeException('Missing work order');
+    });
+    /** @psalm-check-type-exact $_ = WorkOrder */
+
+    return $_;
+}
+
 // Non-fluent mixin method: count() returns int, not HasOne<Invoice, WorkOrder>
 function test_count_returns_int_not_relation(): void {
     /** @var HasOne<Invoice, WorkOrder> $r */


### PR DESCRIPTION
Closes #848.

`Builder::firstOr()` and `BelongsToMany::firstOr()` accept the callback in either argument position; Laravel internally swaps the closure from the first slot into `\$callback`. The previous stub typed `\$columns` as `\Closure|array`, so when the closure was passed as the first argument `TValue` never bound and the return type degraded:

- value-returning closures lost their value type in the return union;
- a closure returning `never` only narrowed to `TModel` by accident (`TValue` defaulted to `never` and the union collapsed).

This PR retypes `\$columns` as `list<string>|(\Closure(): TValue)` so `TValue` binds regardless of position. The shape now matches Laravel's own docblock and Larastan.
