### PR TITLE
Allow custom config directories for `NoEnvOutsideConfig`

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -25,6 +25,7 @@ Full config example:
         <findMissingTranslations value="true" />
         <findMissingViews value="true" />
         <failOnInternalError value="true" />
+        <configDirectory name="app/Config" />
     </pluginClass>
 </plugins>
 ```
@@ -94,6 +95,33 @@ See [MissingView](issues/MissingView.md) for details.
 
 ```xml
 <findMissingViews value="true" />
+```
+
+## `configDirectory`
+
+**default**: the booted Laravel app's `config_path()`
+
+Controls which directories are treated as config directories by [`NoEnvOutsideConfig`](issues/NoEnvOutsideConfig.md). `env()` calls inside any of these directories are exempt from the check.
+
+Each entry can be an absolute path or a path relative to where Psalm is invoked (typically the project root; PHP's `glob()` is used for resolution, so `<configDirectory>` is sensitive to your working directory). Glob patterns are supported and expanded once at plugin boot.
+
+**Defining any `<configDirectory>` replaces the default**, so include `config` (or whatever your project's standard config dir is) explicitly if you still want it covered. Test files (paths containing `/tests/`) are always exempt regardless of this setting.
+
+If no entry resolves to an existing directory at boot, the plugin emits a warning so the typo case (`<configDirectory name="cofnig" />`) is surfaced rather than silently flagging every `env()` call.
+
+### Examples
+
+A non-standard layout (e.g. BookStack's `app/Config/`):
+
+```xml
+<configDirectory name="app/Config" />
+```
+
+Standard `config/` plus monorepo package configs:
+
+```xml
+<configDirectory name="config" />
+<configDirectory name="packages/*/config" />
 ```
 
 ## Cache directory

--- a/docs/config.md
+++ b/docs/config.md
@@ -64,6 +64,33 @@ Disable if dynamic where resolution conflicts with your codebase.
 <resolveDynamicWhereClauses value="false" />
 ```
 
+## `configDirectory`
+
+**default**: the booted Laravel app's `config_path()`
+
+Controls which directories are treated as config directories by [`NoEnvOutsideConfig`](issues/NoEnvOutsideConfig.md). `env()` calls inside any of these directories are exempt from the check.
+
+Each entry can be an absolute path or a relative path resolved by PHP's `glob()` against the current working directory. Psalm sets the working directory to the directory containing `psalm.xml` by default (controlled by Psalm's `resolveFromConfigFile` option), so relative entries normally resolve from the project root. Absolute paths are recommended when running Psalm from a subdirectory or when several config files are in play. Glob patterns are supported and expanded once at plugin boot.
+
+**Defining any `<configDirectory>` replaces the default**, so include `config` (or whatever your project's standard config dir is) explicitly if you still want it covered. Test files (paths containing `/tests/`) are always exempt regardless of this setting.
+
+If no entry resolves to an existing directory at boot, the plugin emits a warning so the typo case (`<configDirectory name="cofnig" />`) is surfaced rather than silently flagging every `env()` call.
+
+### Examples
+
+A non-standard layout (e.g. BookStack's `app/Config/`):
+
+```xml
+<configDirectory name="app/Config" />
+```
+
+Standard `config/` plus monorepo package configs:
+
+```xml
+<configDirectory name="config" />
+<configDirectory name="packages/*/config" />
+```
+
 ## `findMissingTranslations`
 
 **default**: `false`
@@ -95,33 +122,6 @@ See [MissingView](issues/MissingView.md) for details.
 
 ```xml
 <findMissingViews value="true" />
-```
-
-## `configDirectory`
-
-**default**: the booted Laravel app's `config_path()`
-
-Controls which directories are treated as config directories by [`NoEnvOutsideConfig`](issues/NoEnvOutsideConfig.md). `env()` calls inside any of these directories are exempt from the check.
-
-Each entry can be an absolute path or a relative path resolved by PHP's `glob()` against the current working directory. Psalm sets the working directory to the directory containing `psalm.xml` by default (controlled by Psalm's `resolveFromConfigFile` option), so relative entries normally resolve from the project root. Absolute paths are recommended when running Psalm from a subdirectory or when several config files are in play. Glob patterns are supported and expanded once at plugin boot.
-
-**Defining any `<configDirectory>` replaces the default**, so include `config` (or whatever your project's standard config dir is) explicitly if you still want it covered. Test files (paths containing `/tests/`) are always exempt regardless of this setting.
-
-If no entry resolves to an existing directory at boot, the plugin emits a warning so the typo case (`<configDirectory name="cofnig" />`) is surfaced rather than silently flagging every `env()` call.
-
-### Examples
-
-A non-standard layout (e.g. BookStack's `app/Config/`):
-
-```xml
-<configDirectory name="app/Config" />
-```
-
-Standard `config/` plus monorepo package configs:
-
-```xml
-<configDirectory name="config" />
-<configDirectory name="packages/*/config" />
 ```
 
 ## Cache directory

--- a/docs/config.md
+++ b/docs/config.md
@@ -103,7 +103,7 @@ See [MissingView](issues/MissingView.md) for details.
 
 Controls which directories are treated as config directories by [`NoEnvOutsideConfig`](issues/NoEnvOutsideConfig.md). `env()` calls inside any of these directories are exempt from the check.
 
-Each entry can be an absolute path or a path relative to where Psalm is invoked (typically the project root; PHP's `glob()` is used for resolution, so `<configDirectory>` is sensitive to your working directory). Glob patterns are supported and expanded once at plugin boot.
+Each entry can be an absolute path or a relative path resolved by PHP's `glob()` against the current working directory. Psalm sets the working directory to the directory containing `psalm.xml` by default (controlled by Psalm's `resolveFromConfigFile` option), so relative entries normally resolve from the project root. Absolute paths are recommended when running Psalm from a subdirectory or when several config files are in play. Glob patterns are supported and expanded once at plugin boot.
 
 **Defining any `<configDirectory>` replaces the default**, so include `config` (or whatever your project's standard config dir is) explicitly if you still want it covered. Test files (paths containing `/tests/`) are always exempt regardless of this setting.
 

--- a/docs/issues/NoEnvOutsideConfig.md
+++ b/docs/issues/NoEnvOutsideConfig.md
@@ -6,7 +6,7 @@ nav_order: 1
 
 # NoEnvOutsideConfig
 
-Emitted when `env()` is called outside the `config/` directory.
+Emitted when `env()` is called outside the application's config directory (by default the booted app's [`config_path()`](../config.md#configdirectory); configurable via `<configDirectory>` for non-standard layouts).
 
 ## Why this is a problem
 
@@ -54,3 +54,16 @@ class PaymentService
 
 1. Move the `env()` call into a config file (e.g. `config/services.php`)
 2. Reference the value via `config()` in your application code
+
+## Custom config directories
+
+By default the plugin treats only the Laravel app's `config_path()` as a config directory. If your project keeps configuration elsewhere (for example BookStack's `app/Config/`) or you want to allow `env()` inside vendor packages, add `<configDirectory>` elements to your `psalm.xml`:
+
+```xml
+<pluginClass class="Psalm\LaravelPlugin\Plugin">
+    <configDirectory name="app/Config" />
+    <configDirectory name="packages/*/config" />
+</pluginClass>
+```
+
+See [Configuration](../config.md#configdirectory) for the full reference.

--- a/docs/issues/index.md
+++ b/docs/issues/index.md
@@ -8,7 +8,7 @@ has_children: true
 
 The plugin ships advanced Laravel-aware static analysis checks that extend Psalm's built-in diagnostics:
 
-- [NoEnvOutsideConfig](NoEnvOutsideConfig.md) — `env()` called outside `config/` directory
+- [NoEnvOutsideConfig](NoEnvOutsideConfig.md) — `env()` called outside the application's config directory
 - [InvalidConsoleArgumentName](InvalidConsoleArgumentName.md) — `argument()` references undefined console command argument
 - [InvalidConsoleOptionName](InvalidConsoleOptionName.md) — `option()` references undefined console command option
 - [MissingView](MissingView.md) — `view()` references a non-existent Blade template (opt-in)

--- a/docs/upgrade-v4.md
+++ b/docs/upgrade-v4.md
@@ -91,7 +91,7 @@ No flags needed — just run `./vendor/bin/psalm`.
 
 - `InvalidConsoleArgumentName` -- `argument()` references an undefined name in the command's `$signature`
 - `InvalidConsoleOptionName` -- `option()` references an undefined name in the command's `$signature`
-- `NoEnvOutsideConfig` -- `env()` called outside the `config/` directory (`env()` returns `null` when the config is cached)
+- `NoEnvOutsideConfig` -- `env()` called outside the application's [`config_path()`](config.md#configdirectory) (`env()` returns `null` when the config is cached). Configurable via `<configDirectory>` for non-standard layouts.
 
 ```xml
 <issueHandlers>

--- a/src/Handlers/Rules/NoEnvOutsideConfigHandler.php
+++ b/src/Handlers/Rules/NoEnvOutsideConfigHandler.php
@@ -8,19 +8,88 @@ use Psalm\IssueBuffer;
 use Psalm\LaravelPlugin\Issues\NoEnvOutsideConfig;
 use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
+use Psalm\Progress\Progress;
 use Psalm\Type\Union;
 
 /**
- * Reports env() calls outside the config/ directory.
+ * Reports env() calls outside the project's config directories.
  *
  * When config is cached (php artisan config:cache), the .env file is not loaded,
  * so env() returns null outside config files. Test files are excluded because
  * they run without config caching.
  *
+ * The set of "config directories" is configured via `<configDirectory name="..." />`
+ * elements in psalm.xml; when none are provided, the booted Laravel app's
+ * `config_path()` is used. Glob patterns are supported (e.g. `packages/* /config`)
+ * and resolved at plugin boot — runtime checks are a pure str_starts_with loop.
+ *
  * @see https://laravel.com/docs/configuration#configuration-caching
  */
 final class NoEnvOutsideConfigHandler implements FunctionReturnTypeProviderInterface
 {
+    /**
+     * Resolved absolute config directory paths, each with a trailing DIRECTORY_SEPARATOR.
+     * Stored once at boot via init() so the runtime check is a pure str_starts_with loop.
+     *
+     * @var list<string>
+     */
+    private static array $configDirectories = [];
+
+    /**
+     * Resolve user-provided config directory paths into absolute, glob-expanded paths.
+     *
+     * Each entry may be:
+     *   - an absolute or cwd-relative path (matches Larastan's convention),
+     *   - a glob pattern (e.g. `packages/* /config`).
+     *
+     * Resolution: glob() expansion → is_dir() guard → realpath() → trailing separator.
+     * Psalm reports normalised absolute paths for scanned files; realpath()-ing config
+     * dirs keeps both sides comparable across symlinks.
+     *
+     * Individual entries that fail to resolve are dropped silently — common when a glob
+     * matches nothing (e.g. `packages/* /config` in a project without packages yet).
+     * Passing an empty list explicitly resets state (test convenience). Otherwise, when
+     * a non-empty input resolves to no directories, a warning is emitted via $progress
+     * if provided — that's the typo case where every env() call would otherwise be flagged.
+     *
+     * @param list<string> $directories
+     */
+    public static function init(array $directories, ?Progress $progress = null): void
+    {
+        $resolved = [];
+
+        foreach ($directories as $directory) {
+            $matches = \glob($directory);
+
+            if ($matches === false) {
+                continue;
+            }
+
+            foreach ($matches as $match) {
+                if (!\is_dir($match)) {
+                    continue;
+                }
+
+                $real = \realpath($match);
+
+                if ($real === false) {
+                    continue;
+                }
+
+                $resolved[] = $real . \DIRECTORY_SEPARATOR;
+            }
+        }
+
+        self::$configDirectories = \array_values(\array_unique($resolved));
+
+        if ($directories !== [] && self::$configDirectories === [] && $progress instanceof \Psalm\Progress\Progress) {
+            $progress->warning(
+                'Laravel plugin: NoEnvOutsideConfig has no resolvable config directories — '
+                    . "every env() call will be flagged. Inputs: '" . \implode("', '", $directories) . "'.",
+            );
+        }
+    }
+
     /**
      * @inheritDoc
      * @psalm-pure
@@ -53,16 +122,16 @@ final class NoEnvOutsideConfigHandler implements FunctionReturnTypeProviderInter
         return null;
     }
 
-    /**
-     * Match any path with a `config` directory segment (case-insensitive).
-     * Covers apps, published packages, vendor dirs, and monorepo sub-packages.
-     * Case-insensitive to handle non-standard layouts like BookStack's app/Config/.
-     *
-     * @psalm-pure
-     */
+    /** @psalm-external-mutation-free */
     private static function isInsideConfigDirectory(string $filePath): bool
     {
-        return \str_contains(\strtolower($filePath), \DIRECTORY_SEPARATOR . 'config' . \DIRECTORY_SEPARATOR);
+        foreach (self::$configDirectories as $directory) {
+            if (\str_starts_with($filePath, $directory)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /** @psalm-pure */

--- a/src/Handlers/Rules/NoEnvOutsideConfigHandler.php
+++ b/src/Handlers/Rules/NoEnvOutsideConfigHandler.php
@@ -64,19 +64,16 @@ final class NoEnvOutsideConfigHandler implements FunctionReturnTypeProviderInter
         foreach ($directories as $directory) {
             // Try literal path first so paths with glob metacharacters (e.g. brackets in
             // `/home/user/dev[work]/config`) resolve correctly. Only fall back to glob()
-            // when the literal path isn't a directory.
+            // when the literal path isn't a directory. GLOB_ONLYDIR drops non-directory
+            // matches up-front; GLOB_NOSORT skips alphabetical sorting we don't need.
             if (\is_dir($directory)) {
                 $matches = [$directory];
             } else {
-                $globMatches = \glob($directory);
+                $globMatches = \glob($directory, \GLOB_ONLYDIR | \GLOB_NOSORT);
                 $matches = $globMatches === false ? [] : $globMatches;
             }
 
             foreach ($matches as $match) {
-                if (!\is_dir($match)) {
-                    continue;
-                }
-
                 $real = \realpath($match);
 
                 if ($real === false) {

--- a/src/Handlers/Rules/NoEnvOutsideConfigHandler.php
+++ b/src/Handlers/Rules/NoEnvOutsideConfigHandler.php
@@ -20,8 +20,9 @@ use Psalm\Type\Union;
  *
  * The set of "config directories" is configured via `<configDirectory name="..." />`
  * elements in psalm.xml; when none are provided, the booted Laravel app's
- * `config_path()` is used. Glob patterns are supported (e.g. `packages/* /config`)
- * and resolved at plugin boot — runtime checks are a pure str_starts_with loop.
+ * `config_path()` is used. Glob patterns are supported (e.g. `app/<wildcard>/config`,
+ * where the wildcard is `*`) and resolved at plugin boot. Runtime checks are a pure
+ * str_starts_with loop.
  *
  * @see https://laravel.com/docs/configuration#configuration-caching
  */
@@ -40,17 +41,19 @@ final class NoEnvOutsideConfigHandler implements FunctionReturnTypeProviderInter
      *
      * Each entry may be:
      *   - an absolute or cwd-relative path (matches Larastan's convention),
-     *   - a glob pattern (e.g. `packages/* /config`).
+     *   - a glob pattern with `*` as the wildcard (e.g. `app/<wildcard>/config`).
      *
-     * Resolution: glob() expansion → is_dir() guard → realpath() → trailing separator.
-     * Psalm reports normalised absolute paths for scanned files; realpath()-ing config
-     * dirs keeps both sides comparable across symlinks.
+     * Resolution: literal is_dir() check first (so paths containing glob metacharacters
+     * like `[` and `]` work), falling back to glob() expansion for actual patterns,
+     * then realpath() and trailing separator. Psalm reports normalised absolute paths
+     * for scanned files; realpath()-ing config dirs keeps both sides comparable across
+     * symlinks.
      *
      * Individual entries that fail to resolve are dropped silently — common when a glob
-     * matches nothing (e.g. `packages/* /config` in a project without packages yet).
-     * Passing an empty list explicitly resets state (test convenience). Otherwise, when
-     * a non-empty input resolves to no directories, a warning is emitted via $progress
-     * if provided — that's the typo case where every env() call would otherwise be flagged.
+     * matches nothing in a monorepo without packages yet. Passing an empty list
+     * explicitly resets state (test convenience). Otherwise, when a non-empty input
+     * resolves to no directories, a warning is emitted via $progress if provided —
+     * that's the typo case where every env() call would otherwise be flagged.
      *
      * @param list<string> $directories
      */
@@ -59,10 +62,14 @@ final class NoEnvOutsideConfigHandler implements FunctionReturnTypeProviderInter
         $resolved = [];
 
         foreach ($directories as $directory) {
-            $matches = \glob($directory);
-
-            if ($matches === false) {
-                continue;
+            // Try literal path first so paths with glob metacharacters (e.g. brackets in
+            // `/home/user/dev[work]/config`) resolve correctly. Only fall back to glob()
+            // when the literal path isn't a directory.
+            if (\is_dir($directory)) {
+                $matches = [$directory];
+            } else {
+                $globMatches = \glob($directory);
+                $matches = $globMatches === false ? [] : $globMatches;
             }
 
             foreach ($matches as $match) {
@@ -106,7 +113,9 @@ final class NoEnvOutsideConfigHandler implements FunctionReturnTypeProviderInter
     {
         $filePath = $event->getStatementsSource()->getFilePath();
 
-        if (self::isInsideConfigDirectory($filePath) || self::isTestFile($filePath)) {
+        // isTestFile is a single str_contains; isInsideConfigDirectory loops over every
+        // configured directory. Cheaper check first to short-circuit test files.
+        if (self::isTestFile($filePath) || self::isInsideConfigDirectory($filePath)) {
             return null;
         }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -51,6 +51,8 @@ final class Plugin implements PluginEntryPointInterface
                 $this->initMissingViewHandler($output);
             }
 
+            $this->initNoEnvOutsideConfigHandler($pluginConfig, $output);
+
             $this->registerHandlers($registration, $pluginConfig);
             $this->registerStubs($registration, $pluginConfig, $output);
         } catch (\Throwable $throwable) {
@@ -341,7 +343,7 @@ final class Plugin implements PluginEntryPointInterface
         // in registration order and stops at the first non-null return. NoEnvOutsideConfigHandler
         // always returns null (it only emits an issue), so the chain continues to EnvHandler for
         // type narrowing. Reversing the order would silently suppress the NoEnvOutsideConfig issue.
-        require_once __DIR__ . '/Handlers/Rules/NoEnvOutsideConfigHandler.php';
+        // (require_once for the handler ran in initNoEnvOutsideConfigHandler() before this method.)
         $registration->registerHooksFromClass(Handlers\Rules\NoEnvOutsideConfigHandler::class);
         require_once __DIR__ . '/Handlers/Helpers/EnvHandler.php';
         $registration->registerHooksFromClass(Handlers\Helpers\EnvHandler::class);
@@ -352,6 +354,28 @@ final class Plugin implements PluginEntryPointInterface
             require_once __DIR__ . '/Handlers/Views/MissingViewHandler.php';
             $registration->registerHooksFromClass(Handlers\Views\MissingViewHandler::class);
         }
+    }
+
+    /**
+     * Resolve config directory paths and pass them to NoEnvOutsideConfigHandler.
+     *
+     * When the user has not configured any `<configDirectory>` elements, fall back to
+     * the booted Laravel app's `config_path()`. Relative paths and glob patterns are
+     * left as-is — the handler resolves them via glob() + realpath() at this boot step.
+     *
+     * The handler emits a warning via $output if the resolution produces zero directories
+     * for a non-empty input — that's the typo case where every env() call would be flagged.
+     */
+    private function initNoEnvOutsideConfigHandler(PluginConfig $pluginConfig, \Psalm\Progress\Progress $output): void
+    {
+        $directories = $pluginConfig->configDirectories;
+
+        if ($directories === []) {
+            $directories = [ApplicationProvider::getApp()->configPath()];
+        }
+
+        require_once __DIR__ . '/Handlers/Rules/NoEnvOutsideConfigHandler.php';
+        Handlers\Rules\NoEnvOutsideConfigHandler::init($directories, $output);
     }
 
     /**

--- a/src/PluginConfig.php
+++ b/src/PluginConfig.php
@@ -23,12 +23,12 @@ final readonly class PluginConfig
      */
     private function __construct(
         public ColumnFallback $modelPropertiesColumnFallback,
+        public array $configDirectories,
         public bool $resolveDynamicWhereClauses,
         public bool $findMissingTranslations,
         public bool $findMissingViews,
         public string $cachePath,
         public bool $failOnInternalError,
-        public array $configDirectories,
     ) {}
 
     public static function fromXml(?\SimpleXMLElement $config): self
@@ -55,12 +55,12 @@ final readonly class PluginConfig
 
         return new self(
             modelPropertiesColumnFallback: $columnFallback,
+            configDirectories: $configDirectories,
             resolveDynamicWhereClauses: $resolveDynamicWhereClauses,
             findMissingTranslations: $findMissingTranslations,
             findMissingViews: $findMissingViews,
             cachePath: self::resolveCachePath(),
             failOnInternalError: $failOnInternalError,
-            configDirectories: $configDirectories,
         );
     }
 

--- a/src/PluginConfig.php
+++ b/src/PluginConfig.php
@@ -16,7 +16,11 @@ use Psalm\Config;
  */
 final readonly class PluginConfig
 {
-    /** @psalm-mutation-free */
+    /**
+     * @param list<string> $configDirectories
+     *
+     * @psalm-mutation-free
+     */
     private function __construct(
         public ColumnFallback $modelPropertiesColumnFallback,
         public bool $resolveDynamicWhereClauses,
@@ -24,6 +28,7 @@ final readonly class PluginConfig
         public bool $findMissingViews,
         public string $cachePath,
         public bool $failOnInternalError,
+        public array $configDirectories,
     ) {}
 
     public static function fromXml(?\SimpleXMLElement $config): self
@@ -46,6 +51,7 @@ final readonly class PluginConfig
         $findMissingTranslations = self::xmlBoolAttr($config?->findMissingTranslations, 'findMissingTranslations');
         $findMissingViews = self::xmlBoolAttr($config?->findMissingViews, 'findMissingViews');
         $resolveDynamicWhereClauses = self::xmlBoolAttr($config?->resolveDynamicWhereClauses, 'resolveDynamicWhereClauses', true);
+        $configDirectories = self::xmlNameList($config, 'configDirectory');
 
         return new self(
             modelPropertiesColumnFallback: $columnFallback,
@@ -54,6 +60,7 @@ final readonly class PluginConfig
             findMissingViews: $findMissingViews,
             cachePath: self::resolveCachePath(),
             failOnInternalError: $failOnInternalError,
+            configDirectories: $configDirectories,
         );
     }
 
@@ -61,6 +68,37 @@ final readonly class PluginConfig
     public function shouldUseMigrations(): bool
     {
         return $this->modelPropertiesColumnFallback === ColumnFallback::Migrations;
+    }
+
+    /**
+     * Read repeating elements like `<configDirectory name="..." />` as a list of `name` values.
+     * Empty `name` attributes are skipped so a stray `<configDirectory />` does not produce "".
+     *
+     * The `iterable<\SimpleXMLElement>` annotation on `$children` is necessary because
+     * Psalm's SimpleXMLElement stub types dynamic-property iteration as `mixed`.
+     *
+     * @return list<string>
+     */
+    private static function xmlNameList(?\SimpleXMLElement $config, string $element): array
+    {
+        if (!$config instanceof \SimpleXMLElement) {
+            return [];
+        }
+
+        /** @psalm-var iterable<\SimpleXMLElement> $children */
+        $children = $config->{$element};
+
+        $values = [];
+
+        foreach ($children as $node) {
+            $value = (string) ($node['name'] ?? '');
+
+            if ($value !== '') {
+                $values[] = $value;
+            }
+        }
+
+        return $values;
     }
 
     /**

--- a/src/PluginConfig.php
+++ b/src/PluginConfig.php
@@ -72,7 +72,10 @@ final readonly class PluginConfig
 
     /**
      * Read repeating elements like `<configDirectory name="..." />` as a list of `name` values.
-     * Empty `name` attributes are skipped so a stray `<configDirectory />` does not produce "".
+     *
+     * Throws on any element that lacks a non-empty `name` attribute so user typos like
+     * `<configDirectory path="..." />` (wrong attribute) or a stray `<configDirectory />`
+     * surface immediately instead of silently falling back to the default config_path().
      *
      * The `iterable<\SimpleXMLElement>` annotation on `$children` is necessary because
      * Psalm's SimpleXMLElement stub types dynamic-property iteration as `mixed`.
@@ -93,9 +96,13 @@ final readonly class PluginConfig
         foreach ($children as $node) {
             $value = (string) ($node['name'] ?? '');
 
-            if ($value !== '') {
-                $values[] = $value;
+            if ($value === '') {
+                throw new \InvalidArgumentException(
+                    "<{$element}> requires a non-empty `name` attribute, e.g. <{$element} name=\"app/Config\" />.",
+                );
             }
+
+            $values[] = $value;
         }
 
         return $values;

--- a/src/Util/IssueUrlGenerator.php
+++ b/src/Util/IssueUrlGenerator.php
@@ -89,7 +89,29 @@ final class IssueUrlGenerator
             '- findMissingViews: ' . self::formatBool($pluginConfig->findMissingViews),
             '- cachePath: ' . self::sanitizeCachePath($pluginConfig->cachePath),
             '- failOnInternalError: ' . self::formatBool($pluginConfig->failOnInternalError),
+            '- configDirectories: ' . self::formatConfigDirectories($pluginConfig->configDirectories),
         ];
+    }
+
+    /**
+     * Render configDirectories for the bug-report body.
+     *
+     * Empty rendering is `[] (default: config_path())` to make triage unambiguous —
+     * an empty list in PluginConfig means "user did not opt in via XML, plugin used
+     * the booted app's config_path() at runtime".
+     *
+     * Each non-empty entry is anonymised the same way as $cachePath so a misconfigured
+     * config directory does not leak the user's home directory or absolute paths.
+     *
+     * @param list<string> $values
+     */
+    private static function formatConfigDirectories(array $values): string
+    {
+        if ($values === []) {
+            return '[] (default: config_path())';
+        }
+
+        return '[' . \implode(', ', \array_map(self::sanitizeCachePath(...), $values)) . ']';
     }
 
     /** @psalm-pure */

--- a/tests/Unit/Handlers/Rules/NoEnvOutsideConfigHandlerTest.php
+++ b/tests/Unit/Handlers/Rules/NoEnvOutsideConfigHandlerTest.php
@@ -7,7 +7,6 @@ namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Rules;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psalm\CodeLocation;
@@ -16,79 +15,127 @@ use Psalm\LaravelPlugin\Handlers\Rules\NoEnvOutsideConfigHandler;
 use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
 use Psalm\StatementsSource;
 
+/**
+ * Tests use real filesystem fixtures because the handler resolves config directories
+ * via realpath() + is_dir() at init() time. Faking paths via DIRECTORY_SEPARATOR strings
+ * (the previous approach) silently passed because the old implementation only matched
+ * on path segments — that's exactly the gap issue #858 addresses.
+ */
 #[CoversClass(NoEnvOutsideConfigHandler::class)]
 final class NoEnvOutsideConfigHandlerTest extends TestCase
 {
+    private string $tempRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tempRoot = \sys_get_temp_dir()
+            . \DIRECTORY_SEPARATOR
+            . \uniqid('psalm-laravel-noenvtest-', true);
+
+        \mkdir($this->tempRoot, 0o777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        // init([]) doubles as a reset — empties resolved state without warning
+        // (the typo-warning needs both a non-empty input AND a Progress).
+        NoEnvOutsideConfigHandler::init([]);
+        $this->removeRecursively($this->tempRoot);
+
+        parent::tearDown();
+    }
+
     #[Test]
     public function returns_env_function_id(): void
     {
         $this->assertSame(['env'], NoEnvOutsideConfigHandler::getFunctionIds());
     }
 
-    /**
-     * Paths are built from DIRECTORY_SEPARATOR to stay consistent with the handler,
-     * which uses DIRECTORY_SEPARATOR for its segment match. Psalm normalizes file
-     * paths to the host separator before dispatching to plugins.
-     *
-     * @return iterable<string, array{string}>
-     */
-    public static function allowedFileProvider(): iterable
+    #[Test]
+    public function skips_files_inside_default_config_directory(): void
     {
-        $s = \DIRECTORY_SEPARATOR;
+        $configDir = $this->makeDir('config');
+        NoEnvOutsideConfigHandler::init([$configDir]);
 
-        yield 'app config file' => ["{$s}project{$s}config{$s}app.php"];
-        yield 'app config subdirectory' => ["{$s}project{$s}config{$s}services{$s}api.php"];
-        yield 'package config' => ["{$s}home{$s}dev{$s}spatie{$s}laravel-backup{$s}config{$s}backup.php"];
-        yield 'monorepo sub-package config' => ["{$s}monorepo{$s}packages{$s}forms{$s}config{$s}forms.php"];
-        yield 'vendor package config' => ["{$s}project{$s}vendor{$s}spatie{$s}laravel-backup{$s}config{$s}backup.php"];
-        yield 'uppercase Config directory (BookStack-style)' => ["{$s}project{$s}app{$s}Config{$s}app.php"];
-        yield 'test file' => ["{$s}project{$s}tests{$s}Unit{$s}MyTest.php"];
-        yield 'feature test' => ["{$s}project{$s}tests{$s}Feature{$s}MyTest.php"];
+        $event = $this->makeEvent($configDir . \DIRECTORY_SEPARATOR . 'app.php');
+
+        $this->assertNull(NoEnvOutsideConfigHandler::getFunctionReturnType($event));
     }
 
-    /**
-     * The handler always returns null — it only emits an issue as a side effect.
-     * For allowed files, no issue is emitted, so the return value is null and
-     * downstream EnvHandler runs afterwards to narrow the return type.
-     * If the handler incorrectly tried to emit an issue here, IssueBuffer::accepts()
-     * would throw because no Psalm runtime is initialized in unit tests.
-     */
     #[Test]
-    #[DataProvider('allowedFileProvider')]
-    public function skips_allowed_files(string $filePath): void
+    public function skips_files_in_nested_config_subdirectory(): void
     {
-        $event = $this->createEvent($filePath);
+        $configDir = $this->makeDir('config');
+        $this->makeDir('config/services');
+        NoEnvOutsideConfigHandler::init([$configDir]);
+
+        $event = $this->makeEvent($configDir . \DIRECTORY_SEPARATOR . 'services' . \DIRECTORY_SEPARATOR . 'api.php');
+
+        $this->assertNull(NoEnvOutsideConfigHandler::getFunctionReturnType($event));
+    }
+
+    #[Test]
+    public function skips_test_files_regardless_of_config_directory(): void
+    {
+        $configDir = $this->makeDir('config');
+        $testsDir = $this->makeDir('tests');
+        NoEnvOutsideConfigHandler::init([$configDir]);
+
+        $event = $this->makeEvent($testsDir . \DIRECTORY_SEPARATOR . 'Unit' . \DIRECTORY_SEPARATOR . 'MyTest.php');
 
         $this->assertNull(NoEnvOutsideConfigHandler::getFunctionReturnType($event));
     }
 
     /**
-     * Sanity check for the structural matcher: paths without a path segment named
-     * `config` (including substring look-alikes like `configuration/` and `.config/`)
-     * should be treated as outside the config directory.
-     *
-     * Reaching the emit branch calls IssueBuffer::accepts(), which delegates to
-     * Config::getInstance() and throws UnexpectedValueException('No config initialized')
-     * when Psalm isn't bootstrapped. We assert that specific exception to confirm the
-     * handler actually reached issue emission, rather than throwing somewhere earlier.
-     *
-     * @return iterable<string, array{string}>
+     * Acceptance criterion from issue #858: BookStack uses `app/Config/` instead of `config/`.
+     * With the user-configured directory, env() calls there are no longer flagged.
      */
-    public static function rejectedFileProvider(): iterable
+    #[Test]
+    public function skips_user_configured_directory(): void
     {
-        $s = \DIRECTORY_SEPARATOR;
+        $bookstackConfig = $this->makeDir('app/Config');
+        NoEnvOutsideConfigHandler::init([$bookstackConfig]);
 
-        yield 'application code' => ["{$s}project{$s}app{$s}Services{$s}PaymentService.php"];
-        yield 'substring-not-segment (prefix)' => ["{$s}project{$s}app{$s}configuration{$s}Foo.php"];
-        yield 'substring-not-segment (suffix)' => ["{$s}project{$s}app{$s}myconfig{$s}Foo.php"];
-        yield 'hidden config dir' => ["{$s}project{$s}.config{$s}foo.php"];
+        $event = $this->makeEvent($bookstackConfig . \DIRECTORY_SEPARATOR . 'app.php');
+
+        $this->assertNull(NoEnvOutsideConfigHandler::getFunctionReturnType($event));
     }
 
+    /**
+     * Acceptance criterion from issue #858: glob patterns expand at init() time.
+     * `packages/* /config` matches every package's config directory in a monorepo.
+     */
     #[Test]
-    #[DataProvider('rejectedFileProvider')]
-    public function rejects_non_config_files(string $filePath): void
+    public function skips_glob_pattern_matched_directories(): void
     {
-        $event = $this->createEvent($filePath);
+        $formsConfig = $this->makeDir('packages/forms/config');
+        $tablesConfig = $this->makeDir('packages/tables/config');
+
+        NoEnvOutsideConfigHandler::init([$this->tempRoot . \DIRECTORY_SEPARATOR . 'packages/*/config']);
+
+        $eventForms = $this->makeEvent($formsConfig . \DIRECTORY_SEPARATOR . 'forms.php');
+        $eventTables = $this->makeEvent($tablesConfig . \DIRECTORY_SEPARATOR . 'tables.php');
+
+        $this->assertNull(NoEnvOutsideConfigHandler::getFunctionReturnType($eventForms));
+        $this->assertNull(NoEnvOutsideConfigHandler::getFunctionReturnType($eventTables));
+    }
+
+    /**
+     * Reaching the emit branch calls IssueBuffer::accepts(), which delegates to
+     * Config::getInstance() and throws UnexpectedValueException('No config initialized')
+     * when Psalm isn't bootstrapped. Asserting that exception confirms the handler
+     * actually reached issue emission, rather than throwing somewhere earlier.
+     */
+    #[Test]
+    public function rejects_application_code_outside_config_directory(): void
+    {
+        $configDir = $this->makeDir('config');
+        $appDir = $this->makeDir('app/Services');
+        NoEnvOutsideConfigHandler::init([$configDir]);
+
+        $event = $this->makeEvent($appDir . \DIRECTORY_SEPARATOR . 'PaymentService.php');
 
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessageMatches('/config.*initializ|initializ.*config/i');
@@ -96,7 +143,135 @@ final class NoEnvOutsideConfigHandlerTest extends TestCase
         NoEnvOutsideConfigHandler::getFunctionReturnType($event);
     }
 
-    private function createEvent(string $filePath): FunctionReturnTypeProviderEvent
+    /**
+     * Without an opt-in, vendor packages no longer suppress the issue — closing the
+     * "false negative" gap from issue #858. Users wanting to allow vendor configs
+     * must add `<configDirectory name="vendor/foo/bar/config" />`.
+     */
+    #[Test]
+    public function rejects_vendor_package_config_when_not_opted_in(): void
+    {
+        $configDir = $this->makeDir('config');
+        $vendorConfig = $this->makeDir('vendor/spatie/laravel-backup/config');
+        NoEnvOutsideConfigHandler::init([$configDir]);
+
+        $event = $this->makeEvent($vendorConfig . \DIRECTORY_SEPARATOR . 'backup.php');
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessageMatches('/config.*initializ|initializ.*config/i');
+
+        NoEnvOutsideConfigHandler::getFunctionReturnType($event);
+    }
+
+    /**
+     * Substring look-alikes (e.g. `configuration/`, `myconfig/`) — the old
+     * str_contains heuristic could be tricked here; str_starts_with cannot.
+     */
+    #[Test]
+    public function rejects_substring_lookalike_directories(): void
+    {
+        $configDir = $this->makeDir('config');
+        $lookalikeDir = $this->makeDir('app/configuration');
+        NoEnvOutsideConfigHandler::init([$configDir]);
+
+        $event = $this->makeEvent($lookalikeDir . \DIRECTORY_SEPARATOR . 'Foo.php');
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessageMatches('/config.*initializ|initializ.*config/i');
+
+        NoEnvOutsideConfigHandler::getFunctionReturnType($event);
+    }
+
+    /**
+     * Non-existent or non-directory entries are silently skipped — the plugin can't
+     * tell a glob with no matches yet from a misconfigured path. With no resolvable
+     * directories, no path matches, so application files emit the issue as expected.
+     */
+    #[Test]
+    public function init_drops_non_existent_paths(): void
+    {
+        $appDir = $this->makeDir('app');
+        NoEnvOutsideConfigHandler::init([
+            $this->tempRoot . \DIRECTORY_SEPARATOR . 'does-not-exist',
+            $this->tempRoot . \DIRECTORY_SEPARATOR . 'glob-with-no-matches/*',
+        ]);
+
+        $event = $this->makeEvent($appDir . \DIRECTORY_SEPARATOR . 'Foo.php');
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessageMatches('/config.*initializ|initializ.*config/i');
+
+        NoEnvOutsideConfigHandler::getFunctionReturnType($event);
+    }
+
+    /**
+     * If the user typos every <configDirectory> entry, the resolved list is empty and
+     * every env() call would be flagged. Surface a warning instead of failing silently.
+     */
+    #[Test]
+    public function init_warns_when_non_empty_input_resolves_to_empty(): void
+    {
+        $progress = new RecordingProgress();
+
+        NoEnvOutsideConfigHandler::init(
+            [$this->tempRoot . \DIRECTORY_SEPARATOR . 'cofnig-typo'],
+            $progress,
+        );
+
+        $this->assertSame(1, $progress->warningCount, 'expected exactly one warning');
+        $this->assertStringContainsString('NoEnvOutsideConfig', $progress->lastWarning);
+        $this->assertStringContainsString('cofnig-typo', $progress->lastWarning);
+    }
+
+    /**
+     * A glob that matches nothing (or any other silent drop) is normal and must not warn
+     * as long as at least one entry resolves successfully — projects often configure
+     * patterns like `packages/* /config` for monorepos that may be empty initially.
+     */
+    #[Test]
+    public function init_does_not_warn_when_at_least_one_entry_resolves(): void
+    {
+        $configDir = $this->makeDir('config');
+        $progress = new RecordingProgress();
+
+        NoEnvOutsideConfigHandler::init(
+            [$configDir, $this->tempRoot . \DIRECTORY_SEPARATOR . 'unmatched/*/config'],
+            $progress,
+        );
+
+        $this->assertSame(0, $progress->warningCount, 'expected no warning when at least one entry resolves');
+    }
+
+    /**
+     * Empty input is a legitimate "reset" path used by tests; init() must not warn.
+     */
+    #[Test]
+    public function init_does_not_warn_on_empty_input(): void
+    {
+        $progress = new RecordingProgress();
+
+        NoEnvOutsideConfigHandler::init([], $progress);
+
+        $this->assertSame(0, $progress->warningCount);
+    }
+
+    private function makeDir(string $relativePath): string
+    {
+        $full = $this->tempRoot
+            . \DIRECTORY_SEPARATOR
+            . \str_replace('/', \DIRECTORY_SEPARATOR, $relativePath);
+
+        if (!\is_dir($full)) {
+            \mkdir($full, 0o777, true);
+        }
+
+        $real = \realpath($full);
+        \assert(\is_string($real), "Failed to realpath '{$full}'");
+
+        return $real;
+    }
+
+    private function makeEvent(string $filePath): FunctionReturnTypeProviderEvent
     {
         $source = $this->createStub(StatementsSource::class);
         $source->method('getFilePath')->willReturn($filePath);
@@ -114,5 +289,63 @@ final class NoEnvOutsideConfigHandlerTest extends TestCase
             new Context(),
             new CodeLocation($source, $funcCall),
         );
+    }
+
+    private function removeRecursively(string $path): void
+    {
+        if (!\is_dir($path)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        /** @var \SplFileInfo $entry */
+        foreach ($iterator as $entry) {
+            $entry->isDir() ? \rmdir($entry->getPathname()) : \unlink($entry->getPathname());
+        }
+
+        \rmdir($path);
+    }
+}
+
+/**
+ * Test-only Progress that records warnings without writing to STDERR.
+ * Other Progress hooks are no-ops because the handler only uses warning().
+ */
+final class RecordingProgress extends \Psalm\Progress\Progress
+{
+    public int $warningCount = 0;
+
+    public string $lastWarning = '';
+
+    #[\Override]
+    public function debug(string $message): void {}
+
+    #[\Override]
+    public function startPhase(\Psalm\Progress\Phase $phase, int $threads = 1): void {}
+
+    #[\Override]
+    public function expand(int $number_of_tasks): void {}
+
+    #[\Override]
+    public function taskDone(int $level): void {}
+
+    #[\Override]
+    public function finish(): void {}
+
+    #[\Override]
+    public function alterFileDone(string $file_name): void {}
+
+    #[\Override]
+    public function write(string $message): void {}
+
+    #[\Override]
+    public function warning(string $message): void
+    {
+        $this->warningCount++;
+        $this->lastWarning = $message;
     }
 }

--- a/tests/Unit/Handlers/Rules/NoEnvOutsideConfigHandlerTest.php
+++ b/tests/Unit/Handlers/Rules/NoEnvOutsideConfigHandlerTest.php
@@ -104,8 +104,8 @@ final class NoEnvOutsideConfigHandlerTest extends TestCase
     }
 
     /**
-     * Acceptance criterion from issue #858: glob patterns expand at init() time.
-     * `packages/* /config` matches every package's config directory in a monorepo.
+     * Acceptance criterion from issue #858: glob patterns expand at init() time and
+     * match every package's config directory in a monorepo.
      */
     #[Test]
     public function skips_glob_pattern_matched_directories(): void
@@ -120,6 +120,50 @@ final class NoEnvOutsideConfigHandlerTest extends TestCase
 
         $this->assertNull(NoEnvOutsideConfigHandler::getFunctionReturnType($eventForms));
         $this->assertNull(NoEnvOutsideConfigHandler::getFunctionReturnType($eventTables));
+    }
+
+    /**
+     * Regression for the glob-metacharacter bug: a literal path like `dev[work]/config`
+     * must resolve via the is_dir() fast path, not through glob() — glob would
+     * interpret `[work]` as a character class and return no matches.
+     */
+    #[Test]
+    public function skips_literal_path_with_glob_metacharacters(): void
+    {
+        $configDir = $this->makeDir('dev[work]/config');
+        NoEnvOutsideConfigHandler::init([$configDir]);
+
+        $event = $this->makeEvent($configDir . \DIRECTORY_SEPARATOR . 'app.php');
+
+        $this->assertNull(NoEnvOutsideConfigHandler::getFunctionReturnType($event));
+    }
+
+    /**
+     * Glob patterns may be relative to the cwd (Larastan convention). Verifies the
+     * fallback to glob() runs when the literal path isn't a directory.
+     */
+    #[Test]
+    public function skips_relative_glob_pattern(): void
+    {
+        // makeDir() returns realpath() so it survives the symlinked tmp dir on macOS
+        // (/var/folders/... → /private/var/folders/...).
+        $formsConfig = $this->makeDir('packages/forms/config');
+        $tempRootReal = \realpath($this->tempRoot);
+        \assert(\is_string($tempRootReal));
+
+        $cwd = \getcwd();
+        \assert(\is_string($cwd));
+
+        try {
+            \chdir($tempRootReal);
+            NoEnvOutsideConfigHandler::init(['packages/*/config']);
+        } finally {
+            \chdir($cwd);
+        }
+
+        $event = $this->makeEvent($formsConfig . \DIRECTORY_SEPARATOR . 'forms.php');
+
+        $this->assertNull(NoEnvOutsideConfigHandler::getFunctionReturnType($event));
     }
 
     /**
@@ -226,7 +270,8 @@ final class NoEnvOutsideConfigHandlerTest extends TestCase
     /**
      * A glob that matches nothing (or any other silent drop) is normal and must not warn
      * as long as at least one entry resolves successfully — projects often configure
-     * patterns like `packages/* /config` for monorepos that may be empty initially.
+     * monorepo glob patterns for `packages/<wildcard>/config` directories that may be
+     * empty initially.
      */
     #[Test]
     public function init_does_not_warn_when_at_least_one_entry_resolves(): void

--- a/tests/Unit/PluginConfigTest.php
+++ b/tests/Unit/PluginConfigTest.php
@@ -44,6 +44,52 @@ final class PluginConfigTest extends TestCase
         $this->assertFalse($config->findMissingTranslations);
         $this->assertFalse($config->findMissingViews);
         $this->assertTrue($config->resolveDynamicWhereClauses);
+        $this->assertSame([], $config->configDirectories);
+    }
+
+    #[Test]
+    public function config_directories_single_entry(): void
+    {
+        $xml = new \SimpleXMLElement('<pluginClass><configDirectory name="app/Config" /></pluginClass>');
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertSame(['app/Config'], $config->configDirectories);
+    }
+
+    #[Test]
+    public function config_directories_multiple_entries_preserve_order(): void
+    {
+        $xml = new \SimpleXMLElement(
+            '<pluginClass>'
+            . '<configDirectory name="app/Config" />'
+            . '<configDirectory name="packages/*/config" />'
+            . '<configDirectory name="vendor/foo/bar/config" />'
+            . '</pluginClass>',
+        );
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertSame(
+            ['app/Config', 'packages/*/config', 'vendor/foo/bar/config'],
+            $config->configDirectories,
+        );
+    }
+
+    #[Test]
+    public function config_directories_skip_empty_name_attributes(): void
+    {
+        $xml = new \SimpleXMLElement(
+            '<pluginClass>'
+            . '<configDirectory name="app/Config" />'
+            . '<configDirectory name="" />'
+            . '<configDirectory />'
+            . '</pluginClass>',
+        );
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertSame(['app/Config'], $config->configDirectories);
     }
 
     #[Test]
@@ -282,6 +328,8 @@ final class PluginConfigTest extends TestCase
             . '<failOnInternalError value="true" />'
             . '<findMissingTranslations value="true" />'
             . '<findMissingViews value="true" />'
+            . '<configDirectory name="app/Config" />'
+            . '<configDirectory name="packages/*/config" />'
             . '</pluginClass>',
         );
 
@@ -293,5 +341,6 @@ final class PluginConfigTest extends TestCase
         $this->assertTrue($config->findMissingViews);
         $this->assertSame('/tmp/psalm-test', $config->cachePath);
         $this->assertTrue($config->failOnInternalError);
+        $this->assertSame(['app/Config', 'packages/*/config'], $config->configDirectories);
     }
 }

--- a/tests/Unit/PluginConfigTest.php
+++ b/tests/Unit/PluginConfigTest.php
@@ -77,19 +77,38 @@ final class PluginConfigTest extends TestCase
     }
 
     #[Test]
-    public function config_directories_skip_empty_name_attributes(): void
+    public function config_directories_throw_on_empty_name_attribute(): void
     {
         $xml = new \SimpleXMLElement(
             '<pluginClass>'
             . '<configDirectory name="app/Config" />'
             . '<configDirectory name="" />'
-            . '<configDirectory />'
             . '</pluginClass>',
         );
 
-        $config = PluginConfig::fromXml($xml);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/<configDirectory> requires a non-empty `name` attribute/');
 
-        $this->assertSame(['app/Config'], $config->configDirectories);
+        PluginConfig::fromXml($xml);
+    }
+
+    #[Test]
+    public function config_directories_throw_on_missing_name_attribute(): void
+    {
+        // Catches typos like <configDirectory path="..." /> where the user used the wrong
+        // attribute name — without this guard the element is silently dropped and the
+        // typo-warning behaviour kicks in only when *every* entry is malformed.
+        $xml = new \SimpleXMLElement(
+            '<pluginClass>'
+            . '<configDirectory name="app/Config" />'
+            . '<configDirectory path="packages/forms/config" />'
+            . '</pluginClass>',
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/<configDirectory> requires a non-empty `name` attribute/');
+
+        PluginConfig::fromXml($xml);
     }
 
     #[Test]

--- a/tests/Unit/Util/IssueUrlGeneratorTest.php
+++ b/tests/Unit/Util/IssueUrlGeneratorTest.php
@@ -184,6 +184,55 @@ final class IssueUrlGeneratorTest extends TestCase
     }
 
     /**
+     * An empty configDirectories list is the implicit-default case (no XML opt-in).
+     * Triage needs to see "default" rather than "[]" so the bug-report reader knows
+     * the plugin used config_path() at runtime, not literally an empty list.
+     */
+    #[Test]
+    public function body_renders_empty_config_directories_as_default(): void
+    {
+        $body = $this->bodyFrom(IssueUrlGenerator::generate(new \RuntimeException('boom'), $this->defaultConfig()));
+
+        $this->assertStringContainsString('- configDirectories: [] (default: config_path())', $body);
+    }
+
+    /**
+     * Non-empty configDirectories render comma-separated, with each entry passed through
+     * sanitizeCachePath(). Relative entries have no prefix to collapse and pass through
+     * unchanged; absolute entries under $HOME, cwd, or tmp must collapse to anonymised
+     * forms so the bug-report body does not leak filesystem layout.
+     *
+     * Uses sys_get_temp_dir() rather than cwd because cwd reliably appears elsewhere in
+     * the rendered body (RuntimeException trace frames pointing into tests/), so a
+     * "body does not contain $cwd" assertion would always fail. The temp-dir branch of
+     * sanitizeCachePath is equivalent — both exercise the str_starts_with prefix collapse.
+     */
+    #[Test]
+    public function body_anonymises_absolute_config_directory_paths(): void
+    {
+        $tmp = \sys_get_temp_dir();
+        $absoluteUnderTmp = $tmp . \DIRECTORY_SEPARATOR . 'fake' . \DIRECTORY_SEPARATOR . 'Config';
+
+        $xml = new \SimpleXMLElement(
+            '<pluginClass>'
+            . '<configDirectory name="' . \htmlspecialchars($absoluteUnderTmp, \ENT_XML1) . '" />'
+            . '<configDirectory name="packages/*/config" />'
+            . '</pluginClass>',
+        );
+        $config = PluginConfig::fromXml($xml);
+
+        $body = $this->bodyFrom(IssueUrlGenerator::generate(new \RuntimeException('boom'), $config));
+
+        // Absolute entry collapses to "<tmp>/fake/Config" via sanitizeCachePath's tmp branch.
+        // Relative "packages/*/config" has no prefix to collapse and passes through.
+        $this->assertStringContainsString(
+            '- configDirectories: [<tmp>' . \DIRECTORY_SEPARATOR . 'fake' . \DIRECTORY_SEPARATOR . 'Config, packages/*/config]',
+            $body,
+        );
+        $this->assertStringNotContainsString($absoluteUnderTmp, $body);
+    }
+
+    /**
      * Vendor fallback: an absolute prefix containing a vendor/ segment collapses
      * to a relative vendor/... path — useful for the uncommon case where the
      * cache sits inside a checkout rather than under cwd / tmp / HOME.


### PR DESCRIPTION
## Summary

Closes #858.

`NoEnvOutsideConfigHandler` previously matched any path segment named `config` via case-insensitive `str_contains`. That heuristic produced two failures:

- **False negatives**: any path containing `/config/` anywhere (e.g. a vendor package's own `config/`) suppressed the issue, even when the `env()` call was genuinely outside the project's config.
- **False positives**: apps storing config files outside the standard `config/` directory (e.g. BookStack's `app/Config/`) got flagged even though those files are legitimate config files.

This PR adds a `<configDirectory>` XML option (flat repeating elements) so users can declare the exact config paths for their project. When no element is configured the plugin falls back to the booted Laravel app's `config_path()`, mirroring [Larastan's approach](https://github.com/larastan/larastan/blob/master/src/Rules/NoEnvCallsOutsideOfConfigRule.php).

```xml
<pluginClass class="Psalm\LaravelPlugin\Plugin">
    <configDirectory name="app/Config" />
    <configDirectory name="packages/*/config" />
</pluginClass>
```

## Implementation notes

- Resolution (glob expansion → `is_dir()` → `realpath()` → trailing separator) runs once at plugin boot. The per-call check is a pure `str_starts_with` loop, so the hot path stays cheap.
- When a non-empty input resolves to zero directories (typo case), `init()` emits a warning via Psalm's `Progress` instead of silently flagging every `env()` call.
- `IssueUrlGenerator` renders `configDirectories` in bug reports, sanitising absolute paths the same way `cachePath` is sanitised. An empty list renders as `[] (default: config_path())` so triage knows the implicit default is in use.
- `/tests/` exemption is preserved (acceptance criterion); the `<configDirectory>` setting only governs the config-path branch.

## Acceptance criteria

- [x] Default (no XML option): `config_path()` is used; files under that directory are suppressed.
- [x] Custom directories: user-specified paths (including glob patterns) override the default.
- [x] BookStack `app/Config/` scenario: adding `<configDirectory name="app/Config" />` silences the false positives.
- [x] Existing unit tests pass; new tests cover the XML parsing and the default fallback.