### PR TITLE
Fix Psalm crash on AuthManager __call-forwarded methods (#854)

### DIFF
--- a/src/Handlers/Auth/AuthHandler.php
+++ b/src/Handlers/Auth/AuthHandler.php
@@ -39,8 +39,9 @@ final class AuthHandler implements MethodReturnTypeProviderInterface, MethodPara
 
     /**
      * Register for the Auth facade, the concrete AuthManager (common DI target), and the
-     * Factory contract (DI by interface). The handler body below is class-agnostic — it
-     * matches on method name only, so all three surfaces receive the same narrowing.
+     * Factory contract (DI by interface). {@see getMethodReturnType} is class-agnostic and
+     * narrows uniformly across all three surfaces; {@see getMethodParams} has one carve-out
+     * for `guard()` on non-facade receivers (see that method's docblock).
      *
      * @return list<string>
      * @psalm-pure
@@ -135,25 +136,40 @@ final class AuthHandler implements MethodReturnTypeProviderInterface, MethodPara
      * Provide explicit parameter definitions for all methods handled by {@see getMethodReturnType}.
      *
      * In Psalm 7, returning null from a MethodParamsProvider for methods that only exist as
-     * @method annotations on facades causes an UnexpectedValueException crash. We must return
-     * explicit params for every method we handle.
+     * @method annotations on facades causes an UnexpectedValueException crash. The same crash
+     * happens when a method is reached via __call on a class registered as a return type provider
+     * but is not a real method on the class or its @mixin targets. Issue #854 reproduced this with
+     * AuthManager::authenticate / getUser / getLastAttempted / logoutOtherDevices: AuthManager
+     * declares only __call (forwarding to the active guard), and these methods do not appear on
+     * the Guard / StatefulGuard interfaces it @mixins. The MissingMethodCallHandler then asks
+     * Methods::getMethodParams for params Psalm cannot find, throwing UnexpectedValueException.
      *
-     * This override is scoped to the Auth facade only. For AuthManager and the Factory contract
-     * the methods are real (or come from @mixin Guard/StatefulGuard), so Psalm can derive
-     * parameter types from the source without our help. Returning our overrides there would
-     * narrow signatures (e.g. guard()'s \UnitEnum|string|null parameter down to string|null)
-     * and produce false positives on valid calls.
+     * Only `guard()` is scoped to the facade. AuthManager / Factory declare guard() with
+     * `string|null` today, so our override would match — but the early-return guards against
+     * future Laravel signature changes (e.g. accepting \UnitEnum|string|null) that would turn
+     * our override into false positives on valid calls. Letting Psalm derive guard()'s params
+     * from the source for non-facade receivers keeps that signature in sync automatically.
      *
-     * @see https://github.com/psalm/psalm-plugin-laravel/issues/454
+     * INVARIANT: every method handled by {@see getMethodReturnType} above must have a non-null
+     * arm in the match below (the `guard()` early-return is the documented exception, safe because
+     * `guard()` is a real method on AuthManager / Factory). Adding a method to getMethodReturnType
+     * without mirroring it here re-triggers the crash. The unit test `nonFacadeReceiversProvider`
+     * pins the current set, but it is not auto-derived — keep both in sync by hand.
+     *
+     * @see https://github.com/psalm/psalm-plugin-laravel/issues/454 — original crash on facades
+     * @see https://github.com/psalm/psalm-plugin-laravel/issues/854 — same crash on AuthManager
      */
     #[\Override]
     public static function getMethodParams(MethodParamsProviderEvent $event): ?array
     {
-        if ($event->getFqClasslikeName() !== \Illuminate\Support\Facades\Auth::class) {
+        $method_name_lowercase = $event->getMethodNameLowercase();
+
+        // Defer guard()'s params to Laravel source for non-facade receivers — see method docblock.
+        if ($method_name_lowercase === 'guard'
+            && $event->getFqClasslikeName() !== \Illuminate\Support\Facades\Auth::class
+        ) {
             return null;
         }
-
-        $method_name_lowercase = $event->getMethodNameLowercase();
 
         return match ($method_name_lowercase) {
             // Guard::user(), GuardHelpers::authenticate(), SessionGuard::getUser(),

--- a/tests/Type/tests/Auth/AuthTest.phpt
+++ b/tests/Type/tests/Auth/AuthTest.phpt
@@ -80,6 +80,21 @@ function _diAuthManager(\Illuminate\Auth\AuthManager $authManager): void {
     $_amOnceUsingId = $authManager->onceUsingId(1);
     /** @psalm-check-type-exact $_amOnceUsingId = \Illuminate\Foundation\Auth\User|false */
 
+    // Issue #854: methods reached via AuthManager::__call that are NOT on the @mixin
+    // Guard|StatefulGuard interfaces. Without explicit getMethodParams entries Psalm
+    // crashed with "Cannot get method params for Illuminate\Auth\AuthManager::<method>".
+    $_amAuthenticate = $authManager->authenticate();
+    /** @psalm-check-type-exact $_amAuthenticate = \Illuminate\Foundation\Auth\User */
+
+    $_amGetUser = $authManager->getUser();
+    /** @psalm-check-type-exact $_amGetUser = \Illuminate\Foundation\Auth\User|null */
+
+    $_amGetLastAttempted = $authManager->getLastAttempted();
+    /** @psalm-check-type-exact $_amGetLastAttempted = \Illuminate\Foundation\Auth\User|null */
+
+    $_amLogoutOtherDevices = $authManager->logoutOtherDevices('secret');
+    /** @psalm-check-type-exact $_amLogoutOtherDevices = \Illuminate\Foundation\Auth\User|null */
+
     // Chained calls — the acceptance example from issue #765
     $_amChainedUser = $authManager->guard('web')->user();
     /** @psalm-check-type-exact $_amChainedUser = \Illuminate\Foundation\Auth\User|null */

--- a/tests/Unit/Handlers/Auth/AuthHandlerTest.php
+++ b/tests/Unit/Handlers/Auth/AuthHandlerTest.php
@@ -115,17 +115,18 @@ final class AuthHandlerTest extends TestCase
     }
 
     /**
-     * For AuthManager / Factory the methods are real PHP (or routed via @mixin
-     * Guard/StatefulGuard), so Psalm can resolve their parameter types from source.
-     * Returning our facade-oriented overrides there would narrow `guard()`'s
-     * \UnitEnum|string|null parameter down to string|null and flag valid enum calls
-     * as InvalidArgument. See {@see AuthHandler::getMethodParams}.
+     * Issue #854: when AuthManager / Factory are registered as a return type provider, Psalm
+     * routes calls to methods reached only via __call (authenticate, getUser, getLastAttempted,
+     * logoutOtherDevices — none of which appear on the @mixin Guard / StatefulGuard interfaces)
+     * through MissingMethodCallHandler. Returning null from getMethodParams there triggers the
+     * "Cannot get method params for ..." UnexpectedValueException. We must return non-null params
+     * for every method we narrow on these receivers, exactly as we do for the facade.
      *
      * @return \Iterator<string, array{class-string, string}>
      */
     public static function nonFacadeReceiversProvider(): \Iterator
     {
-        $methods = ['user', 'getuser', 'authenticate', 'getlastattempted', 'guard', 'logoutotherdevices', 'loginusingid', 'onceusingid'];
+        $methods = ['user', 'getuser', 'authenticate', 'getlastattempted', 'logoutotherdevices', 'loginusingid', 'onceusingid'];
 
         foreach ($methods as $method) {
             yield "AuthManager::{$method}" => [\Illuminate\Auth\AuthManager::class, $method];
@@ -137,13 +138,42 @@ final class AuthHandlerTest extends TestCase
      * @param class-string $fqClassLikeName
      */
     #[DataProvider('nonFacadeReceiversProvider')]
-    public function testGetMethodParamsReturnsNullForNonFacadeReceivers(string $fqClassLikeName, string $method): void
+    public function testGetMethodParamsReturnsNonNullForNonFacadeReceivers(string $fqClassLikeName, string $method): void
     {
         $event = new MethodParamsProviderEvent($fqClassLikeName, $method);
 
+        $this->assertNotNull(
+            AuthHandler::getMethodParams($event),
+            "getMethodParams() must not return null for {$fqClassLikeName}::{$method} — Psalm 7 crashes when the method is reached via __call (issue #854)",
+        );
+    }
+
+    /**
+     * `guard()` is the one method we still defer to Laravel's source for non-facade receivers.
+     * AuthManager and Factory both declare it as a real method, so Psalm can derive params from
+     * the source — and skipping our override insulates us against future Laravel signature
+     * changes (e.g. adding \UnitEnum to the parameter type) that would otherwise turn our
+     * `string|null` override into false positives.
+     *
+     * @return \Iterator<string, array{class-string}>
+     */
+    public static function nonFacadeReceiversForGuardProvider(): \Iterator
+    {
+        yield 'AuthManager::guard' => [\Illuminate\Auth\AuthManager::class];
+        yield 'Factory::guard' => [\Illuminate\Contracts\Auth\Factory::class];
+    }
+
+    /**
+     * @param class-string $fqClassLikeName
+     */
+    #[DataProvider('nonFacadeReceiversForGuardProvider')]
+    public function testGetMethodParamsReturnsNullForGuardOnNonFacadeReceivers(string $fqClassLikeName): void
+    {
+        $event = new MethodParamsProviderEvent($fqClassLikeName, 'guard');
+
         $this->assertNull(
             AuthHandler::getMethodParams($event),
-            "getMethodParams() must return null for {$fqClassLikeName}::{$method} so Psalm uses the native signature",
+            "getMethodParams() must return null for {$fqClassLikeName}::guard so Psalm uses the native signature",
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #854. Psalm 7 crashed with `UnexpectedValueException: Cannot get method params for Illuminate\Auth\AuthManager::authenticate` (and the same for `getUser`, `getLastAttempted`, `logoutOtherDevices`) whenever code called these methods on a DI-injected `AuthManager`.

## Root cause

Plugin 4.9.0 (PR #773) added `AuthManager` and `Factory` to `AuthHandler::getClassLikeNames()`. For methods reached only via `AuthManager::__call` (i.e., not declared on the class and not on the `@mixin Guard|StatefulGuard` interfaces), Psalm's `MissingMethodCallHandler::handleMagicMethod` invokes `CallAnalyzer::checkMethodArgs` after a return-type provider succeeds. That call asks `Methods::getMethodParams()` for a method Psalm cannot find on the class, throwing the exception.

The four affected methods all live on `GuardHelpers` (the `authenticate` trait method) or `SessionGuard` concretely, never on the `Guard` / `StatefulGuard` interfaces.

## Fix

Scope the existing early-return in `AuthHandler::getMethodParams` from "any non-facade receiver" to just `guard()`. The existing `match` arms now supply params for the four crashing methods on `AuthManager` and `Factory`, satisfying Psalm's params-provider contract.

The `guard()` carve-out is preserved as forward-compat against future Laravel signature changes (e.g., accepting `\UnitEnum`); for non-facade receivers Psalm derives params from Laravel's source.

## Verification

Reproduced the crash on a minimal Laravel 12 project with Psalm 7.0.0-beta19, confirmed all four methods (`authenticate`, `getUser`, `getLastAttempted`, `logoutOtherDevices`) crashed before the fix and pass after. Verified `logout`, `attempt`, `loginUsingId` (which the issue mentions but go through the `@mixin StatefulGuard` interface) were not actually crashing.

Added regression coverage:
- Type tests in `tests/Type/tests/Auth/AuthTest.phpt` for the four methods on a DI-injected `AuthManager`.
- Unit tests split into `testGetMethodParamsReturnsNonNullForNonFacadeReceivers` (new contract for the seven mirrored methods) and `testGetMethodParamsReturnsNullForGuardOnNonFacadeReceivers` (the `guard()` carve-out).

`composer psalm` and `phpunit tests/Unit/Handlers/Auth` pass.