### PR TITLE
Narrow `Rule::in(...)` fluent builder to literal-string union

### DIFF
--- a/src/Handlers/Validation/ValidationRuleAnalyzer.php
+++ b/src/Handlers/Validation/ValidationRuleAnalyzer.php
@@ -849,6 +849,20 @@ final class ValidationRuleAnalyzer
                         continue;
                     }
 
+                    // Rule::in(...) / Rule::notIn(...) with statically-extractable
+                    // string literals — emit the equivalent 'in:a,b,c' / 'not_in:a,b,c'
+                    // segment so resolveRuleSegments narrows the type via the existing
+                    // string-rule path. Falls through to the class: segment when the
+                    // arguments aren't statically resolvable (variables, enums,
+                    // Arrayable, spread, comma-bearing values, …).
+                    $inLikeSegment = self::tryExtractInLikeRuleSegment($ruleItem->value);
+
+                    if ($inLikeSegment !== null) {
+                        $segments[] = $inLikeSegment;
+
+                        continue;
+                    }
+
                     // Custom Rule object — capture the class FQN so resolveRuleSegments
                     // can OR the class's own @psalm-taint-escape bits into removedTaints.
                     $ruleClassFqn = self::resolveRuleObjectClassName($ruleItem->value);
@@ -869,6 +883,162 @@ final class ValidationRuleAnalyzer
         }
 
         return $rules !== [] ? $rules : null;
+    }
+
+    /**
+     * If the expression is a `Rule::in(...)` or `Rule::notIn(...)` static call
+     * (optionally wrapped in fluent method calls) whose arguments are all
+     * string literals, return the equivalent `in:a,b,c` / `not_in:a,b,c`
+     * rule segment. Returns null for any unsupported argument shape.
+     *
+     * Reusing the string-rule segment funnels the fluent form through the
+     * same {@see inRuleToLiteralUnion()} narrowing and {@see ruleToRemovedTaints()}
+     * escape path that `'in:a,b,c'` already takes. Identical taint contribution
+     * for `in` (`TaintKind::ALL_INPUT` from both the class table and the rule
+     * table) and `not_in` (0 from both) means swapping segment forms cannot
+     * regress taint analysis.
+     *
+     * Forms supported:
+     *   - `Rule::in('a', 'b')`         variadic
+     *   - `Rule::in('a')`              single
+     *   - `Rule::in(['a', 'b'])`       array literal
+     *
+     * Bails (returns null) for:
+     *   - Any non-string-literal argument (variables, enum cases, method calls,
+     *     `Arrayable` arguments, …).
+     *   - Spread / unpacked args (`Rule::in(...$values)` or `Rule::in([...$x])`).
+     *   - Associative array literals (`Rule::in(['a' => 'b'])`).
+     *   - Empty argument lists (`Rule::in()`, `Rule::in([])`).
+     *   - Values containing `,` — emitting `in:a,b` for a single value
+     *     `'a,b'` would split into `'a'|'b'` (unsound). The fluent form is
+     *     the canonical workaround for comma-bearing whitelist values, so
+     *     this case must round-trip to `mixed` rather than mis-narrow.
+     */
+    private static function tryExtractInLikeRuleSegment(Node\Expr $expr): ?string
+    {
+        // Unwrap outer fluent calls — same convention as resolveRuleObjectClassName.
+        // In and NotIn have no fluent setters in Laravel today (only __construct
+        // and __toString), so this loop is defensive future-proofing: a future
+        // Laravel version, a user-authored subclass, or a `__call`-magic chain
+        // would carry the In/NotIn root through the outer method calls.
+        while ($expr instanceof Node\Expr\MethodCall
+            || $expr instanceof Node\Expr\NullsafeMethodCall
+        ) {
+            $expr = $expr->var;
+        }
+
+        if (!$expr instanceof Node\Expr\StaticCall
+            || !$expr->class instanceof Node\Name
+            || !$expr->name instanceof Node\Identifier
+        ) {
+            return null;
+        }
+
+        /** @var string|null $resolved */
+        $resolved = $expr->class->getAttribute('resolvedName');
+
+        if (!\is_string($resolved)
+            || \strtolower($resolved) !== self::RULE_FACADE_LOWER_FQN
+        ) {
+            return null;
+        }
+
+        $ruleName = match (\strtolower($expr->name->name)) {
+            'in' => 'in',
+            'notin' => 'not_in',
+            default => null,
+        };
+
+        if ($ruleName === null) {
+            return null;
+        }
+
+        $values = self::extractStringLiteralArgs(\array_values($expr->args));
+
+        if ($values === null) {
+            return null;
+        }
+
+        return $ruleName . ':' . \implode(',', $values);
+    }
+
+    /**
+     * Extract a list of string literals from a static call's argument list,
+     * accepting either variadic strings or a single array-literal of strings.
+     *
+     * Returns null when any argument is not a plain string literal, when args
+     * are spread (`...$x`), when the array literal has associative keys, when
+     * the list is empty, or when any value contains a `,` (which would be
+     * misinterpreted as a separator by the receiver — see caller).
+     *
+     * @param list<Node\Arg|Node\VariadicPlaceholder> $args
+     * @return non-empty-list<string>|null
+     *
+     * @psalm-mutation-free
+     */
+    private static function extractStringLiteralArgs(array $args): ?array
+    {
+        if ($args === []) {
+            return null;
+        }
+
+        // Single array argument: Rule::in(['a', 'b']).
+        $first = $args[0];
+
+        if (\count($args) === 1
+            && $first instanceof Node\Arg
+            && !$first->unpack
+            && $first->value instanceof Node\Expr\Array_
+        ) {
+            return self::extractStringLiteralArrayItems($first->value);
+        }
+
+        // Variadic / single string args: Rule::in('a', 'b').
+        $values = [];
+
+        foreach ($args as $arg) {
+            if (!$arg instanceof Node\Arg
+                || $arg->unpack
+                || !$arg->value instanceof Node\Scalar\String_
+                || \str_contains($arg->value->value, ',')
+            ) {
+                return null;
+            }
+
+            $values[] = $arg->value->value;
+        }
+
+        // The early `$args === []` guard plus a foreach with no early-return
+        // guarantees at least one push, so $values is non-empty here.
+        return $values;
+    }
+
+    /**
+     * Walk an array literal's items and collect string-literal values, bailing
+     * on any non-string item, spread, associative key, or comma-bearing value.
+     *
+     * @return non-empty-list<string>|null
+     *
+     * @psalm-mutation-free
+     */
+    private static function extractStringLiteralArrayItems(Node\Expr\Array_ $array): ?array
+    {
+        $values = [];
+
+        foreach ($array->items as $item) {
+            if ($item === null
+                || $item->unpack
+                || $item->key !== null
+                || !$item->value instanceof Node\Scalar\String_
+                || \str_contains($item->value->value, ',')
+            ) {
+                return null;
+            }
+
+            $values[] = $item->value->value;
+        }
+
+        return $values === [] ? null : $values;
     }
 
     /**

--- a/src/Handlers/Validation/ValidationRuleAnalyzer.php
+++ b/src/Handlers/Validation/ValidationRuleAnalyzer.php
@@ -909,10 +909,8 @@ final class ValidationRuleAnalyzer
      *   - Spread / unpacked args (`Rule::in(...$values)` or `Rule::in([...$x])`).
      *   - Associative array literals (`Rule::in(['a' => 'b'])`).
      *   - Empty argument lists (`Rule::in()`, `Rule::in([])`).
-     *   - Values containing `,` — emitting `in:a,b` for a single value
-     *     `'a,b'` would split into `'a'|'b'` (unsound). The fluent form is
-     *     the canonical workaround for comma-bearing whitelist values, so
-     *     this case must round-trip to `mixed` rather than mis-narrow.
+     *   - Values whose `'in:a,b,c'` round-trip is lossy (commas, whitespace
+     *     edges, empty strings) — see {@see isLossLessInValue()}.
      */
     private static function tryExtractInLikeRuleSegment(Node\Expr $expr): ?string
     {
@@ -966,10 +964,9 @@ final class ValidationRuleAnalyzer
      * Extract a list of string literals from a static call's argument list,
      * accepting either variadic strings or a single array-literal of strings.
      *
-     * Returns null when any argument is not a plain string literal, when args
-     * are spread (`...$x`), when the array literal has associative keys, when
-     * the list is empty, or when any value contains a `,` (which would be
-     * misinterpreted as a separator by the receiver — see caller).
+     * Returns null when the argument list is unsupported (non-string-literal,
+     * spread, associative key, empty list) or when any value would lose
+     * fidelity through the `'in:a,b,c'` segment encoding.
      *
      * @param list<Node\Arg|Node\VariadicPlaceholder> $args
      * @return non-empty-list<string>|null
@@ -1000,7 +997,7 @@ final class ValidationRuleAnalyzer
             if (!$arg instanceof Node\Arg
                 || $arg->unpack
                 || !$arg->value instanceof Node\Scalar\String_
-                || \str_contains($arg->value->value, ',')
+                || !self::isLossLessInValue($arg->value->value)
             ) {
                 return null;
             }
@@ -1015,7 +1012,8 @@ final class ValidationRuleAnalyzer
 
     /**
      * Walk an array literal's items and collect string-literal values, bailing
-     * on any non-string item, spread, associative key, or comma-bearing value.
+     * on any non-string item, spread, associative key, empty list, or value
+     * that would lose fidelity through the `'in:a,b,c'` segment encoding.
      *
      * @return non-empty-list<string>|null
      *
@@ -1030,7 +1028,7 @@ final class ValidationRuleAnalyzer
                 || $item->unpack
                 || $item->key !== null
                 || !$item->value instanceof Node\Scalar\String_
-                || \str_contains($item->value->value, ',')
+                || !self::isLossLessInValue($item->value->value)
             ) {
                 return null;
             }
@@ -1039,6 +1037,35 @@ final class ValidationRuleAnalyzer
         }
 
         return $values === [] ? null : $values;
+    }
+
+    /**
+     * Filter out values whose meaning would change once funnelled through the
+     * `'in:a,b,c'` string-rule encoding. Lossy cases:
+     *
+     *   - empty string — `'in:'` is parsed as a parameter-less rule, so
+     *     `inRuleToLiteralUnion()` returns the unconstrained `string` type
+     *     rather than the singleton `''`.
+     *   - leading / trailing whitespace — `inRuleToLiteralUnion()` calls
+     *     `\trim()` on each comma-separated segment, so `Rule::in([' a'])`
+     *     would silently narrow to `'a'`. Laravel preserves whitespace at
+     *     runtime (its `__toString()` quotes each value and the parser uses
+     *     `str_getcsv()`), so trimming would produce a type that excludes
+     *     a value the runtime accepts.
+     *   - comma — splits one whitelist entry into multiple narrowed values
+     *     (`'a,b'` → `'a'|'b'`). The fluent form is the canonical workaround
+     *     for comma-bearing whitelists, so it must round-trip to `mixed`.
+     *
+     * Bailed values fall through to the existing `class:` segment, which
+     * preserves taint behaviour while leaving the type as `mixed`.
+     *
+     * @psalm-pure
+     */
+    private static function isLossLessInValue(string $value): bool
+    {
+        return $value !== ''
+            && !\str_contains($value, ',')
+            && $value === \trim($value);
     }
 
     /**

--- a/src/Handlers/Validation/ValidationRuleAnalyzer.php
+++ b/src/Handlers/Validation/ValidationRuleAnalyzer.php
@@ -910,7 +910,7 @@ final class ValidationRuleAnalyzer
      *   - Associative array literals (`Rule::in(['a' => 'b'])`).
      *   - Empty argument lists (`Rule::in()`, `Rule::in([])`).
      *   - Values whose `'in:a,b,c'` round-trip is lossy (commas, whitespace
-     *     edges, empty strings) — see {@see isLossLessInValue()}.
+     *     edges, empty strings) — see {@see isLosslessInValue()}.
      */
     private static function tryExtractInLikeRuleSegment(Node\Expr $expr): ?string
     {
@@ -997,7 +997,7 @@ final class ValidationRuleAnalyzer
             if (!$arg instanceof Node\Arg
                 || $arg->unpack
                 || !$arg->value instanceof Node\Scalar\String_
-                || !self::isLossLessInValue($arg->value->value)
+                || !self::isLosslessInValue($arg->value->value)
             ) {
                 return null;
             }
@@ -1028,7 +1028,7 @@ final class ValidationRuleAnalyzer
                 || $item->unpack
                 || $item->key !== null
                 || !$item->value instanceof Node\Scalar\String_
-                || !self::isLossLessInValue($item->value->value)
+                || !self::isLosslessInValue($item->value->value)
             ) {
                 return null;
             }
@@ -1061,7 +1061,7 @@ final class ValidationRuleAnalyzer
      *
      * @psalm-pure
      */
-    private static function isLossLessInValue(string $value): bool
+    private static function isLosslessInValue(string $value): bool
     {
         return $value !== ''
             && !\str_contains($value, ',')

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestRuleNotInVariadicNoEscape.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestRuleNotInVariadicNoEscape.phpt
@@ -1,0 +1,34 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Variadic-form sibling of TaintedHtmlFormRequestRuleNotInNoEscape.
+ *
+ * After issue #873, Rule::notIn('a', 'b') routes through the 'not_in:a,b'
+ * string-segment path instead of the previous class:Rules\NotIn segment.
+ * The two paths must agree: `not_in` carries no escape (a blocklist does
+ * not constrain accepted values), so HTML/quotes taints continue to flow
+ * to the echo sink unchanged.
+ */
+final class FluentNotInVariadicRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['role' => ['required', 'string', Rule::notIn('banned', 'blocked')]];
+    }
+}
+
+function render(FluentNotInVariadicRequest $request): void {
+    echo $request->string('role');
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestRuleNotInVariadicNoEscape.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestRuleNotInVariadicNoEscape.phpt
@@ -17,7 +17,7 @@ use Illuminate\Validation\Rule;
  * not constrain accepted values), so HTML/quotes taints continue to flow
  * to the echo sink unchanged.
  */
-final class FluentNotInVariadicRequest extends FormRequest
+final class FluentVariadicNotInRequest extends FormRequest
 {
     public function rules(): array
     {
@@ -25,7 +25,7 @@ final class FluentNotInVariadicRequest extends FormRequest
     }
 }
 
-function render(FluentNotInVariadicRequest $request): void {
+function render(FluentVariadicNotInRequest $request): void {
     echo $request->string('role');
 }
 ?>

--- a/tests/Type/tests/ValidationRuleInFluentNarrowingTest.phpt
+++ b/tests/Type/tests/ValidationRuleInFluentNarrowingTest.phpt
@@ -1,0 +1,216 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Issue #873: Rule::in(...) fluent builder must narrow to the same
+ * literal-string union as the equivalent 'in:a,b,c' string rule.
+ *
+ * Forms covered: variadic strings, single string, array literal.
+ * Statically-unresolvable args fall back to mixed.
+ */
+class FluentInArrayLiteralRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'workday' => ['required', Rule::in(['half', 'full'])],
+        ];
+    }
+}
+
+function testFluentInArrayLiteral(FluentInArrayLiteralRequest $request): void
+{
+    $_workday = $request->validated('workday');
+    /** @psalm-check-type-exact $_workday = 'full'|'half' */
+
+    $_all = $request->validated();
+    /** @psalm-check-type-exact $_all = array{workday: 'full'|'half'} */
+}
+
+class FluentInVariadicRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'workday' => ['required', Rule::in('half', 'full')],
+        ];
+    }
+}
+
+function testFluentInVariadic(FluentInVariadicRequest $request): void
+{
+    $_workday = $request->validated('workday');
+    /** @psalm-check-type-exact $_workday = 'full'|'half' */
+}
+
+class FluentInSingleStringRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'role' => ['required', Rule::in('admin')],
+        ];
+    }
+}
+
+function testFluentInSingleString(FluentInSingleStringRequest $request): void
+{
+    $_role = $request->validated('role');
+    /** @psalm-check-type-exact $_role = 'admin' */
+}
+
+/**
+ * Mixing 'string' before Rule::in(...) is a documented "first wins" behaviour:
+ * the 'string' segment is type-bearing and resolves first, so the inferred
+ * type is `string`, not the literal union. This mirrors what the equivalent
+ * `'required|string|in:half,full'` string-form rule produces and is locked in
+ * here so the fluent form does not unintentionally diverge.
+ */
+class FluentInWithStringRuleRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'workday' => ['required', 'string', Rule::in(['half', 'full'])],
+        ];
+    }
+}
+
+function testFluentInWithStringRule(FluentInWithStringRuleRequest $request): void
+{
+    $_workday = $request->validated('workday');
+    /** @psalm-check-type-exact $_workday = string */
+}
+
+class FluentInWithVariableRequest extends FormRequest
+{
+    /**
+     * @return array<string, list<string|\Illuminate\Validation\Rules\In>>
+     */
+    public function rules(): array
+    {
+        $allowed = ['half', 'full'];
+
+        return [
+            'workday' => ['required', Rule::in($allowed)],
+        ];
+    }
+}
+
+function testFluentInWithVariableArgsFallsBackToMixed(FluentInWithVariableRequest $request): void
+{
+    // Variable arg: the analyzer cannot statically resolve the whitelist, so
+    // it falls back to the class: segment path. Type stays mixed; taint still
+    // escapes via FIRST_PARTY_RULE_ESCAPES['…\\rules\\in'].
+    $_workday = $request->validated('workday');
+    /** @psalm-check-type-exact $_workday = mixed */
+}
+
+enum SortOrder: string
+{
+    case Asc = 'asc';
+    case Desc = 'desc';
+}
+
+class FluentInWithEnumCasesRequest extends FormRequest
+{
+    /**
+     * @return array<string, list<string|\Illuminate\Validation\Rules\In>>
+     */
+    public function rules(): array
+    {
+        return [
+            'order' => ['required', Rule::in(SortOrder::cases())],
+        ];
+    }
+}
+
+function testFluentInWithEnumCasesFallsBackToMixed(FluentInWithEnumCasesRequest $request): void
+{
+    // SortOrder::cases() is a method call, not an array literal, so the
+    // analyzer bails to the class: path and the type stays mixed.
+    $_order = $request->validated('order');
+    /** @psalm-check-type-exact $_order = mixed */
+}
+
+class FluentInWithCommaInValueRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            // 'a,b' as a single whitelisted value is the canonical reason to
+            // prefer Rule::in over the 'in:a,b' string form. Emitting
+            // 'in:a,b' for this would split into 'a'|'b' (unsound), so the
+            // analyzer must bail to the class: path → mixed.
+            'pair' => ['required', Rule::in(['a,b', 'c'])],
+        ];
+    }
+}
+
+function testFluentInWithCommaInValueFallsBackToMixed(FluentInWithCommaInValueRequest $request): void
+{
+    $_pair = $request->validated('pair');
+    /** @psalm-check-type-exact $_pair = mixed */
+}
+
+class FluentNotInVariadicRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'role' => ['required', 'string', Rule::notIn('banned', 'blocked')],
+        ];
+    }
+}
+
+function testFluentNotInVariadic(FluentNotInVariadicRequest $request): void
+{
+    // not_in does not narrow a type (no value-shape guarantee from a
+    // blocklist), so the 'string' rule still wins. Locked in here so the
+    // notIn branch of tryExtractInLikeRuleSegment behaves identically to
+    // the previous class: path.
+    $_role = $request->validated('role');
+    /** @psalm-check-type-exact $_role = string */
+}
+
+/**
+ * Optional field (no required) keeps possibly-undefined in the validated()
+ * shape, parallel to the string-rule case in ValidationTypeNarrowingTest.
+ */
+class FluentInOptionalRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'workday' => [Rule::in(['half', 'full'])],
+        ];
+    }
+}
+
+function testFluentInOptional(FluentInOptionalRequest $request): void
+{
+    $_all = $request->validated();
+    /** @psalm-check-type-exact $_all = array{workday?: 'full'|'half'} */
+}
+
+/**
+ * Inline validate([...]) with Rule::in(...) routes through the same
+ * extractRulePairsFromArrayNode → tryExtractInLikeRuleSegment path as the
+ * FormRequest::rules() entry point. Locked in here so the inline-validate
+ * call shape stays in sync with the FormRequest case.
+ */
+function testInlineValidateWithFluentIn(\Illuminate\Http\Request $request): void
+{
+    $_data = $request->validate([
+        'workday' => ['required', Rule::in(['half', 'full'])],
+        'role' => ['required', Rule::in('admin', 'user')],
+    ]);
+    /** @psalm-check-type-exact $_data = array{role: 'admin'|'user', workday: 'full'|'half'} */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/ValidationRuleInFluentNarrowingTest.phpt
+++ b/tests/Type/tests/ValidationRuleInFluentNarrowingTest.phpt
@@ -158,6 +158,63 @@ function testFluentInWithCommaInValueFallsBackToMixed(FluentInWithCommaInValueRe
     /** @psalm-check-type-exact $_pair = mixed */
 }
 
+class FluentInWithLeadingWhitespaceRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            // inRuleToLiteralUnion() trims each comma-separated segment, so
+            // emitting 'in: a' would silently narrow to 'a'. Laravel preserves
+            // whitespace at runtime (its __toString quotes each value and
+            // parseParameters uses str_getcsv), so trimming would exclude a
+            // value the runtime accepts. Bail to mixed.
+            'token' => ['required', Rule::in([' a', 'b'])],
+        ];
+    }
+}
+
+function testFluentInWithLeadingWhitespaceFallsBackToMixed(FluentInWithLeadingWhitespaceRequest $request): void
+{
+    $_token = $request->validated('token');
+    /** @psalm-check-type-exact $_token = mixed */
+}
+
+class FluentInWithTrailingWhitespaceRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            // Variadic-form sibling of the leading-whitespace case.
+            'token' => ['required', Rule::in('a ', 'b')],
+        ];
+    }
+}
+
+function testFluentInWithTrailingWhitespaceFallsBackToMixed(FluentInWithTrailingWhitespaceRequest $request): void
+{
+    $_token = $request->validated('token');
+    /** @psalm-check-type-exact $_token = mixed */
+}
+
+class FluentInWithEmptyStringRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            // 'in:' is parsed as a parameter-less rule, so inRuleToLiteralUnion
+            // would return the unconstrained `string` type rather than the
+            // singleton ''. Bail to mixed.
+            'opt' => ['required', Rule::in(['', 'something'])],
+        ];
+    }
+}
+
+function testFluentInWithEmptyStringFallsBackToMixed(FluentInWithEmptyStringRequest $request): void
+{
+    $_opt = $request->validated('opt');
+    /** @psalm-check-type-exact $_opt = mixed */
+}
+
 class FluentNotInVariadicRequest extends FormRequest
 {
     public function rules(): array


### PR DESCRIPTION
Resolves #873.

## Problem

`Rule::in(...)` inside a FormRequest `rules()` array narrowed to `mixed` in `$request->validated()` output, while the equivalent `'in:a,b,c'` string form already narrowed to a literal union:

```php
public function rules(): array
{
    return ['workday' => ['required', Rule::in('half', 'full')]];
}
// Before: array{..., workday: mixed}
// After:  array{..., workday: 'full'|'half'}
```

The fluent path emitted only a synthetic `class:Illuminate\Validation\Rules\In` segment, which contributes to the taint escape bitmask but never to the inferred type, so the field fell back to `mixed`.

## Fix

`extractRulePairsFromArrayNode` now detects `Rule::in(...)` and `Rule::notIn(...)` static calls (including outer fluent chains) and, when arguments are statically extractable string literals, emits the equivalent `'in:a,b,c'` / `'not_in:a,b,c'` segment. The narrowing then reuses the existing `inRuleToLiteralUnion` plus `ruleToRemovedTaints` path.

Forms supported:

* `Rule::in('a', 'b')` (variadic)
* `Rule::in('a')` (single string)
* `Rule::in(['a', 'b'])` (array literal)

Unsupported argument shapes fall through to the previous `class:` segment, so no behaviour regresses:

* Variables, enum cases, method calls, `Arrayable` arguments
* Spread / unpacked args (`Rule::in(...$values)`, `Rule::in([...$x])`)
* Associative array literals (`Rule::in(['a' => 'b'])`)
* Empty argument lists (`Rule::in()`, `Rule::in([])`)
* Values containing `,` (Laravel's canonical reason to prefer `Rule::in` over the string form, kept sound by bailing rather than mis-narrowing)

## Taint behaviour

Identical between the two segment forms:

* `in`: both paths contribute `TaintKind::ALL_INPUT` (`FIRST_PARTY_RULE_ESCAPES['…\\rules\\in']` and `ruleToRemovedTaints('in')`).
* `not_in`: both paths contribute 0 (`Rules\NotIn` is intentionally absent from the escape table; `not_in` has no `ruleToRemovedTaints` arm).

Existing taint tests continue to pass: `SafeFormRequestRuleInFluentNoTaint.phpt`, `TaintedHtmlFormRequestRuleNotInNoEscape.phpt`, `SafeFormRequestRulesInInstanceNoTaint.phpt`.

## Tests

* New `tests/Type/tests/ValidationRuleInFluentNarrowingTest.phpt` covers all three supported forms, the issue's exact example, the fall-through cases (variable arg, enum cases, comma-bearing value), the inline `validate([...])` call shape, the optional-field shape, the first-wins interaction with a `'string'` segment, and the variadic `Rule::notIn` no-narrowing case.
* New `tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestRuleNotInVariadicNoEscape.phpt` pins the variadic-form `not_in` taint behaviour parallel to the existing array-form regression test.

## Out of scope

Generic class to type fallback for argless first-party fluent builders (`Rule::numeric()`, `Rule::email()`, `Rule::date()`, …) per the issue, plus integer or `UnitEnum` literal arguments to `Rule::in`. Tracked separately if useful.