### PR TITLE
Fix `MissingTemplateParam` on `BelongsToMany`/`MorphToMany` relation consumers

### DIFF
--- a/src/Handlers/Eloquent/ModelRelationReturnTypeHandler.php
+++ b/src/Handlers/Eloquent/ModelRelationReturnTypeHandler.php
@@ -51,12 +51,14 @@ use Psalm\Type\Union;
  * arg is dynamic the handler defers.
  *
  * For `BelongsToMany` and `MorphToMany` the parser also walks the chain to capture
- * `->using(CustomPivot::class)` (TPivotModel) and `->as('accessor')` (TAccessor); when
- * present they are emitted as the 3rd and 4th template params so downstream pivot
- * intersections (e.g. `first()` returning `TRelatedModel&object{pivot: TPivotModel}`)
- * resolve to the user-declared pivot model rather than the default `Pivot`. When neither
- * mutator appears the handler emits the 2-param shape and Psalm fills in the template
- * defaults.
+ * `->using(CustomPivot::class)` (TPivotModel) and `->as('accessor')` (TAccessor) and emits
+ * them as the 3rd and 4th template params so downstream pivot intersections (e.g.
+ * `first()` returning `TRelatedModel&object{pivot: TPivotModel}`) resolve to the
+ * user-declared pivot model rather than the default `Pivot`. When neither mutator is
+ * captured the handler still emits all 4 slots, filling slot 3 with the per-relation
+ * pivot default (`Pivot` / `MorphPivot`) and slot 4 with `'pivot'` — emitting only 2
+ * triggers `MissingTemplateParam` on consumers because Psalm rejects a partial form
+ * even when the stub declares `@template-default` (see #883).
  *
  * @see https://github.com/psalm/psalm-plugin-laravel/issues/760
  * @internal
@@ -66,13 +68,14 @@ final class ModelRelationReturnTypeHandler
     /**
      * Relation classes whose stub declares the 4-template
      * `<TRelatedModel, TDeclaringModel, TPivotModel, TAccessor>` shape, mapped to
-     * the stub-declared TPivotModel default. The handler emits this default when
-     * the parser captures `->as(...)` but no `->using(...)` (the all-or-nothing
-     * rule still requires emitting slot 3). Other relations ignore the captured
-     * pivot/accessor — emitting slots 3+4 on a 2-template relation produces a
-     * malformed type. Defaults must match Laravel source: `BelongsToMany` =>
-     * `Pivot`, `MorphToMany` => `MorphPivot` (see Laravel's MorphToMany
-     * constructor and the BelongsToMany stub at
+     * the stub-declared TPivotModel default. The handler always emits slots 3+4
+     * for these relations: when the parser captures `->using(...)` / `->as(...)`
+     * the captured values fill the slots, otherwise the per-relation defaults
+     * (`Pivot` / `MorphPivot`) and `'pivot'` are emitted (see #883). Other
+     * relations ignore the captured pivot/accessor — emitting slots 3+4 on a
+     * 2-template relation produces a malformed type. Defaults must match Laravel
+     * source: `BelongsToMany` => `Pivot`, `MorphToMany` => `MorphPivot` (see
+     * Laravel's MorphToMany constructor and the BelongsToMany stub at
      * stubs/common/Database/Eloquent/Relations/).
      *
      * @var array<class-string, class-string<Pivot>>
@@ -223,12 +226,13 @@ final class ModelRelationReturnTypeHandler
      * `$relationClass`. The shape varies per Relation subclass:
      * - Standard relations: `<TRelatedModel, TDeclaringModel>` — e.g. `HasOne<Post, User>`,
      *   `BelongsTo<User, Post>`.
-     * - BelongsToMany / MorphToMany: `<TRelatedModel, TDeclaringModel>` by default, expanding
-     *   to `<TRelatedModel, TDeclaringModel, TPivotModel, TAccessor>` when the parser captured
-     *   `->using(CustomPivot::class)` / `->as('alias')` chain mutations. The 4-template form
-     *   is needed so downstream pivot intersections (e.g. `first()` returning
-     *   `TRelatedModel&object{pivot: TPivotModel}`) resolve to the user-declared pivot model
-     *   rather than the default `Pivot`.
+     * - BelongsToMany / MorphToMany: always emit the full 4-template form
+     *   `<TRelatedModel, TDeclaringModel, TPivotModel, TAccessor>`. When the parser captured
+     *   `->using(CustomPivot::class)` / `->as('alias')` chain mutations they fill slots 3 and 4;
+     *   otherwise the per-relation pivot default (`Pivot` / `MorphPivot`) and `'pivot'` fill
+     *   them. Emitting all 4 slots is required so downstream pivot intersections (e.g.
+     *   `first()` returning `TRelatedModel&object{pivot: TPivotModel}`) resolve, and so
+     *   consumers don't trip `MissingTemplateParam` on a partial 2-of-4 emission (#883).
      * - Through relations: `<TRelatedModel, TIntermediateModel, TDeclaringModel>` — e.g.
      *   `HasManyThrough<Post, Membership, Country>`. Note the Relation parent's 3rd template
      *   (TResult) is filled implicitly by Psalm via the Through subclass's @template-extends.
@@ -264,14 +268,15 @@ final class ModelRelationReturnTypeHandler
         // the method body lives on a parent class.
         $typeParams[] = new Union([new TNamedObject($bindingClass)]);
 
-        // Emit TPivotModel / TAccessor (slots 3 and 4) only when the parser captured a
-        // chain mutation. Both slots are filled together (with declared defaults filling
-        // any gap); a partial 3-template `BelongsToMany<R, D, P>` would leave TAccessor
-        // unbound on a relation whose template list expects 4 entries when any are given.
-        // The pivot default is per-relation (BelongsToMany => Pivot, MorphToMany => MorphPivot)
-        // to match the stub's @template default expression.
+        // Always emit TPivotModel / TAccessor (slots 3 and 4) for pivot-aware relations,
+        // filling declared defaults when the parser didn't capture a chain mutation.
+        // A partial 2-of-4 emission triggers MissingTemplateParam on consumers (see #883)
+        // because once any template is supplied the partial form is rejected even when
+        // the stub declares a `@template T of … = Default` expression. The pivot default
+        // is per-relation (BelongsToMany => Pivot, MorphToMany => MorphPivot) to match
+        // the corresponding stub default.
         $pivotDefault = self::PIVOT_AWARE_RELATIONS[$relationClass] ?? null;
-        if ($pivotDefault !== null && ($pivotModel !== null || $accessor !== null)) {
+        if ($pivotDefault !== null) {
             $typeParams[] = new Union([new TNamedObject($pivotModel ?? $pivotDefault)]);
             $typeParams[] = new Union([TLiteralString::make($accessor ?? 'pivot')]);
         }

--- a/src/Handlers/Eloquent/ModelRelationReturnTypeHandler.php
+++ b/src/Handlers/Eloquent/ModelRelationReturnTypeHandler.php
@@ -58,7 +58,7 @@ use Psalm\Type\Union;
  * captured the handler still emits all 4 slots, filling slot 3 with the per-relation
  * pivot default (`Pivot` / `MorphPivot`) and slot 4 with `'pivot'` — emitting only 2
  * triggers `MissingTemplateParam` on consumers because Psalm rejects a partial form
- * even when the stub declares `@template-default` (see #883).
+ * even when the stub declares a default via `@template T of … = Default` (see #883).
  *
  * @see https://github.com/psalm/psalm-plugin-laravel/issues/760
  * @internal

--- a/tests/Application/app/Models/Mechanic.php
+++ b/tests/Application/app/Models/Mechanic.php
@@ -69,9 +69,10 @@ final class Mechanic extends Model
     }
 
     /**
-     * Specializations with `->as()` but no `->using()` — exercises the all-or-nothing
-     * emission rule: when only one mutator is captured, the handler still emits both
-     * pivot and accessor slots (filling the missing one with its declared default).
+     * Specializations with `->as()` but no `->using()` — verifies that when only
+     * the accessor is captured, slot 3 is still filled with the per-relation
+     * `Pivot` default. (The handler emits all 4 slots unconditionally for
+     * pivot-aware relations; this test pins the captured-vs-default split.)
      *
      * @psalm-return BelongsToMany<MechanicSpecialization, $this, \Illuminate\Database\Eloquent\Relations\Pivot, 'details'>
      */
@@ -108,8 +109,8 @@ final class Mechanic extends Model
     /**
      * Tagging WorkOrders with `->as()` and no `->using()` — exercises the per-relation
      * pivot default selection: MorphToMany's TPivotModel default is `MorphPivot`, not
-     * `Pivot`. A handler that hard-coded `Pivot` for the all-or-nothing fallback would
-     * silently emit the wrong template here.
+     * `Pivot`. A handler that hard-coded `Pivot` for the missing-mutator fallback
+     * would silently emit the wrong template here.
      *
      * @psalm-return MorphToMany<WorkOrder, $this, \Illuminate\Database\Eloquent\Relations\MorphPivot, 'meta'>
      */

--- a/tests/Type/tests/Relation/GetRelatedNarrowingTest.phpt
+++ b/tests/Type/tests/Relation/GetRelatedNarrowingTest.phpt
@@ -155,10 +155,12 @@ function test_using_chain_narrows_getRelated(): MechanicSpecialization
     return (new Mechanic())->specializationsWithPivot()->getRelated();
 }
 
-// Limitation: a 2-template `BelongsToMany<R, D>` is silently normalised against a
-// 4-template assertion via stub-declared template defaults, so neither the typed-return
-// form below nor `psalm-check-type-exact` will catch a regression that drops back to
-// the 2-template form. These tests pin intent and document the expected emission.
+// Limitation: the typed-return form below silently normalises a 2-template
+// `BelongsToMany<R, D>` against a 4-template assertion via stub-declared template
+// defaults, so the @psalm-return assertions in this section pin intent rather than
+// catch regressions. The trace-based regression coverage for the 4-template
+// emission lives in Issue883FullTemplateEmissionTest.phpt — a regression that
+// drops back to the 2-template form fails there.
 
 // belongsToMany with `->using()`: TPivotModel binds to the user-declared pivot model,
 // so slot 3 carries `SpecializationPivot` rather than the default `Pivot`.
@@ -181,8 +183,9 @@ function test_as_chain_binds_accessor_template(): BelongsToMany
 }
 
 // `->as()` without `->using()`: the parser captures only the accessor, the handler
-// emits the explicit `Pivot` default for slot 3 — exercising the all-or-nothing rule
-// (if either slot is captured, emit both with declared defaults filling the gaps).
+// emits the per-relation `Pivot` default for slot 3. (After #883 the handler emits
+// all 4 slots unconditionally for pivot-aware relations; this test pins the
+// captured-vs-default split.)
 /**
  * @psalm-return BelongsToMany<MechanicSpecialization, Mechanic, Pivot, 'details'>
  */
@@ -213,9 +216,9 @@ function test_morphToMany_using_chain_narrows_pivot_class(): MorphToMany
     return (new Mechanic())->workOrderTagsWithPivot();
 }
 
-// MorphToMany with `->as()` only: the all-or-nothing rule emits TPivotModel as the
-// stub-declared default, which for MorphToMany is `MorphPivot` (not `Pivot` — that's
-// BelongsToMany's default). A handler that hard-coded `Pivot` here would silently
+// MorphToMany with `->as()` only: slot 3 is filled with the per-relation default,
+// which for MorphToMany is `MorphPivot` (not `Pivot` — that's BelongsToMany's default).
+// A handler that hard-coded `Pivot` for the missing-mutator fallback would silently
 // produce a wrong type for accessor-only morph chains.
 /**
  * @psalm-return MorphToMany<WorkOrder, Mechanic, \Illuminate\Database\Eloquent\Relations\MorphPivot, 'meta'>

--- a/tests/Type/tests/Relation/GetRelatedNarrowingTest.phpt
+++ b/tests/Type/tests/Relation/GetRelatedNarrowingTest.phpt
@@ -158,9 +158,9 @@ function test_using_chain_narrows_getRelated(): MechanicSpecialization
 // Limitation: the typed-return form below silently normalises a 2-template
 // `BelongsToMany<R, D>` against a 4-template assertion via stub-declared template
 // defaults, so the @psalm-return assertions in this section pin intent rather than
-// catch regressions. The trace-based regression coverage for the 4-template
-// emission lives in Issue883FullTemplateEmissionTest.phpt — a regression that
-// drops back to the 2-template form fails there.
+// catch regressions. Regression coverage for the 4-template emission lives in
+// Issue883FullTemplateEmissionTest.phpt, where chain-consumer scenarios surface
+// MissingTemplateParam under a 2-of-4 emission.
 
 // belongsToMany with `->using()`: TPivotModel binds to the user-declared pivot model,
 // so slot 3 carries `SpecializationPivot` rather than the default `Pivot`.

--- a/tests/Type/tests/Relation/Issue883FullTemplateEmissionTest.phpt
+++ b/tests/Type/tests/Relation/Issue883FullTemplateEmissionTest.phpt
@@ -1,68 +1,79 @@
 --FILE--
 <?php declare(strict_types=1);
 
+use App\Models\Part;
 use App\Models\Shop;
 use App\Models\WorkOrder;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphPivot;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 
 /**
- * Regression for https://github.com/psalm/psalm-plugin-laravel/issues/883
+ * Regression for https://github.com/psalm/psalm-plugin-laravel/issues/883.
  *
- * `belongsToMany()` / `morphToMany()` relation bodies that don't include
- * `->using(...)` or `->as(...)` chain mutations must still produce a fully-
- * applied 4-template `BelongsToMany<TRelatedModel, TDeclaringModel, TPivotModel,
- * TAccessor>` (or `MorphToMany<...>`). A partial 2-of-4 emission overrides any
- * user-declared 4-template docblock and trips `MissingTemplateParam` on
- * consumers, because Psalm rejects the partial form once any template slot is
- * supplied — even when the stub declares `@template-default`.
+ * BelongsToMany / MorphToMany relation method bodies that don't include
+ * `->using(...)` / `->as(...)` chain mutations must still produce a fully-
+ * applied 4-template type. The handler-emitted Union overrides any user-
+ * declared docblock at the call site, and Psalm rejects partial 2-of-4 forms
+ * (consumers trip MissingTemplateParam) even when the stub declares a default
+ * for the missing slots. The pivot default is per-relation: BelongsToMany =>
+ * Pivot, MorphToMany => MorphPivot. The accessor default is 'pivot'.
  *
- * `@psalm-check-type-exact` silently normalises a 2-template type against a
- * 4-template assertion using stub defaults, so it cannot detect the regression.
- * `@psalm-trace` emits a Trace issue containing the literal inferred type,
- * which EXPECTF matches verbatim — that's the only way to lock in the
- * 4-template emission. Both `Shop::parts()` and `Shop::allWorkOrders()` are
- * declared without a `@psalm-return` docblock, so the handler-emitted Union
- * is what Psalm reports here (no docblock return type to interfere).
- *
- * The pivot default is per-relation: `BelongsToMany` => `Pivot`, `MorphToMany`
- * => `MorphPivot`. The accessor default is `'pivot'`.
+ * The chain-consumer tests below are the regression oracle: empty `--EXPECTF--`
+ * asserts that `wherePivot()->count()` (the user's reported shape) does not
+ * trip MissingTemplateParam. The typed-return tests pin the expected emission
+ * shape; they don't catch a 2-of-4 regression on their own (Psalm normalises
+ * 2-template against 4-template via the stub `@template-default`), but reading
+ * them clarifies which slots the handler should fill.
  */
 
-// belongsToMany without `->using()` / `->as()` and no `@psalm-return` docblock
-// — emits the full 4-template form with the BelongsToMany default (`Pivot`).
-function test_belongsToMany_without_chain_emits_4_templates(): BelongsToMany
+// Typed-return assertions pin the expected emission. `Shop::parts()` and
+// `Shop::allWorkOrders()` carry no `@psalm-return` docblock, so the handler-
+// emitted Union is what Psalm reports here. `WorkOrder::parts()` declares a
+// 2-template `@psalm-return` docblock, demonstrating that handler emission
+// wins over the user docblock at the call site.
+
+/**
+ * @psalm-return BelongsToMany<Part, Shop, Pivot, 'pivot'>
+ */
+function test_belongsToMany_no_chain_emits_4_templates(): BelongsToMany
 {
-    $r = (new Shop())->parts();
-    /** @psalm-trace $r */
-    return $r;
+    return (new Shop())->parts();
 }
 
-// morphToMany without chain mutations and no `@psalm-return` docblock: the
-// per-relation pivot default is `MorphPivot`, not `Pivot`. A handler that
-// hard-coded `Pivot` for the default fallback would silently emit the wrong
-// type for accessor-only morph chains.
-function test_morphToMany_without_chain_emits_4_templates_with_morphPivot_default(): MorphToMany
+/**
+ * @psalm-return MorphToMany<WorkOrder, Shop, MorphPivot, 'pivot'>
+ */
+function test_morphToMany_no_chain_emits_4_templates(): MorphToMany
 {
-    $r = (new Shop())->allWorkOrders();
-    /** @psalm-trace $r */
-    return $r;
+    return (new Shop())->allWorkOrders();
 }
 
-// belongsToMany with a 2-template `@psalm-return BelongsToMany<Part, $this>` docblock:
-// this case verifies the precedence between the user docblock and the handler-emitted
-// type. `WorkOrder::parts()` declares the 2-template form; the handler emits 4
-// templates. The trace shows whichever wins. The 2-template docblock is itself a
-// historical workaround for the partial-emission shape; once the handler emits the
-// full 4-template form, those `@psalm-return` docblocks become redundant.
-function test_belongsToMany_with_two_template_docblock_emits_full_4_templates(): BelongsToMany
+/**
+ * @psalm-return BelongsToMany<Part, WorkOrder, Pivot, 'pivot'>
+ */
+function test_belongsToMany_handler_overrides_two_template_docblock(): BelongsToMany
 {
-    $r = (new WorkOrder())->parts();
-    /** @psalm-trace $r */
-    return $r;
+    return (new WorkOrder())->parts();
+}
+
+// Chain-consumer scenarios from the issue's reproducer. The chain
+// `wherePivot()->count()` trips MissingTemplateParam under a 2-of-4
+// emission, so the empty `--EXPECTF--` block below is the regression oracle.
+
+function test_belongsToMany_no_chain_consumer_chain_resolves(): int
+{
+    return (new Shop())->parts()
+        ->wherePivot('quantity', 1)
+        ->count();
+}
+
+function test_morphToMany_no_chain_consumer_chain_resolves(): int
+{
+    return (new Shop())->allWorkOrders()
+        ->wherePivot('priority', 'high')
+        ->count();
 }
 ?>
 --EXPECTF--
-Trace on line %d: $r: Illuminate\Database\Eloquent\Relations\BelongsToMany<App\Models\Part, App\Models\Shop, Illuminate\Database\Eloquent\Relations\Pivot, 'pivot'>
-Trace on line %d: $r: Illuminate\Database\Eloquent\Relations\MorphToMany<App\Models\WorkOrder, App\Models\Shop, Illuminate\Database\Eloquent\Relations\MorphPivot, 'pivot'>
-Trace on line %d: $r: Illuminate\Database\Eloquent\Relations\BelongsToMany<App\Models\Part, App\Models\WorkOrder, Illuminate\Database\Eloquent\Relations\Pivot, 'pivot'>

--- a/tests/Type/tests/Relation/Issue883FullTemplateEmissionTest.phpt
+++ b/tests/Type/tests/Relation/Issue883FullTemplateEmissionTest.phpt
@@ -1,0 +1,68 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Shop;
+use App\Models\WorkOrder;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+
+/**
+ * Regression for https://github.com/psalm/psalm-plugin-laravel/issues/883
+ *
+ * `belongsToMany()` / `morphToMany()` relation bodies that don't include
+ * `->using(...)` or `->as(...)` chain mutations must still produce a fully-
+ * applied 4-template `BelongsToMany<TRelatedModel, TDeclaringModel, TPivotModel,
+ * TAccessor>` (or `MorphToMany<...>`). A partial 2-of-4 emission overrides any
+ * user-declared 4-template docblock and trips `MissingTemplateParam` on
+ * consumers, because Psalm rejects the partial form once any template slot is
+ * supplied — even when the stub declares `@template-default`.
+ *
+ * `@psalm-check-type-exact` silently normalises a 2-template type against a
+ * 4-template assertion using stub defaults, so it cannot detect the regression.
+ * `@psalm-trace` emits a Trace issue containing the literal inferred type,
+ * which EXPECTF matches verbatim — that's the only way to lock in the
+ * 4-template emission. Both `Shop::parts()` and `Shop::allWorkOrders()` are
+ * declared without a `@psalm-return` docblock, so the handler-emitted Union
+ * is what Psalm reports here (no docblock return type to interfere).
+ *
+ * The pivot default is per-relation: `BelongsToMany` => `Pivot`, `MorphToMany`
+ * => `MorphPivot`. The accessor default is `'pivot'`.
+ */
+
+// belongsToMany without `->using()` / `->as()` and no `@psalm-return` docblock
+// — emits the full 4-template form with the BelongsToMany default (`Pivot`).
+function test_belongsToMany_without_chain_emits_4_templates(): BelongsToMany
+{
+    $r = (new Shop())->parts();
+    /** @psalm-trace $r */
+    return $r;
+}
+
+// morphToMany without chain mutations and no `@psalm-return` docblock: the
+// per-relation pivot default is `MorphPivot`, not `Pivot`. A handler that
+// hard-coded `Pivot` for the default fallback would silently emit the wrong
+// type for accessor-only morph chains.
+function test_morphToMany_without_chain_emits_4_templates_with_morphPivot_default(): MorphToMany
+{
+    $r = (new Shop())->allWorkOrders();
+    /** @psalm-trace $r */
+    return $r;
+}
+
+// belongsToMany with a 2-template `@psalm-return BelongsToMany<Part, $this>` docblock:
+// this case verifies the precedence between the user docblock and the handler-emitted
+// type. `WorkOrder::parts()` declares the 2-template form; the handler emits 4
+// templates. The trace shows whichever wins. The 2-template docblock is itself a
+// historical workaround for the partial-emission shape; once the handler emits the
+// full 4-template form, those `@psalm-return` docblocks become redundant.
+function test_belongsToMany_with_two_template_docblock_emits_full_4_templates(): BelongsToMany
+{
+    $r = (new WorkOrder())->parts();
+    /** @psalm-trace $r */
+    return $r;
+}
+?>
+--EXPECTF--
+Trace on line %d: $r: Illuminate\Database\Eloquent\Relations\BelongsToMany<App\Models\Part, App\Models\Shop, Illuminate\Database\Eloquent\Relations\Pivot, 'pivot'>
+Trace on line %d: $r: Illuminate\Database\Eloquent\Relations\MorphToMany<App\Models\WorkOrder, App\Models\Shop, Illuminate\Database\Eloquent\Relations\MorphPivot, 'pivot'>
+Trace on line %d: $r: Illuminate\Database\Eloquent\Relations\BelongsToMany<App\Models\Part, App\Models\WorkOrder, Illuminate\Database\Eloquent\Relations\Pivot, 'pivot'>

--- a/tests/Type/tests/Relation/Issue883FullTemplateEmissionTest.phpt
+++ b/tests/Type/tests/Relation/Issue883FullTemplateEmissionTest.phpt
@@ -24,8 +24,9 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
  * asserts that `wherePivot()->count()` (the user's reported shape) does not
  * trip MissingTemplateParam. The typed-return tests pin the expected emission
  * shape; they don't catch a 2-of-4 regression on their own (Psalm normalises
- * 2-template against 4-template via the stub `@template-default`), but reading
- * them clarifies which slots the handler should fill.
+ * 2-template against 4-template via the stub default declared by
+ * `@template T of … = Default`), but reading them clarifies which slots the
+ * handler should fill.
  */
 
 // Typed-return assertions pin the expected emission. `Shop::parts()` and


### PR DESCRIPTION
## Issue to Solve

`ModelRelationReturnTypeHandler::buildRelationType` emitted only 2 of the 4 template slots for `BelongsToMany` and `MorphToMany` whenever a relation method body had no `->using(...)` / `->as(...)` chain mutation (e.g. `belongsToMany(X)->withPivot(...)`). The handler-emitted Union overrides the user docblock at the call site, so consumers saw `BelongsToMany<TRelatedModel, TDeclaringModel>` and Psalm tripped `MissingTemplateParam` on every chained call. Psalm rejects partial 2-of-4 forms even when the stub declares a default for the missing slots.

## Related

Fixes #883.

## Solution Description

Drop the `($pivotModel !== null || $accessor !== null)` guard so slots 3 and 4 are always emitted for pivot-aware relations. Captured chain mutators continue to fill the slots with user-declared values; otherwise the per-relation defaults apply (`Pivot` for `BelongsToMany`, `MorphPivot` for `MorphToMany`, accessor `'pivot'`). Defaults match Laravel source (`Illuminate\Database\Eloquent\Relations\BelongsToMany` / `MorphToMany` constructors) and the stub `@template T of … = Default` declarations.

## Verification

`tests/Type/tests/Relation/Issue883FullTemplateEmissionTest.phpt` covers the regression with two complementary mechanisms, both using existing project conventions:

1. Typed-return functions with `@psalm-return BelongsToMany<R, D, P, A>` pin the expected emission shape.
2. Chain-consumer scenarios (`->wherePivot(...)->count()`) on `Shop::parts()` and `Shop::allWorkOrders()` form the regression oracle: with a 2-of-4 emission those chains trip `MissingTemplateParam`, which a phpt empty `--EXPECTF--` block surfaces as a test failure. Verified empirically by reverting the guard.

Stale "all-or-nothing rule" prose in test models and type tests has been refreshed.

Full type suite (377 tests) and unit suite (566 tests) pass. Psalm self-analysis is clean.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
