### PR TITLE
Capture `using`/`as` chain mutations on `belongsToMany` / `morphToMany`

### DIFF
--- a/src/Handlers/Eloquent/ModelRelationReturnTypeHandler.php
+++ b/src/Handlers/Eloquent/ModelRelationReturnTypeHandler.php
@@ -7,6 +7,7 @@ namespace Psalm\LaravelPlugin\Handlers\Eloquent;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\HasOneThrough;
+use Illuminate\Database\Eloquent\Relations\MorphPivot;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\Pivot;
@@ -64,13 +65,22 @@ final class ModelRelationReturnTypeHandler
 {
     /**
      * Relation classes whose stub declares the 4-template
-     * `<TRelatedModel, TDeclaringModel, TPivotModel, TAccessor>` shape. Other
-     * relation classes ignore the captured pivot/accessor — emitting slots 3+4
-     * on a 2-template relation produces a malformed type.
+     * `<TRelatedModel, TDeclaringModel, TPivotModel, TAccessor>` shape, mapped to
+     * the stub-declared TPivotModel default. The handler emits this default when
+     * the parser captures `->as(...)` but no `->using(...)` (the all-or-nothing
+     * rule still requires emitting slot 3). Other relations ignore the captured
+     * pivot/accessor — emitting slots 3+4 on a 2-template relation produces a
+     * malformed type. Defaults must match Laravel source: `BelongsToMany` =>
+     * `Pivot`, `MorphToMany` => `MorphPivot` (see Laravel's MorphToMany
+     * constructor and the BelongsToMany stub at
+     * stubs/common/Database/Eloquent/Relations/).
      *
-     * @var list<class-string>
+     * @var array<class-string, class-string<Pivot>>
      */
-    private const PIVOT_AWARE_RELATIONS = [BelongsToMany::class, MorphToMany::class];
+    private const PIVOT_AWARE_RELATIONS = [
+        BelongsToMany::class => Pivot::class,
+        MorphToMany::class => MorphPivot::class,
+    ];
 
     /**
      * Memoized return-type Unions keyed by "declaringClass|bindingClass::method".
@@ -258,11 +268,11 @@ final class ModelRelationReturnTypeHandler
         // chain mutation. Both slots are filled together (with declared defaults filling
         // any gap); a partial 3-template `BelongsToMany<R, D, P>` would leave TAccessor
         // unbound on a relation whose template list expects 4 entries when any are given.
-        if (
-            \in_array($relationClass, self::PIVOT_AWARE_RELATIONS, true)
-            && ($pivotModel !== null || $accessor !== null)
-        ) {
-            $typeParams[] = new Union([new TNamedObject($pivotModel ?? Pivot::class)]);
+        // The pivot default is per-relation (BelongsToMany => Pivot, MorphToMany => MorphPivot)
+        // to match the stub's @template default expression.
+        $pivotDefault = self::PIVOT_AWARE_RELATIONS[$relationClass] ?? null;
+        if ($pivotDefault !== null && ($pivotModel !== null || $accessor !== null)) {
+            $typeParams[] = new Union([new TNamedObject($pivotModel ?? $pivotDefault)]);
             $typeParams[] = new Union([TLiteralString::make($accessor ?? 'pivot')]);
         }
 

--- a/src/Handlers/Eloquent/ModelRelationReturnTypeHandler.php
+++ b/src/Handlers/Eloquent/ModelRelationReturnTypeHandler.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Handlers\Eloquent;
 
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 use Psalm\Codebase;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\Type\Atomic\TGenericObject;
+use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Union;
 
@@ -45,11 +49,29 @@ use Psalm\Type\Union;
  * (`$bindingClass`), not a factory arg, so it is always available; if either factory
  * arg is dynamic the handler defers.
  *
+ * For `BelongsToMany` and `MorphToMany` the parser also walks the chain to capture
+ * `->using(CustomPivot::class)` (TPivotModel) and `->as('accessor')` (TAccessor); when
+ * present they are emitted as the 3rd and 4th template params so downstream pivot
+ * intersections (e.g. `first()` returning `TRelatedModel&object{pivot: TPivotModel}`)
+ * resolve to the user-declared pivot model rather than the default `Pivot`. When neither
+ * mutator appears the handler emits the 2-param shape and Psalm fills in the template
+ * defaults.
+ *
  * @see https://github.com/psalm/psalm-plugin-laravel/issues/760
  * @internal
  */
 final class ModelRelationReturnTypeHandler
 {
+    /**
+     * Relation classes whose stub declares the 4-template
+     * `<TRelatedModel, TDeclaringModel, TPivotModel, TAccessor>` shape. Other
+     * relation classes ignore the captured pivot/accessor — emitting slots 3+4
+     * on a 2-template relation produces a malformed type.
+     *
+     * @var list<class-string>
+     */
+    private const PIVOT_AWARE_RELATIONS = [BelongsToMany::class, MorphToMany::class];
+
     /**
      * Memoized return-type Unions keyed by "declaringClass|bindingClass::method".
      *
@@ -125,15 +147,6 @@ final class ModelRelationReturnTypeHandler
         try {
             $parsed = RelationMethodParser::parse($codebase, $declaringClass, $methodName);
 
-            // Known limitation: when the body wraps the factory in
-            // `->using(CustomPivot::class)` or `->as('accessor')`, those calls rebind
-            // TPivotModel / TAccessor on BelongsToMany / MorphToMany. The handler emits
-            // only the 2-template `Relation<TRelatedModel, TDeclaringModel>` shape and
-            // silently defaults TPivotModel = Pivot, TAccessor = 'pivot'. Deferring to
-            // the user's `@psalm-return BelongsToMany<X, $this, CustomPivot, 'pivot'>`
-            // does not help either — Psalm 7 collapses the entire annotation (including
-            // TPivotModel) when it cannot substitute `$this`. The primary issue from
-            // #760, TDeclaringModel collapsing to Model, stays fixed.
             if ($parsed === null) {
                 $result = null;
             } else {
@@ -144,6 +157,8 @@ final class ModelRelationReturnTypeHandler
                         $parsed['relationClass'],
                         $relatedModelType,
                         $parsed['intermediateModel'],
+                        $parsed['pivotModel'],
+                        $parsed['accessor'],
                         $bindingClass,
                     )
                     : null;
@@ -172,7 +187,7 @@ final class ModelRelationReturnTypeHandler
      * {@see RelationMethodParser::extractDocblockRelatedModelType} reads from the
      * docblock. Returns null when neither path produces a usable type.
      *
-     * @param array{relationClass: class-string, relatedModel: ?string, intermediateModel: ?string} $parsed
+     * @param array{relationClass: class-string, relatedModel: ?string, intermediateModel: ?string, pivotModel: ?string, accessor: ?string} $parsed
      */
     private static function resolveRelatedModelType(array $parsed, Codebase $codebase, string $declaringClass, string $methodName): ?Union
     {
@@ -197,7 +212,13 @@ final class ModelRelationReturnTypeHandler
      * The returned Union wraps a `TGenericObject` for the concrete relation class named by
      * `$relationClass`. The shape varies per Relation subclass:
      * - Standard relations: `<TRelatedModel, TDeclaringModel>` — e.g. `HasOne<Post, User>`,
-     *   `BelongsTo<User, Post>`, `BelongsToMany<Tag, Post>` (TPivotModel/TAccessor default).
+     *   `BelongsTo<User, Post>`.
+     * - BelongsToMany / MorphToMany: `<TRelatedModel, TDeclaringModel>` by default, expanding
+     *   to `<TRelatedModel, TDeclaringModel, TPivotModel, TAccessor>` when the parser captured
+     *   `->using(CustomPivot::class)` / `->as('alias')` chain mutations. The 4-template form
+     *   is needed so downstream pivot intersections (e.g. `first()` returning
+     *   `TRelatedModel&object{pivot: TPivotModel}`) resolve to the user-declared pivot model
+     *   rather than the default `Pivot`.
      * - Through relations: `<TRelatedModel, TIntermediateModel, TDeclaringModel>` — e.g.
      *   `HasManyThrough<Post, Membership, Country>`. Note the Relation parent's 3rd template
      *   (TResult) is filled implicitly by Psalm via the Through subclass's @template-extends.
@@ -210,6 +231,8 @@ final class ModelRelationReturnTypeHandler
         string $relationClass,
         Union $relatedModel,
         ?string $intermediateModel,
+        ?string $pivotModel,
+        ?string $accessor,
         string $bindingClass,
     ): ?Union {
         $isThrough = $relationClass === HasOneThrough::class || $relationClass === HasManyThrough::class;
@@ -230,6 +253,18 @@ final class ModelRelationReturnTypeHandler
         // should resolve to at the call site (User for `(new User())->posts()`), even if
         // the method body lives on a parent class.
         $typeParams[] = new Union([new TNamedObject($bindingClass)]);
+
+        // Emit TPivotModel / TAccessor (slots 3 and 4) only when the parser captured a
+        // chain mutation. Both slots are filled together (with declared defaults filling
+        // any gap); a partial 3-template `BelongsToMany<R, D, P>` would leave TAccessor
+        // unbound on a relation whose template list expects 4 entries when any are given.
+        if (
+            \in_array($relationClass, self::PIVOT_AWARE_RELATIONS, true)
+            && ($pivotModel !== null || $accessor !== null)
+        ) {
+            $typeParams[] = new Union([new TNamedObject($pivotModel ?? Pivot::class)]);
+            $typeParams[] = new Union([TLiteralString::make($accessor ?? 'pivot')]);
+        }
 
         return new Union([new TGenericObject($relationClass, $typeParams)]);
     }

--- a/src/Handlers/Eloquent/RelationMethodParser.php
+++ b/src/Handlers/Eloquent/RelationMethodParser.php
@@ -44,7 +44,9 @@ final class RelationMethodParser
 {
     /**
      * Parsed result: the relationship factory method, related model FQCN, and (for "through"
-     * relations only) the intermediate model FQCN.
+     * relations only) the intermediate model FQCN. For BelongsToMany / MorphToMany only,
+     * the chain is also scanned for `->using(Pivot::class)` and `->as('accessor')` mutations
+     * which rebind TPivotModel / TAccessor on the relation.
      *
      * relatedModel is null when:
      * - The relation is polymorphic (morphTo) — the related type is not statically determinable
@@ -54,7 +56,11 @@ final class RelationMethodParser
      * relation factory it stays null. Resolves the same way as relatedModel: missing or non-
      * literal class-string arguments produce null.
      *
-     * @var array<string, ?array{relationClass: class-string<Relation>, relatedModel: ?string, intermediateModel: ?string}>
+     * pivotModel / accessor are non-null only when an explicit `->using(...)` / `->as(...)` was
+     * detected on a BelongsToMany or MorphToMany chain with a statically resolvable argument.
+     * Other relations leave them null.
+     *
+     * @var array<string, ?array{relationClass: class-string<Relation>, relatedModel: ?string, intermediateModel: ?string, pivotModel: ?string, accessor: ?string}>
      */
     private static array $cache = [];
 
@@ -87,14 +93,17 @@ final class RelationMethodParser
     ];
 
     /**
-     * Parse a relationship method body and extract the relation class, related model, and (for
-     * through relations only) the intermediate model.
+     * Parse a relationship method body and extract the relation class, related model, (for
+     * through relations only) the intermediate model, and (for BelongsToMany / MorphToMany
+     * only) any `->using()` / `->as()` mutations detected on the chain.
      *
-     * @return ?array{relationClass: class-string<Relation>, relatedModel: ?string, intermediateModel: ?string}
+     * @return ?array{relationClass: class-string<Relation>, relatedModel: ?string, intermediateModel: ?string, pivotModel: ?string, accessor: ?string}
      *         null if the method cannot be parsed as a relationship method.
      *         relatedModel is null when polymorphic (morphTo) or when the first argument
      *         could not be statically resolved. intermediateModel is non-null only for
-     *         hasOneThrough / hasManyThrough.
+     *         hasOneThrough / hasManyThrough. pivotModel / accessor are non-null only when
+     *         an explicit `->using(Pivot::class)` / `->as('alias')` chain mutation was
+     *         detected with a statically resolvable argument.
      */
     public static function parse(Codebase $codebase, string $className, string $methodName): ?array
     {
@@ -111,7 +120,7 @@ final class RelationMethodParser
     }
 
     /**
-     * @return ?array{relationClass: class-string<Relation>, relatedModel: ?string, intermediateModel: ?string}
+     * @return ?array{relationClass: class-string<Relation>, relatedModel: ?string, intermediateModel: ?string, pivotModel: ?string, accessor: ?string}
      */
     private static function doParse(Codebase $codebase, string $className, string $methodName): ?array
     {
@@ -133,7 +142,7 @@ final class RelationMethodParser
      * like $this->belongsTo(Vault::class).
      *
      * @param array<array-key, PhpParser\Node\Stmt> $stmts
-     * @return ?array{relationClass: class-string<Relation>, relatedModel: ?string, intermediateModel: ?string}
+     * @return ?array{relationClass: class-string<Relation>, relatedModel: ?string, intermediateModel: ?string, pivotModel: ?string, accessor: ?string}
      */
     private static function parseMethodBody(array $stmts): ?array
     {
@@ -142,7 +151,10 @@ final class RelationMethodParser
                 continue;
             }
 
-            return self::findRelationCallInExpr($stmt->expr);
+            $pivotModel = null;
+            $accessor = null;
+
+            return self::findRelationCallInExpr($stmt->expr, $pivotModel, $accessor);
         }
 
         return null;
@@ -150,12 +162,21 @@ final class RelationMethodParser
 
     /**
      * Recursively search an expression for a relationship factory method call.
-     * Handles both direct calls and method chains.
+     * Handles both direct calls and method chains. While unwrapping the chain on the way
+     * to the inner factory call, also collect any `->using(Pivot::class)` and
+     * `->as('accessor')` mutations — these rebind TPivotModel / TAccessor on
+     * BelongsToMany and MorphToMany. Other chain calls (`->withDefault()`, `->wherePivot()`,
+     * etc.) are transparent: the recursion descends past them without recording anything.
      *
-     * @return ?array{relationClass: class-string<Relation>, relatedModel: ?string, intermediateModel: ?string}
+     * @param ?string $pivotModel out-parameter: FQCN captured from `->using(...)` if found
+     * @param ?string $accessor   out-parameter: literal string captured from `->as(...)` if found
+     * @return ?array{relationClass: class-string<Relation>, relatedModel: ?string, intermediateModel: ?string, pivotModel: ?string, accessor: ?string}
      */
-    private static function findRelationCallInExpr(PhpParser\Node\Expr $expr): ?array
-    {
+    private static function findRelationCallInExpr(
+        PhpParser\Node\Expr $expr,
+        ?string &$pivotModel,
+        ?string &$accessor,
+    ): ?array {
         if (!$expr instanceof PhpParser\Node\Expr\MethodCall) {
             return null;
         }
@@ -175,13 +196,63 @@ final class RelationMethodParser
                     'intermediateModel' => \in_array($lowerName, ['hasonethrough', 'hasmanythrough'], true)
                         ? self::extractClassStringArg($expr, $lowerName, 1, 'through')
                         : null,
+                    'pivotModel' => $pivotModel,
+                    'accessor' => $accessor,
                 ];
+            }
+
+            // Pivot / accessor mutators: capture the first statically resolvable argument.
+            // Outside-in recursion visits the outermost call first, so the outermost
+            // `using()` / `as()` wins via `??=` — inner ones cannot overwrite once set.
+            if ($lowerName === 'using') {
+                $pivotModel ??= self::firstClassStringArg($expr);
+            } elseif ($lowerName === 'as') {
+                $accessor ??= self::firstStringLiteralArg($expr);
             }
         }
 
         // Not a relationship call — try the inner expression (unwrap chain).
         // e.g. for $this->belongsTo(X::class)->withDefault(), $expr->var is $this->belongsTo(X::class)
-        return self::findRelationCallInExpr($expr->var);
+        return self::findRelationCallInExpr($expr->var, $pivotModel, $accessor);
+    }
+
+    /**
+     * Resolve the first argument of `->using(Pivot::class)` to its FQCN, or null when the
+     * argument is dynamic (a variable, a method call, etc.).
+     *
+     * Named-argument form `->using(class: SomePivot::class)` is uncommon for a single-argument
+     * mutator, so only the positional first arg is honored here.
+     */
+    private static function firstClassStringArg(PhpParser\Node\Expr\MethodCall $call): ?string
+    {
+        $first = $call->args[0] ?? null;
+        if (!$first instanceof PhpParser\Node\Arg) {
+            return null;
+        }
+
+        return self::resolveClassConstFetch($first->value);
+    }
+
+    /**
+     * Resolve the first argument of `->as('accessor')` to its literal string value, or null
+     * when the argument is dynamic. Only literal scalars produce a usable TAccessor binding —
+     * variables and concatenation cannot be statically pinned.
+     *
+     * @psalm-mutation-free
+     */
+    private static function firstStringLiteralArg(PhpParser\Node\Expr\MethodCall $call): ?string
+    {
+        $first = $call->args[0] ?? null;
+        if (!$first instanceof PhpParser\Node\Arg) {
+            return null;
+        }
+
+        $value = $first->value;
+        if ($value instanceof PhpParser\Node\Scalar\String_) {
+            return $value->value;
+        }
+
+        return null;
     }
 
     /**

--- a/src/Handlers/Eloquent/RelationMethodParser.php
+++ b/src/Handlers/Eloquent/RelationMethodParser.php
@@ -218,10 +218,10 @@ final class RelationMethodParser
 
     /**
      * Resolve the first argument of `->using(Pivot::class)` to its FQCN, or null when the
-     * argument is dynamic (a variable, a method call, etc.).
-     *
-     * Named-argument form `->using(class: SomePivot::class)` is uncommon for a single-argument
-     * mutator, so only the positional first arg is honored here.
+     * argument is dynamic (a variable, a method call, etc.). The first physical arg is
+     * read regardless of whether it carries a name token — `using()` is a single-parameter
+     * method, so named (`->using(class: P::class)`) and positional (`->using(P::class)`)
+     * forms are both honored.
      */
     private static function firstClassStringArg(PhpParser\Node\Expr\MethodCall $call): ?string
     {

--- a/src/Handlers/SuppressHandler.php
+++ b/src/Handlers/SuppressHandler.php
@@ -126,6 +126,12 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
         'PossiblyUnusedMethod' => [
             'Illuminate\Foundation\Events\Dispatchable' => ['broadcastOn'],
             'Illuminate\Foundation\Bus\Dispatchable' => ['handle'],
+            // The combined Queueable trait Laravel 11+ uses for `make:job` scaffolds
+            // (composes Bus\Queueable, InteractsWithQueue, etc). The `handle()` entry
+            // point is invoked by the queue worker via Container::call(), not from
+            // user code — without this suppression, default queued jobs always trip
+            // PossiblyUnusedMethod.
+            'Illuminate\Foundation\Queue\Queueable' => ['handle'],
         ],
     ];
 

--- a/tests/Application/app/Models/Mechanic.php
+++ b/tests/Application/app/Models/Mechanic.php
@@ -106,6 +106,19 @@ final class Mechanic extends Model
     }
 
     /**
+     * Tagging WorkOrders with `->as()` and no `->using()` — exercises the per-relation
+     * pivot default selection: MorphToMany's TPivotModel default is `MorphPivot`, not
+     * `Pivot`. A handler that hard-coded `Pivot` for the all-or-nothing fallback would
+     * silently emit the wrong template here.
+     *
+     * @psalm-return MorphToMany<WorkOrder, $this, \Illuminate\Database\Eloquent\Relations\MorphPivot, 'meta'>
+     */
+    public function workOrderTagsAccessorOnly(): MorphToMany
+    {
+        return $this->morphedByMany(WorkOrder::class, 'taggable')->as('meta');
+    }
+
+    /**
      * Admin bookmarks for this mechanic (inverse of Admin::mechanics()).
      *
      * @psalm-return MorphToMany<Admin>

--- a/tests/Application/app/Models/Mechanic.php
+++ b/tests/Application/app/Models/Mechanic.php
@@ -56,6 +56,56 @@ final class Mechanic extends Model
     }
 
     /**
+     * Specializations with both a custom pivot model and a custom accessor name —
+     * exercises the chain capture for `->as('alias')` in addition to `->using()`.
+     *
+     * @psalm-return BelongsToMany<MechanicSpecialization, $this, SpecializationPivot, 'details'>
+     */
+    public function specializationsWithCustomAccessor(): BelongsToMany
+    {
+        return $this->belongsToMany(MechanicSpecialization::class)
+            ->using(SpecializationPivot::class)
+            ->as('details');
+    }
+
+    /**
+     * Specializations with `->as()` but no `->using()` — exercises the all-or-nothing
+     * emission rule: when only one mutator is captured, the handler still emits both
+     * pivot and accessor slots (filling the missing one with its declared default).
+     *
+     * @psalm-return BelongsToMany<MechanicSpecialization, $this, \Illuminate\Database\Eloquent\Relations\Pivot, 'details'>
+     */
+    public function specializationsAccessorOnly(): BelongsToMany
+    {
+        return $this->belongsToMany(MechanicSpecialization::class)->as('details');
+    }
+
+    /**
+     * Specializations with `->as()` then `->using()` — exercises order-independence
+     * of the chain-capture recursion (the outside-in walk should record both
+     * mutators regardless of their source-order).
+     *
+     * @psalm-return BelongsToMany<MechanicSpecialization, $this, SpecializationPivot, 'details'>
+     */
+    public function specializationsAsThenUsing(): BelongsToMany
+    {
+        return $this->belongsToMany(MechanicSpecialization::class)
+            ->as('details')
+            ->using(SpecializationPivot::class);
+    }
+
+    /**
+     * Tagging WorkOrders polymorphically with a custom pivot — used to test that the
+     * chain-capture also fires for MorphToMany (not just BelongsToMany).
+     *
+     * @psalm-return MorphToMany<WorkOrder, $this, SpecializationPivot, 'pivot'>
+     */
+    public function workOrderTagsWithPivot(): MorphToMany
+    {
+        return $this->morphedByMany(WorkOrder::class, 'taggable')->using(SpecializationPivot::class);
+    }
+
+    /**
      * Admin bookmarks for this mechanic (inverse of Admin::mechanics()).
      *
      * @psalm-return MorphToMany<Admin>

--- a/tests/Application/laravel-test-psalm.xml
+++ b/tests/Application/laravel-test-psalm.xml
@@ -3,7 +3,7 @@
     xmlns="https://getpsalm.org/schema/config"
     errorLevel="1"
     findUnusedBaselineEntry="false"
-    findUnusedCode="false"
+    findUnusedCode="true"
     resolveFromConfigFile="false"
     xsi:schemaLocation="https://getpsalm.org/schema/config ../../vendor/vimeo/psalm/config.xsd"
     errorBaseline="../../tests/Application/laravel-test-psalm-baseline.xml"

--- a/tests/Type/tests/Relation/GetRelatedNarrowingTest.phpt
+++ b/tests/Type/tests/Relation/GetRelatedNarrowingTest.phpt
@@ -8,9 +8,13 @@ use App\Models\Invoice;
 use App\Models\Mechanic;
 use App\Models\MechanicSpecialization;
 use App\Models\Part;
+use App\Models\SpecializationPivot;
 use App\Models\Vehicle;
 use App\Models\WorkOrder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Eloquent\Relations\Relation;
 
 /**
@@ -142,16 +146,71 @@ function test_plain_relation_parameter_returns_model(Relation $relation): string
     return $record->getKeyName();
 }
 
-// belongsToMany with `->using(CustomPivot::class)`: the handler still narrows
-// TRelatedModel and TDeclaringModel — getRelated() resolves correctly. TPivotModel
-// rebinding via `using()` is a known Psalm 7 limitation (the stub's
-// `@psalm-this-out` does not propagate, and the user's `@psalm-return` annotation
-// also collapses when `$this` cannot be substituted), so the pivot defaults to
-// Pivot. The primary fix from #760 — getRelated() not returning Model — is
-// preserved.
-function test_using_chain_still_narrows_getRelated(): MechanicSpecialization
+// belongsToMany with `->using(CustomPivot::class)`: the handler walks the chain to
+// capture the pivot model and emits a 4-template `BelongsToMany<R, D, P, 'pivot'>`,
+// so getRelated() narrows and downstream pivot intersections resolve to the
+// user-declared pivot model rather than the default `Pivot`.
+function test_using_chain_narrows_getRelated(): MechanicSpecialization
 {
     return (new Mechanic())->specializationsWithPivot()->getRelated();
+}
+
+// Limitation: a 2-template `BelongsToMany<R, D>` is silently normalised against a
+// 4-template assertion via stub-declared template defaults, so neither the typed-return
+// form below nor `psalm-check-type-exact` will catch a regression that drops back to
+// the 2-template form. These tests pin intent and document the expected emission.
+
+// belongsToMany with `->using()`: TPivotModel binds to the user-declared pivot model,
+// so slot 3 carries `SpecializationPivot` rather than the default `Pivot`.
+/**
+ * @psalm-return BelongsToMany<MechanicSpecialization, Mechanic, SpecializationPivot, 'pivot'>
+ */
+function test_using_chain_narrows_pivot_class(): BelongsToMany
+{
+    return (new Mechanic())->specializationsWithPivot();
+}
+
+// belongsToMany with `->using()` and `->as('details')`: both mutators are captured,
+// so slot 3 = SpecializationPivot, slot 4 = 'details'.
+/**
+ * @psalm-return BelongsToMany<MechanicSpecialization, Mechanic, SpecializationPivot, 'details'>
+ */
+function test_as_chain_binds_accessor_template(): BelongsToMany
+{
+    return (new Mechanic())->specializationsWithCustomAccessor();
+}
+
+// `->as()` without `->using()`: the parser captures only the accessor, the handler
+// emits the explicit `Pivot` default for slot 3 — exercising the all-or-nothing rule
+// (if either slot is captured, emit both with declared defaults filling the gaps).
+/**
+ * @psalm-return BelongsToMany<MechanicSpecialization, Mechanic, Pivot, 'details'>
+ */
+function test_as_only_chain_emits_pivot_default(): BelongsToMany
+{
+    return (new Mechanic())->specializationsAccessorOnly();
+}
+
+// Reverse-order chain `->as('details')->using(...)`: outside-in recursion records
+// both mutators regardless of source-order — ensures the chain capture isn't
+// brittle to reordering.
+/**
+ * @psalm-return BelongsToMany<MechanicSpecialization, Mechanic, SpecializationPivot, 'details'>
+ */
+function test_as_then_using_chain_captures_both(): BelongsToMany
+{
+    return (new Mechanic())->specializationsAsThenUsing();
+}
+
+// MorphToMany also opts into the 4-template emit path. Without this test, a regression
+// that drops `MorphToMany::class` from the allow-list would ship undetected — the
+// BelongsToMany tests above wouldn't catch it.
+/**
+ * @psalm-return MorphToMany<WorkOrder, Mechanic, SpecializationPivot, 'pivot'>
+ */
+function test_morphToMany_using_chain_narrows_pivot_class(): MorphToMany
+{
+    return (new Mechanic())->workOrderTagsWithPivot();
 }
 
 ?>

--- a/tests/Type/tests/Relation/GetRelatedNarrowingTest.phpt
+++ b/tests/Type/tests/Relation/GetRelatedNarrowingTest.phpt
@@ -213,5 +213,17 @@ function test_morphToMany_using_chain_narrows_pivot_class(): MorphToMany
     return (new Mechanic())->workOrderTagsWithPivot();
 }
 
+// MorphToMany with `->as()` only: the all-or-nothing rule emits TPivotModel as the
+// stub-declared default, which for MorphToMany is `MorphPivot` (not `Pivot` — that's
+// BelongsToMany's default). A handler that hard-coded `Pivot` here would silently
+// produce a wrong type for accessor-only morph chains.
+/**
+ * @psalm-return MorphToMany<WorkOrder, Mechanic, \Illuminate\Database\Eloquent\Relations\MorphPivot, 'meta'>
+ */
+function test_morphToMany_as_only_emits_morphPivot_default(): MorphToMany
+{
+    return (new Mechanic())->workOrderTagsAccessorOnly();
+}
+
 ?>
 --EXPECTF--


### PR DESCRIPTION
Follow-up to #860 addressing review concerns.

## Validation of reviewer concerns

| Concern | Verdict |
|---|---|
| `->using()` / `->as()` chain mutations discarded on belongsToMany / morphToMany | **Valid**, fixed here |
| Annotated `morphTo()` not narrowed | Already addressed in commit 4cb7f2bb (handler calls `extractDocblockRelatedModelType` for `MorphTo`) |
| `DynamicRelationNameStaysMixedTest` uses loose `%A` pattern | Already addressed in commit 4cb7f2bb (tightened to specific issue + line) |

## What changes

`RelationMethodParser` now walks the relation factory chain outside-in to collect `->using(Pivot::class)` (TPivotModel) and `->as('alias')` (TAccessor) before reaching the inner factory call. The first (outermost) match wins via `??=`.

`ModelRelationReturnTypeHandler::buildRelationType` emits the captured pivot/accessor as the 3rd and 4th template params for `BelongsToMany` and `MorphToMany`. The two-class allow-list lives in `PIVOT_AWARE_RELATIONS` (the parser captures unconditionally; the handler gates emission). Both slots are emitted together (with declared defaults filling any gap) since Psalm rejects a partial 3-template form when the relation expects 4.

Without this, the user docblock `@psalm-return BelongsToMany<R, $this, P, 'pivot'>` collapses in Psalm 7 (cannot substitute `$this` in template position), so `TPivotModel` silently defaults to `Pivot` and `Relation::first()` returns `R&object{pivot: Pivot}` instead of `R&object{pivot: P}`.

## Test fixtures (Mechanic)

Five chain shapes, each pinning a distinct path:

- `specializationsWithPivot` — `using` only
- `specializationsWithCustomAccessor` — `using` + `as`
- `specializationsAccessorOnly` — `as` only (all-or-nothing rule)
- `specializationsAsThenUsing` — order-independence
- `workOrderTagsWithPivot` — MorphToMany allow-list path

A test preamble documents a Psalm 7 limitation: a 2-template `BelongsToMany<R, D>` is silently normalised against a 4-template assertion via stub-declared defaults, so neither typed-return nor `psalm-check-type-exact` will fire on a regression that drops back to 2-template. The tests pin intent rather than strict regression detection.

## Bonus: unused-code in application tests

Separate commit (`80244704`):

- `tests/Application/laravel-test-psalm.xml` flips `findUnusedCode="false"` to `"true"`.
- `SuppressHandler` adds `Foundation\Queue\Queueable => ['handle']` so default `make:job --queued` scaffolds (Laravel 11+) don't trip `PossiblyUnusedMethod` once dead-code finding is on.