### PR TITLE
fix(stubs): backport stub-location fixes to 3.x (#827)

### DIFF
--- a/stubs/common/Http/Concerns/InteractsWithFlashData.stubphp
+++ b/stubs/common/Http/Concerns/InteractsWithFlashData.stubphp
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Http\Concerns;
+
+trait InteractsWithFlashData
+{
+    /**
+     * Retrieve old input for the given key.
+     *
+     * @param  string|null  $key
+     * @param  mixed  $default
+     * @return ($key is null ? array<string, mixed> : mixed)
+     *
+     * @psalm-taint-source input
+     */
+    public function old($key = null, $default = null) {}
+}

--- a/stubs/common/Http/Concerns/InteractsWithInput.stubphp
+++ b/stubs/common/Http/Concerns/InteractsWithInput.stubphp
@@ -17,16 +17,6 @@ trait InteractsWithInput
     public function input($key = null, $default = null) {}
 
     /**
-     * Retrieve input from the request as a collection.
-     *
-     * @param  string[]|string|null  $key
-     * @return \Illuminate\Support\Collection
-     *
-     * @psalm-taint-source input
-     */
-    public function collect($key = null) {}
-
-    /**
      * Get all of the input and files for the request.
      *
      * @param  string[]|string|null  $keys
@@ -132,28 +122,6 @@ trait InteractsWithInput
     public function bearerToken() {}
 
     /**
-     * Retrieve input from the request as a Stringable instance.
-     *
-     * @param  string  $key
-     * @param  mixed  $default
-     * @return \Illuminate\Support\Stringable
-     *
-     * @psalm-taint-source input
-     */
-    public function str($key, $default = null) {}
-
-    /**
-     * Retrieve input from the request as a Stringable instance.
-     *
-     * @param  string  $key
-     * @param  mixed  $default
-     * @return \Illuminate\Support\Stringable
-     *
-     * @psalm-taint-source input
-     */
-    public function string($key, $default = null) {}
-
-    /**
      * Retrieve input from the request as a Fluent object instance.
      *
      * @param  array|string|null  $key
@@ -164,101 +132,11 @@ trait InteractsWithInput
      */
     public function fluent($key = null, array $default = []) {}
 
-    /**
-     * Retrieve input as an integer value.
-     *
-     * Not a taint source: (int) cast cannot produce an injection payload.
-     * e.g. (int) "1; DROP TABLE users" → 1
-     *
-     * @param  string  $key
-     * @param  int  $default
-     * @return int
-     */
-    public function integer($key, $default = 0) {}
-
-    /**
-     * Retrieve input as a float value.
-     *
-     * Not a taint source: (float) cast cannot produce an injection payload.
-     * e.g. (float) "<script>alert(1)</script>" → 0.0
-     *
-     * @param  string  $key
-     * @param  float  $default
-     * @return float
-     */
-    public function float($key, $default = 0.0) {}
-
-    /**
-     * Retrieve input from the request as a boolean value.
-     *
-     * Returns strict true/false via filter_var(FILTER_VALIDATE_BOOLEAN).
-     * Not a taint source: a boolean cannot carry injectable content.
-     *
-     * @param  string|null  $key
-     * @param  bool  $default
-     * @return bool
-     */
-    public function boolean($key = null, $default = false) {}
-
-    /**
-     * Retrieve input from the request as a Carbon instance.
-     *
-     * Not a taint source: Date::parse()/createFromFormat() validates input
-     * into a structured Carbon object. The string representation is a
-     * formatted date, not raw user input.
-     *
-     * @param  string  $key
-     * @param  string|null  $format
-     * @param  \UnitEnum|string|null  $tz
-     * @return \Illuminate\Support\Carbon|null
-     */
-    public function date($key, $format = null, $tz = null) {}
-
-    /**
-     * Retrieve input from the request as an enum.
-     *
-     * Not a taint source: BackedEnum::tryFrom() is a strict whitelist —
-     * the return value can only be one of the developer-defined enum cases
-     * (or the $default).
-     *
-     * @template TEnum of \BackedEnum
-     * @template TDefault of TEnum|null
-     *
-     * @param  string  $key
-     * @param  class-string<TEnum>  $enumClass
-     * @param  TDefault  $default
-     * @return TEnum|TDefault
-     */
-    public function enum($key, $enumClass, $default = null) {}
-
-    /**
-     * Get a subset containing the provided keys with values from the input data.
-     *
-     * @param  string[]|string  $keys
-     * @return array
-     *
-     * @psalm-taint-source input
-     */
-    public function only($keys) {}
-
-    /**
-     * Get all of the input except for a specified array of items.
-     *
-     * @param  string[]|string  $keys
-     * @return array
-     *
-     * @psalm-taint-source input
-     */
-    public function except($keys) {}
-
-    /**
-     * Retrieve old input for the given key.
-     *
-     * @param  string|null  $key
-     * @param  mixed  $default
-     * @return ($key is null ? array<string, mixed> : mixed)
-     *
-     * @psalm-taint-source input
-     */
-    public function old($key = null, $default = null) {}
+    // Note: str(), string(), integer(), float(), boolean(), clamp(), date(),
+    // enum(), enums(), array(), collect(), only(), except() live on
+    // Illuminate\Support\Traits\InteractsWithData in Laravel 11+
+    // (stubbed at stubs/common/Support/Traits/InteractsWithData.stubphp).
+    //
+    // Note: old() lives on Illuminate\Http\Concerns\InteractsWithFlashData
+    // (stubbed at stubs/common/Http/Concerns/InteractsWithFlashData.stubphp).
 }

--- a/stubs/common/Support/Traits/InteractsWithData.stubphp
+++ b/stubs/common/Support/Traits/InteractsWithData.stubphp
@@ -5,6 +5,110 @@ namespace Illuminate\Support\Traits;
 trait InteractsWithData
 {
     /**
+     * Retrieve data from the instance as a Stringable instance.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return \Illuminate\Support\Stringable
+     *
+     * @psalm-taint-source input
+     */
+    public function str($key, $default = null) {}
+
+    /**
+     * Retrieve data from the instance as a Stringable instance.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return \Illuminate\Support\Stringable
+     *
+     * @psalm-taint-source input
+     */
+    public function string($key, $default = null) {}
+
+    /**
+     * Retrieve data as an integer value.
+     *
+     * Not a taint source: (int) cast cannot produce an injection payload.
+     * e.g. (int) "1; DROP TABLE users" → 1
+     *
+     * @param  string  $key
+     * @param  int  $default
+     * @return int
+     */
+    public function integer($key, $default = 0) {}
+
+    /**
+     * Retrieve data as a float value.
+     *
+     * Not a taint source: (float) cast cannot produce an injection payload.
+     * e.g. (float) "<script>alert(1)</script>" → 0.0
+     *
+     * @param  string  $key
+     * @param  float  $default
+     * @return float
+     */
+    public function float($key, $default = 0.0) {}
+
+    /**
+     * Retrieve data from the instance as a boolean value.
+     *
+     * Returns strict true/false via filter_var(FILTER_VALIDATE_BOOLEAN).
+     * Not a taint source: a boolean cannot carry injectable content.
+     *
+     * @param  string|null  $key
+     * @param  bool  $default
+     * @return bool
+     */
+    public function boolean($key = null, $default = false) {}
+
+    /**
+     * Retrieve data clamped between min and max values.
+     *
+     * Not a taint source: returns a numeric value constrained by min()
+     * and max(). Like integer()/float(), a number cannot carry an
+     * injection payload.
+     *
+     * @param  string  $key
+     * @param  int|float  $min
+     * @param  int|float  $max
+     * @param  int|float  $default
+     * @return int|float
+     */
+    public function clamp($key, $min, $max, $default = 0) {}
+
+    /**
+     * Retrieve data from the instance as a Carbon instance.
+     *
+     * Not a taint source: Date::parse()/createFromFormat() validates input
+     * into a structured Carbon object. The string representation is a
+     * formatted date, not raw user input.
+     *
+     * @param  string  $key
+     * @param  string|null  $format
+     * @param  \UnitEnum|string|null  $tz
+     * @return \Illuminate\Support\Carbon|null
+     */
+    public function date($key, $format = null, $tz = null) {}
+
+    /**
+     * Retrieve data from the instance as an enum.
+     *
+     * Not a taint source: BackedEnum::tryFrom() is a strict whitelist —
+     * the return value can only be one of the developer-defined enum cases
+     * (or the $default).
+     *
+     * @template TEnum of \BackedEnum
+     * @template TDefault of TEnum|null
+     *
+     * @param  string  $key
+     * @param  class-string<TEnum>  $enumClass
+     * @param  TDefault  $default
+     * @return TEnum|TDefault
+     */
+    public function enum($key, $enumClass, $default = null) {}
+
+    /**
      * Retrieve data from the instance as an array of enums.
      *
      * Not a taint source: BackedEnum::tryFrom() is a strict whitelist.
@@ -29,17 +133,38 @@ trait InteractsWithData
     public function array($key = null) {}
 
     /**
-     * Retrieve data clamped between min and max values.
+     * Retrieve data from the instance as a collection.
      *
-     * Not a taint source: returns a numeric value constrained by min()
-     * and max(). Like integer()/float(), a number cannot carry an
-     * injection payload.
+     * @param  array|string|null  $key
+     * @return \Illuminate\Support\Collection
      *
-     * @param  string  $key
-     * @param  int|float  $min
-     * @param  int|float  $max
-     * @param  int|float  $default
-     * @return int|float
+     * @psalm-taint-source input
      */
-    public function clamp($key, $min, $max, $default = 0) {}
+    public function collect($key = null) {}
+
+    /**
+     * Get a subset containing the provided keys with values from the instance data.
+     *
+     * Accepts an array of keys, a single key, or variadic string keys via func_get_args().
+     *
+     * @param  string[]|string  $keys
+     * @return array
+     *
+     * @psalm-taint-source input
+     * @psalm-variadic
+     */
+    public function only($keys) {}
+
+    /**
+     * Get all of the data except for a specified array of items.
+     *
+     * Accepts an array of keys, a single key, or variadic string keys via func_get_args().
+     *
+     * @param  string[]|string  $keys
+     * @return array
+     *
+     * @psalm-taint-source input
+     * @psalm-variadic
+     */
+    public function except($keys) {}
 }

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestOnly.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestOnly.phpt
@@ -1,0 +1,34 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Positive: FormRequest::only() returns tainted input.
+ *
+ * Regression guard for the trait-composition chain on FormRequest:
+ * FormRequest extends Request, Request uses InteractsWithInput,
+ * InteractsWithInput uses InteractsWithData (where the stub lives after #823).
+ * If any link in that chain breaks, the echo below stops firing TaintedHtml.
+ */
+final class OnlyAccessorRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['body' => 'required|string'];
+    }
+}
+
+function render(OnlyAccessorRequest $request): void {
+    $data = $request->only(['body']);
+
+    echo $data['body'];
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestCollect.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestCollect.phpt
@@ -1,0 +1,18 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Positive: Request::collect() returns a Collection wrapping tainted input.
+ *
+ * Regression guard for the stub-location fix (#823): collect() lives on
+ * Illuminate\Support\Traits\InteractsWithData in Laravel 11+.
+ */
+function renderCollectRequestData(\Illuminate\Http\Request $request): void {
+    echo $request->collect('name')->first();
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestExcept.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestExcept.phpt
@@ -1,0 +1,20 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Positive: Request::except() returns a tainted array of the remaining input.
+ *
+ * Regression guard for the stub-location fix (#823): except() lives on
+ * Illuminate\Support\Traits\InteractsWithData in Laravel 11+.
+ */
+function renderExceptRequestData(\Illuminate\Http\Request $request): void {
+    $data = $request->except(['password']);
+
+    echo $data['name'];
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestOld.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestOld.phpt
@@ -1,0 +1,19 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Positive: Request::old() returns tainted flash-session input.
+ *
+ * Regression guard for the stub-location fix (#824): old() lives on
+ * Illuminate\Http\Concerns\InteractsWithFlashData, not on
+ * Illuminate\Http\Concerns\InteractsWithInput where the stub used to live.
+ */
+function renderOldRequestData(\Illuminate\Http\Request $request): void {
+    echo $request->old('name');
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestOnly.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestOnly.phpt
@@ -1,0 +1,22 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Positive: Request::only() returns a tainted array of input values.
+ *
+ * Regression guard for the stub-location fix (#823): only() lives on
+ * Illuminate\Support\Traits\InteractsWithData in Laravel 11+, not on
+ * Illuminate\Http\Concerns\InteractsWithInput. If the @psalm-taint-source
+ * annotation ends up on the wrong trait, this test stops firing.
+ */
+function renderOnlyRequestData(\Illuminate\Http\Request $request): void {
+    $data = $request->only(['name']);
+
+    echo $data['name'];
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes


### PR DESCRIPTION
## Summary

Backports the stub-location fixes from master's #821 + #825 to 3.x. Closes #827.

Without this, Psalm silently drops the `@psalm-taint-source input` annotations on these methods on Laravel 11+, because the stubs were attached to the wrong declaring trait. The result is false-negative taint analysis for very common request input accessors.

## Stub changes

- Move `str`, `string`, `integer`, `float`, `boolean`, `date`, `enum` from `Http/Concerns/InteractsWithInput` to `Support/Traits/InteractsWithData`.
- Move `collect`, `only`, `except` to `InteractsWithData` (with `@psalm-variadic` on `only`/`except` so 3+ arg calls don't trip `TooManyArguments`).
- Move `old` to a new `Http/Concerns/InteractsWithFlashData` stub.
- Leave `// Note:` breadcrumbs at the old location, matching the 4.x convention.

## Tests

5 positive taint-propagation PHPTs:
- `TaintedHtmlRequestOnly.phpt`
- `TaintedHtmlRequestExcept.phpt`
- `TaintedHtmlRequestCollect.phpt`
- `TaintedHtmlRequestOld.phpt`
- `TaintedHtmlFormRequestOnly.phpt` (trait-composition guard)

All 280 type tests pass on Psalm 6.

## Out of scope

Per #827, this PR covers stub relocation + tests only. The `KEYED_ACCESSOR_METHODS` rule extension from master's #821 (`ValidationTaintHandler`) is a separate extension and not required to fix the silent-drop bug.

The `dump()` method that master added to `InteractsWithInput` is also excluded as orthogonal (it came in via #806's `@psalm-variadic` pass, not the relocation PRs).