### PR TITLE
Resolve Factory `for*()`/`has*()` magic methods from model relations

### DIFF
--- a/src/Handlers/Eloquent/FactoryMagicMethodHandler.php
+++ b/src/Handlers/Eloquent/FactoryMagicMethodHandler.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Eloquent;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Psalm\Codebase;
+use Psalm\Plugin\EventHandler\Event\MethodExistenceProviderEvent;
+use Psalm\Plugin\EventHandler\Event\MethodParamsProviderEvent;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\Event\MethodVisibilityProviderEvent;
+use Psalm\StatementsSource;
+use Psalm\Storage\FunctionLikeParameter;
+use Psalm\Type;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Union;
+
+/**
+ * Resolves Laravel Factory magic methods `for{Relation}()` and `has{Relation}()`
+ * that map to relationship methods on the associated Model.
+ *
+ *   Post::factory()->forUser()->hasComments(3)->create();
+ *
+ * Laravel's Factory::__call dispatches these dynamically: it strips the for/has prefix,
+ * camelCases the remainder, then calls `$this->newModel()->{$relationship}()` to look
+ * up the relation on the model. This handler mirrors that resolution at static-analysis
+ * time so Psalm doesn't report UndefinedMagicMethod for these chained calls.
+ *
+ * Registered per-factory class by {@see FactoryRegistrationHandler} because Psalm's
+ * provider lookup is exact-class — a handler on Factory::class is not consulted for
+ * concrete user subclasses like App\Factories\PostFactory.
+ *
+ * @internal
+ */
+final class FactoryMagicMethodHandler
+{
+    /**
+     * Map: lowercased Factory FQCN → associated Model FQCN.
+     *
+     * Lowercased to match the casing of {@see MethodExistenceProviderEvent::getFqClasslikeName}
+     * results (Psalm normalizes class names to the declared casing, but lookups via
+     * `strtolower()` are the safe convention across the plugin).
+     *
+     * @var array<lowercase-string, class-string<Model>>
+     */
+    private static array $factoryToModel = [];
+
+    /**
+     * Memoizes whether a given (model, methodName) pair is a relationship method.
+     * Each call site triggers up to four event lookups (existence/visibility/params/
+     * return), so caching avoids redundant `getMethodReturnType()` work.
+     *
+     * @var array<string, bool>
+     */
+    private static array $relationshipMethodCache = [];
+
+    /**
+     * Register the model associated with a Factory subclass. Called by
+     * {@see FactoryRegistrationHandler} once per concrete factory whose target
+     * model could be resolved.
+     *
+     * @param class-string<Factory> $factoryClass
+     * @param class-string<Model> $modelClass
+     * @psalm-external-mutation-free
+     */
+    public static function registerFactoryToModelMapping(string $factoryClass, string $modelClass): void
+    {
+        self::$factoryToModel[\strtolower($factoryClass)] = $modelClass;
+    }
+
+    public static function doesMethodExist(MethodExistenceProviderEvent $event): ?bool
+    {
+        return self::magicCallApplies(
+            $event->getSource(),
+            $event->getFqClasslikeName(),
+            $event->getMethodNameLowercase(),
+        );
+    }
+
+    public static function isMethodVisible(MethodVisibilityProviderEvent $event): ?bool
+    {
+        return self::magicCallApplies(
+            $event->getSource(),
+            $event->getFqClasslikeName(),
+            $event->getMethodNameLowercase(),
+        );
+    }
+
+    /**
+     * @return list<FunctionLikeParameter>|null
+     */
+    public static function getMethodParams(MethodParamsProviderEvent $event): ?array
+    {
+        if (
+            self::magicCallApplies(
+                $event->getStatementsSource(),
+                $event->getFqClasslikeName(),
+                $event->getMethodNameLowercase(),
+            ) !== true
+        ) {
+            return null;
+        }
+
+        // Variadic mixed mirrors Factory::__call($method, $parameters) — the dispatcher
+        // accepts any positional args and dispatches at runtime. Encoding the precise
+        // overload set (for: ?array|callable|Factory|Model; has: int|array|callable
+        // plus optional second array, plus the sequence-of-arrays form) would be lossy
+        // and risk false-positives on legitimate call shapes.
+        return [
+            new FunctionLikeParameter(
+                name: 'parameters',
+                by_ref: false,
+                type: Type::getMixed(),
+                is_variadic: true,
+            ),
+        ];
+    }
+
+    public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        if (
+            self::magicCallApplies(
+                $event->getSource(),
+                $event->getFqClasslikeName(),
+                $event->getMethodNameLowercase(),
+            ) !== true
+        ) {
+            return null;
+        }
+
+        // Use the called class so subclass chains preserve the most-derived type.
+        // Each Factory subclass gets its own handler registered (see
+        // FactoryRegistrationHandler), so `getCalledFqClasslikeName()` already
+        // returns the most-derived class — no `is_static` flag needed, which would
+        // only render as a noisy `WorkOrderFactory&static` intersection.
+        $calledClass = $event->getCalledFqClasslikeName() ?? $event->getFqClasslikeName();
+
+        return new Union([new TNamedObject($calledClass)]);
+    }
+
+    /**
+     * Whether the call qualifies as a Factory magic for*()/has*() invocation that
+     * resolves to a relationship method on the registered model.
+     *
+     * Returns true on success; null otherwise (which causes the corresponding
+     * provider to decline the event so the next handler / native lookup runs).
+     * Null is the correct decline signal — returning false would assert "this
+     * method definitely does not exist," shadowing real Factory methods.
+     *
+     * Critically, this also declines when the method is declared natively on the
+     * factory class (or inherited from {@see Factory}). Psalm's
+     * {@see \Psalm\Internal\Analyzer\Statements\Expression\Call\Method\MethodCallReturnTypeFetcher}
+     * consults registered providers for *every* method call on the class — not
+     * just unrecognized ones — so without this guard our params/return-type
+     * providers would shadow real methods like `Factory::hasAttached()` whenever
+     * the model happens to expose a relation named `attached`.
+     */
+    private static function magicCallApplies(
+        ?StatementsSource $source,
+        string $factoryClass,
+        string $methodNameLowercase,
+    ): ?bool {
+        if (!$source instanceof StatementsSource) {
+            return null;
+        }
+
+        // Cheap rejects first — most calls on factories are non-magic methods
+        // (`make`, `create`, `count`, `state`, ...), so failing fast on the prefix
+        // shape avoids the `strtolower` + map lookup for the common case.
+        $relationshipName = self::extractRelationshipName($methodNameLowercase);
+        if ($relationshipName === null) {
+            return null;
+        }
+
+        $modelClass = self::$factoryToModel[\strtolower($factoryClass)] ?? null;
+        if ($modelClass === null) {
+            return null;
+        }
+
+        $codebase = $source->getCodebase();
+
+        // Decline when the method exists natively on the factory class. This
+        // includes both inherited Factory methods (`hasAttached`, `forEachSequence`,
+        // etc.) and user-defined overrides on the factory subclass — both must
+        // win over our magic resolution to preserve their real signatures.
+        //
+        // use_method_existence_provider: false is critical here: Psalm's
+        // methodExists() defaults to consulting the existence_provider, which
+        // would call back into THIS handler with identical args and recurse
+        // unboundedly. We only care about native (storage-based) existence here.
+        // The string-form method id sidesteps MethodIdentifier's lowercase-string
+        // constraint; Psalm's $codebase->methodExists() lowercases internally.
+        if ($codebase->methodExists(
+            $factoryClass . '::' . $methodNameLowercase,
+            use_method_existence_provider: false,
+        )) {
+            return null;
+        }
+
+        if (!self::isRelationshipMethod($codebase, $modelClass, $relationshipName)) {
+            return null;
+        }
+
+        return true;
+    }
+
+    /**
+     * Extract the relationship-method name from a magic for*()/has*() call.
+     *
+     *   "foruser"     → "user"
+     *   "hascomments" → "comments"
+     *
+     * Returns null for the bare "for" / "has" methods (which exist natively on
+     * Factory and never reach this handler) and for any other prefix.
+     *
+     * Laravel applies `Str::camel(Str::substr($method, 3))` to the original (cased)
+     * method name. We work with the lowercased form because Psalm's method lookup is
+     * case-insensitive — `methodExists('App\Models\Post::user')` matches a `user()`
+     * declaration regardless of the cased input.
+     *
+     * @psalm-pure
+     */
+    private static function extractRelationshipName(string $methodNameLowercase): ?string
+    {
+        if (\strlen($methodNameLowercase) <= 3) {
+            return null;
+        }
+
+        $prefix = \substr($methodNameLowercase, 0, 3);
+        if ($prefix !== 'for' && $prefix !== 'has') {
+            return null;
+        }
+
+        return \substr($methodNameLowercase, 3);
+    }
+
+    /**
+     * Check whether $relationshipName on $modelClass is a relationship method.
+     *
+     * Mirrors {@see ModelRelationshipPropertyHandler::relationExists()} — accept both
+     * generic (`HasMany<Comment, $this>`) and non-generic (`HasMany`) Relation return
+     * types, and parse the method body via {@see RelationMethodParser} when no return
+     * type is declared (e.g. `public function image() { return $this->morphOne(...); }`).
+     */
+    private static function isRelationshipMethod(Codebase $codebase, string $modelClass, string $relationshipName): bool
+    {
+        $methodId = $modelClass . '::' . $relationshipName;
+        if (\array_key_exists($methodId, self::$relationshipMethodCache)) {
+            return self::$relationshipMethodCache[$methodId];
+        }
+
+        if (!$codebase->methodExists($methodId)) {
+            return self::$relationshipMethodCache[$methodId] = false;
+        }
+
+        // getMethodReturnType() takes $self_class by reference and may set it to null,
+        // so use a disposable copy to protect $modelClass.
+        $selfClass = $modelClass;
+        try {
+            $returnType = $codebase->getMethodReturnType($methodId, $selfClass);
+        } catch (\InvalidArgumentException $e) {
+            $codebase->progress->debug("Laravel plugin: could not get return type for {$methodId}: {$e->getMessage()}\n");
+            return self::$relationshipMethodCache[$methodId] = false;
+        }
+
+        if ($returnType instanceof Union) {
+            foreach ($returnType->getAtomicTypes() as $type) {
+                if ($type instanceof TNamedObject && \is_a($type->value, Relation::class, true)) {
+                    return self::$relationshipMethodCache[$methodId] = true;
+                }
+            }
+        }
+
+        // No return type declared — fall back to AST inspection of the method body.
+        if (!$returnType instanceof Union
+            && RelationMethodParser::parse($codebase, $modelClass, $relationshipName) !== null
+        ) {
+            return self::$relationshipMethodCache[$methodId] = true;
+        }
+
+        return self::$relationshipMethodCache[$methodId] = false;
+    }
+}

--- a/src/Handlers/Eloquent/FactoryMagicMethodHandler.php
+++ b/src/Handlers/Eloquent/FactoryMagicMethodHandler.php
@@ -261,8 +261,8 @@ final class FactoryMagicMethodHandler
         $selfClass = $modelClass;
         try {
             $returnType = $codebase->getMethodReturnType($methodId, $selfClass);
-        } catch (\InvalidArgumentException $e) {
-            $codebase->progress->debug("Laravel plugin: could not get return type for {$methodId}: {$e->getMessage()}\n");
+        } catch (\InvalidArgumentException $invalidArgumentException) {
+            $codebase->progress->debug("Laravel plugin: could not get return type for {$methodId}: {$invalidArgumentException->getMessage()}\n");
             return self::$relationshipMethodCache[$methodId] = false;
         }
 

--- a/src/Handlers/Eloquent/FactoryRegistrationHandler.php
+++ b/src/Handlers/Eloquent/FactoryRegistrationHandler.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Eloquent;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Model;
+use Psalm\Codebase;
+use Psalm\LaravelPlugin\Util\AnonymousClassNameDetector;
+use Psalm\Plugin\EventHandler\AfterCodebasePopulatedInterface;
+use Psalm\Plugin\EventHandler\Event\AfterCodebasePopulatedEvent;
+use Psalm\Storage\ClassLikeStorage;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Union;
+
+/**
+ * Discovers Eloquent Factory subclasses and registers {@see FactoryMagicMethodHandler}
+ * hooks for each one whose target Model can be resolved.
+ *
+ * Resolution priority (matches Laravel's own behavior in Factory::modelName() where
+ * possible, falling back to static analysis when runtime instantiation is not viable):
+ *
+ *  1. Reflection: instantiate the factory and call modelName(). Covers all three
+ *     runtime resolution paths in one shot — `#[UseModel]` attribute (highest), then
+ *     `protected $model`, then the naming-convention resolver
+ *     (Database\Factories\PostFactory → App\Models\Post).
+ *
+ *  2. Static fallback: read the @extends Factory<TModel> template binding from
+ *     {@see ClassLikeStorage::$template_extended_params}. This covers factories that
+ *     are not autoloadable in the analysis environment (e.g. inline declarations in
+ *     PHPT type-tests) but have an explicit generic extends.
+ *
+ * @internal
+ */
+final class FactoryRegistrationHandler implements AfterCodebasePopulatedInterface
+{
+    #[\Override]
+    public static function afterCodebasePopulated(AfterCodebasePopulatedEvent $event): void
+    {
+        $codebase = $event->getCodebase();
+        $factoryFqcnLower = \strtolower(Factory::class);
+
+        foreach ($codebase->classlike_storage_provider::getAll() as $storage) {
+            // Skip abstract bases — they don't bind a concrete model and are
+            // typically intermediate parents in user-land factory hierarchies.
+            if ($storage->abstract) {
+                continue;
+            }
+
+            if (!isset($storage->parent_classes[$factoryFqcnLower])) {
+                continue;
+            }
+
+            // Anonymous Factory subclasses (e.g. `new class extends Factory {}`) get a
+            // synthetic FQCN that no autoloader can resolve. Skip them before any
+            // class_exists() probe to avoid misleading warnings.
+            if (
+                $storage->stmt_location !== null
+                && AnonymousClassNameDetector::isSynthetic($storage->name, $storage->stmt_location->file_path)
+            ) {
+                continue;
+            }
+
+            // Caller verified parent_classes contains Factory, so the name is a
+            // class-string<Factory>. Narrow it for downstream Reflection / closure
+            // registration which both require the tighter type.
+            /** @var class-string<Factory> $factoryClass */
+            $factoryClass = $storage->name;
+
+            $modelClass = self::resolveTargetModel($codebase, $factoryClass, $storage);
+            if ($modelClass === null) {
+                continue;
+            }
+
+            FactoryMagicMethodHandler::registerFactoryToModelMapping($factoryClass, $modelClass);
+
+            $methods = $codebase->methods;
+            $methods->existence_provider->registerClosure(
+                $factoryClass,
+                FactoryMagicMethodHandler::doesMethodExist(...),
+            );
+            $methods->visibility_provider->registerClosure(
+                $factoryClass,
+                FactoryMagicMethodHandler::isMethodVisible(...),
+            );
+            $methods->params_provider->registerClosure(
+                $factoryClass,
+                FactoryMagicMethodHandler::getMethodParams(...),
+            );
+            $methods->return_type_provider->registerClosure(
+                $factoryClass,
+                FactoryMagicMethodHandler::getMethodReturnType(...),
+            );
+        }
+    }
+
+    /**
+     * Resolve the Model FQCN for a Factory subclass, trying Reflection-based runtime
+     * resolution first and falling back to static template extraction.
+     *
+     * @param class-string<Factory> $factoryClass
+     * @return class-string<Model>|null
+     */
+    private static function resolveTargetModel(Codebase $codebase, string $factoryClass, ClassLikeStorage $storage): ?string
+    {
+        $modelClass = self::resolveViaReflection($codebase, $factoryClass);
+        if ($modelClass !== null) {
+            return $modelClass;
+        }
+
+        return self::resolveViaTemplateBinding($codebase, $storage);
+    }
+
+    /**
+     * Instantiate the factory and call modelName(). Returns null when the class is
+     * not autoloadable, instantiation throws, or the resolved string is not a
+     * loaded Model subclass.
+     *
+     * Uses ReflectionClass rather than `new $factoryClass()` so that an autoload
+     * failure surfaces as a typed ReflectionException we can ignore quietly,
+     * instead of a fatal Error.
+     *
+     * @param class-string<Factory> $factoryClass
+     * @return class-string<Model>|null
+     */
+    private static function resolveViaReflection(Codebase $codebase, string $factoryClass): ?string
+    {
+        try {
+            $reflection = new \ReflectionClass($factoryClass);
+            $factory = $reflection->newInstance();
+            $modelClass = $factory->modelName();
+        } catch (\Error|\Exception $error) {
+            // Surface as a warning (mirrors ModelRegistrationHandler's autoload
+            // failure handling) — the user needs to know why their factory's
+            // magic methods aren't recognized. \Error|\Exception narrowed from
+            // \Throwable so genuinely unexpected exception types propagate.
+            $codebase->progress->warning(
+                "Laravel plugin: skipping factory '{$factoryClass}': could not call modelName(): {$error->getMessage()}",
+            );
+            return null;
+        }
+
+        // Verify the resolved string is a real Model subclass. The naming-convention
+        // resolver in Laravel's modelName() always returns a string even when no
+        // matching class exists, so this guard prevents registering handlers with a
+        // dangling target. is_subclass_of triggers autoloading which can throw on
+        // broken classes — fall through and warn in that case.
+        try {
+            if (!\is_subclass_of($modelClass, Model::class, true)) {
+                return null;
+            }
+        } catch (\Error|\Exception $error) {
+            $codebase->progress->warning(
+                "Laravel plugin: factory '{$factoryClass}' resolved model '{$modelClass}' that failed validation: {$error->getMessage()}",
+            );
+            return null;
+        }
+
+        return $modelClass;
+    }
+
+    /**
+     * Fallback: read TModel from `@extends Factory<TModel>`.
+     *
+     * Psalm populates {@see ClassLikeStorage::$template_extended_params} during
+     * scanning. The map is keyed by the parent FQCN (original case); the value maps
+     * template-parameter names to their Union bindings. We accept any single
+     * named-object param — Factory's first template is TModel.
+     *
+     * Validation runs against Psalm's classlike storage rather than runtime
+     * reflection, since this fallback exists precisely for cases where the model
+     * is not autoloadable (e.g. inline declarations in PHPT type-tests).
+     *
+     * @return class-string<Model>|null
+     * @psalm-mutation-free
+     */
+    private static function resolveViaTemplateBinding(Codebase $codebase, ClassLikeStorage $storage): ?string
+    {
+        if ($storage->template_extended_params === null) {
+            return null;
+        }
+
+        $factoryFqcnLower = \strtolower(Factory::class);
+
+        foreach ($storage->template_extended_params as $extendedClass => $params) {
+            if (\strtolower($extendedClass) !== $factoryFqcnLower) {
+                continue;
+            }
+
+            // Psalm always keys $params by the declared template-parameter name
+            // (Populator.php walks `array_keys($parent_storage->template_types)`),
+            // and Factory's docblock declares `@template TModel`. Read 'TModel'
+            // first; fall back to the first positional value if Laravel ever
+            // renames the template — defensive but expected to be dead code.
+            $tModel = $params['TModel'] ?? null;
+            if (!$tModel instanceof Union) {
+                $firstKey = \array_key_first($params);
+                $tModel = $firstKey !== null ? $params[$firstKey] : null;
+            }
+
+            if (!$tModel instanceof Union) {
+                return null;
+            }
+
+            foreach ($tModel->getAtomicTypes() as $atomic) {
+                if (!$atomic instanceof TNamedObject) {
+                    continue;
+                }
+
+                if (!self::isModelInCodebase($codebase, $atomic->value)) {
+                    return null;
+                }
+
+                /** @var class-string<Model> $resolved */
+                $resolved = $atomic->value;
+                return $resolved;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Check via Psalm's classlike storage whether $className is a Model subclass.
+     *
+     * Used by the template-binding fallback path because the model is typically
+     * not autoloadable when the factory itself isn't (e.g. inline classes). The
+     * check uses the case-insensitive `parent_classes` map populated during scan.
+     *
+     * @psalm-mutation-free
+     */
+    private static function isModelInCodebase(Codebase $codebase, string $className): bool
+    {
+        try {
+            $modelStorage = $codebase->classlike_storage_provider->get($className);
+        } catch (\InvalidArgumentException) {
+            return false;
+        }
+
+        return $className === Model::class
+            || isset($modelStorage->parent_classes[\strtolower(Model::class)]);
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -221,12 +221,20 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Eloquent/ModelRelationshipPropertyHandler.php';
         require_once __DIR__ . '/Handlers/Eloquent/ModelFactoryTypeProvider.php';
         require_once __DIR__ . '/Handlers/Eloquent/ModelPropertyAccessorHandler.php';
+        require_once __DIR__ . '/Handlers/Eloquent/FactoryMagicMethodHandler.php';
+        require_once __DIR__ . '/Handlers/Eloquent/FactoryRegistrationHandler.php';
         if ($pluginConfig->shouldUseMigrations()) {
             require_once __DIR__ . '/Handlers/Eloquent/ModelPropertyHandler.php';
             Handlers\Eloquent\ModelRegistrationHandler::enableMigrations();
         }
 
         $registration->registerHooksFromClass(Handlers\Eloquent\ModelRegistrationHandler::class);
+        // Discovers Factory subclasses and registers per-class hooks so that
+        // for{Relation}() / has{Relation}() magic calls type-check (issue #696).
+        // Runs after ModelRegistrationHandler in registration order; order doesn't
+        // affect correctness — both subscribe to AfterCodebasePopulated and only
+        // query the codebase at analysis time, by which point both have registered.
+        $registration->registerHooksFromClass(Handlers\Eloquent\FactoryRegistrationHandler::class);
 
         // Magic method forwarding: Relation -> Builder (decorated forwarding).
         // Must be registered BEFORE BuilderScopeHandler, BuilderPluckHandler, and

--- a/tests/Application/app/Factories/WorkOrderFactory.php
+++ b/tests/Application/app/Factories/WorkOrderFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Factories;
+
+use App\Models\WorkOrder;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * Test fixture covering the most common Factory pattern: explicit `protected $model`.
+ *
+ * Used by tests/Type/tests/Factory/MagicMethodsTest.phpt to verify that
+ * forVehicle() / hasParts() and friends are recognized as magic methods returning
+ * the same factory type.
+ *
+ * @extends Factory<WorkOrder>
+ */
+final class WorkOrderFactory extends Factory
+{
+    /**
+     * @var class-string<WorkOrder>
+     */
+    protected $model = WorkOrder::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[\Override]
+    public function definition(): array
+    {
+        return [];
+    }
+}

--- a/tests/Type/tests/Factory/MagicMethodsNativeShadowingTest.phpt
+++ b/tests/Type/tests/Factory/MagicMethodsNativeShadowingTest.phpt
@@ -1,0 +1,52 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Factories\WorkOrderFactory;
+
+/**
+ * Regression coverage for the native-method shadowing guard in
+ * FactoryMagicMethodHandler::magicCallApplies().
+ *
+ * Psalm consults registered method providers for *every* method call on a class
+ * once any closure is registered there, not just for unrecognized methods. The
+ * handler must therefore explicitly decline when the call resolves to a real
+ * declared method on the factory class — including methods inherited from the
+ * Factory base — so that real signatures (parameter requirements, return types)
+ * are preserved.
+ *
+ * Test strategy: call real Factory methods with too few arguments. Psalm should
+ * report TooFewArguments using the real method signatures. If the handler's
+ * variadic-mixed params provider were shadowing them, those errors would be
+ * suppressed and the calls would silently type-check.
+ *
+ * Confirmed shadow risks if the guard is removed:
+ *   - hasAttached($factory, $pivot, $relationship)  — `has` prefix + `attached` model relation
+ *   - forEachSequence(...$sequence)                 — `for` prefix + `eachSequence` relation
+ *
+ * has() and for() at exact length 3 are also caught by extractRelationshipName's
+ * length>=4 guard, but the methodExists() check is the primary defense.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/696
+ */
+function test_real_has_arity_preserved(WorkOrderFactory $factory): void
+{
+    $factory->has();
+}
+
+function test_real_for_arity_preserved(WorkOrderFactory $factory): void
+{
+    $factory->for();
+}
+
+function test_real_hasAttached_arity_preserved(WorkOrderFactory $factory): void
+{
+    $factory->hasAttached();
+}
+?>
+--EXPECTF--
+TooFewArguments on line %d: Too few arguments for App\Factories\WorkOrderFactory::has%s
+TooFewArguments on line %d: Too few arguments for%shas saw 0
+TooFewArguments on line %d: Too few arguments for App\Factories\WorkOrderFactory::for%s
+TooFewArguments on line %d: Too few arguments for%sfor saw 0
+TooFewArguments on line %d: Too few arguments for App\Factories\WorkOrderFactory::hasAttached%s
+TooFewArguments on line %d: Too few arguments for%shasattached saw 0

--- a/tests/Type/tests/Factory/MagicMethodsTemplateExtendsTest.phpt
+++ b/tests/Type/tests/Factory/MagicMethodsTemplateExtendsTest.phpt
@@ -1,0 +1,54 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\WorkOrder;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * Verifies the static fallback in FactoryRegistrationHandler.
+ *
+ * The factory below is declared inline in this PHPT file and is therefore not
+ * autoloadable in the analysis environment, so resolveViaReflection() returns
+ * null. The fallback path reads TModel from `@extends Factory<WorkOrder>` via
+ * Psalm's classlike storage instead, which keeps the magic for*()/has*() methods
+ * type-checking even when runtime reflection is unavailable.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/696
+ *
+ * @extends Factory<WorkOrder>
+ */
+class TemplatedWorkOrderFactory extends Factory
+{
+    /** @var class-string<WorkOrder> */
+    protected $model = WorkOrder::class;
+
+    /** @return array<string, mixed> */
+    #[\Override]
+    public function definition(): array
+    {
+        return [];
+    }
+}
+
+function test_template_binding_for(TemplatedWorkOrderFactory $factory): TemplatedWorkOrderFactory
+{
+    /** @psalm-check-type-exact $chained = TemplatedWorkOrderFactory */
+    $chained = $factory->forVehicle();
+    return $chained;
+}
+
+function test_template_binding_has(TemplatedWorkOrderFactory $factory): TemplatedWorkOrderFactory
+{
+    /** @psalm-check-type-exact $chained = TemplatedWorkOrderFactory */
+    $chained = $factory->hasParts(2);
+    return $chained;
+}
+
+function test_template_binding_chain(TemplatedWorkOrderFactory $factory): TemplatedWorkOrderFactory
+{
+    /** @psalm-check-type-exact $chained = TemplatedWorkOrderFactory */
+    $chained = $factory->forVehicle()->hasParts(3);
+    return $chained;
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Factory/MagicMethodsTest.phpt
+++ b/tests/Type/tests/Factory/MagicMethodsTest.phpt
@@ -1,0 +1,87 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Factories\WorkOrderFactory;
+
+/**
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/696
+ *
+ * Factory subclasses expose magic for{Relation}() / has{Relation}() methods derived
+ * from the associated model's relationship methods. Laravel's Factory::__call
+ * dispatches these dynamically; the plugin must recognize them at static-analysis
+ * time so chained builder calls type-check.
+ *
+ * WorkOrder has these relationships:
+ *   - vehicle()    : BelongsTo<Vehicle>
+ *   - mechanic()   : BelongsTo<Mechanic>
+ *   - invoice()    : HasOne<Invoice>
+ *   - parts()      : BelongsToMany<Part>
+ */
+
+// for{Relation}() — single relation, BelongsTo.
+function test_for_belongs_to(WorkOrderFactory $factory): WorkOrderFactory
+{
+    /** @psalm-check-type-exact $chained = WorkOrderFactory */
+    $chained = $factory->forVehicle();
+    return $chained;
+}
+
+// for{Relation}() — second BelongsTo on the same model.
+function test_for_second_belongs_to(WorkOrderFactory $factory): WorkOrderFactory
+{
+    /** @psalm-check-type-exact $chained = WorkOrderFactory */
+    $chained = $factory->forMechanic();
+    return $chained;
+}
+
+// has{Relation}() — HasOne with no count.
+function test_has_one(WorkOrderFactory $factory): WorkOrderFactory
+{
+    /** @psalm-check-type-exact $chained = WorkOrderFactory */
+    $chained = $factory->hasInvoice();
+    return $chained;
+}
+
+// has{Relation}(int) — BelongsToMany with explicit count.
+function test_has_many_with_count(WorkOrderFactory $factory): WorkOrderFactory
+{
+    /** @psalm-check-type-exact $chained = WorkOrderFactory */
+    $chained = $factory->hasParts(3);
+    return $chained;
+}
+
+// Chained for / has — preserves the factory type across multiple magic dispatches.
+function test_chained_for_and_has(WorkOrderFactory $factory): WorkOrderFactory
+{
+    /** @psalm-check-type-exact $chained = WorkOrderFactory */
+    $chained = $factory->forVehicle()->hasParts(3)->forMechanic();
+    return $chained;
+}
+
+// for{Relation}(array) — passes a state array to the related factory.
+function test_for_with_state_array(WorkOrderFactory $factory): WorkOrderFactory
+{
+    /** @psalm-check-type-exact $chained = WorkOrderFactory */
+    $chained = $factory->forVehicle(['make' => 'Toyota']);
+    return $chained;
+}
+
+// has{Relation}(array, array) — sequence-of-arrays form supported by Factory::__call.
+function test_has_with_sequence(WorkOrderFactory $factory): WorkOrderFactory
+{
+    /** @psalm-check-type-exact $chained = WorkOrderFactory */
+    $chained = $factory->hasParts(['unit_price' => 10], ['unit_price' => 20]);
+    return $chained;
+}
+
+// has{Relation}() — MorphMany. Exercises the morph branch of the Relation
+// subclass detection in isRelationshipMethod (WorkOrder::damageReports returns
+// MorphMany rather than HasMany).
+function test_has_morph_many(WorkOrderFactory $factory): WorkOrderFactory
+{
+    /** @psalm-check-type-exact $chained = WorkOrderFactory */
+    $chained = $factory->hasDamageReports(2);
+    return $chained;
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Factory/MagicMethodsUnknownRelationTest.phpt
+++ b/tests/Type/tests/Factory/MagicMethodsUnknownRelationTest.phpt
@@ -1,0 +1,26 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Factories\WorkOrderFactory;
+
+/**
+ * Negative coverage: a for{Foo}() / has{Foo}() call whose tail does not match a
+ * relationship method on the model must surface UndefinedMagicMethod. Without
+ * this regression, a future change that loosens the relation check (e.g. always
+ * returning true) would silently accept any prefix call.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/696
+ */
+function test_unknown_for_relation_is_rejected(WorkOrderFactory $factory): void
+{
+    $factory->forNonexistentRelation();
+}
+
+function test_unknown_has_relation_is_rejected(WorkOrderFactory $factory): void
+{
+    $factory->hasNonexistentRelation(3);
+}
+?>
+--EXPECTF--
+UndefinedMagicMethod on line %d: Magic method App\Factories\WorkOrderFactory::fornonexistentrelation does not exist
+UndefinedMagicMethod on line %d: Magic method App\Factories\WorkOrderFactory::hasnonexistentrelation does not exist

--- a/tests/Type/tests/Factory/MagicMethodsUserOverrideTest.phpt
+++ b/tests/Type/tests/Factory/MagicMethodsUserOverrideTest.phpt
@@ -1,0 +1,51 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\WorkOrder;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * A user-declared `forFoo()` / `hasFoo()` method on a Factory subclass must keep
+ * its real signature and return type — the magic-method handler must decline
+ * for any method that exists natively, regardless of whether the underlying
+ * model has a same-named relation.
+ *
+ * This is the second half of the native-shadowing guard's contract (the first
+ * half, inherited Factory methods like hasAttached, lives in
+ * MagicMethodsNativeShadowingTest.phpt).
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/696
+ *
+ * @extends Factory<WorkOrder>
+ */
+class UserOverrideWorkOrderFactory extends Factory
+{
+    /** @var class-string<WorkOrder> */
+    protected $model = WorkOrder::class;
+
+    /** @return array<string, mixed> */
+    #[\Override]
+    public function definition(): array
+    {
+        return [];
+    }
+
+    /**
+     * Real method that shadows the magic forVehicle() resolution. Returns a
+     * literal int rather than a Factory so any handler-injected `static`
+     * return-type would surface as a CheckType mismatch.
+     */
+    public function forVehicle(): int
+    {
+        return 42;
+    }
+}
+
+function test_user_declared_method_wins(UserOverrideWorkOrderFactory $factory): int
+{
+    /** @psalm-check-type-exact $result = int */
+    $result = $factory->forVehicle();
+    return $result;
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

Laravel factories expose magic `for{Relation}()` / `has{Relation}()` methods derived from the associated model's relationship methods, dispatched at runtime by `Factory::__call`. Psalm previously reported `UndefinedMagicMethod` for these chained calls.

```php
Post::factory()->forUser()->hasComments(3)->create();
// forUser()      → BelongsTo to User, dispatched via Factory::__call
// hasComments(3) → 3 related Comment factories, dispatched via Factory::__call
```

## Related

Closes #696

## Solution Description

`FactoryRegistrationHandler` runs in `AfterCodebasePopulated`, discovers every concrete `Factory` subclass, and resolves its target Model via two paths:

1. **Reflection** — instantiate the factory and call `modelName()`, which internally handles `#[UseModel]`, `protected $model`, and Laravel's naming-convention resolver in one shot.
2. **Static fallback** — read `TModel` from `@extends Factory<TModel>` via `ClassLikeStorage::$template_extended_params`, for factories that are not autoloadable in the analysis environment (e.g. inline declarations in PHPT type-tests).

For each resolved (factory, model) pair, `FactoryMagicMethodHandler` is registered as a per-class existence/visibility/params/return-type provider. The handler:

- Recognizes `for{Relation}()` / `has{Relation}()` whose tail names a `Relation`-returning method on the model (mirrors the runtime `Str::camel(Str::substr($method, 3))` lookup).
- Declines (returns `null`) when the method exists natively on the factory class. Psalm's `MethodCallReturnTypeFetcher` consults registered providers for *every* method call once any closure is registered, so without an explicit guard our variadic-mixed params would shadow real Factory methods like `has()`, `for()`, `hasAttached()`, `forEachSequence()`, and any user-declared override on the subclass.
- Returns the called class (each subclass registers its own handler, so chaining preserves the most-derived type without an `is_static` flag).

The native-method probe uses `use_method_existence_provider: false` so the existence_provider does not recurse back into this handler.

### Test coverage

Five PHPT tests exercise the new functionality:

- `MagicMethodsTest.phpt` — happy path: `BelongsTo`, `HasOne`, `BelongsToMany`, `MorphMany`, chains, state arrays, sequence-of-arrays form (autoloaded factory).
- `MagicMethodsTemplateExtendsTest.phpt` — `@extends Factory<TModel>` static fallback (inline non-autoloadable factory).
- `MagicMethodsNativeShadowingTest.phpt` — verifies real Factory methods (`has`, `for`, `hasAttached`) keep their real arities.
- `MagicMethodsUnknownRelationTest.phpt` — verifies `UndefinedMagicMethod` still surfaces for non-existent relations.
- `MagicMethodsUserOverrideTest.phpt` — verifies a user-declared `forVehicle(): int` wins over magic resolution.

## Checklist

- [x] Tests cover the change (5 type tests in `tests/Type/tests/Factory/`)
