### PR TITLE
Suppress `PossiblyUnusedMethod` reports for FormRequest hooks

### DIFF
--- a/src/Handlers/SuppressHandler.php
+++ b/src/Handlers/SuppressHandler.php
@@ -108,6 +108,14 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
     /** @var array<string, array<string, list<string>>> */
     private const METHOD_LEVEL_BY_PARENT_CLASS = [
         'PossiblyUnusedMethod' => [
+            'Illuminate\Foundation\Http\FormRequest' => [
+                'after',
+                'authorize',
+                'rules',
+                'validator',
+                'validationRules',
+                'withValidator',
+            ],
             'Illuminate\Mail\Mailable' => ['__construct', 'build', 'envelope', 'content', 'attachments'],
             'Illuminate\Notifications\Notification' => ['__construct', 'via', 'toMail', 'toArray'],
         ],


### PR DESCRIPTION
## Issue to Solve
<!-- Brief description of the problem this PR solves -->
The framework encourages people to introduce classes that extend `\Illuminate\Foundation\Http\FormRequest` and to add the `rules` and `authorize` methods.
As of the `\Illuminate\Foundation\Http\FormRequest` implementation, it uses `method_exists` to check whether the current instance has such methods, and there is no interface/phpdoc that might help Psalm understand that such a method will be used.

Because of that, Psalm complains with `PossiblyUnusedMethod` for such a class.
```php
use Illuminate\Foundation\Http\FormRequest;

class PasswordUpdateRequest extends FormRequest
{
    public function rules(): array
    {
        return [
            'current_password' => ['required', 'string'],
            'password' => ['required', 'string'],
        ];
    }
}
```

https://laravel.com/docs/13.x/validation#creating-form-requests

## Related
<!-- Reference related issues with "Fixes #123" or "Closes #123". -->
n/a

## Solution Description
<!-- How did you verify the change works? e.g. new type test, unit test, manual testing -->
manual testing

## Checklist
- [ ] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)
