### PR TITLE
Use level 4 by default and level info instead of suppress

### DIFF
--- a/src/Cli/InitCommand.php
+++ b/src/Cli/InitCommand.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 )]
 final class InitCommand extends Command
 {
-    private const DEFAULT_ERROR_LEVEL = '3';
+    private const DEFAULT_ERROR_LEVEL = '4';
 
     private const PSALM_XML_TEMPLATE = <<<'XML'
         <?xml version="1.0"?>
@@ -41,6 +41,7 @@ final class InitCommand extends Command
                     <directory name="vendor"/>
                     <directory name="storage"/>
                     <directory name="bootstrap/cache"/>
+                    <directory name="tests"/><!-- install psalm/plugin-phpunit and psalm/plugin-mockery for the full tests support -->
                 </ignoreFiles>
             </projectFiles>
 
@@ -49,15 +50,16 @@ final class InitCommand extends Command
             </plugins>
 
             <issueHandlers>
-                <ClassMustBeFinal errorLevel="suppress"/>
-                <MissingAbstractPureAnnotation errorLevel="suppress"/>
-                <MissingClosureReturnType errorLevel="suppress"/>
-                <MissingImmutableAnnotation errorLevel="suppress"/>
-                <MissingInterfaceImmutableAnnotation errorLevel="suppress"/>
-                <MissingOverrideAttribute errorLevel="suppress"/>
-                <MissingPureAnnotation errorLevel="suppress"/>
-                <RedundantCast errorLevel="suppress"/>
-                <RedundantCondition errorLevel="suppress"/>
+                <ClassMustBeFinal errorLevel="info"/>
+                <ImplicitToStringCast errorLevel="info"/>
+                <MissingAbstractPureAnnotation errorLevel="info"/>
+                <MissingClosureReturnType errorLevel="info"/>
+                <MissingImmutableAnnotation errorLevel="info"/>
+                <MissingInterfaceImmutableAnnotation errorLevel="info"/>
+                <MissingOverrideAttribute errorLevel="info"/>
+                <MissingPureAnnotation errorLevel="info"/>
+                <RedundantCast errorLevel="info"/>
+                <RedundantCondition errorLevel="info"/>
                 <UnnecessaryVarAnnotation errorLevel="suppress"/>
             </issueHandlers>
         </psalm>

--- a/tests/Unit/Cli/InitCommandTest.php
+++ b/tests/Unit/Cli/InitCommandTest.php
@@ -50,15 +50,15 @@ final class InitCommandTest extends TestCase
 
         $contents = \file_get_contents($target);
         $this->assertIsString($contents);
-        $this->assertStringContainsString('errorLevel="3"', $contents);
+        $this->assertStringContainsString('errorLevel="4"', $contents);
         $this->assertStringContainsString('findUnusedCode="false"', $contents);
         $this->assertStringContainsString('ensureOverrideAttribute="false"', $contents);
         $this->assertStringContainsString('<pluginClass class="Psalm\\LaravelPlugin\\Plugin"/>', $contents);
         $this->assertStringContainsString('<directory name="vendor"/>', $contents);
         $this->assertStringContainsString('<directory name="storage"/>', $contents);
         $this->assertStringContainsString('<directory name="bootstrap/cache"/>', $contents);
-        $this->assertStringContainsString('<ClassMustBeFinal errorLevel="suppress"/>', $contents);
-        $this->assertStringContainsString('<MissingOverrideAttribute errorLevel="suppress"/>', $contents);
+        $this->assertStringContainsString('<ClassMustBeFinal errorLevel="info"/>', $contents);
+        $this->assertStringContainsString('<MissingOverrideAttribute errorLevel="info"/>', $contents);
         $this->assertStringContainsString('<UnnecessaryVarAnnotation errorLevel="suppress"/>', $contents);
     }
 


### PR DESCRIPTION
Exclude tests dir by default as it requires other Psalm plugins plus makes dead code detection less usable.
