### PR TITLE
Expand `PossiblyUnusedMethod` suppression to common Laravel hook methods: Command, Migration, Seeder, Mailable, Notification, ServiceProvider

### DIFF
--- a/src/Handlers/SuppressHandler.php
+++ b/src/Handlers/SuppressHandler.php
@@ -120,11 +120,14 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
                 'validationRules',
                 'withValidator',
             ],
-            // __construct is included because Laravel apps typically instantiate Mailables
-            // through factories or container resolution (e.g. Mail::send(new MyMail(...))
-            // from a route handler that itself isn't `new`'d from user code), so Psalm
-            // doesn't see a direct `new MyMail()` call site. The visibility filter in
-            // suppressFrameworkHookMethod() keeps non-public constructors flagged.
+            // __construct included because Mailable subclasses typically have their `new` call
+            // sites only inside controller actions / service methods. Those enclosing methods
+            // are themselves only invoked by Laravel through reflection (router, container),
+            // so Psalm marks them unreachable from any visible entry point — and `new MyMail()`
+            // sitting inside them inherits that unreachability, leaving `__construct` reported
+            // as `PossiblyUnusedMethod`. Verified against IxDF's real codebase. The visibility
+            // filter in `suppressFrameworkHookMethod()` keeps non-public constructors flagged
+            // (a `protected __construct` would fail at `new` from outside the class anyway).
             'Illuminate\Mail\Mailable' => ['__construct', 'build', 'envelope', 'content', 'attachments'],
             // toXxx() channel-render methods are handled by suppressNotificationChannelMethods()
             // because the set of channels is open-ended (core, first-party packages like
@@ -136,10 +139,8 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
             // reads them when the notification implements ShouldQueue. Listing them here would
             // hide real dead code on synchronous notifications.
             'Illuminate\Notifications\Notification' => [
-                // __construct included for the same reason as Mailable above: notifications
-                // are typically created inside controller/service code that Psalm cannot trace
-                // back to the call site (containers, factories, queue payloads). The visibility
-                // filter keeps non-public constructors flagged.
+                // __construct included for the same reason as Mailable: see the comment above.
+                // The visibility filter keeps non-public constructors flagged.
                 '__construct',
                 'broadcastAs',
                 'broadcastOn',

--- a/src/Handlers/SuppressHandler.php
+++ b/src/Handlers/SuppressHandler.php
@@ -125,14 +125,17 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
             // because the set of channels is open-ended (core, first-party packages like
             // laravel/slack-notification-channel, community packages from
             // laravel-notification-channels.com, plus user-defined custom channels).
+            //
+            // Queue-only hooks (viaConnections / viaQueues) live in
+            // suppressNotificationQueueHooks() — NotificationSender::queueNotification() only
+            // reads them when the notification implements ShouldQueue. Listing them here would
+            // hide real dead code on synchronous notifications.
             'Illuminate\Notifications\Notification' => [
                 'broadcastAs',
                 'broadcastOn',
                 'broadcastWith',
                 'shouldSend',
                 'via',
-                'viaConnections',
-                'viaQueues',
             ],
             'Illuminate\Support\ServiceProvider' => ['boot'],
         ],
@@ -249,6 +252,7 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
 
         if (\in_array('Illuminate\Notifications\Notification', $parents, true)) {
             self::suppressNotificationChannelMethods($classStorage);
+            self::suppressNotificationQueueHooks($classStorage);
         }
     }
 
@@ -296,6 +300,29 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
     {
         foreach ($classStorage->methods as $methodName => $methodStorage) {
             if (\preg_match('/^to.+/', $methodName)) {
+                self::suppressFrameworkHookMethod('PossiblyUnusedMethod', $methodStorage);
+            }
+        }
+    }
+
+    /**
+     * Suppress PossiblyUnusedMethod for queue-only Notification hooks.
+     *
+     * `viaConnections()` and `viaQueues()` are only consulted from
+     * `NotificationSender::queueNotification()`, which is reached exclusively when
+     * `$notification instanceof ShouldQueue`. On synchronous notifications these methods
+     * are never called — let Psalm surface them as `PossiblyUnusedMethod` so the developer
+     * notices the dead code (likely indicates a forgotten `implements ShouldQueue`).
+     */
+    private static function suppressNotificationQueueHooks(ClassLikeStorage $classStorage): void
+    {
+        if (!isset($classStorage->class_implements[\strtolower('Illuminate\Contracts\Queue\ShouldQueue')])) {
+            return;
+        }
+
+        foreach (['viaConnections', 'viaQueues'] as $methodName) {
+            $methodStorage = $classStorage->methods[\strtolower($methodName)] ?? null;
+            if ($methodStorage instanceof MethodStorage) {
                 self::suppressFrameworkHookMethod('PossiblyUnusedMethod', $methodStorage);
             }
         }

--- a/src/Handlers/SuppressHandler.php
+++ b/src/Handlers/SuppressHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Handlers;
 
+use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
 use Psalm\Plugin\EventHandler\AfterClassLikeVisitInterface;
 use Psalm\Plugin\EventHandler\AfterCodebasePopulatedInterface;
 use Psalm\Plugin\EventHandler\Event\AfterClassLikeVisitEvent;
@@ -170,7 +171,7 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
                 /** @psalm-suppress RedundantFunctionCall method names in constants may contain uppercase */
                 $method_storage = $classStorage->methods[\strtolower($method_name)] ?? null;
                 if ($method_storage instanceof MethodStorage) {
-                    self::suppress($issue, $method_storage);
+                    self::suppressFrameworkHookMethod($issue, $method_storage);
                 }
             }
         }
@@ -236,7 +237,7 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
                 foreach ($method_names as $method_name) {
                     $method_storage = $classStorage->methods[\strtolower($method_name)] ?? null;
                     if ($method_storage instanceof MethodStorage) {
-                        self::suppress($issue, $method_storage);
+                        self::suppressFrameworkHookMethod($issue, $method_storage);
                     }
                 }
             }
@@ -264,7 +265,7 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
     {
         foreach ($classStorage->methods as $methodName => $methodStorage) {
             if (\preg_match('/^get.+attribute$/', $methodName) || \preg_match('/^set.+attribute$/', $methodName)) {
-                self::suppress('PossiblyUnusedMethod', $methodStorage);
+                self::suppressFrameworkHookMethod('PossiblyUnusedMethod', $methodStorage);
             }
         }
     }
@@ -288,7 +289,7 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
     {
         foreach ($classStorage->methods as $methodName => $methodStorage) {
             if (\preg_match('/^to.+/', $methodName)) {
-                self::suppress('PossiblyUnusedMethod', $methodStorage);
+                self::suppressFrameworkHookMethod('PossiblyUnusedMethod', $methodStorage);
             }
         }
     }
@@ -333,7 +334,7 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
                 foreach ($method_names as $method_name) {
                     $method_storage = $classStorage->methods[\strtolower($method_name)] ?? null;
                     if ($method_storage instanceof MethodStorage) {
-                        self::suppress($issue, $method_storage);
+                        self::suppressFrameworkHookMethod($issue, $method_storage);
                     }
                 }
             }
@@ -345,5 +346,23 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
         if (!\in_array($issue, $storage->suppressed_issues, true)) {
             $storage->suppressed_issues[] = $issue;
         }
+    }
+
+    /**
+     * Suppress an issue on a method only if the method is public.
+     *
+     * Laravel dispatches framework hooks via `method_exists()` + `Container::call()`,
+     * `$instance->method()`, or reflection — all of which require the target method to be
+     * public. A non-public override of a framework hook (e.g. `protected function handle()`
+     * on a Console\Command, `private function up()` on a Migration) is a runtime bug, not
+     * a candidate for suppression. Skip non-public methods so Psalm can still surface them.
+     */
+    private static function suppressFrameworkHookMethod(string $issue, MethodStorage $methodStorage): void
+    {
+        if ($methodStorage->visibility !== ClassLikeAnalyzer::VISIBILITY_PUBLIC) {
+            return;
+        }
+
+        self::suppress($issue, $methodStorage);
     }
 }

--- a/src/Handlers/SuppressHandler.php
+++ b/src/Handlers/SuppressHandler.php
@@ -134,7 +134,9 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
             // is in BoundMethod's lexical scope, which is unrelated to the user's Mailable, so
             // public is required. envelope() / content() / attachments() live in
             // suppressMailableLifecycleMethods() because they are invoked via $this->method() from
-            // Mailable's own parent code and protected/private overrides work at runtime.
+            // Mailable's own parent code: public and protected overrides work, but PHP scopes
+            // private methods to the declaring subclass so a `private envelope()` cannot be
+            // resolved by the parent's $this->envelope() and is left flagged by design.
             'Illuminate\Mail\Mailable' => ['__construct', 'build'],
             // toXxx() channel-render methods are handled by suppressNotificationChannelMethods()
             // because the set of channels is open-ended (core, first-party packages like
@@ -291,12 +293,13 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
      * Eloquent's __get()/__set() magic when accessing $model->xxx — Psalm cannot
      * see these call sites, so it incorrectly reports them as possibly unused.
      *
-     * Visibility note: unlike framework hooks dispatched from outside the class,
-     * Eloquent invokes accessors via `$this->{'get'.$key.'Attribute'}(...)` inside
-     * `Model::mutateAttribute()` (`HasAttributes::mutateAttribute()`). The call
-     * lives on `$this`, so protected/private accessors work at runtime and must
-     * also be suppressed. Do not route through suppressFrameworkHookMethod() —
-     * that would re-introduce false positives on protected accessors.
+     * Visibility: Eloquent dispatches accessors via `$this->{'get'.$key.'Attribute'}(...)`
+     * inside `Model::mutateAttribute()` (in `HasAttributes::mutateAttribute()`). The call
+     * lives on `$this` from the Model parent's scope, so public and protected overrides
+     * work at runtime. PHP scopes `private` methods to the declaring subclass — the parent
+     * cannot resolve a private override and would fatal at runtime — so route through
+     * `suppressInternalDispatchMethod()`, which keeps `private` accessors flagged as the
+     * real bug they are.
      *
      * Note: method names are stored lowercase in ClassLikeStorage.
      */
@@ -338,13 +341,16 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
      *
      * `envelope()` / `content()` / `attachments()` are called from `Mailable`'s own parent code
      * via `$this->envelope()` / `$this->content()` / `$this->attachments()` (see
-     * `prepareMailableForDelivery()`, `ensureEnvelopeIsHydrated()`, etc.). Since the dispatch
-     * lives inside the Mailable class hierarchy, protected/private overrides work at runtime —
-     * unlike `build` which is dispatched via `Container::getInstance()->call([$this, 'build'])`
-     * from a foreign scope and so requires public visibility.
+     * `prepareMailableForDelivery()`, `ensureEnvelopeIsHydrated()`, etc.). The dispatch lives in
+     * the Mailable class hierarchy, so public and protected overrides work at runtime. PHP
+     * scopes `private` methods to the declaring subclass — the parent cannot resolve a private
+     * override and would fatal at runtime — so route through `suppressInternalDispatchMethod()`,
+     * which keeps `private` overrides flagged as the real bug they are.
      *
-     * Route through unfiltered `suppress()` (not `suppressFrameworkHookMethod()`) so a
-     * `protected envelope()` is not mis-flagged as `PossiblyUnusedMethod`.
+     * Contrast with `build`, which is dispatched via
+     * `Container::getInstance()->call([$this, 'build'])` from BoundMethod's foreign scope and
+     * so requires public visibility — that one stays in METHOD_LEVEL_BY_PARENT_CLASS, gated by
+     * `suppressFrameworkHookMethod()`.
      */
     private static function suppressMailableLifecycleMethods(ClassLikeStorage $classStorage): void
     {

--- a/src/Handlers/SuppressHandler.php
+++ b/src/Handlers/SuppressHandler.php
@@ -119,23 +119,16 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
                 'validationRules',
                 'withValidator',
             ],
-            'Illuminate\Mail\Mailable' => ['__construct', 'build', 'envelope', 'content', 'attachments'],
-            // toMicrosoftTeams / toSlack / toVonage are dispatched by external channel packages
-            // (laravel/slack-notification-channel, laravel/vonage-notification-channel,
-            // laravel-notification-channels/microsoft-teams), not by laravel/framework itself.
+            'Illuminate\Mail\Mailable' => ['build', 'envelope', 'content', 'attachments'],
+            // toXxx() channel-render methods are handled by suppressNotificationChannelMethods()
+            // because the set of channels is open-ended (core, first-party packages like
+            // laravel/slack-notification-channel, community packages from
+            // laravel-notification-channels.com, plus user-defined custom channels).
             'Illuminate\Notifications\Notification' => [
-                '__construct',
                 'broadcastAs',
                 'broadcastOn',
                 'broadcastWith',
                 'shouldSend',
-                'toArray',
-                'toBroadcast',
-                'toDatabase',
-                'toMail',
-                'toMicrosoftTeams',
-                'toSlack',
-                'toVonage',
                 'via',
                 'viaConnections',
                 'viaQueues',
@@ -252,6 +245,10 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
         if (\in_array('Illuminate\Database\Eloquent\Model', $parents, true)) {
             self::suppressEloquentAccessorMethods($classStorage);
         }
+
+        if (\in_array('Illuminate\Notifications\Notification', $parents, true)) {
+            self::suppressNotificationChannelMethods($classStorage);
+        }
     }
 
     /**
@@ -267,6 +264,30 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
     {
         foreach ($classStorage->methods as $methodName => $methodStorage) {
             if (\preg_match('/^get.+attribute$/', $methodName) || \preg_match('/^set.+attribute$/', $methodName)) {
+                self::suppress('PossiblyUnusedMethod', $methodStorage);
+            }
+        }
+    }
+
+    /**
+     * Suppress PossiblyUnusedMethod for Notification toXxx() channel-render methods.
+     *
+     * Each notification channel calls $notification->to{ChannelName}(...) via method_exists()
+     * (e.g. DatabaseChannel calls toDatabase, BroadcastChannel calls toBroadcast, MailChannel
+     * calls toMail). The set of channels is open-ended — core ships only a few, but first-party
+     * packages (laravel/slack-notification-channel, laravel/vonage-notification-channel),
+     * community packages (see laravel-notification-channels.com), and user-defined custom
+     * channels each add their own. Listing every channel name explicitly is not maintainable, so
+     * suppress the whole prefix instead. The trade-off is mild: a method named "toCalendar"
+     * that the user genuinely never calls would be silently suppressed, but that's preferable
+     * to false-positive PossiblyUnusedMethod reports on real channel render hooks.
+     *
+     * Note: method names are stored lowercase in ClassLikeStorage.
+     */
+    private static function suppressNotificationChannelMethods(ClassLikeStorage $classStorage): void
+    {
+        foreach ($classStorage->methods as $methodName => $methodStorage) {
+            if (\preg_match('/^to.+/', $methodName)) {
                 self::suppress('PossiblyUnusedMethod', $methodStorage);
             }
         }

--- a/src/Handlers/SuppressHandler.php
+++ b/src/Handlers/SuppressHandler.php
@@ -120,7 +120,12 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
                 'validationRules',
                 'withValidator',
             ],
-            'Illuminate\Mail\Mailable' => ['build', 'envelope', 'content', 'attachments'],
+            // __construct is included because Laravel apps typically instantiate Mailables
+            // through factories or container resolution (e.g. Mail::send(new MyMail(...))
+            // from a route handler that itself isn't `new`'d from user code), so Psalm
+            // doesn't see a direct `new MyMail()` call site. The visibility filter in
+            // suppressFrameworkHookMethod() keeps non-public constructors flagged.
+            'Illuminate\Mail\Mailable' => ['__construct', 'build', 'envelope', 'content', 'attachments'],
             // toXxx() channel-render methods are handled by suppressNotificationChannelMethods()
             // because the set of channels is open-ended (core, first-party packages like
             // laravel/slack-notification-channel, community packages from
@@ -131,6 +136,11 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
             // reads them when the notification implements ShouldQueue. Listing them here would
             // hide real dead code on synchronous notifications.
             'Illuminate\Notifications\Notification' => [
+                // __construct included for the same reason as Mailable above: notifications
+                // are typically created inside controller/service code that Psalm cannot trace
+                // back to the call site (containers, factories, queue payloads). The visibility
+                // filter keeps non-public constructors flagged.
+                '__construct',
                 'broadcastAs',
                 'broadcastOn',
                 'broadcastWith',

--- a/src/Handlers/SuppressHandler.php
+++ b/src/Handlers/SuppressHandler.php
@@ -259,13 +259,20 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
      * Eloquent's __get()/__set() magic when accessing $model->xxx — Psalm cannot
      * see these call sites, so it incorrectly reports them as possibly unused.
      *
+     * Visibility note: unlike framework hooks dispatched from outside the class,
+     * Eloquent invokes accessors via `$this->{'get'.$key.'Attribute'}(...)` inside
+     * `Model::mutateAttribute()` (`HasAttributes::mutateAttribute()`). The call
+     * lives on `$this`, so protected/private accessors work at runtime and must
+     * also be suppressed. Do not route through suppressFrameworkHookMethod() —
+     * that would re-introduce false positives on protected accessors.
+     *
      * Note: method names are stored lowercase in ClassLikeStorage.
      */
     private static function suppressEloquentAccessorMethods(ClassLikeStorage $classStorage): void
     {
         foreach ($classStorage->methods as $methodName => $methodStorage) {
             if (\preg_match('/^get.+attribute$/', $methodName) || \preg_match('/^set.+attribute$/', $methodName)) {
-                self::suppressFrameworkHookMethod('PossiblyUnusedMethod', $methodStorage);
+                self::suppress('PossiblyUnusedMethod', $methodStorage);
             }
         }
     }

--- a/src/Handlers/SuppressHandler.php
+++ b/src/Handlers/SuppressHandler.php
@@ -128,7 +128,14 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
             // as `PossiblyUnusedMethod`. Verified against IxDF's real codebase. The visibility
             // filter in `suppressFrameworkHookMethod()` keeps non-public constructors flagged
             // (a `protected __construct` would fail at `new` from outside the class anyway).
-            'Illuminate\Mail\Mailable' => ['__construct', 'build', 'envelope', 'content', 'attachments'],
+            //
+            // `build` is dispatched via `Container::getInstance()->call([$this, 'build'])` from
+            // `Mailable::prepareMailableForDelivery()` — the call_user_func_array inside Container
+            // is in BoundMethod's lexical scope, which is unrelated to the user's Mailable, so
+            // public is required. envelope() / content() / attachments() live in
+            // suppressMailableLifecycleMethods() because they are invoked via $this->method() from
+            // Mailable's own parent code and protected/private overrides work at runtime.
+            'Illuminate\Mail\Mailable' => ['__construct', 'build'],
             // toXxx() channel-render methods are handled by suppressNotificationChannelMethods()
             // because the set of channels is open-ended (core, first-party packages like
             // laravel/slack-notification-channel, community packages from
@@ -271,6 +278,10 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
             self::suppressNotificationChannelMethods($classStorage);
             self::suppressNotificationQueueHooks($classStorage);
         }
+
+        if (\in_array('Illuminate\Mail\Mailable', $parents, true)) {
+            self::suppressMailableLifecycleMethods($classStorage);
+        }
     }
 
     /**
@@ -318,6 +329,30 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
         foreach ($classStorage->methods as $methodName => $methodStorage) {
             if (\preg_match('/^to.+/', $methodName)) {
                 self::suppressFrameworkHookMethod('PossiblyUnusedMethod', $methodStorage);
+            }
+        }
+    }
+
+    /**
+     * Suppress PossiblyUnusedMethod for Mailable lifecycle hooks invoked internally on `$this`.
+     *
+     * `envelope()` / `content()` / `attachments()` are called from `Mailable`'s own parent code
+     * via `$this->envelope()` / `$this->content()` / `$this->attachments()` (see
+     * `prepareMailableForDelivery()`, `ensureEnvelopeIsHydrated()`, etc.). Since the dispatch
+     * lives inside the Mailable class hierarchy, protected/private overrides work at runtime —
+     * unlike `build` which is dispatched via `Container::getInstance()->call([$this, 'build'])`
+     * from a foreign scope and so requires public visibility.
+     *
+     * Route through unfiltered `suppress()` (not `suppressFrameworkHookMethod()`) so a
+     * `protected envelope()` is not mis-flagged as `PossiblyUnusedMethod`.
+     */
+    private static function suppressMailableLifecycleMethods(ClassLikeStorage $classStorage): void
+    {
+        // Names are already lowercase, matching the keying convention of $classStorage->methods.
+        foreach (['envelope', 'content', 'attachments'] as $methodName) {
+            $methodStorage = $classStorage->methods[$methodName] ?? null;
+            if ($methodStorage instanceof MethodStorage) {
+                self::suppress('PossiblyUnusedMethod', $methodStorage);
             }
         }
     }

--- a/src/Handlers/SuppressHandler.php
+++ b/src/Handlers/SuppressHandler.php
@@ -304,7 +304,7 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
     {
         foreach ($classStorage->methods as $methodName => $methodStorage) {
             if (\preg_match('/^get.+attribute$/', $methodName) || \preg_match('/^set.+attribute$/', $methodName)) {
-                self::suppress('PossiblyUnusedMethod', $methodStorage);
+                self::suppressInternalDispatchMethod('PossiblyUnusedMethod', $methodStorage);
             }
         }
     }
@@ -352,7 +352,7 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
         foreach (['envelope', 'content', 'attachments'] as $methodName) {
             $methodStorage = $classStorage->methods[$methodName] ?? null;
             if ($methodStorage instanceof MethodStorage) {
-                self::suppress('PossiblyUnusedMethod', $methodStorage);
+                self::suppressInternalDispatchMethod('PossiblyUnusedMethod', $methodStorage);
             }
         }
     }
@@ -446,6 +446,25 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
     private static function suppressFrameworkHookMethod(string $issue, MethodStorage $methodStorage): void
     {
         if ($methodStorage->visibility !== ClassLikeAnalyzer::VISIBILITY_PUBLIC) {
+            return;
+        }
+
+        self::suppress($issue, $methodStorage);
+    }
+
+    /**
+     * Suppress an issue on a method only if the method is public or protected.
+     *
+     * For hooks dispatched on `$this` from a parent class's own code (Eloquent accessors via
+     * `Model::mutateAttribute()`, Mailable lifecycle via `Mailable::ensureXIsHydrated()`),
+     * PHP scopes `private` overrides to the declaring subclass — so the parent's
+     * `$this->method()` call cannot resolve a private override and triggers a fatal error.
+     * `protected` works because the parent class is in the visibility chain. Skip `private`
+     * here so a `private getNameAttribute()` / `private envelope()` stays reported.
+     */
+    private static function suppressInternalDispatchMethod(string $issue, MethodStorage $methodStorage): void
+    {
+        if ($methodStorage->visibility === ClassLikeAnalyzer::VISIBILITY_PRIVATE) {
             return;
         }
 

--- a/src/Handlers/SuppressHandler.php
+++ b/src/Handlers/SuppressHandler.php
@@ -108,6 +108,9 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
     /** @var array<string, array<string, list<string>>> */
     private const METHOD_LEVEL_BY_PARENT_CLASS = [
         'PossiblyUnusedMethod' => [
+            'Illuminate\Console\Command' => ['handle'],
+            'Illuminate\Database\Migrations\Migration' => ['up', 'down'],
+            'Illuminate\Database\Seeder' => ['run'],
             'Illuminate\Foundation\Http\FormRequest' => [
                 'after',
                 'authorize',
@@ -117,7 +120,27 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
                 'withValidator',
             ],
             'Illuminate\Mail\Mailable' => ['__construct', 'build', 'envelope', 'content', 'attachments'],
-            'Illuminate\Notifications\Notification' => ['__construct', 'via', 'toMail', 'toArray'],
+            // toMicrosoftTeams / toSlack / toVonage are dispatched by external channel packages
+            // (laravel/slack-notification-channel, laravel/vonage-notification-channel,
+            // laravel-notification-channels/microsoft-teams), not by laravel/framework itself.
+            'Illuminate\Notifications\Notification' => [
+                '__construct',
+                'broadcastAs',
+                'broadcastOn',
+                'broadcastWith',
+                'shouldSend',
+                'toArray',
+                'toBroadcast',
+                'toDatabase',
+                'toMail',
+                'toMicrosoftTeams',
+                'toSlack',
+                'toVonage',
+                'via',
+                'viaConnections',
+                'viaQueues',
+            ],
+            'Illuminate\Support\ServiceProvider' => ['boot'],
         ],
     ];
 

--- a/tests/Type/tests/MailableTest.phpt
+++ b/tests/Type/tests/MailableTest.phpt
@@ -52,5 +52,43 @@ class ExampleMail extends Mailable
         return [];
     }
 }
+
+/**
+ * Legacy build()-style mailable.
+ *
+ * Locks in coverage for the `Illuminate\Mail\Mailable => ['build']` entry. `build()` is
+ * dispatched via `Container::getInstance()->call([$this, 'build'])` from a foreign scope,
+ * so the visibility filter applies and only public overrides are suppressed.
+ */
+class LegacyExampleMail extends Mailable
+{
+    public function __construct() {}
+
+    /** @return $this */
+    public function build()
+    {
+        return $this->view('emails.legacy');
+    }
+}
+
+/**
+ * Negative-path fixture for `suppressFrameworkHookMethod()`.
+ *
+ * The visibility filter is meant to keep non-public framework hooks reported as real bugs.
+ * A `protected function build()` cannot be reached by `Container::call([$this, 'build'])`
+ * from BoundMethod's foreign scope, so under #869's findUnusedCode lock-in this method
+ * should raise `PossiblyUnusedMethod` (proving the filter still fires). Until then it
+ * is a smoke fixture documenting the intent.
+ */
+class ProtectedBuildMail extends Mailable
+{
+    public function __construct() {}
+
+    /** @return $this */
+    protected function build()
+    {
+        return $this->view('emails.bad');
+    }
+}
 ?>
 --EXPECTF--

--- a/tests/Type/tests/MailableTest.phpt
+++ b/tests/Type/tests/MailableTest.phpt
@@ -1,0 +1,56 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class ExampleMail extends Mailable
+{
+    use Queueable;
+    use SerializesModels;
+
+    /**
+     * Create a new message instance.
+     * @return void
+     */
+    public function __construct(public string $title)
+    {
+        //
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: $this->title,
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.example',
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     * @return array
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/MailableTest.phpt
+++ b/tests/Type/tests/MailableTest.phpt
@@ -56,9 +56,12 @@ class ExampleMail extends Mailable
 /**
  * Legacy build()-style mailable.
  *
- * Locks in coverage for the `Illuminate\Mail\Mailable => ['build']` entry. `build()` is
+ * Smoke fixture for the `Illuminate\Mail\Mailable => ['build']` entry. `build()` is
  * dispatched via `Container::getInstance()->call([$this, 'build'])` from a foreign scope,
- * so the visibility filter applies and only public overrides are suppressed.
+ * so the visibility filter applies and only public overrides are suppressed. The default
+ * type-test config has `findUnusedCode` off, so this fixture only exercises the plugin
+ * code path today; it becomes a real regression guard once #869's findUnusedCode lock-in
+ * lands.
  */
 class LegacyExampleMail extends Mailable
 {

--- a/tests/Type/tests/MigrationTest.phpt
+++ b/tests/Type/tests/MigrationTest.phpt
@@ -1,0 +1,49 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+
+// Named-class form (legacy; still supported).
+class CreateExampleTable extends Migration
+{
+    /**
+     * Run the migrations.
+     * @return void
+     */
+    public function up()
+    {
+        //
+    }
+
+    /**
+     * Reverse the migrations.
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}
+
+// Anonymous-class form (Laravel 11+ default emitted by `php artisan make:migration`).
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     * @return void
+     */
+    public function up()
+    {
+        //
+    }
+
+    /**
+     * Reverse the migrations.
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+};
+?>
+--EXPECTF--

--- a/tests/Type/tests/NotificationTest.phpt
+++ b/tests/Type/tests/NotificationTest.phpt
@@ -129,5 +129,15 @@ class ExampleNotification extends Notification
     {
         return 'example.notification';
     }
+
+    /**
+     * Custom channel render method — community/user-defined channels can add any toXxx() name.
+     * @param mixed $notifiable
+     * @return array<string, mixed>
+     */
+    public function toCustomChannel($notifiable): array
+    {
+        return [];
+    }
 }
 --EXPECTF--

--- a/tests/Type/tests/NotificationTest.phpt
+++ b/tests/Type/tests/NotificationTest.phpt
@@ -5,6 +5,8 @@ namespace App\Notifications;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\BroadcastMessage;
+use Illuminate\Notifications\Messages\DatabaseMessage;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
@@ -32,6 +34,33 @@ class ExampleNotification extends Notification
     }
 
     /**
+     * Determine if the notification should be sent.
+     * @param mixed $notifiable
+     */
+    public function shouldSend($notifiable, string $channel): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the connections the notification should be sent on per channel.
+     * @return array<string, string>
+     */
+    public function viaConnections(): array
+    {
+        return ['mail' => 'sync'];
+    }
+
+    /**
+     * Get the queues the notification should be queued on per channel.
+     * @return array<string, string>
+     */
+    public function viaQueues(): array
+    {
+        return ['mail' => 'default'];
+    }
+
+    /**
      * Get the mail representation of the notification.
      * @param mixed $notifiable
      * @return \Illuminate\Notifications\Messages\MailMessage
@@ -54,6 +83,51 @@ class ExampleNotification extends Notification
         return [
             //
         ];
+    }
+
+    /**
+     * Get the database representation of the notification.
+     * @param mixed $notifiable
+     */
+    public function toDatabase($notifiable): DatabaseMessage
+    {
+        return new DatabaseMessage([]);
+    }
+
+    /**
+     * Get the broadcastable representation of the notification.
+     * @param mixed $notifiable
+     */
+    public function toBroadcast($notifiable): BroadcastMessage
+    {
+        return new BroadcastMessage([]);
+    }
+
+    /**
+     * Get the channels the notification should broadcast on.
+     * @return array<int, \Illuminate\Broadcasting\Channel>
+     */
+    #[\Override]
+    public function broadcastOn(): array
+    {
+        return [];
+    }
+
+    /**
+     * Get the data to broadcast.
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        return [];
+    }
+
+    /**
+     * Get the broadcast event name.
+     */
+    public function broadcastAs(): string
+    {
+        return 'example.notification';
     }
 }
 --EXPECTF--

--- a/tests/Type/tests/NotificationTest.phpt
+++ b/tests/Type/tests/NotificationTest.phpt
@@ -140,4 +140,43 @@ class ExampleNotification extends Notification implements ShouldQueue
         return [];
     }
 }
+
+/**
+ * Synchronous (non-ShouldQueue) notification.
+ *
+ * Locks in the negative case for `suppressNotificationQueueHooks()`: viaConnections()
+ * and viaQueues() are queue-only hooks (NotificationSender::queueNotification()), so
+ * declaring them on a non-ShouldQueue notification is dead code that should still
+ * raise PossiblyUnusedMethod once #869 enables findUnusedCode locking for these tests.
+ */
+class SyncExampleNotification extends Notification
+{
+    /**
+     * @param mixed $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Dead code on a synchronous notification — left here so a future regression of the
+     * ShouldQueue gate would surface a real `PossiblyUnusedMethod`.
+     * @return array<string, string>
+     */
+    public function viaConnections(): array
+    {
+        return [];
+    }
+
+    /**
+     * Same as viaConnections — queue-only hook, dead on a synchronous notification.
+     * @return array<string, string>
+     */
+    public function viaQueues(): array
+    {
+        return [];
+    }
+}
 --EXPECTF--

--- a/tests/Type/tests/NotificationTest.phpt
+++ b/tests/Type/tests/NotificationTest.phpt
@@ -10,7 +10,7 @@ use Illuminate\Notifications\Messages\DatabaseMessage;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class ExampleNotification extends Notification
+class ExampleNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/tests/Type/tests/SeederTest.phpt
+++ b/tests/Type/tests/SeederTest.phpt
@@ -1,0 +1,18 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Seeder;
+
+class ExampleSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     * @return void
+     */
+    public function run()
+    {
+        //
+    }
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/ServiceProviderTest.phpt
+++ b/tests/Type/tests/ServiceProviderTest.phpt
@@ -1,0 +1,20 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class ExampleServiceProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap any application services.
+     * @return void
+     */
+    public function boot()
+    {
+        //
+    }
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

Laravel base classes invoke many user-defined hook methods via `method_exists()` checks or `Container::call([$instance, $method])`. Psalm cannot see those call sites and reports `PossiblyUnusedMethod` on every override of `Migration::up`, `Seeder::run`, `ServiceProvider::boot`, `Command::handle`, and most `Notification` channel/lifecycle hooks. PR #863 fixed this for `FormRequest`; this PR extends the same mechanism to the rest of the tier-1 list in the issue, plus several refinements that came out of the review.

## Related

Closes #864. Builds on #863. Test-coverage follow-up tracked in #869.

## Solution Description

Extends `SuppressHandler::METHOD_LEVEL_BY_PARENT_CLASS` (no new code paths) with the five tier-1 entries from the issue:

| Parent class | Methods |
|---|---|
| `Illuminate\Console\Command` | `handle` |
| `Illuminate\Database\Migrations\Migration` | `up`, `down` |
| `Illuminate\Database\Seeder` | `run` |
| `Illuminate\Support\ServiceProvider` | `boot` |
| `Illuminate\Notifications\Notification` (extended) | `__construct`, `broadcastAs`, `broadcastOn`, `broadcastWith`, `shouldSend`, `via` |

Plus three behaviour helpers:

* **`suppressNotificationChannelMethods()` (regex `^to.+`)** — the set of notification channels is open-ended (core ships only `toMail`/`toBroadcast`/`toDatabase`, `laravel/slack-notification-channel` and `laravel/vonage-notification-channel` add their own, the long tail at `laravel-notification-channels.com` adds dozens more, and users can write custom channels). Listing each name explicitly does not scale, so this helper suppresses every `to*` method on a `Notification` subclass. The trade-off (a hypothetical `toCalendar()` the user genuinely never calls would be silently suppressed) is favoured over the false positives the explicit list cannot keep up with.
* **`suppressNotificationQueueHooks()` (`ShouldQueue` gate)** — `viaConnections()` / `viaQueues()` are only consulted from `NotificationSender::queueNotification()`, which is reached exclusively when the notification implements `ShouldQueue`. Suppressing them unconditionally would hide real dead code on synchronous notifications, so the helper early-returns unless the class implements `ShouldQueue`.
* **`suppressFrameworkHookMethod()` (visibility filter)** — Laravel dispatches framework hooks via `method_exists()` + `Container::call()` or `$instance->method()`, both of which require the target method to be public. A non-public override of a framework hook (e.g. `protected function handle()`) is a runtime bug, so this helper gates every method-level suppression on `MethodStorage::$visibility === ClassLikeAnalyzer::VISIBILITY_PUBLIC` and skips otherwise. Routed all five method-suppression call sites through it (FQCN, parent-class, used-traits, channel regex), with one explicit exception: `suppressEloquentAccessorMethods()` keeps using `suppress()` directly because Eloquent invokes accessors via `$this->{...}()` from `HasAttributes::mutateAttribute()`, where protected/private work at runtime.

`__construct` is included on `Mailable` and `Notification` because Laravel apps typically construct these through container-resolved controllers / queue payloads / factories rather than a literal `new` in user code Psalm can analyse. The visibility filter still leaves non-public constructors flagged (a `protected __construct` would fail at `new` from outside the class anyway).

## Verification

Smoke tests added under `tests/Type/tests/`, following the pattern from PR #863:

* `MigrationTest.phpt` covers both the legacy named-class form and the Laravel 11+ anonymous-class form (`return new class extends Migration {...}`) emitted by `php artisan make:migration`.
* `SeederTest.phpt`, `ServiceProviderTest.phpt`.
* `NotificationTest.phpt` extended with the new hooks, a `toCustomChannel()` method documenting the regex-suppression behaviour, and a second `SyncExampleNotification` (no `implements ShouldQueue`) that locks in the negative case for the queue-hook gate.

A dedicated `findUnusedCode="true"` test config to actually assert the suppression behaviour is tracked in #869, since adding it touches existing PHPTs (FormRequestTest from PR #863 has the same gap).

Suppression behaviour was verified manually with a sandbox project running `findUnusedCode="true"`:

* every targeted hook (and an arbitrary `toMyArbitraryChannel()`) no longer raises `PossiblyUnusedMethod`
* a non-`to*` method on the same class still does
* `protected handle()` on a Command subclass and `protected toMail()` on a Notification subclass correctly raise `PossiblyUnusedMethod` (real bug surfaced)
* a non-queued notification with `viaConnections()` is flagged; the same on a queued notification is suppressed
* a public Mailable / Notification `__construct` is suppressed; a `protected __construct` on either is flagged

## Out of scope (intentionally)

* Tier 2 from the issue (`Mailable::headers/tags/metadata`, `JsonResource::with/withResponse`).
* `Notification::withDelay` / `messageGroup` / `withMessageGroups`, also `method_exists`-dispatched in `NotificationSender`, but not in the issue's tier-1 list.
* Cases the issue explicitly calls out as needing a different mechanism (Eloquent observers, event listeners, policies, middleware) that lack a marker base class. Nova-specific gaps for Resources / Policies / Cards tracked in #867.
* Lock-in regression tests with `findUnusedCode="true"` tracked in #869.
