### PR TITLE
Bind `TDeclaringModel` to `static` on `$this` relation dispatch

### DIFF
--- a/src/Handlers/Eloquent/ModelRelationReturnTypeHandler.php
+++ b/src/Handlers/Eloquent/ModelRelationReturnTypeHandler.php
@@ -11,6 +11,8 @@ use Illuminate\Database\Eloquent\Relations\MorphPivot;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
 use Psalm\Codebase;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
@@ -143,10 +145,27 @@ final class ModelRelationReturnTypeHandler
         $bindingClass = $event->getCalledFqClasslikeName() ?? $declaringClass;
         $methodName = $event->getMethodNameLowercase();
 
-        // Cache keyed by the (declaring, binding) tuple — the Union returned for
-        // BaseUser::posts dispatched on User differs from BaseUser::posts dispatched
-        // on AdminUser, since each binds a different TDeclaringModel.
-        $cacheKey = $declaringClass . '|' . $bindingClass . '::' . $methodName;
+        // Detect `$this->relation()` (vs `(new Model())->relation()` or `$var->relation()`)
+        // so the emitted TDeclaringModel can be `static<bindingClass>` instead of plain
+        // `bindingClass`. Required when the receiver is `$this` because user docblocks
+        // routinely declare `@return Rel<X, $this>` (= `Rel<X, bindingClass&static>` under
+        // psalm/psalm#11768), and a method body like
+        // `return $this->users()->where(...)` re-enters this handler with a `$this`
+        // receiver — emitting plain `bindingClass` would mismatch the declared
+        // `bindingClass&static`. External dispatch like `(new Model())->m()` keeps the
+        // plain concrete-class emission so existing tests asserting `Rel<X, ConcreteClass>`
+        // (no `&static`) still pass. Covariance on TDeclaringModel in the relation stubs
+        // additionally lets the `&static` form satisfy concrete-class declarations like
+        // `@return Rel<X, Campaign>` (ixdf-web pattern).
+        $stmt = $event->getStmt();
+        $isThisDispatch = $stmt instanceof MethodCall
+            && $stmt->var instanceof Variable
+            && $stmt->var->name === 'this';
+
+        // Cache keyed by the (declaring, binding, isThisDispatch) tuple — the same
+        // (declaring, binding) pair can produce two different Unions depending on
+        // whether the receiver was `$this` (static-aware) or a concrete instance.
+        $cacheKey = $declaringClass . '|' . $bindingClass . '|' . ($isThisDispatch ? '1' : '0') . '::' . $methodName;
 
         if (\array_key_exists($cacheKey, self::$unionCache)) {
             return self::$unionCache[$cacheKey];
@@ -170,6 +189,7 @@ final class ModelRelationReturnTypeHandler
                         $parsed['pivotModel'],
                         $parsed['accessor'],
                         $bindingClass,
+                        $isThisDispatch,
                     )
                     : null;
             }
@@ -244,6 +264,7 @@ final class ModelRelationReturnTypeHandler
         ?string $pivotModel,
         ?string $accessor,
         string $bindingClass,
+        bool $isThisDispatch,
     ): ?Union {
         $isThrough = $relationClass === HasOneThrough::class || $relationClass === HasManyThrough::class;
 
@@ -261,8 +282,11 @@ final class ModelRelationReturnTypeHandler
 
         // $bindingClass is the late-static-bound receiver class — what TDeclaringModel
         // should resolve to at the call site (User for `(new User())->posts()`), even if
-        // the method body lives on a parent class.
-        $typeParams[] = new Union([new TNamedObject($bindingClass)]);
+        // the method body lives on a parent class. When dispatched on `$this`, mark the
+        // type as static (`bindingClass&static`) so it matches `$this` in user docblocks
+        // declaring `@return Rel<X, $this>`. External dispatch keeps the plain concrete
+        // class so `(new User())->posts()` still resolves to `Rel<X, User>` (no `&static`).
+        $typeParams[] = new Union([new TNamedObject($bindingClass, is_static: $isThisDispatch)]);
 
         // Emit TPivotModel / TAccessor (slots 3 and 4) only when the parser captured a
         // chain mutation. Both slots are filled together (with declared defaults filling

--- a/stubs/common/Database/Eloquent/Relations/BelongsTo.stubphp
+++ b/stubs/common/Database/Eloquent/Relations/BelongsTo.stubphp
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
 
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
- * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
  * @template-extends Relation<TRelatedModel, TDeclaringModel, ?TRelatedModel>
  * @mixin \Illuminate\Database\Eloquent\Builder<TRelatedModel>
  */

--- a/stubs/common/Database/Eloquent/Relations/BelongsToMany.stubphp
+++ b/stubs/common/Database/Eloquent/Relations/BelongsToMany.stubphp
@@ -4,7 +4,7 @@ namespace Illuminate\Database\Eloquent\Relations;
 
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
- * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
  * @template TPivotModel of \Illuminate\Database\Eloquent\Relations\Pivot = \Illuminate\Database\Eloquent\Relations\Pivot
  * @template TAccessor of string = 'pivot'
  * @template-extends Relation<TRelatedModel, TDeclaringModel, \Illuminate\Database\Eloquent\Collection<int, TRelatedModel&object{pivot: TPivotModel}>>

--- a/stubs/common/Database/Eloquent/Relations/HasMany.stubphp
+++ b/stubs/common/Database/Eloquent/Relations/HasMany.stubphp
@@ -4,7 +4,7 @@ namespace Illuminate\Database\Eloquent\Relations;
 
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
- * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
  * @template-extends HasOneOrMany<TRelatedModel, TDeclaringModel, \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>>
  * @mixin \Illuminate\Database\Eloquent\Builder<TRelatedModel>
  */

--- a/stubs/common/Database/Eloquent/Relations/HasManyThrough.stubphp
+++ b/stubs/common/Database/Eloquent/Relations/HasManyThrough.stubphp
@@ -5,7 +5,7 @@ namespace Illuminate\Database\Eloquent\Relations;
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
  * @template TIntermediateModel of \Illuminate\Database\Eloquent\Model
- * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
  * @template-extends HasOneOrManyThrough<TRelatedModel, TIntermediateModel, TDeclaringModel, \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>>
  * @mixin \Illuminate\Database\Eloquent\Builder<TRelatedModel>
  */

--- a/stubs/common/Database/Eloquent/Relations/HasOne.stubphp
+++ b/stubs/common/Database/Eloquent/Relations/HasOne.stubphp
@@ -12,7 +12,7 @@ use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
  * must be repeated verbatim or callers typed on the contract break.
  *
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
- * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
  * @template-extends HasOneOrMany<TRelatedModel, TDeclaringModel, ?TRelatedModel>
  * @mixin \Illuminate\Database\Eloquent\Builder<TRelatedModel>
  */

--- a/stubs/common/Database/Eloquent/Relations/HasOneOrMany.stubphp
+++ b/stubs/common/Database/Eloquent/Relations/HasOneOrMany.stubphp
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Builder;
 
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
- * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
  * @template TResult
  * @template-extends Relation<TRelatedModel, TDeclaringModel, TResult>
  * @mixin \Illuminate\Database\Eloquent\Builder<TRelatedModel>

--- a/stubs/common/Database/Eloquent/Relations/HasOneOrManyThrough.stubphp
+++ b/stubs/common/Database/Eloquent/Relations/HasOneOrManyThrough.stubphp
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
  * @template TIntermediateModel of \Illuminate\Database\Eloquent\Model
- * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
  * @template TResult
  * @template-extends Relation<TRelatedModel, TIntermediateModel, TResult>
  * @mixin \Illuminate\Database\Eloquent\Builder<TRelatedModel>

--- a/stubs/common/Database/Eloquent/Relations/HasOneThrough.stubphp
+++ b/stubs/common/Database/Eloquent/Relations/HasOneThrough.stubphp
@@ -13,7 +13,7 @@ use Illuminate\Database\Eloquent\Relations\Concerns\SupportsDefaultModels;
  *
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
  * @template TIntermediateModel of \Illuminate\Database\Eloquent\Model
- * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
  * @template-extends HasOneOrManyThrough<TRelatedModel, TIntermediateModel, TDeclaringModel, ?TRelatedModel>
  * @mixin \Illuminate\Database\Eloquent\Builder<TRelatedModel>
  */

--- a/stubs/common/Database/Eloquent/Relations/MorphMany.stubphp
+++ b/stubs/common/Database/Eloquent/Relations/MorphMany.stubphp
@@ -4,7 +4,7 @@ namespace Illuminate\Database\Eloquent\Relations;
 
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
- * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
  * @template-extends MorphOneOrMany<TRelatedModel, TDeclaringModel, \Illuminate\Database\Eloquent\Collection<int, TRelatedModel>>
  * @mixin \Illuminate\Database\Eloquent\Builder<TRelatedModel>
  */

--- a/stubs/common/Database/Eloquent/Relations/MorphOne.stubphp
+++ b/stubs/common/Database/Eloquent/Relations/MorphOne.stubphp
@@ -10,7 +10,7 @@ use Illuminate\Contracts\Database\Eloquent\SupportsPartialRelations;
  * must be repeated verbatim or callers typed on the contract break.
  *
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
- * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
  * @template-extends MorphOneOrMany<TRelatedModel, TDeclaringModel, ?TRelatedModel>
  * @mixin \Illuminate\Database\Eloquent\Builder<TRelatedModel>
  */

--- a/stubs/common/Database/Eloquent/Relations/MorphOneOrMany.stubphp
+++ b/stubs/common/Database/Eloquent/Relations/MorphOneOrMany.stubphp
@@ -4,7 +4,7 @@ namespace Illuminate\Database\Eloquent\Relations;
 
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
- * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
  * @template TResult
  * @template-extends HasOneOrMany<TRelatedModel, TDeclaringModel, TResult>
  * @mixin \Illuminate\Database\Eloquent\Builder<TRelatedModel>

--- a/stubs/common/Database/Eloquent/Relations/MorphTo.stubphp
+++ b/stubs/common/Database/Eloquent/Relations/MorphTo.stubphp
@@ -4,7 +4,7 @@ namespace Illuminate\Database\Eloquent\Relations;
 
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
- * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
  * @template-extends BelongsTo<TRelatedModel, TDeclaringModel>
  * @mixin \Illuminate\Database\Eloquent\Builder<TRelatedModel>
  */

--- a/stubs/common/Database/Eloquent/Relations/MorphToMany.stubphp
+++ b/stubs/common/Database/Eloquent/Relations/MorphToMany.stubphp
@@ -4,7 +4,7 @@ namespace Illuminate\Database\Eloquent\Relations;
 
 /**
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
- * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
  * @template TPivotModel of \Illuminate\Database\Eloquent\Relations\Pivot = \Illuminate\Database\Eloquent\Relations\MorphPivot
  * @template TAccessor of string = 'pivot'
  * @template-extends BelongsToMany<TRelatedModel, TDeclaringModel, TPivotModel, TAccessor>

--- a/stubs/common/Database/Eloquent/Relations/Relation.stubphp
+++ b/stubs/common/Database/Eloquent/Relations/Relation.stubphp
@@ -14,7 +14,7 @@ use Illuminate\Support\Traits\Macroable;
  * must be repeated verbatim or callers typed on the contract break.
  *
  * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
- * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
  * @template TResult
  * @mixin \Illuminate\Database\Eloquent\Builder<TRelatedModel>
  */


### PR DESCRIPTION
## Issue to Solve

`ModelRelationReturnTypeHandler` emitted plain `bindingClass` for the `TDeclaringModel` template slot regardless of whether the receiver was `$this` or a concrete instance. Once Psalm parses `$this` in template position (vimeo/psalm#11768), user docblocks like `@return BelongsToMany<User, $this, Pivot, 'membership'>` resolve to `BelongsToMany<User, Class&static, ...>`. A method body that re-enters the handler via `$this->relation()->where(...)` then mismatched the declared `Class&static` and triggered `MoreSpecificReturnType` + `LessSpecificReturnStatement`.

Surfaced by the v4.10.0 app benchmark on solidtime's `Organization::realUsers` pattern.

## Related

Depends on vimeo/psalm#11768 for the user-visible benefit. Backward compatible with stock Psalm 7 (where `$this` does not parse in template position and the fix is a no-op).

## Solution Description

Two complementary changes:

1. **`ModelRelationReturnTypeHandler`** detects `$this` dispatch via `$event->getStmt()`. On `$this` calls it emits `TNamedObject($bindingClass, is_static: true)` so the inferred type carries the same `&static` constraint as `$this` in user docblocks. External dispatch like `(new Model())->m()` keeps the plain concrete-class emission, so existing assertions like `Rel<X, ConcreteClass>` (no `&static`) still hold. Cache key was extended with `isThisDispatch` because the same `(declaring, binding)` pair now produces two different `Union`s depending on the receiver.

2. **Relation stubs (14 files)** mark `TDeclaringModel` as `@template-covariant`. Lets the handler-emitted `Rel<X, Concrete&static>` satisfy declarations using a plain concrete class (`@return Rel<X, Campaign>`). Without covariance, change 1 would introduce `InvalidReturnType` errors on those.

### Verification

* 374 type tests pass.
* 566 unit tests pass.
* Self-analysis clean.
* App benchmark on 15 real-world apps versus v4.9.1: net **-1,614** issues, no regressions. solidtime's 2 `Organization::realUsers` errors removed (1001 -> 999). ixdf-web, which uses Psalm without vimeo/psalm#11768, goes from 7,772 to 7,759 with no new errors, confirming the fix is backward compatible with stock Psalm 7.

## Checklist

- [x] Tests cover the change. Existing relation tests in `tests/Type/tests/Relation/` exercise external dispatch and continue to pass. The `$this`-dispatch path is validated end-to-end via the solidtime app benchmark. A dedicated PHPT regression test was deliberately skipped because Psalm 7.0.0-beta19 does not parse `$this` in template position at all, so any PHPT exercising the bug pattern would simply fall through to upper bounds and pass trivially regardless of the fix. A regression test should be added once vimeo/psalm#11768 ships in a Psalm release.
