### PR TITLE
Provide template type info for Relation methods

### DIFF
--- a/src/Handlers/Eloquent/ModelRegistrationHandler.php
+++ b/src/Handlers/Eloquent/ModelRegistrationHandler.php
@@ -198,6 +198,15 @@ final class ModelRegistrationHandler implements AfterCodebasePopulatedInterface
             $className,
             CustomCollectionHandler::getModelMethodReturnType(...),
         );
+        // Relationship method return types: precise generics for hasOne/belongsTo/etc.
+        // Registered AFTER the forwarding/collection providers because those handlers
+        // already returned null for relation method names. The first non-null result
+        // wins, so safe ordering — no return-type swap relative to the prior chain.
+        // See https://github.com/psalm/psalm-plugin-laravel/issues/760
+        $methods->return_type_provider->registerClosure(
+            $className,
+            ModelRelationReturnTypeHandler::getReturnType(...),
+        );
 
         // Registration order matters — the first non-null result wins.
 

--- a/src/Handlers/Eloquent/ModelRelationReturnTypeHandler.php
+++ b/src/Handlers/Eloquent/ModelRelationReturnTypeHandler.php
@@ -129,14 +129,14 @@ final class ModelRelationReturnTypeHandler
             } else {
                 $relatedModelType = self::resolveRelatedModelType($parsed, $codebase, $declaringClass, $methodName);
 
-                $result = $relatedModelType === null
-                    ? null
-                    : self::buildRelationType(
+                $result = $relatedModelType instanceof \Psalm\Type\Union
+                    ? self::buildRelationType(
                         $parsed['relationClass'],
                         $relatedModelType,
                         $parsed['intermediateModel'],
                         $bindingClass,
-                    );
+                    )
+                    : null;
             }
         } catch (\Throwable $throwable) {
             // Plugin closures are invoked by Psalm without a safety net. Surface the

--- a/src/Handlers/Eloquent/ModelRelationReturnTypeHandler.php
+++ b/src/Handlers/Eloquent/ModelRelationReturnTypeHandler.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Eloquent;
+
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Relations\HasOneThrough;
+use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Type\Atomic\TGenericObject;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Union;
+
+/**
+ * Returns the precise generic relation type for user-defined relationship methods on Models.
+ *
+ * Without this handler, `(new WorkOrder())->invoice()` resolves to `HasOne<Model, Model>`
+ * even when the method body is `return $this->hasOne(Invoice::class)` and the docblock
+ * says `@psalm-return HasOne<Invoice, $this>`. Two Psalm limitations cause the collapse:
+ *
+ * 1. The `class-string<TRelatedModel>` argument's TRelatedModel binding is not propagated
+ *    to the stub's `@return HasOne<TRelatedModel, $this>` return.
+ * 2. `$this` in template position is not substituted with the late-static-bound class.
+ *
+ * Both collapses happen before any handler registered on the Relation hierarchy can
+ * observe a useful generic — the called-on type already arrives at `getRelated()` etc.
+ * with `[Model, Model]` template params. Fixing the upstream method's return is the
+ * only path that lets the existing stub `@return TRelatedModel` resolve correctly.
+ *
+ * Strategy: at codebase population time, {@see ModelRegistrationHandler} registers this
+ * closure per concrete Model class. For every method call dispatched on the model,
+ * {@see RelationMethodParser} parses the AST body to detect a relation factory call
+ * (`$this->hasOne(X::class)`, `$this->belongsTo(X::class)`, ...) and returns the
+ * properly templated `Relation<TRelatedModel, TDeclaringModel>`. Polymorphic morphTo
+ * is intentionally skipped (the related class is determined at runtime). hasOneThrough
+ * and hasManyThrough require all three class-strings (related, intermediate, declaring)
+ * to resolve statically; if either factory arg is dynamic the handler defers.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/760
+ * @internal
+ */
+final class ModelRelationReturnTypeHandler
+{
+    /**
+     * Memoized return-type Unions keyed by "class::method".
+     *
+     * The closure is dispatched for every method call on every Model subclass during
+     * analysis. RelationMethodParser caches the parsed metadata, but without this
+     * second-tier cache we still rebuild the same Union/TGenericObject/TNamedObject
+     * graph on every hit. Cache hits return the previously constructed Union directly.
+     *
+     * Negative results (null) are cached too: methods that turned out not to be a
+     * relation factory short-circuit on subsequent dispatches without re-entering
+     * the parser at all.
+     *
+     * @var array<string, ?Union>
+     */
+    private static array $unionCache = [];
+
+    /**
+     * Closure target registered per-class by {@see ModelRegistrationHandler}.
+     *
+     * Returns null for any method that does not match the relation-factory shape, so
+     * other return-type providers downstream (custom collection narrowing, scope
+     * proxies, etc.) still get a chance to fire.
+     *
+     * Not pure: {@see RelationMethodParser::parse} maintains an internal read-through
+     * cache, so the call mutates static state on the first hit per (class, method).
+     * The Throwable guard is intentionally broad — Psalm's
+     * MethodReturnTypeProvider invokes this closure with no top-level catch
+     * (vendor/vimeo/psalm/src/Psalm/Internal/Provider/MethodReturnTypeProvider.php),
+     * so any escaping exception fatally aborts the whole analysis run. This pattern
+     * mirrors the AppFacadeRegistrationHandler closure (see #787).
+     */
+    public static function getReturnType(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        $source = $event->getSource();
+        if (!$source instanceof StatementsAnalyzer) {
+            return null;
+        }
+
+        // Two distinct classes matter here. For direct dispatch they're equal; for an
+        // inherited method (Psalm 7's "inherited method" branch in MethodCallReturnTypeFetcher),
+        // they diverge:
+        //
+        // - $declaringClass: where the method body actually lives. AST + storage lookups
+        //   must use this — asking for `User::posts` when posts is defined on BaseUser
+        //   misses storage and the parser returns null.
+        // - $bindingClass: the receiver / late-static-bound class. TDeclaringModel
+        //   should bind here so that `(new User())->posts()->getParent()` resolves to
+        //   User, not BaseUser.
+        //
+        // Closures are registered per concrete Model class; for the inherited path
+        // Psalm dispatches to the closure registered under the *declaring* class
+        // ($event->getFqClasslikeName()), so this branch only fires when both
+        // declaring and called classes are concrete (registered) Models.
+        $declaringClass = $event->getFqClasslikeName();
+        $bindingClass = $event->getCalledFqClasslikeName() ?? $declaringClass;
+        $methodName = $event->getMethodNameLowercase();
+
+        // Cache keyed by the (declaring, binding) tuple — the Union returned for
+        // BaseUser::posts dispatched on User differs from BaseUser::posts dispatched
+        // on AdminUser, since each binds a different TDeclaringModel.
+        $cacheKey = $declaringClass . '|' . $bindingClass . '::' . $methodName;
+
+        if (\array_key_exists($cacheKey, self::$unionCache)) {
+            return self::$unionCache[$cacheKey];
+        }
+
+        $codebase = $source->getCodebase();
+
+        try {
+            $parsed = RelationMethodParser::parse($codebase, $declaringClass, $methodName);
+
+            $result = $parsed === null
+                ? null
+                : self::buildRelationType(
+                    $parsed['relationClass'],
+                    $parsed['relatedModel'],
+                    $parsed['intermediateModel'],
+                    $bindingClass,
+                );
+        } catch (\Throwable $throwable) {
+            // Plugin closures are invoked by Psalm without a safety net. Surface the
+            // failure as a debug message rather than crashing the whole analysis run.
+            // The negative result is intentionally NOT cached — a future invocation
+            // may succeed (e.g., codebase storage warmed up by another analyzer pass).
+            $codebase->progress->debug(
+                "Laravel plugin: relation return-type provider failed for {$declaringClass}::{$methodName}: {$throwable->getMessage()}\n",
+            );
+
+            return null;
+        }
+
+        self::$unionCache[$cacheKey] = $result;
+
+        return $result;
+    }
+
+    /**
+     * Construct the relation type with the right template-param shape. Returns null when
+     * the related model is not statically known (morphTo / dynamic class-string), or when
+     * a through relation is missing its intermediate class-string.
+     *
+     * Two template-param shapes are emitted:
+     * - Standard: `Relation<TRelatedModel, TDeclaringModel>`
+     * - Through:  `Relation<TRelatedModel, TIntermediateModel, TDeclaringModel>`
+     *
+     * @param class-string $relationClass
+     *
+     * @psalm-pure
+     */
+    private static function buildRelationType(
+        string $relationClass,
+        ?string $relatedModel,
+        ?string $intermediateModel,
+        string $declaringClass,
+    ): ?Union {
+        if ($relatedModel === null) {
+            // morphTo (polymorphic) or unresolved class-string arg — leave to default.
+            return null;
+        }
+
+        $isThrough = $relationClass === HasOneThrough::class || $relationClass === HasManyThrough::class;
+
+        if ($isThrough && $intermediateModel === null) {
+            // Through factory called with a dynamic intermediate arg — emitting a 2-param
+            // shape would be wrong (the Relation hierarchy expects 3 templates here).
+            return null;
+        }
+
+        $typeParams = [new Union([new TNamedObject($relatedModel)])];
+
+        if ($intermediateModel !== null) {
+            $typeParams[] = new Union([new TNamedObject($intermediateModel)]);
+        }
+
+        $typeParams[] = new Union([new TNamedObject($declaringClass)]);
+
+        return new Union([new TGenericObject($relationClass, $typeParams)]);
+    }
+}

--- a/src/Handlers/Eloquent/ModelRelationReturnTypeHandler.php
+++ b/src/Handlers/Eloquent/ModelRelationReturnTypeHandler.php
@@ -34,7 +34,8 @@ use Psalm\Type\Union;
  * closure per concrete Model class. For every method call dispatched on the model,
  * {@see RelationMethodParser} parses the AST body to detect a relation factory call
  * (`$this->hasOne(X::class)`, `$this->belongsTo(X::class)`, ...) and returns the
- * properly templated `Relation<TRelatedModel, TDeclaringModel>`. Polymorphic morphTo
+ * properly templated concrete relation type (e.g. `HasOne<Invoice, WorkOrder>`,
+ * `BelongsToMany<Tag, Post>`, not `Relation<...>`). Polymorphic morphTo
  * is intentionally skipped (the related class is determined at runtime). hasOneThrough
  * and hasManyThrough require all three class-strings (related, intermediate, declaring)
  * to resolve statically; if either factory arg is dynamic the handler defers.

--- a/src/Handlers/Eloquent/ModelRelationReturnTypeHandler.php
+++ b/src/Handlers/Eloquent/ModelRelationReturnTypeHandler.php
@@ -35,10 +35,15 @@ use Psalm\Type\Union;
  * {@see RelationMethodParser} parses the AST body to detect a relation factory call
  * (`$this->hasOne(X::class)`, `$this->belongsTo(X::class)`, ...) and returns the
  * properly templated concrete relation type (e.g. `HasOne<Invoice, WorkOrder>`,
- * `BelongsToMany<Tag, Post>`, not `Relation<...>`). Polymorphic morphTo
- * is intentionally skipped (the related class is determined at runtime). hasOneThrough
- * and hasManyThrough require all three class-strings (related, intermediate, declaring)
- * to resolve statically; if either factory arg is dynamic the handler defers.
+ * `BelongsToMany<Tag, Post>`, not `Relation<...>`). `MorphTo` can be narrowed when the
+ * related model is statically declared via a docblock generic
+ * (`@phpstan-return MorphTo<User|Post, $this>` — read by
+ * {@see RelationMethodParser::extractDocblockRelatedModelType}); without that the
+ * handler defers because the related class is determined at runtime. `HasOneThrough`
+ * and `HasManyThrough` require both factory class-string args (related and intermediate)
+ * to resolve statically. The declaring-model generic comes from the receiver
+ * (`$bindingClass`), not a factory arg, so it is always available; if either factory
+ * arg is dynamic the handler defers.
  *
  * @see https://github.com/psalm/psalm-plugin-laravel/issues/760
  * @internal

--- a/src/Handlers/Eloquent/ModelRelationReturnTypeHandler.php
+++ b/src/Handlers/Eloquent/ModelRelationReturnTypeHandler.php
@@ -184,9 +184,13 @@ final class ModelRelationReturnTypeHandler
      * Construct the relation type with the right template-param shape. Returns null when
      * a through relation is missing its intermediate class-string.
      *
-     * Two template-param shapes are emitted:
-     * - Standard: `Relation<TRelatedModel, TDeclaringModel>`
-     * - Through:  `Relation<TRelatedModel, TIntermediateModel, TDeclaringModel>`
+     * The returned Union wraps a `TGenericObject` for the concrete relation class named by
+     * `$relationClass`. The shape varies per Relation subclass:
+     * - Standard relations: `<TRelatedModel, TDeclaringModel>` — e.g. `HasOne<Post, User>`,
+     *   `BelongsTo<User, Post>`, `BelongsToMany<Tag, Post>` (TPivotModel/TAccessor default).
+     * - Through relations: `<TRelatedModel, TIntermediateModel, TDeclaringModel>` — e.g.
+     *   `HasManyThrough<Post, Membership, Country>`. Note the Relation parent's 3rd template
+     *   (TResult) is filled implicitly by Psalm via the Through subclass's @template-extends.
      *
      * @param class-string $relationClass
      *
@@ -196,7 +200,7 @@ final class ModelRelationReturnTypeHandler
         string $relationClass,
         Union $relatedModel,
         ?string $intermediateModel,
-        string $declaringClass,
+        string $bindingClass,
     ): ?Union {
         $isThrough = $relationClass === HasOneThrough::class || $relationClass === HasManyThrough::class;
 
@@ -212,7 +216,10 @@ final class ModelRelationReturnTypeHandler
             $typeParams[] = new Union([new TNamedObject($intermediateModel)]);
         }
 
-        $typeParams[] = new Union([new TNamedObject($declaringClass)]);
+        // $bindingClass is the late-static-bound receiver class — what TDeclaringModel
+        // should resolve to at the call site (User for `(new User())->posts()`), even if
+        // the method body lives on a parent class.
+        $typeParams[] = new Union([new TNamedObject($bindingClass)]);
 
         return new Union([new TGenericObject($relationClass, $typeParams)]);
     }

--- a/src/Handlers/Eloquent/ModelRelationReturnTypeHandler.php
+++ b/src/Handlers/Eloquent/ModelRelationReturnTypeHandler.php
@@ -6,6 +6,8 @@ namespace Psalm\LaravelPlugin\Handlers\Eloquent;
 
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\HasOneThrough;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Psalm\Codebase;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\Type\Atomic\TGenericObject;
@@ -113,14 +115,29 @@ final class ModelRelationReturnTypeHandler
         try {
             $parsed = RelationMethodParser::parse($codebase, $declaringClass, $methodName);
 
-            $result = $parsed === null
-                ? null
-                : self::buildRelationType(
-                    $parsed['relationClass'],
-                    $parsed['relatedModel'],
-                    $parsed['intermediateModel'],
-                    $bindingClass,
-                );
+            // Known limitation: when the body wraps the factory in
+            // `->using(CustomPivot::class)` or `->as('accessor')`, those calls rebind
+            // TPivotModel / TAccessor on BelongsToMany / MorphToMany. The handler emits
+            // only the 2-template `Relation<TRelatedModel, TDeclaringModel>` shape and
+            // silently defaults TPivotModel = Pivot, TAccessor = 'pivot'. Deferring to
+            // the user's `@psalm-return BelongsToMany<X, $this, CustomPivot, 'pivot'>`
+            // does not help either — Psalm 7 collapses the entire annotation (including
+            // TPivotModel) when it cannot substitute `$this`. The primary issue from
+            // #760, TDeclaringModel collapsing to Model, stays fixed.
+            if ($parsed === null) {
+                $result = null;
+            } else {
+                $relatedModelType = self::resolveRelatedModelType($parsed, $codebase, $declaringClass, $methodName);
+
+                $result = $relatedModelType === null
+                    ? null
+                    : self::buildRelationType(
+                        $parsed['relationClass'],
+                        $relatedModelType,
+                        $parsed['intermediateModel'],
+                        $bindingClass,
+                    );
+            }
         } catch (\Throwable $throwable) {
             // Plugin closures are invoked by Psalm without a safety net. Surface the
             // failure as a debug message rather than crashing the whole analysis run.
@@ -139,8 +156,32 @@ final class ModelRelationReturnTypeHandler
     }
 
     /**
+     * Resolve the related-model Union for the parsed relation. Most factories return a
+     * single Model FQCN via `relatedModel`; polymorphic `morphTo` returns null there
+     * but may declare its target via `@psalm-return MorphTo<User|Post, $this>`, which
+     * {@see RelationMethodParser::extractDocblockRelatedModelType} reads from the
+     * docblock. Returns null when neither path produces a usable type.
+     *
+     * @param array{relationClass: class-string, relatedModel: ?string, intermediateModel: ?string} $parsed
+     */
+    private static function resolveRelatedModelType(array $parsed, Codebase $codebase, string $declaringClass, string $methodName): ?Union
+    {
+        if ($parsed['relatedModel'] !== null) {
+            return new Union([new TNamedObject($parsed['relatedModel'])]);
+        }
+
+        // morphTo: the factory's first arg is not a class-string, so the parser yields
+        // null. Fall back to the docblock generic for users who annotated their morphTo
+        // with the candidate model union.
+        if ($parsed['relationClass'] === MorphTo::class) {
+            return RelationMethodParser::extractDocblockRelatedModelType($codebase, $declaringClass, $methodName);
+        }
+
+        return null;
+    }
+
+    /**
      * Construct the relation type with the right template-param shape. Returns null when
-     * the related model is not statically known (morphTo / dynamic class-string), or when
      * a through relation is missing its intermediate class-string.
      *
      * Two template-param shapes are emitted:
@@ -153,15 +194,10 @@ final class ModelRelationReturnTypeHandler
      */
     private static function buildRelationType(
         string $relationClass,
-        ?string $relatedModel,
+        Union $relatedModel,
         ?string $intermediateModel,
         string $declaringClass,
     ): ?Union {
-        if ($relatedModel === null) {
-            // morphTo (polymorphic) or unresolved class-string arg — leave to default.
-            return null;
-        }
-
         $isThrough = $relationClass === HasOneThrough::class || $relationClass === HasManyThrough::class;
 
         if ($isThrough && $intermediateModel === null) {
@@ -170,7 +206,7 @@ final class ModelRelationReturnTypeHandler
             return null;
         }
 
-        $typeParams = [new Union([new TNamedObject($relatedModel)])];
+        $typeParams = [$relatedModel];
 
         if ($intermediateModel !== null) {
             $typeParams[] = new Union([new TNamedObject($intermediateModel)]);

--- a/src/Handlers/Eloquent/ModelRelationReturnTypeHandler.php
+++ b/src/Handlers/Eloquent/ModelRelationReturnTypeHandler.php
@@ -46,7 +46,11 @@ use Psalm\Type\Union;
 final class ModelRelationReturnTypeHandler
 {
     /**
-     * Memoized return-type Unions keyed by "class::method".
+     * Memoized return-type Unions keyed by "declaringClass|bindingClass::method".
+     *
+     * The (declaring, binding) pair distinguishes inherited dispatches: `BaseUser::posts`
+     * called on `User` and on `AdminUser` produce different Unions because TDeclaringModel
+     * binds to the receiver, not to the class where the method body lives.
      *
      * The closure is dispatched for every method call on every Model subclass during
      * analysis. RelationMethodParser caches the parsed metadata, but without this

--- a/src/Handlers/Eloquent/RelationMethodParser.php
+++ b/src/Handlers/Eloquent/RelationMethodParser.php
@@ -43,13 +43,18 @@ use Psalm\Type\Union;
 final class RelationMethodParser
 {
     /**
-     * Parsed result: the relationship factory method and optionally the related model FQCN.
+     * Parsed result: the relationship factory method, related model FQCN, and (for "through"
+     * relations only) the intermediate model FQCN.
      *
      * relatedModel is null when:
      * - The relation is polymorphic (morphTo) — the related type is not statically determinable
      * - The first argument could not be statically resolved (e.g. a variable or method call)
      *
-     * @var array<string, ?array{relationClass: class-string<Relation>, relatedModel: ?string}>
+     * intermediateModel is non-null only for hasOneThrough / hasManyThrough — for every other
+     * relation factory it stays null. Resolves the same way as relatedModel: missing or non-
+     * literal class-string arguments produce null.
+     *
+     * @var array<string, ?array{relationClass: class-string<Relation>, relatedModel: ?string, intermediateModel: ?string}>
      */
     private static array $cache = [];
 
@@ -82,12 +87,14 @@ final class RelationMethodParser
     ];
 
     /**
-     * Parse a relationship method body and extract the relation class and related model.
+     * Parse a relationship method body and extract the relation class, related model, and (for
+     * through relations only) the intermediate model.
      *
-     * @return ?array{relationClass: class-string<Relation>, relatedModel: ?string}
+     * @return ?array{relationClass: class-string<Relation>, relatedModel: ?string, intermediateModel: ?string}
      *         null if the method cannot be parsed as a relationship method.
      *         relatedModel is null when polymorphic (morphTo) or when the first argument
-     *         could not be statically resolved.
+     *         could not be statically resolved. intermediateModel is non-null only for
+     *         hasOneThrough / hasManyThrough.
      */
     public static function parse(Codebase $codebase, string $className, string $methodName): ?array
     {
@@ -104,7 +111,7 @@ final class RelationMethodParser
     }
 
     /**
-     * @return ?array{relationClass: class-string<Relation>, relatedModel: ?string}
+     * @return ?array{relationClass: class-string<Relation>, relatedModel: ?string, intermediateModel: ?string}
      */
     private static function doParse(Codebase $codebase, string $className, string $methodName): ?array
     {
@@ -126,7 +133,7 @@ final class RelationMethodParser
      * like $this->belongsTo(Vault::class).
      *
      * @param array<array-key, PhpParser\Node\Stmt> $stmts
-     * @return ?array{relationClass: class-string<Relation>, relatedModel: ?string}
+     * @return ?array{relationClass: class-string<Relation>, relatedModel: ?string, intermediateModel: ?string}
      */
     private static function parseMethodBody(array $stmts): ?array
     {
@@ -145,7 +152,7 @@ final class RelationMethodParser
      * Recursively search an expression for a relationship factory method call.
      * Handles both direct calls and method chains.
      *
-     * @return ?array{relationClass: class-string<Relation>, relatedModel: ?string}
+     * @return ?array{relationClass: class-string<Relation>, relatedModel: ?string, intermediateModel: ?string}
      */
     private static function findRelationCallInExpr(PhpParser\Node\Expr $expr): ?array
     {
@@ -161,7 +168,13 @@ final class RelationMethodParser
             if ($relationClass !== null) {
                 return [
                     'relationClass' => $relationClass,
-                    'relatedModel' => self::extractClassStringArg($expr, $lowerName),
+                    'relatedModel' => self::extractClassStringArg($expr, $lowerName, 0),
+                    // Through relations carry the intermediate model as the second class-string
+                    // argument: hasOneThrough(Related, Intermediate) / hasManyThrough(Related, Intermediate).
+                    // Every other factory leaves this null.
+                    'intermediateModel' => \in_array($lowerName, ['hasonethrough', 'hasmanythrough'], true)
+                        ? self::extractClassStringArg($expr, $lowerName, 1)
+                        : null,
                 ];
             }
         }
@@ -172,13 +185,16 @@ final class RelationMethodParser
     }
 
     /**
-     * Extract the class-string first argument from a relationship factory call.
+     * Extract the class-string argument at $argIndex from a relationship factory call.
      *
      * morphTo() is special: it may have no arguments (Laravel infers the type from the method name),
      * or it may have string arguments rather than a class-string. Returns null for morphTo()
      * since the related model type is polymorphic and not statically determinable.
+     *
+     * $argIndex=0 captures the related model. $argIndex=1 is used by the through relations
+     * (hasOneThrough / hasManyThrough) to capture the intermediate model.
      */
-    private static function extractClassStringArg(PhpParser\Node\Expr\MethodCall $call, string $lowerMethodName): ?string
+    private static function extractClassStringArg(PhpParser\Node\Expr\MethodCall $call, string $lowerMethodName, int $argIndex): ?string
     {
         // morphTo() doesn't take a class-string<Model> as first arg — the related type is polymorphic
         if ($lowerMethodName === 'morphto') {
@@ -186,11 +202,11 @@ final class RelationMethodParser
         }
 
         $args = $call->args;
-        if ($args === [] || !$args[0] instanceof PhpParser\Node\Arg) {
+        if (!isset($args[$argIndex]) || !$args[$argIndex] instanceof PhpParser\Node\Arg) {
             return null;
         }
 
-        $firstArg = $args[0]->value;
+        $firstArg = $args[$argIndex]->value;
 
         // Expect ClassName::class
         if (
@@ -260,11 +276,20 @@ final class RelationMethodParser
     private static function findClassMethodWithStatements(Codebase $codebase, string $className, string $methodName): ?array
     {
         $methodId = $className . '::' . $methodName;
+        $methodIdentifier = MethodIdentifier::wrap($methodId);
+
+        // Pre-check via the non-throwing API. The new ModelRelationReturnTypeHandler
+        // (see https://github.com/psalm/psalm-plugin-laravel/issues/760) calls this
+        // path for every method dispatch on every Model subclass — including Builder
+        // forwards (find/where/save/etc.) that aren't declared on the subclass at all.
+        // Falling through to getStorage() and catching the resulting UnexpectedValueException
+        // for each cold miss adds a real cost per (class, method) pair on first analysis.
+        if (!$codebase->methods->hasStorage($methodIdentifier)) {
+            return null;
+        }
 
         try {
-            $methodStorage = $codebase->methods->getStorage(
-                MethodIdentifier::wrap($methodId),
-            );
+            $methodStorage = $codebase->methods->getStorage($methodIdentifier);
         } catch (\InvalidArgumentException|\UnexpectedValueException $e) {
             $codebase->progress->debug("Laravel plugin: could not get method storage for {$methodId}: {$e->getMessage()}\n");
             return null;

--- a/src/Handlers/Eloquent/RelationMethodParser.php
+++ b/src/Handlers/Eloquent/RelationMethodParser.php
@@ -229,7 +229,7 @@ final class RelationMethodParser
         if (
             !isset($args[$positionalIndex])
             || !$args[$positionalIndex] instanceof PhpParser\Node\Arg
-            || $args[$positionalIndex]->name !== null
+            || $args[$positionalIndex]->name instanceof \PhpParser\Node\Identifier
         ) {
             return null;
         }

--- a/src/Handlers/Eloquent/RelationMethodParser.php
+++ b/src/Handlers/Eloquent/RelationMethodParser.php
@@ -168,12 +168,12 @@ final class RelationMethodParser
             if ($relationClass !== null) {
                 return [
                     'relationClass' => $relationClass,
-                    'relatedModel' => self::extractClassStringArg($expr, $lowerName, 0),
+                    'relatedModel' => self::extractClassStringArg($expr, $lowerName, 0, 'related'),
                     // Through relations carry the intermediate model as the second class-string
                     // argument: hasOneThrough(Related, Intermediate) / hasManyThrough(Related, Intermediate).
                     // Every other factory leaves this null.
                     'intermediateModel' => \in_array($lowerName, ['hasonethrough', 'hasmanythrough'], true)
-                        ? self::extractClassStringArg($expr, $lowerName, 1)
+                        ? self::extractClassStringArg($expr, $lowerName, 1, 'through')
                         : null,
                 ];
             }
@@ -185,47 +185,81 @@ final class RelationMethodParser
     }
 
     /**
-     * Extract the class-string argument at $argIndex from a relationship factory call.
+     * Extract the class-string argument at the given position from a relationship factory call.
+     *
+     * Resolves named arguments (`hasManyThrough(through: Vehicle::class, related: WorkOrder::class)`)
+     * by `$paramName` first, then falls back to positional lookup at `$positionalIndex` when the
+     * call uses bare positional args. The two arg-naming worlds are kept separate: a positional
+     * lookup ignores any arg that carries a `name` token, since named args may have shifted the
+     * positions and indexing into them would mis-identify the intended arg.
      *
      * morphTo() is special: it may have no arguments (Laravel infers the type from the method name),
      * or it may have string arguments rather than a class-string. Returns null for morphTo()
      * since the related model type is polymorphic and not statically determinable.
      *
-     * $argIndex=0 captures the related model. $argIndex=1 is used by the through relations
-     * (hasOneThrough / hasManyThrough) to capture the intermediate model.
+     * $positionalIndex=0 / $paramName='related' captures the related model. $positionalIndex=1 /
+     * $paramName='through' captures the intermediate model on through relations.
      */
-    private static function extractClassStringArg(PhpParser\Node\Expr\MethodCall $call, string $lowerMethodName, int $argIndex): ?string
-    {
+    private static function extractClassStringArg(
+        PhpParser\Node\Expr\MethodCall $call,
+        string $lowerMethodName,
+        int $positionalIndex,
+        string $paramName,
+    ): ?string {
         // morphTo() doesn't take a class-string<Model> as first arg — the related type is polymorphic
         if ($lowerMethodName === 'morphto') {
             return null;
         }
 
         $args = $call->args;
-        if (!isset($args[$argIndex]) || !$args[$argIndex] instanceof PhpParser\Node\Arg) {
+
+        // Named-arg form: search by param name regardless of position.
+        foreach ($args as $arg) {
+            if (
+                $arg instanceof PhpParser\Node\Arg
+                && $arg->name instanceof PhpParser\Node\Identifier
+                && $arg->name->name === $paramName
+            ) {
+                return self::resolveClassConstFetch($arg->value);
+            }
+        }
+
+        // Positional form: only valid when the arg at $positionalIndex is itself positional
+        // (named args may have shifted positions, so a positional lookup is unreliable).
+        if (
+            !isset($args[$positionalIndex])
+            || !$args[$positionalIndex] instanceof PhpParser\Node\Arg
+            || $args[$positionalIndex]->name !== null
+        ) {
             return null;
         }
 
-        $firstArg = $args[$argIndex]->value;
+        return self::resolveClassConstFetch($args[$positionalIndex]->value);
+    }
 
-        // Expect ClassName::class
+    /**
+     * Resolve a `ClassName::class` expression to the resolved FQCN, or null when the
+     * expression is anything else (a variable, a method call, a string literal, etc.).
+     */
+    private static function resolveClassConstFetch(PhpParser\Node\Expr $expr): ?string
+    {
         if (
-            $firstArg instanceof PhpParser\Node\Expr\ClassConstFetch
-            && $firstArg->class instanceof PhpParser\Node\Name
-            && $firstArg->name instanceof PhpParser\Node\Identifier
-            && $firstArg->name->name === 'class'
+            !$expr instanceof PhpParser\Node\Expr\ClassConstFetch
+            || !$expr->class instanceof PhpParser\Node\Name
+            || !$expr->name instanceof PhpParser\Node\Identifier
+            || $expr->name->name !== 'class'
         ) {
-            // Prefer the FQCN resolved by Psalm's name-resolution pass
-            /** @var string|null $resolved */
-            $resolved = $firstArg->class->getAttribute('resolvedName');
-            if (\is_string($resolved)) {
-                return $resolved;
-            }
-
-            return $firstArg->class->toString();
+            return null;
         }
 
-        return null;
+        // Prefer the FQCN resolved by Psalm's name-resolution pass
+        /** @var string|null $resolved */
+        $resolved = $expr->class->getAttribute('resolvedName');
+        if (\is_string($resolved)) {
+            return $resolved;
+        }
+
+        return $expr->class->toString();
     }
 
     /**

--- a/tests/Type/tests/Relation/DynamicRelationNameStaysMixedTest.phpt
+++ b/tests/Type/tests/Relation/DynamicRelationNameStaysMixedTest.phpt
@@ -1,0 +1,28 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\WorkOrder;
+
+/**
+ * Pins the explicit out-of-scope case from issue #760: dynamic relation names
+ * (e.g. `$record->{$namePart}()->getRelated()`) cannot be narrowed because the
+ * dispatched method is unknown until runtime. The plugin's
+ * ModelRelationReturnTypeHandler relies on a literal method-name lookup, so it
+ * never fires for variable-method calls — the result stays mixed.
+ *
+ * If a future change accidentally narrowed this case (e.g. by guessing the
+ * relation from the Model alone), the handler would emit a wrong generic and
+ * downstream callers would silently lose type safety. This test catches that.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/760
+ */
+
+function dynamic_relation_call_remains_mixed(string $name): void
+{
+    $record = (new WorkOrder())->{$name}();
+    $record->getRelated();
+}
+
+?>
+--EXPECTF--
+%AMixedMethodCall%A

--- a/tests/Type/tests/Relation/DynamicRelationNameStaysMixedTest.phpt
+++ b/tests/Type/tests/Relation/DynamicRelationNameStaysMixedTest.phpt
@@ -25,4 +25,5 @@ function dynamic_relation_call_remains_mixed(string $name): void
 
 ?>
 --EXPECTF--
-%AMixedMethodCall%A
+MixedAssignment on line 22: Unable to determine the type that $record is being assigned to
+MixedMethodCall on line 23: Cannot determine the type of $record when calling method getRelated

--- a/tests/Type/tests/Relation/DynamicWhereDisabledTest.phpt
+++ b/tests/Type/tests/Relation/DynamicWhereDisabledTest.phpt
@@ -5,7 +5,6 @@
 
 use App\Models\Invoice;
 use App\Models\WorkOrder;
-use Illuminate\Database\Eloquent\Relations\HasOne;
 
 /**
  * When resolveDynamicWhereClauses is disabled (<resolveDynamicWhereClauses value="false" />),
@@ -16,7 +15,6 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  */
 
 function test_dynamic_where_not_resolved_when_disabled(): void {
-    /** @var HasOne<Invoice, WorkOrder> $r */
     $r = (new WorkOrder())->invoice();
     // whereInvoiceNumber IS a valid @property on Invoice, but the feature is off —
     // must fall through to mixed instead of preserving the relation generic type.

--- a/tests/Type/tests/Relation/DynamicWhereMethodTest.phpt
+++ b/tests/Type/tests/Relation/DynamicWhereMethodTest.phpt
@@ -3,7 +3,6 @@
 
 use App\Models\Invoice;
 use App\Models\WorkOrder;
-use Illuminate\Database\Eloquent\Relations\HasOne;
 
 /**
  * Tests for dynamic where{Column} method resolution on Eloquent Relation chains.
@@ -12,8 +11,8 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * With resolveDynamicWhereClauses enabled (default), these are resolved on relation chains when the
  * column exists in the model's @property annotations.
  *
- * Uses HasOne<Invoice, WorkOrder> with an explicit @var annotation to get a stable
- * relation type regardless of batch analysis context.
+ * The relation generic type is supplied by ModelRelationReturnTypeHandler so the
+ * dynamic where() narrowing has a concrete model to reflect against.
  *
  * @see https://github.com/psalm/psalm-plugin-laravel/issues/647
  */
@@ -22,7 +21,6 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 // Psalm lowercases method names, so "whereInvoiceNumber" → "whereinvoicenumber",
 // and "invoice_number" normalises to "invoicenumber" — they match.
 function test_dynamic_where_multi_word_column(): void {
-    /** @var HasOne<Invoice, WorkOrder> $r */
     $r = (new WorkOrder())->invoice();
     $_ = $r->whereInvoiceNumber('INV-2024-001')->first();
     /** @psalm-check-type-exact $_ = App\Models\Invoice|null */
@@ -30,7 +28,6 @@ function test_dynamic_where_multi_word_column(): void {
 
 // Single-word column: whereStatus matches @property string $status.
 function test_dynamic_where_single_word_column(): void {
-    /** @var HasOne<Invoice, WorkOrder> $r */
     $r = (new WorkOrder())->invoice();
     $_ = $r->whereStatus('paid')->first();
     /** @psalm-check-type-exact $_ = App\Models\Invoice|null */

--- a/tests/Type/tests/Relation/DynamicWhereUnknownColumnTest.phpt
+++ b/tests/Type/tests/Relation/DynamicWhereUnknownColumnTest.phpt
@@ -3,7 +3,6 @@
 
 use App\Models\Invoice;
 use App\Models\WorkOrder;
-use Illuminate\Database\Eloquent\Relations\HasOne;
 
 /**
  * When resolveDynamicWhereClauses is enabled (default), a where{Column} call
@@ -15,7 +14,6 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  */
 
 function test_dynamic_where_unknown_column_falls_through_to_mixed(): void {
-    /** @var HasOne<Invoice, WorkOrder> $r */
     $r = (new WorkOrder())->invoice();
     // "nonexistent_column" is not a @property on Invoice — handler returns null,
     // Psalm falls to __call on the Relation, which returns mixed.

--- a/tests/Type/tests/Relation/ForwardingHandlerTest.phpt
+++ b/tests/Type/tests/Relation/ForwardingHandlerTest.phpt
@@ -19,7 +19,6 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 
 // Path 1: Builder method via @mixin (where is in Builder's declaring_method_ids)
 function test_where_preserves_relation_type(): void {
-    /** @var HasOne<Invoice, WorkOrder> $r */
     $r = (new WorkOrder())->invoice();
     $_ = $r->where('active', true);
     /** @psalm-check-type-exact $_ = HasOne<Invoice, WorkOrder> */
@@ -27,7 +26,6 @@ function test_where_preserves_relation_type(): void {
 
 // Path 2: QueryBuilder-only method via __call
 function test_orderBy_preserves_relation_type(): void {
-    /** @var HasOne<Invoice, WorkOrder> $r */
     $r = (new WorkOrder())->invoice();
     $_ = $r->orderBy('name');
     /** @psalm-check-type-exact $_ = HasOne<Invoice, WorkOrder> */
@@ -35,7 +33,6 @@ function test_orderBy_preserves_relation_type(): void {
 
 // Chained call across both paths
 function test_chain_preserves_relation_type(): void {
-    /** @var HasOne<Invoice, WorkOrder> $r */
     $r = (new WorkOrder())->invoice();
     $_ = $r->where('active', true)->orderBy('name');
     /** @psalm-check-type-exact $_ = HasOne<Invoice, WorkOrder> */
@@ -43,7 +40,6 @@ function test_chain_preserves_relation_type(): void {
 
 // Non-fluent: get() from Relation stub returns custom collection (Invoice has InvoiceCollection)
 function test_get_returns_collection(): void {
-    /** @var HasOne<Invoice, WorkOrder> $r */
     $r = (new WorkOrder())->invoice();
     $_ = $r->get();
     /** @psalm-check-type-exact $_ = \App\Collections\InvoiceCollection */
@@ -51,7 +47,6 @@ function test_get_returns_collection(): void {
 
 // Mixin-only method NOT on Relation stubs
 function test_mixin_only_preserves_relation_type(): void {
-    /** @var HasOne<Invoice, WorkOrder> $r */
     $r = (new WorkOrder())->invoice();
     $_ = $r->withoutGlobalScopes();
     /** @psalm-check-type-exact $_ = HasOne<Invoice, WorkOrder> */
@@ -60,7 +55,6 @@ function test_mixin_only_preserves_relation_type(): void {
 // Builder::scopes() returns static|mixed. The fluent detector must match any
 // self-like atomic in the union, not fail on the mixed branch.
 function test_scopes_preserves_relation_type(): void {
-    /** @var HasOne<Invoice, WorkOrder> $r */
     $r = (new WorkOrder())->invoice();
     $_ = $r->scopes('urgent');
     /** @psalm-check-type-exact $_ = HasOne<Invoice, WorkOrder> */
@@ -68,14 +62,12 @@ function test_scopes_preserves_relation_type(): void {
 
 // Different Relation subclass: BelongsToMany (verifies template params work beyond HasOne)
 function test_belongsToMany_where_preserves_relation_type(): void {
-    /** @var BelongsToMany<Part, WorkOrder, Pivot, 'pivot'> $r */
     $r = (new WorkOrder())->parts();
     $_ = $r->where('active', true);
     /** @psalm-check-type-exact $_ = BelongsToMany<Part, WorkOrder, Pivot, 'pivot'> */
 }
 
 function test_belongsToMany_orderBy_preserves_relation_type(): void {
-    /** @var BelongsToMany<Part, WorkOrder, Pivot, 'pivot'> $r */
     $r = (new WorkOrder())->parts();
     $_ = $r->orderBy('name');
     /** @psalm-check-type-exact $_ = BelongsToMany<Part, WorkOrder, Pivot, 'pivot'> */
@@ -83,7 +75,6 @@ function test_belongsToMany_orderBy_preserves_relation_type(): void {
 
 // Non-fluent: first() resolved via Relation stub (workaround for Psalm mixin template bug)
 function test_first_returns_model_or_null(): void {
-    /** @var HasOne<Invoice, WorkOrder> $r */
     $r = (new WorkOrder())->invoice();
     $_ = $r->first();
     /** @psalm-check-type-exact $_ = Invoice|null */
@@ -91,7 +82,6 @@ function test_first_returns_model_or_null(): void {
 
 // Terminal after chain: where()+orderBy() preserve HasOne, first() resolves via stub
 function test_terminal_after_chain(): void {
-    /** @var HasOne<Invoice, WorkOrder> $r */
     $r = (new WorkOrder())->invoice();
     $_ = $r->where('active', true)->orderBy('name')->first();
     /** @psalm-check-type-exact $_ = Invoice|null */
@@ -99,7 +89,6 @@ function test_terminal_after_chain(): void {
 
 // firstOrFail() via Relation stub returns TRelatedModel (no |null)
 function test_firstOrFail_returns_model(): void {
-    /** @var HasOne<Invoice, WorkOrder> $r */
     $r = (new WorkOrder())->invoice();
     $_ = $r->firstOrFail();
     /** @psalm-check-type-exact $_ = Invoice */
@@ -107,7 +96,6 @@ function test_firstOrFail_returns_model(): void {
 
 // Non-fluent mixin method: count() returns int, not HasOne<Invoice, WorkOrder>
 function test_count_returns_int_not_relation(): void {
-    /** @var HasOne<Invoice, WorkOrder> $r */
     $r = (new WorkOrder())->invoice();
     $_ = $r->count();
     /** @psalm-check-type-exact $_ = int<0, max> */
@@ -115,7 +103,6 @@ function test_count_returns_int_not_relation(): void {
 
 // HasManyThrough: 3 template params (verifies TGenericObject construction with varying arity)
 function test_hasManyThrough_where_preserves_relation_type(): void {
-    /** @var HasManyThrough<WorkOrder, Vehicle, Customer> $r */
     $r = (new Customer())->workOrders();
     $_ = $r->where('active', true);
     /** @psalm-check-type-exact $_ = HasManyThrough<WorkOrder, Vehicle, Customer> */
@@ -124,7 +111,6 @@ function test_hasManyThrough_where_preserves_relation_type(): void {
 // Path 2: limit() is QueryBuilder-only with typed param (int $value).
 // MethodParamsProvider forwards the param types so Psalm validates arguments.
 function test_limit_validates_arguments(): void {
-    /** @var HasOne<Invoice, WorkOrder> $r */
     $r = (new WorkOrder())->invoice();
     $_ = $r->limit(10);
     /** @psalm-check-type-exact $_ = HasOne<Invoice, WorkOrder>&static */

--- a/tests/Type/tests/Relation/GetRelatedNarrowingTest.phpt
+++ b/tests/Type/tests/Relation/GetRelatedNarrowingTest.phpt
@@ -6,7 +6,9 @@ use App\Models\Customer;
 use App\Models\DamageReport;
 use App\Models\Invoice;
 use App\Models\Mechanic;
+use App\Models\MechanicSpecialization;
 use App\Models\Part;
+use App\Models\SpecializationPivot;
 use App\Models\Vehicle;
 use App\Models\WorkOrder;
 use Illuminate\Database\Eloquent\Model;
@@ -116,13 +118,19 @@ function test_belongsTo_no_psalm_return_resolves(): Mechanic
     return (new WorkOrder())->mechanic()->getRelated();
 }
 
-// morphTo: the handler defers (related model is polymorphic / not statically known).
-// The stub's `MorphTo<Model, $this>` default applies and getRelated returns Model.
-// What matters here is that no MixedMethodCall fires on the chain — the handler
-// must not accidentally emit a wrong relation generic for morphTo.
-function test_morphTo_getRelated_does_not_break(): string
+// morphTo with a docblock-declared candidate set narrows getRelated() to that union.
+// DamageReport::reportable() is annotated `@phpstan-return MorphTo<Vehicle|WorkOrder, $this>`;
+// the handler reads that via RelationMethodParser::extractDocblockRelatedModelType.
+function test_morphTo_with_docblock_narrows_to_union(): Vehicle|WorkOrder
 {
-    return (new DamageReport())->reportable()->getRelated()->getKeyName();
+    return (new DamageReport())->reportable()->getRelated();
+}
+
+// morphTo without a docblock — the handler defers, the stub's `MorphTo<Model, $this>`
+// default applies. What matters here is that no MixedMethodCall fires on the chain.
+function test_morphTo_no_docblock_does_not_break(\Illuminate\Database\Eloquent\Relations\MorphTo $r): string
+{
+    return $r->getRelated()->getKeyName();
 }
 
 // Plain Relation parameter — handler is not registered on Relation, so the stub's
@@ -133,6 +141,18 @@ function test_plain_relation_parameter_returns_model(Relation $relation): string
     $record = $relation->getRelated();
     /** @psalm-check-type-exact $record = Model */
     return $record->getKeyName();
+}
+
+// belongsToMany with `->using(CustomPivot::class)`: the handler still narrows
+// TRelatedModel and TDeclaringModel — getRelated() resolves correctly. TPivotModel
+// rebinding via `using()` is a known Psalm 7 limitation (the stub's
+// `@psalm-this-out` does not propagate, and the user's `@psalm-return` annotation
+// also collapses when `$this` cannot be substituted), so the pivot defaults to
+// Pivot. The primary fix from #760 — getRelated() not returning Model — is
+// preserved.
+function test_using_chain_still_narrows_getRelated(): MechanicSpecialization
+{
+    return (new Mechanic())->specializationsWithPivot()->getRelated();
 }
 
 ?>

--- a/tests/Type/tests/Relation/GetRelatedNarrowingTest.phpt
+++ b/tests/Type/tests/Relation/GetRelatedNarrowingTest.phpt
@@ -8,7 +8,6 @@ use App\Models\Invoice;
 use App\Models\Mechanic;
 use App\Models\MechanicSpecialization;
 use App\Models\Part;
-use App\Models\SpecializationPivot;
 use App\Models\Vehicle;
 use App\Models\WorkOrder;
 use Illuminate\Database\Eloquent\Model;

--- a/tests/Type/tests/Relation/GetRelatedNarrowingTest.phpt
+++ b/tests/Type/tests/Relation/GetRelatedNarrowingTest.phpt
@@ -1,0 +1,139 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Admin;
+use App\Models\Customer;
+use App\Models\DamageReport;
+use App\Models\Invoice;
+use App\Models\Mechanic;
+use App\Models\Part;
+use App\Models\Vehicle;
+use App\Models\WorkOrder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+
+/**
+ * Verify that user-defined relationship methods on Models return the precisely
+ * templated relation type so downstream calls (`getRelated()`, `getParent()`,
+ * `get()`, etc.) resolve through the existing stub annotations.
+ *
+ * Without ModelRelationReturnTypeHandler, Psalm collapses generics on these
+ * methods to upper bounds — e.g. `(new WorkOrder())->invoice()` resolves to
+ * `HasOne<Model, Model>`, and `getRelated()` returns `Model` instead of `Invoice`.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/760
+ */
+
+// hasOne
+function test_hasOne_getRelated_narrows_to_Invoice(): Invoice
+{
+    return (new WorkOrder())->invoice()->getRelated();
+}
+
+// belongsTo
+function test_belongsTo_getRelated_narrows_to_Vehicle(): Vehicle
+{
+    return (new WorkOrder())->vehicle()->getRelated();
+}
+
+// belongsToMany
+function test_belongsToMany_getRelated_narrows_to_Part(): Part
+{
+    return (new WorkOrder())->parts()->getRelated();
+}
+
+// hasMany
+function test_hasMany_getRelated_narrows_to_Vehicle(): Vehicle
+{
+    return (new Customer())->vehicles()->getRelated();
+}
+
+// hasOneThrough — three template params, exercises argIndex=1 in the parser
+function test_hasOneThrough_getRelated_narrows_to_Customer(): Customer
+{
+    return (new Mechanic())->vehicleOwner()->getRelated();
+}
+
+// hasManyThrough — three template params (related, intermediate, declaring)
+function test_hasManyThrough_getRelated_narrows_to_WorkOrder(): WorkOrder
+{
+    return (new Customer())->workOrders()->getRelated();
+}
+
+// morphOne
+function test_morphOne_getRelated_narrows_to_DamageReport(): DamageReport
+{
+    return (new Vehicle())->latestReport()->getRelated();
+}
+
+// morphMany
+function test_morphMany_getRelated_narrows_to_DamageReport(): DamageReport
+{
+    return (new WorkOrder())->damageReports()->getRelated();
+}
+
+// morphToMany
+function test_morphToMany_getRelated_narrows_to_WorkOrder(): WorkOrder
+{
+    return (new Admin())->workOrders()->getRelated();
+}
+
+// morphedByMany — same Relation class as morphToMany, inverse direction
+function test_morphedByMany_getRelated_narrows_to_Admin(): Admin
+{
+    return (new Customer())->bookmarkedAdmins()->getRelated();
+}
+
+// Chained call — the original issue's representative shape
+function test_getRelated_chained_call_resolves(): string
+{
+    return (new WorkOrder())->invoice()->getRelated()->getKeyName();
+}
+
+// getParent() — second template param resolves to the declaring model
+function test_getParent_narrows_to_declaring_model(): WorkOrder
+{
+    return (new WorkOrder())->invoice()->getParent();
+}
+
+// Through-relation getParent() pins which template slot wins.
+// HasManyThrough<TRelatedModel, TIntermediateModel, TDeclaringModel> binds the
+// parent Relation's second template (TDeclaringModel-of-Relation) to TIntermediateModel,
+// not to the far parent — see stubs/common/Database/Eloquent/Relations/HasOneOrManyThrough.stubphp.
+// At runtime $parent is the immediate "throughParent" (Vehicle), matching Laravel's
+// HasOneOrManyThrough constructor. This test locks the contract so a stub edit can't
+// silently flip it.
+function test_hasManyThrough_getParent_returns_intermediate(): Vehicle
+{
+    return (new Customer())->workOrders()->getParent();
+}
+
+// belongsTo without @psalm-return — relies entirely on the handler-emitted generics.
+// Verifies the handler covers methods declared with only the abstract relation class
+// (`: BelongsTo`), the original failure shape from issue #760.
+function test_belongsTo_no_psalm_return_resolves(): Mechanic
+{
+    return (new WorkOrder())->mechanic()->getRelated();
+}
+
+// morphTo: the handler defers (related model is polymorphic / not statically known).
+// The stub's `MorphTo<Model, $this>` default applies and getRelated returns Model.
+// What matters here is that no MixedMethodCall fires on the chain — the handler
+// must not accidentally emit a wrong relation generic for morphTo.
+function test_morphTo_getRelated_does_not_break(): string
+{
+    return (new DamageReport())->reportable()->getRelated()->getKeyName();
+}
+
+// Plain Relation parameter — handler is not registered on Relation, so the stub's
+// `@return TRelatedModel` resolves to the upper bound `Model`. Cascading calls on
+// the result must remain valid (no MixedMethodCall).
+function test_plain_relation_parameter_returns_model(Relation $relation): string
+{
+    $record = $relation->getRelated();
+    /** @psalm-check-type-exact $record = Model */
+    return $record->getKeyName();
+}
+
+?>
+--EXPECTF--

--- a/tests/Type/tests/Relation/RelationChainScopeTest.phpt
+++ b/tests/Type/tests/Relation/RelationChainScopeTest.phpt
@@ -15,7 +15,8 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * via __call. The MethodForwardingHandler now detects these scopes on the related
  * model and preserves the Relation's generic type for fluent chaining.
  *
- * Uses explicit @var annotations to get stable relation types regardless of context.
+ * Generic params propagate through the user's relation methods automatically via
+ * ModelRelationReturnTypeHandler — no @var coercion required.
  *
  * @see https://github.com/psalm/psalm-plugin-laravel/issues/646
  */
@@ -23,7 +24,6 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 // Modern #[Scope] attribute (no extra args): Vehicle::#[Scope] electric → electric()
 // Customer::vehicles() returns HasMany<Vehicle, Customer>
 function test_attribute_scope_on_hasmany(): void {
-    /** @var HasMany<\App\Models\Vehicle, Customer> $r */
     $r = (new Customer())->vehicles();
     $_ = $r->electric();
     /** @psalm-check-type-exact $_ = HasMany<\App\Models\Vehicle, Customer> */
@@ -31,7 +31,6 @@ function test_attribute_scope_on_hasmany(): void {
 
 // Legacy scope with args: Vehicle::scopeByMake(Builder $query, string $make) → byMake('Toyota')
 function test_legacy_scope_with_args_on_hasmany(): void {
-    /** @var HasMany<\App\Models\Vehicle, Customer> $r */
     $r = (new Customer())->vehicles();
     $_ = $r->byMake('Toyota');
     /** @psalm-check-type-exact $_ = HasMany<\App\Models\Vehicle, Customer> */
@@ -39,7 +38,6 @@ function test_legacy_scope_with_args_on_hasmany(): void {
 
 // Scope + terminal: scope preserves HasMany, first() returns the model type
 function test_scope_then_terminal_on_hasmany(): void {
-    /** @var HasMany<\App\Models\Vehicle, Customer> $r */
     $r = (new Customer())->vehicles();
     $_ = $r->electric()->first();
     /** @psalm-check-type-exact $_ = \App\Models\Vehicle|null */
@@ -47,7 +45,6 @@ function test_scope_then_terminal_on_hasmany(): void {
 
 // Scope chaining: two scopes in a row preserve the Relation generic type
 function test_scope_chain_on_hasmany(): void {
-    /** @var HasMany<\App\Models\Vehicle, Customer> $r */
     $r = (new Customer())->vehicles();
     $_ = $r->electric()->byMake('Tesla');
     /** @psalm-check-type-exact $_ = HasMany<\App\Models\Vehicle, Customer> */
@@ -56,7 +53,6 @@ function test_scope_chain_on_hasmany(): void {
 // HasOne: Customer::primaryVehicle() returns HasOne<Vehicle, Customer>
 // Vehicle::#[Scope] electric → electric()
 function test_attribute_scope_on_hasone(): void {
-    /** @var HasOne<\App\Models\Vehicle, Customer> $r */
     $r = (new Customer())->primaryVehicle();
     $_ = $r->electric();
     /** @psalm-check-type-exact $_ = HasOne<\App\Models\Vehicle, Customer> */
@@ -65,7 +61,6 @@ function test_attribute_scope_on_hasone(): void {
 // BelongsTo: WorkOrder::vehicle() returns BelongsTo<Vehicle, WorkOrder>
 // Vehicle::scopeByMake → byMake()
 function test_legacy_scope_on_belongsto(): void {
-    /** @var BelongsTo<\App\Models\Vehicle, WorkOrder> $r */
     $r = (new WorkOrder())->vehicle();
     $_ = $r->byMake('Toyota');
     /** @psalm-check-type-exact $_ = BelongsTo<\App\Models\Vehicle, WorkOrder> */
@@ -74,7 +69,6 @@ function test_legacy_scope_on_belongsto(): void {
 // HasManyThrough: legacy scope WorkOrder::scopeUrgent() → urgent()
 // Customer::workOrders() returns HasManyThrough<WorkOrder, Vehicle, Customer>
 function test_legacy_scope_on_hasmanythrough(): void {
-    /** @var HasManyThrough<\App\Models\WorkOrder, \App\Models\Vehicle, Customer> $r */
     $r = (new Customer())->workOrders();
     $_ = $r->urgent();
     /** @psalm-check-type-exact $_ = HasManyThrough<\App\Models\WorkOrder, \App\Models\Vehicle, Customer> */
@@ -82,7 +76,6 @@ function test_legacy_scope_on_hasmanythrough(): void {
 
 // HasManyThrough + modern #[Scope] attribute: WorkOrder::completed()
 function test_attribute_scope_on_hasmanythrough(): void {
-    /** @var HasManyThrough<\App\Models\WorkOrder, \App\Models\Vehicle, Customer> $r */
     $r = (new Customer())->workOrders();
     $_ = $r->completed();
     /** @psalm-check-type-exact $_ = HasManyThrough<\App\Models\WorkOrder, \App\Models\Vehicle, Customer> */
@@ -90,7 +83,6 @@ function test_attribute_scope_on_hasmanythrough(): void {
 
 // Scope + Builder method chain: scope then where() preserves the Relation generic type
 function test_scope_then_builder_method_chain(): void {
-    /** @var HasMany<\App\Models\Vehicle, Customer> $r */
     $r = (new Customer())->vehicles();
     $_ = $r->electric()->where('year', '>=', 2020);
     /** @psalm-check-type-exact $_ = HasMany<\App\Models\Vehicle, Customer> */
@@ -99,7 +91,6 @@ function test_scope_then_builder_method_chain(): void {
 // Negative: a method that is NOT a scope on the related model falls through to mixed.
 // The handler does not match it, Relation::__call returns mixed.
 function test_non_scope_method_falls_through(): void {
-    /** @var HasMany<\App\Models\Vehicle, Customer> $r */
     $r = (new Customer())->vehicles();
     $_ = $r->completelyFakeNotAScope();
     /** @psalm-check-type-exact $_ = mixed */

--- a/tests/Type/tests/Relation/RelationGenericsTest.phpt
+++ b/tests/Type/tests/Relation/RelationGenericsTest.phpt
@@ -30,13 +30,13 @@ function test_hasManyThrough_returns_typed_relation(): HasManyThrough
 }
 
 /**
- * When the generic type is explicitly annotated, getRelated()/getParent() resolve correctly.
- * Psalm cannot yet infer full generic params through trait methods, so @var is used to
- * verify template parameter propagation through the relation API.
+ * Generic params now propagate through user-defined relation methods directly via the
+ * ModelRelationReturnTypeHandler — no @var coercion required. getRelated()/getParent()
+ * resolve through the existing relation stubs once the called-on type carries the
+ * right template params.
  */
 function test_hasOne_getRelated_returns_invoice(): Invoice
 {
-    /** @var HasOne<Invoice, WorkOrder> $relation */
     $relation = (new WorkOrder())->invoice();
     /** @psalm-check-type-exact $relation = HasOne<Invoice, WorkOrder> */
     return $relation->getRelated();
@@ -44,7 +44,6 @@ function test_hasOne_getRelated_returns_invoice(): Invoice
 
 function test_hasOne_getParent_returns_workOrder(): WorkOrder
 {
-    /** @var HasOne<Invoice, WorkOrder> $relation */
     $relation = (new WorkOrder())->invoice();
     return $relation->getParent();
 }
@@ -54,7 +53,6 @@ function test_hasOne_getParent_returns_workOrder(): WorkOrder
 
 function test_latest_preserves_relation_type(): HasOne
 {
-    /** @var HasOne<Invoice, WorkOrder> $relation */
     $relation = (new WorkOrder())->invoice();
     /** @psalm-check-type-exact $latest = HasOne<Invoice, WorkOrder>&static */
     $latest = $relation->latest();
@@ -64,7 +62,6 @@ function test_latest_preserves_relation_type(): HasOne
 /** @return \App\Collections\InvoiceCollection */
 function test_get_returns_collection(): \App\Collections\InvoiceCollection
 {
-    /** @var HasOne<Invoice, WorkOrder> $relation */
     $relation = (new WorkOrder())->invoice();
     /** @psalm-check-type-exact $collection = \App\Collections\InvoiceCollection */
     $collection = $relation->get();
@@ -73,7 +70,6 @@ function test_get_returns_collection(): \App\Collections\InvoiceCollection
 
 function test_sole_returns_model(): Invoice
 {
-    /** @var HasOne<Invoice, WorkOrder> $relation */
     $relation = (new WorkOrder())->invoice();
     /** @psalm-check-type-exact $model = Invoice */
     $model = $relation->sole();
@@ -86,7 +82,6 @@ function test_sole_returns_model(): Invoice
  */
 function test_select_variadic_on_relation(): HasOne
 {
-    /** @var HasOne<Invoice, WorkOrder> $relation */
     $relation = (new WorkOrder())->invoice();
     return $relation->select('id', 'name', 'created_at');
 }


### PR DESCRIPTION
Fixes #760.

## Summary

User-defined relation methods (`Model::posts()`, `Model::user()`, etc.) collapsed to upper-bound generics like `HasOne<Model, Model>` instead of the precise `HasOne<Post, User>`, even when the docblock said `@psalm-return HasOne<Post, $this>`. Cascaded into broken `getRelated()`, `getParent()`, `getQuery()`, and any chained call on the relation.

## Root cause (verified)

Psalm fails to substitute two things in the existing relation factory stubs (`stubs/common/Database/Eloquent/Concerns/HasRelationships.stubphp`):

1. `class-string<TRelatedModel>` from the factory argument doesn't propagate to `@return HasOne<TRelatedModel, $this>`.
2. `$this` in template position doesn't resolve to the late-static-bound class.

Both collapses happen *before* any provider on the `Relation` hierarchy can observe a useful generic. The proposed fix in #760 (a method return-type provider on `Relation::getRelated`) is a no-op for this reason — the called-on type's templates are already `[Model, Model]` by the time it dispatches.

The fix has to happen one level up, on the user's relation method itself.

## What changes

`src/Handlers/Eloquent/ModelRelationReturnTypeHandler.php` (new): per-class return-type provider that uses the existing `RelationMethodParser` to detect a relation factory call in the method body and emits the properly templated relation:

- `(new WorkOrder())->invoice()` → `HasOne<Invoice, WorkOrder>`
- `(new Customer())->workOrders()` → `HasManyThrough<WorkOrder, Vehicle, Customer>`
- `(new Admin())->customers()` → `MorphToMany<Customer, Admin>`

Registered as a closure in `ModelRegistrationHandler::registerForClass` so dispatch works for every concrete Model subclass (Psalm's exact-class lookup requires this).

`RelationMethodParser` is extended to also surface the intermediate model for through relations (`hasOneThrough` / `hasManyThrough`).

`RelationMethodParser::findClassMethodWithStatements` now pre-checks `$codebase->methods->hasStorage(...)` before calling the throwing `getStorage(...)` — the new handler runs for every method dispatch on every Model, so the cold-path exception cost (every Builder forward like `find`, `where`, `save` on a User instance) was real.

The handler maintains its own Union-level cache so cache hits avoid both the parser call and Union reconstruction. The closure body is wrapped in `try { ... } catch (\Throwable)` because Psalm's `MethodReturnTypeProvider` does not catch escaping exceptions and would crash the analysis (mirrors the pattern from #854).

## Tests

- `tests/Type/tests/Relation/GetRelatedNarrowingTest.phpt` (new): one assertion per relation factory (`hasOne`, `hasMany`, `belongsTo`, `belongsToMany`, `hasOneThrough`, `hasManyThrough`, `morphOne`, `morphMany`, `morphToMany`, `morphedByMany`), plus `getParent()` slot semantics for through relations (returns the intermediate, not the far parent — matches Laravel's `HasOneOrManyThrough` template binding), plus the chained `getRelated()->getKeyName()` shape from the issue's reproduction, plus the `morphTo` defer case.
- `tests/Type/tests/Relation/DynamicRelationNameStaysMixedTest.phpt` (new): regression pin — `$record->{$name}()->getRelated()` must keep emitting `MixedMethodCall`. The issue acknowledges this as out of scope.
- Existing tests (`RelationGenericsTest`, `RelationChainScopeTest`, `ForwardingHandlerTest`, `DynamicWhere*Test`) had `@var Relation<...>` annotations to coerce types around the upstream collapse. Those annotations are now redundant, the tests are simplified, and the same generics still pin via the inferred types.

## Out of scope

- Dynamic relation names (`$record->{$name}()`) cannot be narrowed without runtime info.
- Inherited relations declared on an *abstract* base model: the abstract base isn't registered as a Model, so per-class dispatch finds no closure. Pre-existing limitation, also true for every other plugin handler.