### PR TITLE
feat: narrow `Request::route()` by route bindings and constraints

### DIFF
--- a/src/Handlers/Routing/RequestRouteReturnTypeProvider.php
+++ b/src/Handlers/Routing/RequestRouteReturnTypeProvider.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Routing;
+
+use Illuminate\Http\Request;
+use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\Type;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Atomic\TNull;
+use Psalm\Type\Union;
+
+/**
+ * Narrows {@see Request::route()} calls when the parameter name is a literal
+ * string and {@see RouteParameterRegistry} has information about it.
+ *
+ * Two narrowing modes:
+ *
+ *  - Binding known (Route::bind / Route::model with a Model subclass) → the
+ *    return is `BoundClass|null` for the resolved subclass, replacing the
+ *    stub's `TDefault|string|Model|BackedEnum|null`. Eliminates
+ *    `InvalidPropertyFetch` on `$request->route('genre')->id` and gives the
+ *    caller the exact bound type to chain Eloquent attribute access on.
+ *    Issues #801, #803.
+ *
+ *  - No binding but a safe regex constraint is registered for the name →
+ *    the return narrows to `string|null`. The narrowing itself is what
+ *    causes Psalm to drop the stub's `@psalm-taint-source` annotation, which
+ *    is the whole point: when the route's regex defeats the relevant sinks
+ *    the value should not propagate as tainted input. The companion
+ *    {@see RequestRouteTaintHandler} keeps the source removed for sinks the
+ *    constraint provably defeats and partially re-adds it for sinks that
+ *    accept alphanumeric identifiers (callable/include/eval/extract/shell).
+ *    Issue #849.
+ *
+ * Calls without a literal first argument and calls outside the registry's
+ * coverage are left alone, so the stub's `($param is null ? Route :
+ * TDefault|string|Model|BackedEnum|null)` falls through with its taint source
+ * intact.
+ */
+final class RequestRouteReturnTypeProvider implements MethodReturnTypeProviderInterface
+{
+    /**
+     * @return list<string>
+     * @psalm-pure
+     */
+    #[\Override]
+    public static function getClassLikeNames(): array
+    {
+        // Request::route() is declared on Request; FormRequest and Symfony's
+        // Request subclasses inherit it, so a single hook covers every caller
+        // shape we care about. Psalm's MethodCallReturnTypeFetcher resolves
+        // inherited calls to the declaring class, which dispatches here.
+        return [Request::class];
+    }
+
+    /** @inheritDoc */
+    #[\Override]
+    public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        if ($event->getMethodNameLowercase() !== 'route') {
+            return null;
+        }
+
+        $source = $event->getSource();
+
+        if (!$source instanceof StatementsAnalyzer) {
+            return null;
+        }
+
+        $name = RouteParameterArg::extractLiteralName($event->getCallArgs(), $source);
+
+        if ($name === null) {
+            return null;
+        }
+
+        $registry = RouteParameterRegistry::instance();
+        $boundModel = $registry->getBoundModel($name);
+
+        if ($boundModel !== null) {
+            return new Union([
+                new TNamedObject($boundModel),
+                new TNull(),
+            ]);
+        }
+
+        if ($registry->hasSafeConstraint($name)) {
+            // Strictly narrower than the stub (drops TDefault, Model, and
+            // BackedEnum). Acceptable: the safe-constraint branch targets
+            // the URL-segment-as-string pattern, where callers rarely chain
+            // model-shaped access on the result. Returning a non-null type
+            // is what causes Psalm to drop the stub's @psalm-taint-source —
+            // the actual sink-level safety lives in RequestRouteTaintHandler.
+            return Type::combineUnionTypes(Type::getString(), Type::getNull());
+        }
+
+        return null;
+    }
+}

--- a/src/Handlers/Routing/RequestRouteTaintHandler.php
+++ b/src/Handlers/Routing/RequestRouteTaintHandler.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Routing;
+
+use Illuminate\Http\Request;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\LaravelPlugin\Util\MethodCallerResolver;
+use Psalm\Plugin\EventHandler\AddTaintsInterface;
+use Psalm\Plugin\EventHandler\Event\AddRemoveTaintsEvent;
+use Psalm\Type\TaintKind;
+
+/**
+ * Coordinates with {@see RequestRouteReturnTypeProvider} to keep taint
+ * accounting correct on `$request->route('name')`.
+ *
+ * The type provider replaces the stub's return type whenever the registry
+ * has any opinion about the parameter name. The mechanism that drops the
+ * stub's `@psalm-taint-source` is the early return in
+ * {@see \Psalm\Internal\Analyzer\Statements\Expression\Call\Method\MethodCallReturnTypeFetcher::fetch()}:
+ * once a type provider returns non-null, the fetcher exits before
+ * `taintMethodCallResult` runs, so the stub source is never applied to the
+ * outgoing edge. We must put the source back ourselves in the cases where
+ * the value is still attacker-controlled (see also vimeo/psalm#11765).
+ *
+ * Decision table (matches the registry-state branches; the override question
+ * is determined by binding||safe-constraint, so it isn't an independent
+ * column):
+ *
+ *   binding | safe constraint | what we re-add
+ *   --------|-----------------|----------------
+ *      —    |      yes        |  IDENTIFIER_KINDS — constraint genuinely defeats structural-injection sinks, regardless of whether a binding also exists
+ *     yes   |      no         |  ALL_INPUT — value originated as a URL segment; the bound Model only paints over that for the type, not for the data flow
+ *      no   |      no         |  0 — stub source is still in effect
+ *
+ * The first row covers both bound+safe and unbound+safe: a route's regex
+ * either rules out the relevant sink or it does not — having a binding on top
+ * doesn't introduce additional attacker reach. So the constraint-only mask is
+ * always the correct (and tighter) choice when a safe constraint is in play.
+ *
+ * Dynamic parameter names (`$request->route($name)`) and calls outside a
+ * Request caller never trigger an override, so they keep the stub source
+ * unconditionally. We bail out fast in those branches.
+ *
+ * Why partial re-addition for safe constraints: {@see SafeRoutePattern}
+ * accepts alphanumeric / underscore / dash shapes (`\w+`, `[A-Za-z0-9_-]+`,
+ * UUID, ULID, …). Those defeat structural-injection sinks (HTML, SQL,
+ * headers, cookies, LDAP, file paths, SSRF, XPath) but NOT identifier-eating
+ * sinks: a user-controlled `\w+` is a perfectly valid PHP function name
+ * (`call_user_func($req->route('handler'))` ⇒ RCE), include path component,
+ * `eval` payload, or extract() key. Shell sinks remain risky too because
+ * `[A-Za-z0-9_-]+` admits leading-dash CLI flag injection. The plugin keeps
+ * those source kinds tainted; the rest are dropped.
+ */
+final class RequestRouteTaintHandler implements AddTaintsInterface
+{
+    /**
+     * Sink kinds that survive a "safe constraint" because the regex shapes
+     * the plugin recognises don't restrict the value enough to make these
+     * targets unreachable. Inverse of the kinds the constraint defeats.
+     */
+    private const SAFE_CONSTRAINT_RESIDUAL_TAINTS
+        = TaintKind::INPUT_CALLABLE
+        | TaintKind::INPUT_INCLUDE
+        | TaintKind::INPUT_EVAL
+        | TaintKind::INPUT_EXTRACT
+        | TaintKind::INPUT_SHELL
+        | TaintKind::INPUT_LLM_PROMPT;
+
+    /**
+     * Decide what taint to apply to `Request::route('literal')` calls based
+     * on the route registry's verdict on the parameter name.
+     *
+     * Bail-out chain is ordered cheapest → most expensive: AST shape and
+     * method-name compares run first; the literal-arg type lookup is next
+     * (a single `node_data->getType()` hash hit); the caller-class walk
+     * (which iterates atomic types and may invoke `Codebase::classExtends`)
+     * runs last, only after we've confirmed the call is structurally a
+     * candidate for narrowing.
+     */
+    #[\Override]
+    public static function addTaints(AddRemoveTaintsEvent $event): int
+    {
+        $expr = $event->getExpr();
+
+        if (!$expr instanceof MethodCall || !$expr->name instanceof Identifier) {
+            return 0;
+        }
+
+        if ($expr->name->name !== 'route') {
+            return 0;
+        }
+
+        $statementsAnalyzer = $event->getStatementsSource();
+
+        if (!$statementsAnalyzer instanceof StatementsAnalyzer) {
+            return 0;
+        }
+
+        // Cheap shape check: bail out if the registry has nothing to say
+        // about ANY route parameter. Saves the literal-arg lookup AND the
+        // caller-class walk for projects that haven't registered any
+        // bindings or constraints (testbench fallback, scanner failures,
+        // simple apps).
+        $registry = RouteParameterRegistry::instance();
+
+        if ($registry->isEmpty()) {
+            return 0;
+        }
+
+        $name = RouteParameterArg::extractLiteralNameFromCall($expr, $statementsAnalyzer);
+
+        if ($name === null) {
+            // Dynamic name — type provider didn't override, stub source stands.
+            return 0;
+        }
+
+        $hasSafeConstraint = $registry->hasSafeConstraint($name);
+        $boundModel = $registry->getBoundModel($name);
+
+        if (!$hasSafeConstraint && $boundModel === null) {
+            // Neither binding nor safe constraint → no override → nothing to compensate.
+            return 0;
+        }
+
+        // We will be applying taint, so confirm the call really lands on a
+        // Request (or subclass like FormRequest). Done late because it's the
+        // most expensive check: it walks the caller's atomic types and may
+        // call Codebase::classExtends per atomic.
+        $callerClass = MethodCallerResolver::resolveCallerClass(
+            $expr,
+            $statementsAnalyzer,
+            $event->getCodebase(),
+            Request::class,
+        );
+
+        if ($callerClass === null) {
+            return 0;
+        }
+
+        if ($hasSafeConstraint) {
+            // Constraint defeats structural-injection sinks; identifier-eating
+            // sinks (callable/include/eval/extract/shell) and LLM prompt
+            // injection still receive tainted input.
+            return self::SAFE_CONSTRAINT_RESIDUAL_TAINTS;
+        }
+
+        // Binding known but no safe constraint. The stub's
+        // `@psalm-taint-source` was dropped along with the return type, so
+        // re-introduce a full input source. Psalm propagates taint through
+        // string sinks but does not auto-flow object taint into property
+        // reads (e.g. `$model->name`), so this primarily protects
+        // stringification/serialization paths (`__toString`, `json_encode`,
+        // direct `echo`) where the bound object is consumed as a whole.
+        return TaintKind::ALL_INPUT;
+    }
+}

--- a/src/Handlers/Routing/RouteParameterArg.php
+++ b/src/Handlers/Routing/RouteParameterArg.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Routing;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Type\Union;
+
+/**
+ * Shared first-argument literal extractor for `Request::route('name')` calls.
+ *
+ * The two routing handlers (return type provider, taint handler) both need
+ * to read the literal parameter name out of a `route(...)` call, but Psalm
+ * exposes the call shape differently in each event:
+ *
+ *  - {@see MethodReturnTypeProviderEvent::getCallArgs()} hands us a
+ *    pre-extracted `list<Arg>`.
+ *  - {@see \Psalm\Plugin\EventHandler\Event\AddRemoveTaintsEvent::getExpr()}
+ *    hands us a raw {@see MethodCall} AST node.
+ *
+ * Extracting the same logic into one helper keeps the two handlers from
+ * drifting apart on edge cases (no args, dynamic first arg, default arg,
+ * non-literal expression).
+ *
+ * @internal
+ */
+final class RouteParameterArg
+{
+    /**
+     * @param list<Arg> $callArgs
+     */
+    public static function extractLiteralName(
+        array $callArgs,
+        StatementsAnalyzer $statementsAnalyzer,
+    ): ?string {
+        if ($callArgs === []) {
+            // route() with no arg returns the Route object — handled by stub.
+            return null;
+        }
+
+        $type = $statementsAnalyzer->node_data->getType($callArgs[0]->value);
+
+        if (!$type instanceof Union || !$type->isSingleStringLiteral()) {
+            return null;
+        }
+
+        return $type->getSingleStringLiteral()->value;
+    }
+
+    public static function extractLiteralNameFromCall(
+        MethodCall $call,
+        StatementsAnalyzer $statementsAnalyzer,
+    ): ?string {
+        return self::extractLiteralName(\array_values($call->getArgs()), $statementsAnalyzer);
+    }
+}

--- a/src/Handlers/Routing/RouteParameterRegistry.php
+++ b/src/Handlers/Routing/RouteParameterRegistry.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Routing;
+
+/**
+ * Read-only per-route-parameter metadata store.
+ *
+ * Aggregates two pieces of information for each route parameter name:
+ *
+ * 1. The bound model class, if a binding is registered globally via
+ *    {@see \Illuminate\Routing\Router::bind()} or {@see \Illuminate\Routing\Router::model()}
+ *    (the latter being a thin wrapper that also stores the binding in the
+ *    {@see \Illuminate\Routing\Router::$binders} map). Used to narrow the
+ *    return type of {@see \Illuminate\Http\Request::route()} from string|null
+ *    to ModelClass|null. See issues #801 and #803.
+ *
+ * 2. Whether the parameter is constrained by a regex that demonstrably defeats
+ *    every taint sink — i.e. only allows characters from a conservative
+ *    whitelist (`\w`, `\d`, `[a-zA-Z0-9_-]`, UUID/ULID shapes). Used by the
+ *    taint handler to drop the input source from `Request::route('name')`.
+ *    Built by intersecting per-route `wheres` against the global
+ *    {@see \Illuminate\Routing\Router::$patterns}; if any route uses the
+ *    parameter without a safe constraint, this entry is omitted (conservative).
+ *    See issue #849.
+ *
+ * Populated once during plugin boot by {@see RouteParameterRegistryBuilder}
+ * (which calls {@see RouteScanner} against the booted Laravel router).
+ * Handlers query `RouteParameterRegistry::instance()` inside event callbacks.
+ *
+ * The sibling `@internal RouteParameterRegistryBuilder` owns mutation of the
+ * static instance; instances themselves are read-only after construction.
+ *
+ * @psalm-external-mutation-free
+ */
+final class RouteParameterRegistry
+{
+    private static ?self $instance = null;
+
+    /**
+     * @param array<string, class-string> $bindings parameter name => bound model FQCN
+     * @param array<string, true> $safeConstraints parameter name => true when the constraint is safe for every sink
+     *
+     * @psalm-mutation-free
+     */
+    public function __construct(
+        private readonly array $bindings,
+        private readonly array $safeConstraints,
+    ) {}
+
+    /** @psalm-external-mutation-free */
+    public static function instance(): self
+    {
+        if (!self::$instance instanceof self) {
+            self::$instance = new self([], []);
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Replace the singleton. Called by {@see RouteParameterRegistryBuilder}
+     * at plugin boot, and by unit tests that need a known fixture.
+     *
+     * @internal
+     *
+     * @psalm-external-mutation-free
+     */
+    public static function setInstance(self $instance): void
+    {
+        self::$instance = $instance;
+    }
+
+    /**
+     * @return class-string|null
+     *
+     * @psalm-mutation-free
+     */
+    public function getBoundModel(string $parameterName): ?string
+    {
+        return $this->bindings[$parameterName] ?? null;
+    }
+
+    /** @psalm-mutation-free */
+    public function hasSafeConstraint(string $parameterName): bool
+    {
+        return isset($this->safeConstraints[$parameterName]);
+    }
+
+    /**
+     * Whether the registry has any opinion at all. Used by the taint handler
+     * as an early-out: when no bindings and no safe constraints have been
+     * collected, no `Request::route(...)` call can be narrowed, so the
+     * handler skips the (relatively expensive) caller-class walk on every
+     * subsequent call site.
+     *
+     * @psalm-mutation-free
+     */
+    public function isEmpty(): bool
+    {
+        return $this->bindings === [] && $this->safeConstraints === [];
+    }
+}

--- a/src/Handlers/Routing/RouteParameterRegistryBuilder.php
+++ b/src/Handlers/Routing/RouteParameterRegistryBuilder.php
@@ -28,7 +28,7 @@ final class RouteParameterRegistryBuilder
     {
         try {
             $app = ApplicationProvider::getApp();
-        } catch (\Throwable $bootFailure) {
+        } catch (\Throwable $throwable) {
             // ApplicationProvider warns once on the FIRST failed bootApp(),
             // but `getApp()` does not cache that null result (`self::$app`
             // stays unset on failure), so a second call here re-runs
@@ -39,7 +39,7 @@ final class RouteParameterRegistryBuilder
             // accordingly.
             $output->warning(
                 "Laravel plugin: route binding scan skipped — application not bootable: "
-                . $bootFailure->getMessage(),
+                . $throwable->getMessage(),
             );
 
             return;
@@ -54,10 +54,10 @@ final class RouteParameterRegistryBuilder
         try {
             /** @var Router $router */
             $router = $app->make('router');
-        } catch (\Throwable $resolutionFailure) {
+        } catch (\Throwable $throwable) {
             $output->warning(
                 "Laravel plugin: could not resolve router service for route binding analysis: "
-                . $resolutionFailure->getMessage(),
+                . $throwable->getMessage(),
             );
 
             return;
@@ -65,13 +65,13 @@ final class RouteParameterRegistryBuilder
 
         try {
             $registry = (new RouteScanner())->scan($router);
-        } catch (\Throwable $scanFailure) {
+        } catch (\Throwable $throwable) {
             // RouteScanner is defensive but reflection on a non-standard
             // Router subclass could still surprise us — keep the warning
             // visible so plugin maintainers can fix the regression.
             $output->warning(
                 "Laravel plugin: route binding scan failed, falling back to empty registry: "
-                . $scanFailure->getMessage(),
+                . $throwable->getMessage(),
             );
 
             return;

--- a/src/Handlers/Routing/RouteParameterRegistryBuilder.php
+++ b/src/Handlers/Routing/RouteParameterRegistryBuilder.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Routing;
+
+use Illuminate\Routing\Router;
+use Psalm\LaravelPlugin\Providers\ApplicationProvider;
+use Psalm\Progress\Progress;
+
+/**
+ * Boots {@see RouteParameterRegistry} once at plugin start-up.
+ *
+ * Resolves the booted Laravel router (RouteServiceProvider runs during
+ * {@see ApplicationProvider::doGetApp()}'s console-kernel bootstrap, so
+ * `routes/web.php`, `routes/api.php`, etc. have already executed by the
+ * time this fires) and hands it to {@see RouteScanner}.
+ *
+ * Failures are absorbed: routing introspection is best-effort, and an
+ * empty registry is a valid degraded mode (the stub fallback still
+ * returns Model|null and the existing taint source remains in place).
+ *
+ * @internal
+ */
+final class RouteParameterRegistryBuilder
+{
+    public static function boot(Progress $output): void
+    {
+        try {
+            $app = ApplicationProvider::getApp();
+        } catch (\Throwable $bootFailure) {
+            // ApplicationProvider warns once on the FIRST failed bootApp(),
+            // but `getApp()` does not cache that null result (`self::$app`
+            // stays unset on failure), so a second call here re-runs
+            // `doGetApp()` and can re-throw. We must surface that — silently
+            // dropping it leaves the registry empty without explanation,
+            // which the user reads as missing taint suppression / type
+            // narrowing they configured for. Promoted from debug to warning
+            // accordingly.
+            $output->warning(
+                "Laravel plugin: route binding scan skipped — application not bootable: "
+                . $bootFailure->getMessage(),
+            );
+
+            return;
+        }
+
+        if (!$app->bound('router')) {
+            // Testbench fallback path or a user app without the router service.
+            // Either way there is nothing to scan; leave the registry empty.
+            return;
+        }
+
+        try {
+            /** @var Router $router */
+            $router = $app->make('router');
+        } catch (\Throwable $resolutionFailure) {
+            $output->warning(
+                "Laravel plugin: could not resolve router service for route binding analysis: "
+                . $resolutionFailure->getMessage(),
+            );
+
+            return;
+        }
+
+        try {
+            $registry = (new RouteScanner())->scan($router);
+        } catch (\Throwable $scanFailure) {
+            // RouteScanner is defensive but reflection on a non-standard
+            // Router subclass could still surprise us — keep the warning
+            // visible so plugin maintainers can fix the regression.
+            $output->warning(
+                "Laravel plugin: route binding scan failed, falling back to empty registry: "
+                . $scanFailure->getMessage(),
+            );
+
+            return;
+        }
+
+        RouteParameterRegistry::setInstance($registry);
+    }
+}

--- a/src/Handlers/Routing/RouteScanner.php
+++ b/src/Handlers/Routing/RouteScanner.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Routing;
+
+use Closure;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Routing\Route;
+use Illuminate\Routing\Router;
+use ReflectionFunction;
+
+/**
+ * Walks a booted {@see Router} once and produces the data backing
+ * {@see RouteParameterRegistry}.
+ *
+ * Two passes:
+ *
+ *  1. Bindings — enumerated from {@see Router::$binders} via reflection
+ *     (the property is protected and Laravel exposes no public iterator).
+ *     For each binder closure we try, in order:
+ *       a. Closure return type via {@see ReflectionFunction::getReturnType()}
+ *          — covers explicit `Route::bind('name', fn (...): Genre => ...)`.
+ *       b. Closure static variables via {@see ReflectionFunction::getStaticVariables()}
+ *          looking for a `class` (or `$class`) string that is a Model FQCN —
+ *          covers `Route::model('name', Genre::class)`, where Laravel internally
+ *          wraps the lookup in a closure that captures `$class`.
+ *
+ *  2. Constraints — for each parameter name appearing in any registered route,
+ *     we collect the regex from the route's `wheres` array, falling back to
+ *     {@see Router::getPatterns()} for global patterns. The name is reported
+ *     as having a "safe constraint" only when EVERY route using the name has
+ *     a constraint AND every collected regex is in
+ *     {@see SafeRoutePattern::isSafe()}'s whitelist (issue #849).
+ *
+ * Construction never throws: any reflection or container error is caught and
+ * the scanner falls back to an empty registry. The plugin is best-effort —
+ * a runtime quirk in a user's router subclass must not break analysis.
+ *
+ * @internal
+ */
+final class RouteScanner
+{
+    public function scan(Router $router): RouteParameterRegistry
+    {
+        $bindings = $this->collectBindings($router);
+        $safeConstraints = $this->collectSafeConstraints($router);
+
+        return new RouteParameterRegistry($bindings, $safeConstraints);
+    }
+
+    /**
+     * @return array<string, class-string>
+     */
+    private function collectBindings(Router $router): array
+    {
+        $binders = $this->readProtectedBinders($router);
+
+        if ($binders === null) {
+            return [];
+        }
+
+        $bindings = [];
+
+        foreach ($binders as $name => $binder) {
+            if (!\is_string($name) || !$binder instanceof \Closure) {
+                continue;
+            }
+
+            $modelClass = $this->resolveBinderModelClass($binder);
+
+            if ($modelClass !== null) {
+                $bindings[$name] = $modelClass;
+            }
+        }
+
+        return $bindings;
+    }
+
+    /**
+     * Read Router::$binders, which is protected.
+     *
+     * Returns null when reflection fails (subclass hides the property,
+     * Laravel internals change shape, ...). Caller treats null as "no
+     * bindings discoverable" and proceeds without erroring.
+     *
+     * @return array<array-key, mixed>|null
+     */
+    private function readProtectedBinders(Router $router): ?array
+    {
+        // ReflectionClass::getProperty() already walks up the ancestor chain,
+        // so a Router subclass that inherits `binders` works without an
+        // explicit climb. We only need to surface the failure if the
+        // property is genuinely absent (Laravel internals changed).
+        try {
+            $property = (new \ReflectionClass($router))->getProperty('binders');
+        } catch (\ReflectionException) {
+            return null;
+        }
+
+        /** @var mixed $value */
+        $value = $property->getValue($router);
+
+        return \is_array($value) ? $value : null;
+    }
+
+    /**
+     * Inspect a binder closure for the bound model class.
+     *
+     * Two strategies:
+     *
+     *  - Declared return type: `Route::bind('genre', fn (string $v): ?Genre => ...)`
+     *    We unwrap nullable, reject `void`/`mixed`/scalars, and accept a class
+     *    name that is a subclass of {@see Model}.
+     *
+     *  - Static (captured) variables: `Route::model('genre', Genre::class)`
+     *    Laravel's `RouteBinding::forModel` returns a closure that captures
+     *    `$class` (and `$callback`). We look for a captured string that
+     *    names a Model subclass.
+     *
+     * Returns null when neither strategy yields a Model subclass — the caller
+     * skips the entry, leaving the parameter without a registered binding.
+     *
+     * @return class-string|null
+     */
+    private function resolveBinderModelClass(\Closure $binder): ?string
+    {
+        try {
+            $reflection = new \ReflectionFunction($binder);
+        } catch (\ReflectionException) {
+            return null;
+        }
+
+        $returnType = $reflection->getReturnType();
+
+        if ($returnType instanceof \ReflectionNamedType && !$returnType->isBuiltin()) {
+            $name = $returnType->getName();
+
+            if ($this->isModelClass($name)) {
+                return $name;
+            }
+        }
+
+        /** @var array<string, mixed> $staticVariables */
+        $staticVariables = $reflection->getStaticVariables();
+
+        /** @var mixed $value */
+        foreach ($staticVariables as $value) {
+            if (\is_string($value) && $this->isModelClass($value)) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @psalm-assert-if-true class-string<Model> $candidate
+     */
+    private function isModelClass(string $candidate): bool
+    {
+        if ($candidate === '' || $candidate === Model::class) {
+            return false;
+        }
+
+        if (!\class_exists($candidate)) {
+            return false;
+        }
+
+        return \is_subclass_of($candidate, Model::class);
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    private function collectSafeConstraints(Router $router): array
+    {
+        /** @var array<string, string> $globalPatterns */
+        $globalPatterns = $router->getPatterns();
+
+        // For each parameter name we track every constraint observed across
+        // the registered routes. Names with at least one unconstrained route
+        // are removed (conservative): the call site can't know which route
+        // resolves a given Request, so we only suppress taint when EVERY
+        // route binds the name to a known-safe shape.
+        /** @var array<string, list<string>> $perName collected regexes per name */
+        $perName = [];
+        /** @var array<string, true> $unconstrained names that appear without a regex anywhere */
+        $unconstrained = [];
+
+        foreach ($router->getRoutes()->getRoutes() as $route) {
+            if (!$route instanceof Route) {
+                continue;
+            }
+
+            /** @var list<string> $parameterNames */
+            $parameterNames = $route->parameterNames();
+
+            /** @var array<string, string> $wheres */
+            $wheres = $route->wheres;
+
+            foreach ($parameterNames as $name) {
+                $regex = $wheres[$name] ?? $globalPatterns[$name] ?? null;
+
+                if ($regex === null) {
+                    $unconstrained[$name] = true;
+
+                    continue;
+                }
+
+                $perName[$name][] = $regex;
+            }
+        }
+
+        $safe = [];
+
+        foreach ($perName as $name => $regexes) {
+            if (isset($unconstrained[$name])) {
+                continue;
+            }
+
+            $allSafe = true;
+
+            foreach ($regexes as $regex) {
+                if (!SafeRoutePattern::isSafe($regex)) {
+                    $allSafe = false;
+
+                    break;
+                }
+            }
+
+            if ($allSafe) {
+                $safe[$name] = true;
+            }
+        }
+
+        return $safe;
+    }
+}

--- a/src/Handlers/Routing/RouteScanner.php
+++ b/src/Handlers/Routing/RouteScanner.php
@@ -98,7 +98,6 @@ final class RouteScanner
             return null;
         }
 
-        /** @var mixed $value */
         $value = $property->getValue($router);
 
         return \is_array($value) ? $value : null;

--- a/src/Handlers/Routing/SafeRoutePattern.php
+++ b/src/Handlers/Routing/SafeRoutePattern.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Routing;
+
+/**
+ * Decides whether a route-parameter regex constraint defeats every taint sink.
+ *
+ * "Safe" means the regex only matches characters from a conservative whitelist
+ * — alphanumerics, underscore, dash, hyphen — so the value can never carry a
+ * shell metachar, header CRLF, HTML brace, SQL quote, etc. A safe regex lets
+ * the taint handler drop the `input` source from `Request::route('name')`.
+ *
+ * Permissive regexes (`.+`, `[^/]+`, anything outside the whitelist) are
+ * rejected — taint stays.
+ *
+ * Two intentional limitations:
+ *  - We accept the regex string verbatim from `Route::$wheres` /
+ *    `Router::$patterns`. Laravel does not parse it; it just splices it into
+ *    the compiled route pattern with `(?P<name>$regex)`. We mirror that — no
+ *    PHP regex engine is invoked here.
+ *  - We deliberately accept only well-known shapes. A novel shape that is in
+ *    fact safe will be rejected; this keeps false-negatives at zero (a safe
+ *    constraint we miss costs the user a noisy taint warning, not a missed
+ *    vulnerability).
+ *
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final class SafeRoutePattern
+{
+    /**
+     * Patterns that match only characters in `[A-Za-z0-9_-]`. Anchors are
+     * tolerated but not required (Laravel wraps the regex in `(?P<name>...)`).
+     *
+     * Each entry is the regex source (without delimiters) as it would appear
+     * in `Route::$wheres`. Comparison is case-sensitive — Laravel doesn't
+     * normalise these and neither does the runtime route compiler.
+     *
+     * @var list<string>
+     */
+    private const SAFE_PATTERNS = [
+        // Digits
+        '\d+',
+        '[0-9]+',
+        '\d*',
+        '[0-9]*',
+
+        // Alpha
+        '[a-z]+',
+        '[A-Z]+',
+        '[a-zA-Z]+',
+        '[A-Za-z]+',
+
+        // Alphanumeric
+        '[a-z0-9]+',
+        '[A-Z0-9]+',
+        '[a-zA-Z0-9]+',
+        '[A-Za-z0-9]+',
+        '[0-9a-zA-Z]+',
+        '[0-9A-Za-z]+',
+
+        // Slug-style (alphanumeric + dash/underscore)
+        '[a-zA-Z0-9_-]+',
+        '[A-Za-z0-9_-]+',
+        '[a-zA-Z0-9-]+',
+        '[A-Za-z0-9-]+',
+        '[a-zA-Z0-9_]+',
+        '[A-Za-z0-9_]+',
+        '[\w-]+',
+        '\w+',
+
+        // Hex (UUID component shape, also covers whereIn-of-hex use cases)
+        '[0-9a-f]+',
+        '[0-9A-F]+',
+        '[0-9a-fA-F]+',
+        '[a-fA-F0-9]+',
+
+        // Standard UUID. The first entry is exactly what Laravel's whereUuid()
+        // shortcut emits in
+        // Routing/CreatesRegularExpressionRouteConstraints::whereUuid() —
+        // mixing the `\d` shorthand with `[a-fA-F]` literals. Comparison is
+        // string-equal, so we keep both `\d`- and `[0-9]`-flavoured shapes.
+        '[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}',
+        '[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}',
+        '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}',
+        '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}',
+
+        // ULID (Laravel's whereUlid shorthand). The first entry is exactly
+        // what Routing/CreatesRegularExpressionRouteConstraints::whereUlid()
+        // emits: a leading `[0-7]` (ULIDs are 128-bit and the first byte is
+        // capped) plus 25 mixed-case Crockford base32 characters. The looser
+        // shapes below tolerate hand-rolled where()s that approximate the
+        // same shape.
+        '[0-7][0-9a-hjkmnp-tv-zA-HJKMNP-TV-Z]{25}',
+        '[0-9A-HJKMNP-TV-Z]{26}',
+        '[0-9A-Z]{26}',
+    ];
+
+    /** @psalm-pure */
+    public static function isSafe(string $regex): bool
+    {
+        $trimmed = self::stripAnchors($regex);
+
+        foreach (self::SAFE_PATTERNS as $candidate) {
+            if ($trimmed === $candidate) {
+                return true;
+            }
+        }
+
+        // whereIn(name, [...]) compiles to an alternation of literal strings.
+        // If every alternative is itself a safe literal (alphanumerics + dashes),
+        // the overall pattern is safe. We don't strip optional whitespace —
+        // Laravel's emitter doesn't insert any.
+        if (\str_contains($trimmed, '|')) {
+            $alternatives = \explode('|', $trimmed);
+            foreach ($alternatives as $alt) {
+                if ($alt === '' || \preg_match('/^[A-Za-z0-9_-]+$/', $alt) !== 1) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /** @psalm-pure */
+    private static function stripAnchors(string $regex): string
+    {
+        // Laravel allows users to author wheres with or without ^ / $ anchors.
+        // Both compile identically because the runtime route compiler wraps the
+        // expression in a named group anyway. We strip them so the equality
+        // check matches both styles.
+        if (\str_starts_with($regex, '^')) {
+            $regex = \substr($regex, 1);
+        }
+
+        if (\str_ends_with($regex, '$')) {
+            $regex = \substr($regex, 0, -1);
+        }
+
+        return $regex;
+    }
+}

--- a/src/Handlers/Validation/InlineValidateRulesCollector.php
+++ b/src/Handlers/Validation/InlineValidateRulesCollector.php
@@ -791,7 +791,7 @@ final class InlineValidateRulesCollector implements
         StatementsSource $source,
         Codebase $codebase,
     ): bool {
-        return ValidationCallerResolver::resolveCallerClass(
+        return \Psalm\LaravelPlugin\Util\MethodCallerResolver::resolveCallerClass(
             $expr,
             $source,
             $codebase,

--- a/src/Handlers/Validation/ValidationTaintHandler.php
+++ b/src/Handlers/Validation/ValidationTaintHandler.php
@@ -501,7 +501,7 @@ final class ValidationTaintHandler implements AddTaintsInterface, RemoveTaintsIn
             return null;
         }
 
-        return ValidationCallerResolver::resolveCallerClass(
+        return \Psalm\LaravelPlugin\Util\MethodCallerResolver::resolveCallerClass(
             $expr,
             $event->getStatementsSource(),
             $event->getCodebase(),

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -47,6 +47,14 @@ final class Plugin implements PluginEntryPointInterface
             // of whether findMissingTranslations is enabled
             $this->initTranslationKeyHandler($output, $pluginConfig->findMissingTranslations);
 
+            // Scan the booted Laravel router for route-model bindings and
+            // safe parameter constraints. RouteServiceProvider has already
+            // run (it's part of the console-kernel bootstrap inside
+            // ApplicationProvider::doGetApp), so the route collection is
+            // populated. Failures fall back to an empty registry — the stub
+            // remains conservative.
+            Handlers\Routing\RouteParameterRegistryBuilder::boot($output);
+
             if ($pluginConfig->findMissingViews) {
                 $this->initMissingViewHandler($output);
             }
@@ -292,6 +300,16 @@ final class Plugin implements PluginEntryPointInterface
 
         require_once __DIR__ . '/Handlers/Console/CommandArgumentHandler.php';
         $registration->registerHooksFromClass(Handlers\Console\CommandArgumentHandler::class);
+
+        // Routing handlers consult RouteParameterRegistry (populated by
+        // RouteParameterRegistryBuilder::boot above). Type provider must
+        // be registered before the taint handler so reviewers reading
+        // top-to-bottom see the override decision before the source
+        // compensation that depends on it.
+        require_once __DIR__ . '/Handlers/Routing/RequestRouteReturnTypeProvider.php';
+        $registration->registerHooksFromClass(Handlers\Routing\RequestRouteReturnTypeProvider::class);
+        require_once __DIR__ . '/Handlers/Routing/RequestRouteTaintHandler.php';
+        $registration->registerHooksFromClass(Handlers\Routing\RequestRouteTaintHandler::class);
 
         require_once __DIR__ . '/Handlers/Validation/ValidatedTypeHandler.php';
         $registration->registerHooksFromClass(Handlers\Validation\ValidatedTypeHandler::class);

--- a/src/Util/MethodCallerResolver.php
+++ b/src/Util/MethodCallerResolver.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Psalm\LaravelPlugin\Handlers\Validation;
+namespace Psalm\LaravelPlugin\Util;
 
 use PhpParser\Node\Expr\MethodCall;
 use Psalm\Codebase;
@@ -13,18 +13,23 @@ use Psalm\Type\Union;
 
 /**
  * Walks a method call's caller type (`$caller->method(...)`) looking for a
- * TNamedObject that matches or extends `$baseClass`. Returns the first matching
- * class-string, or null when nothing in the caller's type union qualifies.
+ * TNamedObject that matches or extends `$baseClass`. Returns the first
+ * matching class-string, or null when nothing in the caller's type union
+ * qualifies.
  *
- * Shared between {@see InlineValidateRulesCollector} (which wants a bool "is
- * the caller a Request?") and {@see ValidationTaintHandler} (which wants the
- * concrete class-string for further lookups). The walk handles exact-class
- * match, extends match, unpopulated classlikes, and invalid class-string
- * exceptions uniformly so both callers get the same semantics.
+ * Used by handlers that need to confirm a method call lands on a particular
+ * Laravel base class (Request, FormRequest, …) before applying narrowing or
+ * taint logic. The walk handles exact-class match, extends match, unpopulated
+ * classlikes, and invalid class-string exceptions uniformly so all callers
+ * get the same semantics.
+ *
+ * Promoted from `Handlers\Validation\ValidationCallerResolver` once a second
+ * (Routing) handler started consuming it — the routing namespace must not
+ * depend on validation internals, so the helper now lives in `Util/`.
  *
  * @internal
  */
-final class ValidationCallerResolver
+final class MethodCallerResolver
 {
     /**
      * @param class-string $baseClass

--- a/stubs/common/Http/Request.stubphp
+++ b/stubs/common/Http/Request.stubphp
@@ -27,11 +27,29 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     /**
      * Get the route handling the request.
      *
+     * Route-model binding (implicit type-hinted controller params, Route::bind,
+     * Route::model) replaces the URL segment string with the resolved object
+     * at runtime: a Model instance for Eloquent bindings, a BackedEnum for
+     * implicit enum binding (Illuminate\Routing\ImplicitRouteBinding::resolveBackedEnumsForRoute).
+     * The plugin's RequestRouteReturnTypeProvider narrows the return to the
+     * concrete bound class when it can resolve the binding from the registered
+     * routes (issues #801, #803). The Model and BackedEnum members of the
+     * union are the fallback for cases the registry can't resolve and prevent
+     * InvalidPropertyFetch on `$request->route('x')->id`-style chains.
+     * Plain-object bindings via `Route::bind('name', fn () => new Dto())` to a
+     * non-Model, non-BackedEnum class — including non-Model UrlRoutable
+     * implementors like JsonResource resolved via implicit binding — are out
+     * of scope for the fallback union; they still type-check against TDefault.
+     *
+     * Constraint-driven taint suppression (issue #849) is handled by
+     * RequestRouteTaintHandler — the @psalm-taint-source below stays on the
+     * stub and is conditionally dropped/partially re-added at the call site.
+     *
      * @template TDefault of object
      *
      * @param string|null $param
      * @param TDefault $default
-     * @psalm-return ($param is null ? \Illuminate\Routing\Route : TDefault|string|null)
+     * @psalm-return ($param is null ? \Illuminate\Routing\Route : TDefault|string|\Illuminate\Database\Eloquent\Model|\BackedEnum|null)
      *
      * @psalm-taint-source input
      */

--- a/tests/Type/tests/Http/RequestTest.phpt
+++ b/tests/Type/tests/Http/RequestTest.phpt
@@ -12,5 +12,18 @@ function it_returns_one_header(\Illuminate\Http\Request $request): ?string {
 function it_returns_route(\Illuminate\Http\Request $request): \Illuminate\Routing\Route {
     return $request->route();
 };
+
+// Issue #801: chained property access on $request->route('name') must not
+// trigger InvalidPropertyFetch. The stub fallback adds Model|null to the
+// return union (and BackedEnum, for Laravel's implicit enum binding) so
+// callers that rely on route-model binding don't trip over the
+// unresolved-binding case.
+function it_returns_route_param_with_model_fallback(
+    \Illuminate\Http\Request $request,
+): null|string|\Illuminate\Database\Eloquent\Model|\BackedEnum {
+    /** @psalm-check-type-exact $value = string|\Illuminate\Database\Eloquent\Model|\BackedEnum|null */
+    $value = $request->route('station');
+    return $value;
+};
 ?>
 --EXPECTF--

--- a/tests/Unit/Handlers/Routing/RouteScannerTest.php
+++ b/tests/Unit/Handlers/Routing/RouteScannerTest.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Tests\Unit\Handlers\Routing;
+
+use Illuminate\Container\Container;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Routing\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Handlers\Routing\RouteParameterRegistry;
+use Psalm\LaravelPlugin\Handlers\Routing\RouteScanner;
+
+/**
+ * End-to-end coverage for the runtime scan used at plugin boot.
+ *
+ * Each test wires a real {@see Router} (with an empty container + dispatcher,
+ * which is enough — we never dispatch anything), registers the routing fixture
+ * for the case under test, runs the scanner, and asserts the resulting
+ * {@see RouteParameterRegistry} agrees with the documented behaviour.
+ */
+#[CoversClass(RouteScanner::class)]
+#[CoversClass(RouteParameterRegistry::class)]
+final class RouteScannerTest extends TestCase
+{
+    private function makeRouter(): Router
+    {
+        return new Router(new Dispatcher(new Container()));
+    }
+
+    #[Test]
+    public function empty_router_yields_empty_registry(): void
+    {
+        $registry = (new RouteScanner())->scan($this->makeRouter());
+
+        $this->assertNull($registry->getBoundModel('anything'));
+        $this->assertFalse($registry->hasSafeConstraint('anything'));
+    }
+
+    #[Test]
+    public function bind_with_declared_return_type_registers_model(): void
+    {
+        $router = $this->makeRouter();
+        $router->bind('genre', static fn(string $value): RouteScannerTestGenre
+            => new RouteScannerTestGenre());
+
+        $registry = (new RouteScanner())->scan($router);
+
+        $this->assertSame(
+            RouteScannerTestGenre::class,
+            $registry->getBoundModel('genre'),
+        );
+    }
+
+    #[Test]
+    public function bind_with_nullable_return_type_registers_model(): void
+    {
+        $router = $this->makeRouter();
+        $router->bind('genre', static fn(string $value): ?RouteScannerTestGenre
+            => null);
+
+        $registry = (new RouteScanner())->scan($router);
+
+        $this->assertSame(RouteScannerTestGenre::class, $registry->getBoundModel('genre'));
+    }
+
+    #[Test]
+    public function bind_without_return_type_is_skipped(): void
+    {
+        $router = $this->makeRouter();
+        $router->bind('opaque', static fn(string $value) => $value);
+
+        $registry = (new RouteScanner())->scan($router);
+
+        $this->assertNull($registry->getBoundModel('opaque'));
+    }
+
+    #[Test]
+    public function bind_with_non_model_return_type_is_skipped(): void
+    {
+        $router = $this->makeRouter();
+        $router->bind('weird', static fn(string $value): \stdClass => new \stdClass());
+
+        $registry = (new RouteScanner())->scan($router);
+
+        $this->assertNull($registry->getBoundModel('weird'));
+    }
+
+    #[Test]
+    public function model_registers_via_static_variable(): void
+    {
+        $router = $this->makeRouter();
+        // Route::model wraps the lookup in a closure that captures `$class`.
+        // The scanner reads it via ReflectionFunction::getStaticVariables()
+        // because the closure has no declared return type.
+        $router->model('genre', RouteScannerTestGenre::class);
+
+        $registry = (new RouteScanner())->scan($router);
+
+        $this->assertSame(RouteScannerTestGenre::class, $registry->getBoundModel('genre'));
+    }
+
+    #[Test]
+    public function model_with_non_model_class_is_skipped(): void
+    {
+        $router = $this->makeRouter();
+        // `Route::model` accepts any class-string at registration time;
+        // Laravel only validates at resolution. The scanner must reject
+        // non-Model captures so we don't claim a binding that the
+        // ImplicitRouteBinding resolver will fail to honour.
+        $router->model('weird', \stdClass::class);
+
+        $registry = (new RouteScanner())->scan($router);
+
+        $this->assertNull($registry->getBoundModel('weird'));
+    }
+
+    #[Test]
+    public function bind_returning_base_model_is_skipped(): void
+    {
+        $router = $this->makeRouter();
+        // The bare base Model isn't useful as a binding target — every model
+        // is a Model, so this would always over-narrow callers. Reject.
+        $router->bind('thing', static fn(string $value): Model => new RouteScannerTestGenre());
+
+        $registry = (new RouteScanner())->scan($router);
+
+        $this->assertNull($registry->getBoundModel('thing'));
+    }
+
+    #[Test]
+    public function isEmpty_short_circuit_works(): void
+    {
+        $router = $this->makeRouter();
+        $registry = (new RouteScanner())->scan($router);
+
+        $this->assertTrue(
+            $registry->isEmpty(),
+            'Empty router must produce an empty registry — taint handler relies on this for hot-path skip',
+        );
+
+        $router->bind('genre', static fn(string $value): RouteScannerTestGenre
+            => new RouteScannerTestGenre());
+
+        $populated = (new RouteScanner())->scan($router);
+        $this->assertFalse($populated->isEmpty());
+    }
+
+    #[Test]
+    public function safe_global_pattern_marks_constraint_safe(): void
+    {
+        $router = $this->makeRouter();
+        $router->pattern('id', '\d+');
+        // A route must use the parameter for the registry to surface it,
+        // because the scanner scopes safe constraints to names that actually
+        // appear in registered routes (see RouteScanner::collectSafeConstraints).
+        $router->get('/foo/{id}', static fn() => null);
+
+        $registry = (new RouteScanner())->scan($router);
+
+        $this->assertTrue($registry->hasSafeConstraint('id'));
+    }
+
+    #[Test]
+    public function unsafe_global_pattern_does_not_mark_safe(): void
+    {
+        $router = $this->makeRouter();
+        $router->pattern('id', '.+');
+        $router->get('/foo/{id}', static fn() => null);
+
+        $registry = (new RouteScanner())->scan($router);
+
+        $this->assertFalse($registry->hasSafeConstraint('id'));
+    }
+
+    #[Test]
+    public function per_route_safe_where_marks_constraint_safe(): void
+    {
+        $router = $this->makeRouter();
+        $router->get('/foo/{key}', static fn() => null)
+            ->where('key', '[A-Za-z0-9]+');
+
+        $registry = (new RouteScanner())->scan($router);
+
+        $this->assertTrue(
+            $registry->hasSafeConstraint('key'),
+            'koel reproducer (issue #849) should be recognised',
+        );
+    }
+
+    #[Test]
+    public function unconstrained_route_disables_safety_for_name(): void
+    {
+        $router = $this->makeRouter();
+        // Two routes share the name 'id'. One has a safe where, the other has
+        // none. The scanner must conservatively reject — at the call site we
+        // can't know which route resolves the request.
+        $router->get('/safe/{id}', static fn() => null)->where('id', '\d+');
+        $router->get('/unsafe/{id}', static fn() => null);
+
+        $registry = (new RouteScanner())->scan($router);
+
+        $this->assertFalse(
+            $registry->hasSafeConstraint('id'),
+            'mixed safe/unconstrained routes must be treated as unsafe to avoid false negatives',
+        );
+    }
+
+    #[Test]
+    public function disagreeing_safe_constraints_are_still_safe(): void
+    {
+        $router = $this->makeRouter();
+        // Both regexes are individually safe — different shapes still produce
+        // the same property (no metachar) so the conservative aggregation
+        // stays safe.
+        $router->get('/digits/{id}', static fn() => null)->where('id', '\d+');
+        $router->get('/alpha/{id}', static fn() => null)->where('id', '[a-zA-Z0-9]+');
+
+        $registry = (new RouteScanner())->scan($router);
+
+        $this->assertTrue($registry->hasSafeConstraint('id'));
+    }
+
+    #[Test]
+    public function one_unsafe_route_disables_safety_for_name(): void
+    {
+        $router = $this->makeRouter();
+        $router->get('/safe/{key}', static fn() => null)->where('key', '\d+');
+        $router->get('/unsafe/{key}', static fn() => null)->where('key', '.+');
+
+        $registry = (new RouteScanner())->scan($router);
+
+        $this->assertFalse($registry->hasSafeConstraint('key'));
+    }
+}
+
+/**
+ * @internal fixture model used only inside this test file.
+ */
+class RouteScannerTestGenre extends Model {}

--- a/tests/Unit/Handlers/Routing/RouteScannerTest.php
+++ b/tests/Unit/Handlers/Routing/RouteScannerTest.php
@@ -71,7 +71,7 @@ final class RouteScannerTest extends TestCase
     public function bind_without_return_type_is_skipped(): void
     {
         $router = $this->makeRouter();
-        $router->bind('opaque', static fn(string $value) => $value);
+        $router->bind('opaque', static fn(string $value): string => $value);
 
         $registry = (new RouteScanner())->scan($router);
 
@@ -157,7 +157,7 @@ final class RouteScannerTest extends TestCase
         // A route must use the parameter for the registry to surface it,
         // because the scanner scopes safe constraints to names that actually
         // appear in registered routes (see RouteScanner::collectSafeConstraints).
-        $router->get('/foo/{id}', static fn() => null);
+        $router->get('/foo/{id}', static fn(): null => null);
 
         $registry = (new RouteScanner())->scan($router);
 
@@ -169,7 +169,7 @@ final class RouteScannerTest extends TestCase
     {
         $router = $this->makeRouter();
         $router->pattern('id', '.+');
-        $router->get('/foo/{id}', static fn() => null);
+        $router->get('/foo/{id}', static fn(): null => null);
 
         $registry = (new RouteScanner())->scan($router);
 
@@ -180,7 +180,7 @@ final class RouteScannerTest extends TestCase
     public function per_route_safe_where_marks_constraint_safe(): void
     {
         $router = $this->makeRouter();
-        $router->get('/foo/{key}', static fn() => null)
+        $router->get('/foo/{key}', static fn(): null => null)
             ->where('key', '[A-Za-z0-9]+');
 
         $registry = (new RouteScanner())->scan($router);
@@ -198,8 +198,8 @@ final class RouteScannerTest extends TestCase
         // Two routes share the name 'id'. One has a safe where, the other has
         // none. The scanner must conservatively reject — at the call site we
         // can't know which route resolves the request.
-        $router->get('/safe/{id}', static fn() => null)->where('id', '\d+');
-        $router->get('/unsafe/{id}', static fn() => null);
+        $router->get('/safe/{id}', static fn(): null => null)->where('id', '\d+');
+        $router->get('/unsafe/{id}', static fn(): null => null);
 
         $registry = (new RouteScanner())->scan($router);
 
@@ -216,8 +216,8 @@ final class RouteScannerTest extends TestCase
         // Both regexes are individually safe — different shapes still produce
         // the same property (no metachar) so the conservative aggregation
         // stays safe.
-        $router->get('/digits/{id}', static fn() => null)->where('id', '\d+');
-        $router->get('/alpha/{id}', static fn() => null)->where('id', '[a-zA-Z0-9]+');
+        $router->get('/digits/{id}', static fn(): null => null)->where('id', '\d+');
+        $router->get('/alpha/{id}', static fn(): null => null)->where('id', '[a-zA-Z0-9]+');
 
         $registry = (new RouteScanner())->scan($router);
 
@@ -228,8 +228,8 @@ final class RouteScannerTest extends TestCase
     public function one_unsafe_route_disables_safety_for_name(): void
     {
         $router = $this->makeRouter();
-        $router->get('/safe/{key}', static fn() => null)->where('key', '\d+');
-        $router->get('/unsafe/{key}', static fn() => null)->where('key', '.+');
+        $router->get('/safe/{key}', static fn(): null => null)->where('key', '\d+');
+        $router->get('/unsafe/{key}', static fn(): null => null)->where('key', '.+');
 
         $registry = (new RouteScanner())->scan($router);
 

--- a/tests/Unit/Handlers/Routing/SafeRoutePatternTest.php
+++ b/tests/Unit/Handlers/Routing/SafeRoutePatternTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Tests\Unit\Handlers\Routing;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Handlers\Routing\SafeRoutePattern;
+
+/**
+ * Verifies the conservative whitelist of route-parameter regexes that the
+ * plugin treats as "definitely defeats every taint sink". Two failure modes
+ * matter:
+ *
+ *  - False positives (regex accepted but actually unsafe) → security regression,
+ *    plugin would tell users a tainted value is clean.
+ *  - False negatives (regex rejected but actually safe) → noisy warnings,
+ *    cosmetic but annoying. We accept some false negatives by design.
+ */
+#[CoversClass(SafeRoutePattern::class)]
+final class SafeRoutePatternTest extends TestCase
+{
+    /** @return \Iterator<string, array{string}> */
+    public static function safePatternsProvider(): \Iterator
+    {
+        yield 'digits plus' => ['\d+'];
+        yield 'digits star' => ['\d*'];
+        yield 'numeric range' => ['[0-9]+'];
+        yield 'lowercase alpha' => ['[a-z]+'];
+        yield 'mixed alpha' => ['[a-zA-Z]+'];
+        yield 'alphanumeric' => ['[a-zA-Z0-9]+'];
+        yield 'koel slug example (issue #849)' => ['[A-Za-z0-9]+'];
+        yield 'slug with dash' => ['[a-zA-Z0-9-]+'];
+        yield 'slug with dash and underscore' => ['[a-zA-Z0-9_-]+'];
+        yield 'word chars' => ['\w+'];
+        yield 'hex' => ['[0-9a-f]+'];
+        yield 'mixed hex' => ['[0-9a-fA-F]+'];
+        yield 'standard uuid' => [
+            '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}',
+        ];
+        yield 'uuid case-insensitive' => [
+            '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}',
+        ];
+        yield 'ulid' => ['[0-9A-HJKMNP-TV-Z]{26}'];
+        yield 'simple ulid' => ['[0-9A-Z]{26}'];
+        yield 'whereIn-style alternation of safe literals' => ['draft|published|archived'];
+        yield 'anchored digits' => ['^\d+$'];
+    }
+
+    /** @return \Iterator<string, array{string}> */
+    public static function unsafePatternsProvider(): \Iterator
+    {
+        yield 'wildcard' => ['.+'];
+        yield 'non-slash' => ['[^/]+'];
+        yield 'with quote' => ['[a-zA-Z0-9\']+'];
+        yield 'with newline class' => ['[\s\S]+'];
+        yield 'with shell metachar' => ['[A-Za-z0-9;]+'];
+        yield 'with html bracket' => ['[A-Za-z0-9<>]+'];
+        yield 'empty' => [''];
+        yield 'permissive alternation' => ['draft|published|with;semicolon'];
+        yield 'lookahead' => ['(?=\d)\d+'];
+    }
+
+    #[Test]
+    #[DataProvider('safePatternsProvider')]
+    public function safe_patterns_are_recognised(string $regex): void
+    {
+        $this->assertTrue(
+            SafeRoutePattern::isSafe($regex),
+            "Expected '{$regex}' to be classified as safe — false negative weakens taint suppression",
+        );
+    }
+
+    #[Test]
+    #[DataProvider('unsafePatternsProvider')]
+    public function unsafe_patterns_are_rejected(string $regex): void
+    {
+        $this->assertFalse(
+            SafeRoutePattern::isSafe($regex),
+            "Expected '{$regex}' to be classified as UNSAFE — false positive would let tainted values through",
+        );
+    }
+
+    #[Test]
+    public function alternation_with_one_unsafe_alternative_is_unsafe(): void
+    {
+        // Even if 9 of 10 whereIn() values are safe, one with a quote breaks it.
+        $this->assertFalse(SafeRoutePattern::isSafe("alpha|beta|gamma|with'quote"));
+    }
+}

--- a/tests/Unit/Handlers/Routing/SafeRoutePatternTest.php
+++ b/tests/Unit/Handlers/Routing/SafeRoutePatternTest.php
@@ -55,7 +55,7 @@ final class SafeRoutePatternTest extends TestCase
     {
         yield 'wildcard' => ['.+'];
         yield 'non-slash' => ['[^/]+'];
-        yield 'with quote' => ['[a-zA-Z0-9\']+'];
+        yield 'with quote' => ["[a-zA-Z0-9']+"];
         yield 'with newline class' => ['[\s\S]+'];
         yield 'with shell metachar' => ['[A-Za-z0-9;]+'];
         yield 'with html bracket' => ['[A-Za-z0-9<>]+'];


### PR DESCRIPTION
## Summary

Closes #801, #803, #849.

Adds runtime introspection of the booted Laravel router to drive two new Psalm hooks on `Request::route('name')`:

- A `MethodReturnTypeProvider` narrows the return type to the concrete bound class when `Route::bind()` / `Route::model()` registers a Model subclass, replacing the stub's `string|null`. Eliminates the `InvalidPropertyFetch` koel saw on `$request->route('genre')->id`.
- An `AddTaintsInterface` handler refines the stub's `@psalm-taint-source input` based on the route's regex constraint. When the constraint is on a conservative whitelist (`\d+`, `[A-Za-z0-9]+`, `whereUuid`, `whereUlid`, `whereIn` of safe literals, etc.), structural-injection sinks (HTML, SQL, headers, cookies, LDAP, file paths, SSRF, XPath, sleep, has-quotes, unserialize) drop the source. Identifier-eating sinks (callable, include, eval, extract, shell) and LLM prompts keep it — `\w+` is a valid PHP function name, so `call_user_func($req->route('handler'))` must not be silently de-tainted.

The stub fallback now also includes `BackedEnum` from Laravel's implicit enum binding (`ImplicitRouteBinding::resolveBackedEnumsForRoute`), so unresolved cases still type-check.

Per-route `where()` constraints are aggregated conservatively: a name appearing on any unconstrained route is rejected (no taint suppression), and all collected regexes for the name must individually be safe.

## What's new

- `src/Handlers/Routing/RouteParameterRegistry` — read-only singleton populated once at plugin boot.
- `src/Handlers/Routing/RouteParameterRegistryBuilder` — boot entry point; warns on resolve/scan failures, falls back to an empty registry.
- `src/Handlers/Routing/RouteScanner` — walks `app('router')->getRoutes()`, uses reflection on the protected `Router::$binders` to enumerate binders, reads return types via `ReflectionFunction::getReturnType()` and falls back to captured static variables for `Route::model()`.
- `src/Handlers/Routing/SafeRoutePattern` — verbatim string-match against a small whitelist mirroring Laravel's `whereAlpha` / `whereAlphaNumeric` / `whereNumber` / `whereUuid` / `whereUlid` / `whereIn` shorthand emit. Anchors are stripped; alternations of safe literals are accepted.
- `src/Handlers/Routing/RequestRouteReturnTypeProvider` and `RequestRouteTaintHandler` — coordinated override + partial re-add.
- `src/Util/MethodCallerResolver` — promoted from `Handlers\Validation\ValidationCallerResolver` once a second handler started consuming it. `InlineValidateRulesCollector` and `ValidationTaintHandler` updated to the new path.

## Out of scope

Per-route resolution (mapping a controller method to its route(s)) and implicit binding from typed controller parameters are not covered. Both would need additional infrastructure and were left for a follow-up.