### PR TITLE
Fix AuthManager forwarded auth methods

### DIFF
--- a/src/Handlers/Auth/AuthHandler.php
+++ b/src/Handlers/Auth/AuthHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Handlers\Auth;
 
+use Illuminate\Foundation\Application;
 use Psalm\LaravelPlugin\Handlers\Auth\Concerns\ExtractsGuardNameFromCallLike;
 use Psalm\Plugin\EventHandler\Event\MethodParamsProviderEvent;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
@@ -138,11 +139,12 @@ final class AuthHandler implements MethodReturnTypeProviderInterface, MethodPara
      * @method annotations on facades causes an UnexpectedValueException crash. We must return
      * explicit params for every method we handle.
      *
-     * This override is scoped to the Auth facade only. For AuthManager and the Factory contract
-     * the methods are real (or come from @mixin Guard/StatefulGuard), so Psalm can derive
-     * parameter types from the source without our help. Returning our overrides there would
-     * narrow signatures (e.g. guard()'s \UnitEnum|string|null parameter down to string|null)
-     * and produce false positives on valid calls.
+     * This override is scoped to the Auth facade only. For AuthManager, forwarded guard methods
+     * are declared in our AuthManager stub so Psalm can derive parameter types without routing
+     * through __call. For the Factory contract, the methods it owns are real source methods.
+     * Returning our overrides there would narrow signatures (e.g. guard()'s
+     * \UnitEnum|string|null parameter down to string|null) and produce false positives on valid
+     * calls.
      *
      * @see https://github.com/psalm/psalm-plugin-laravel/issues/454
      */
@@ -160,13 +162,13 @@ final class AuthHandler implements MethodReturnTypeProviderInterface, MethodPara
             // SessionGuard::getLastAttempted() — all take no parameters
             'user', 'getuser', 'authenticate', 'getlastattempted' => [],
 
-            // AuthManager::guard(?string $name = null)
+            // AuthManager::guard(\UnitEnum|string|null $name = null) on Laravel 13+
             'guard' => [
                 new FunctionLikeParameter(
                     'name',
                     false,
-                    new Type\Union([new Type\Atomic\TString(), new Type\Atomic\TNull()]),
-                    new Type\Union([new Type\Atomic\TString(), new Type\Atomic\TNull()]),
+                    self::getGuardNameParameterType(),
+                    self::getGuardNameParameterType(),
                     is_optional: true,
                     default_type: Type::getNull(),
                 ),
@@ -190,5 +192,22 @@ final class AuthHandler implements MethodReturnTypeProviderInterface, MethodPara
 
             default => null,
         };
+    }
+
+    /** @psalm-pure */
+    private static function getGuardNameParameterType(?string $laravelVersion = null): Type\Union
+    {
+        $laravelVersion ??= Application::VERSION;
+
+        $types = [
+            new Type\Atomic\TString(),
+            new Type\Atomic\TNull(),
+        ];
+
+        if (\version_compare($laravelVersion, '13.0.0', '>=')) {
+            $types[] = new Type\Atomic\TNamedObject(\UnitEnum::class);
+        }
+
+        return new Type\Union($types);
     }
 }

--- a/stubs/common/Auth/AuthManager.stubphp
+++ b/stubs/common/Auth/AuthManager.stubphp
@@ -1,0 +1,104 @@
+<?php
+
+namespace Illuminate\Auth;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\Factory as FactoryContract;
+use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Contracts\Auth\StatefulGuard;
+use Illuminate\Contracts\Auth\UserProvider;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @mixin Guard
+ * @mixin StatefulGuard
+ */
+class AuthManager implements FactoryContract
+{
+    public function check(): bool {}
+
+    public function guest(): bool {}
+
+    public function authenticate(): Authenticatable {}
+
+    public function user(): ?Authenticatable {}
+
+    /**
+     * @return int|string|null
+     */
+    public function id() {}
+
+    /**
+     * @param  array<array-key, mixed>  $credentials
+     */
+    public function validate(array $credentials = []): bool {}
+
+    public function hasUser(): bool {}
+
+    public function setUser(Authenticatable $user): Guard {}
+
+    public function forgetUser(): Guard {}
+
+    public function getProvider(): UserProvider {}
+
+    public function setProvider(UserProvider $provider): void {}
+
+    /**
+     * @param  array<array-key, mixed>  $credentials
+     */
+    public function attempt(array $credentials = [], bool $remember = false): bool {}
+
+    /**
+     * @param  array<array-key, mixed>  $credentials
+     */
+    public function once(array $credentials = []): bool {}
+
+    public function login(Authenticatable $user, bool $remember = false): void {}
+
+    /**
+     * @param  mixed  $id
+     *
+     * @return Authenticatable|false
+     */
+    public function loginUsingId($id, bool $remember = false) {}
+
+    /**
+     * @param  mixed  $id
+     *
+     * @return Authenticatable|false
+     */
+    public function onceUsingId($id) {}
+
+    public function viaRemember(): bool {}
+
+    public function logout(): void {}
+
+    /**
+     * @param  array<array-key, mixed>  $extraConditions
+     */
+    public function basic(string $field = 'email', array $extraConditions = []): ?Response {}
+
+    /**
+     * @param  array<array-key, mixed>  $extraConditions
+     */
+    public function onceBasic(string $field = 'email', array $extraConditions = []): ?Response {}
+
+    /**
+     * @param  array<array-key, mixed>  $credentials
+     * @param  array<array-key, mixed>|callable|null  $callbacks
+     */
+    public function attemptWhen(array $credentials = [], array|callable|null $callbacks = null, bool $remember = false): bool {}
+
+    public function logoutCurrentDevice(): void {}
+
+    public function logoutOtherDevices(string $password): ?Authenticatable {}
+
+    /**
+     * @param  mixed  $callback
+     */
+    public function attempting($callback): void {}
+
+    public function getLastAttempted(): ?Authenticatable {}
+
+    public function getUser(): ?Authenticatable {}
+}

--- a/tests/Type/tests/Auth/AuthTest.phpt
+++ b/tests/Type/tests/Auth/AuthTest.phpt
@@ -74,11 +74,38 @@ function _diAuthManager(\Illuminate\Auth\AuthManager $authManager): void {
     $_amUser = $authManager->user();
     /** @psalm-check-type-exact $_amUser = \Illuminate\Foundation\Auth\User|null */
 
+    $_amAuthenticate = $authManager->authenticate();
+    /** @psalm-check-type-exact $_amAuthenticate = \Illuminate\Foundation\Auth\User */
+
+    $_amGetUser = $authManager->getUser();
+    /** @psalm-check-type-exact $_amGetUser = \Illuminate\Foundation\Auth\User|null */
+
+    $_amGetLastAttempted = $authManager->getLastAttempted();
+    /** @psalm-check-type-exact $_amGetLastAttempted = \Illuminate\Foundation\Auth\User|null */
+
+    $_amAttempt = $authManager->attempt(['email' => 'me@example.com', 'password' => 'secret']);
+    /** @psalm-check-type-exact $_amAttempt = bool */
+
+    $_amAttemptRemember = $authManager->attempt(['email' => 'me@example.com', 'password' => 'secret'], true);
+    /** @psalm-check-type-exact $_amAttemptRemember = bool */
+
+    $_amAttemptWhen = $authManager->attemptWhen(
+        ['email' => 'me@example.com', 'password' => 'secret'],
+        static fn (): bool => true,
+        true,
+    );
+    /** @psalm-check-type-exact $_amAttemptWhen = bool */
+
     $_amLoginUsingId = $authManager->loginUsingId(1);
     /** @psalm-check-type-exact $_amLoginUsingId = \Illuminate\Foundation\Auth\User|false */
 
+    $_amLoginUsingIdWithRemember = $authManager->loginUsingId(1, true);
+    /** @psalm-check-type-exact $_amLoginUsingIdWithRemember = \Illuminate\Foundation\Auth\User|false */
+
     $_amOnceUsingId = $authManager->onceUsingId(1);
     /** @psalm-check-type-exact $_amOnceUsingId = \Illuminate\Foundation\Auth\User|false */
+
+    $authManager->logout();
 
     // Chained calls — the acceptance example from issue #765
     $_amChainedUser = $authManager->guard('web')->user();

--- a/tests/Unit/Handlers/Auth/AuthHandlerTest.php
+++ b/tests/Unit/Handlers/Auth/AuthHandlerTest.php
@@ -102,6 +102,20 @@ final class AuthHandlerTest extends TestCase
         $this->assertTrue($params[0]->is_optional);
     }
 
+    public function testGuardNameParameterTypeTracksLaravelVersion(): void
+    {
+        $method = new \ReflectionMethod(AuthHandler::class, 'getGuardNameParameterType');
+
+        $this->assertStringNotContainsString(
+            'UnitEnum',
+            $method->invoke(null, '12.99.0')->getId(),
+        );
+        $this->assertStringContainsString(
+            'UnitEnum',
+            $method->invoke(null, '13.0.0')->getId(),
+        );
+    }
+
     public function testGetMethodParamsForUnknownMethod(): void
     {
         $event = new MethodParamsProviderEvent(
@@ -115,8 +129,8 @@ final class AuthHandlerTest extends TestCase
     }
 
     /**
-     * For AuthManager / Factory the methods are real PHP (or routed via @mixin
-     * Guard/StatefulGuard), so Psalm can resolve their parameter types from source.
+     * For AuthManager / Factory the methods are declared in source or stubs, so Psalm can
+     * resolve their parameter types without facade-specific overrides.
      * Returning our facade-oriented overrides there would narrow `guard()`'s
      * \UnitEnum|string|null parameter down to string|null and flag valid enum calls
      * as InvalidArgument. See {@see AuthHandler::getMethodParams}.

--- a/tests/Unit/Handlers/Auth/AuthHandlerTest.php
+++ b/tests/Unit/Handlers/Auth/AuthHandlerTest.php
@@ -108,11 +108,11 @@ final class AuthHandlerTest extends TestCase
 
         $this->assertStringNotContainsString(
             'UnitEnum',
-            $method->invoke(null, '12.99.0')->getId(),
+            (string) $method->invoke(null, '12.99.0')->getId(),
         );
         $this->assertStringContainsString(
             'UnitEnum',
-            $method->invoke(null, '13.0.0')->getId(),
+            (string) $method->invoke(null, '13.0.0')->getId(),
         );
     }
 


### PR DESCRIPTION
## Issue to Solve
AuthManager forwards guard methods such as `authenticate()`, `attempt()`, and `logout()` through `__call`. After the plugin registered `AuthManager` for auth return type narrowing, Psalm 7 could route those calls through magic method handling and crash while asking for params on methods missing from `AuthManager` storage.

## Related
Fixes #854

## Solution Description
- Added an `AuthManager` stub declaring the forwarded guard/session-guard methods so Psalm sees concrete method storage instead of entering the failing magic-method path.
- Kept facade-specific param overrides scoped to the facade, while making `Auth::guard()` params version-aware for Laravel 13 enum guard names.
- Added unit coverage for the version-aware guard param type and type-test coverage for `AuthManager::authenticate()`, `attempt()`, `attemptWhen()`, `logout()`, and related forwarded methods.

Verified with:
- `vendor/bin/phpunit tests/Unit/Handlers/Auth/AuthHandlerTest.php`
- `composer test:type`
- `composer psalm`
- `composer cs:check`

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)