### PR TITLE
Resolve `self::class`/`static::class`/`parent::class` in relation factories

### DIFF
--- a/src/Handlers/Eloquent/RelationMethodParser.php
+++ b/src/Handlers/Eloquent/RelationMethodParser.php
@@ -134,17 +134,47 @@ final class RelationMethodParser
             return null;
         }
 
-        return self::parseMethodBody($classMethod->stmts);
+        // Resolve the parent FQCN once so `parent::class` in factory args can be substituted
+        // without re-querying class storage per occurrence. `findClassMethodWithStatements`
+        // searches the file by `$className`, so a successful lookup means the method body
+        // lives in `$className` itself — `self::class` and (conservatively) `static::class`
+        // both resolve to `$className`. See {@see resolveClassConstFetch} for the trade-off.
+        $parentClass = self::resolveParentClass($codebase, $className);
+
+        return self::parseMethodBody($classMethod->stmts, $className, $parentClass);
+    }
+
+    /**
+     * Look up the immediate parent FQCN of `$className`, or null when the class has no
+     * parent (or storage isn't available). Used to substitute `parent::class` in relation
+     * factory arguments. The InvalidArgumentException catch mirrors the surrounding
+     * fail-soft style — a missing parent yields null and the handler defers, rather than
+     * crashing the analysis run.
+     */
+    private static function resolveParentClass(Codebase $codebase, string $className): ?string
+    {
+        try {
+            $storage = $codebase->classlike_storage_provider->get($className);
+        } catch (\InvalidArgumentException $invalidArgumentException) {
+            $codebase->progress->debug("Laravel plugin: could not resolve parent class for {$className}: {$invalidArgumentException->getMessage()}\n");
+            return null;
+        }
+
+        return $storage->parent_class;
     }
 
     /**
      * Walk the method body to find a return statement containing a relationship factory call
      * like $this->belongsTo(Vault::class).
      *
+     * `$declaringClass` and `$parentClass` thread down to {@see resolveClassConstFetch} so
+     * `self::class` / `static::class` / `parent::class` arguments resolve to real FQCNs
+     * instead of leaking the keyword as the related-model template parameter.
+     *
      * @param array<array-key, PhpParser\Node\Stmt> $stmts
      * @return ?array{relationClass: class-string<Relation>, relatedModel: ?string, intermediateModel: ?string, pivotModel: ?string, accessor: ?string}
      */
-    private static function parseMethodBody(array $stmts): ?array
+    private static function parseMethodBody(array $stmts, string $declaringClass, ?string $parentClass): ?array
     {
         foreach ($stmts as $stmt) {
             if (!$stmt instanceof PhpParser\Node\Stmt\Return_ || !$stmt->expr instanceof PhpParser\Node\Expr) {
@@ -154,7 +184,7 @@ final class RelationMethodParser
             $pivotModel = null;
             $accessor = null;
 
-            return self::findRelationCallInExpr($stmt->expr, $pivotModel, $accessor);
+            return self::findRelationCallInExpr($stmt->expr, $declaringClass, $parentClass, $pivotModel, $accessor);
         }
 
         return null;
@@ -174,6 +204,8 @@ final class RelationMethodParser
      */
     private static function findRelationCallInExpr(
         PhpParser\Node\Expr $expr,
+        string $declaringClass,
+        ?string $parentClass,
         ?string &$pivotModel,
         ?string &$accessor,
     ): ?array {
@@ -189,12 +221,12 @@ final class RelationMethodParser
             if ($relationClass !== null) {
                 return [
                     'relationClass' => $relationClass,
-                    'relatedModel' => self::extractClassStringArg($expr, $lowerName, 0, 'related'),
+                    'relatedModel' => self::extractClassStringArg($expr, $lowerName, 0, 'related', $declaringClass, $parentClass),
                     // Through relations carry the intermediate model as the second class-string
                     // argument: hasOneThrough(Related, Intermediate) / hasManyThrough(Related, Intermediate).
                     // Every other factory leaves this null.
                     'intermediateModel' => \in_array($lowerName, ['hasonethrough', 'hasmanythrough'], true)
-                        ? self::extractClassStringArg($expr, $lowerName, 1, 'through')
+                        ? self::extractClassStringArg($expr, $lowerName, 1, 'through', $declaringClass, $parentClass)
                         : null,
                     'pivotModel' => $pivotModel,
                     'accessor' => $accessor,
@@ -205,7 +237,7 @@ final class RelationMethodParser
             // Outside-in recursion visits the outermost call first, so the outermost
             // `using()` / `as()` wins via `??=` — inner ones cannot overwrite once set.
             if ($lowerName === 'using') {
-                $pivotModel ??= self::firstClassStringArg($expr);
+                $pivotModel ??= self::firstClassStringArg($expr, $declaringClass, $parentClass);
             } elseif ($lowerName === 'as') {
                 $accessor ??= self::firstStringLiteralArg($expr);
             }
@@ -213,7 +245,7 @@ final class RelationMethodParser
 
         // Not a relationship call — try the inner expression (unwrap chain).
         // e.g. for $this->belongsTo(X::class)->withDefault(), $expr->var is $this->belongsTo(X::class)
-        return self::findRelationCallInExpr($expr->var, $pivotModel, $accessor);
+        return self::findRelationCallInExpr($expr->var, $declaringClass, $parentClass, $pivotModel, $accessor);
     }
 
     /**
@@ -223,14 +255,14 @@ final class RelationMethodParser
      * method, so named (`->using(class: P::class)`) and positional (`->using(P::class)`)
      * forms are both honored.
      */
-    private static function firstClassStringArg(PhpParser\Node\Expr\MethodCall $call): ?string
+    private static function firstClassStringArg(PhpParser\Node\Expr\MethodCall $call, string $declaringClass, ?string $parentClass): ?string
     {
         $first = $call->args[0] ?? null;
         if (!$first instanceof PhpParser\Node\Arg) {
             return null;
         }
 
-        return self::resolveClassConstFetch($first->value);
+        return self::resolveClassConstFetch($first->value, $declaringClass, $parentClass);
     }
 
     /**
@@ -276,6 +308,8 @@ final class RelationMethodParser
         string $lowerMethodName,
         int $positionalIndex,
         string $paramName,
+        string $declaringClass,
+        ?string $parentClass,
     ): ?string {
         // morphTo() doesn't take a class-string<Model> as first arg — the related type is polymorphic
         if ($lowerMethodName === 'morphto') {
@@ -291,7 +325,7 @@ final class RelationMethodParser
                 && $arg->name instanceof PhpParser\Node\Identifier
                 && $arg->name->name === $paramName
             ) {
-                return self::resolveClassConstFetch($arg->value);
+                return self::resolveClassConstFetch($arg->value, $declaringClass, $parentClass);
             }
         }
 
@@ -305,14 +339,35 @@ final class RelationMethodParser
             return null;
         }
 
-        return self::resolveClassConstFetch($args[$positionalIndex]->value);
+        return self::resolveClassConstFetch($args[$positionalIndex]->value, $declaringClass, $parentClass);
     }
 
     /**
      * Resolve a `ClassName::class` expression to the resolved FQCN, or null when the
      * expression is anything else (a variable, a method call, a string literal, etc.).
+     *
+     * Handles the `self` / `static` / `parent` keywords specifically. PhpParser's
+     * `NameResolver` deliberately leaves them unresolved (`resolvedName` attribute is
+     * null) because they are context-sensitive — without substituting them here,
+     * `toString()` would return the literal keyword and the parser would emit, e.g.,
+     * `HasMany<self, User>` instead of `HasMany<User, User>` (#879).
+     *
+     * Substitution rules:
+     * - `self::class` → `$declaringClass` (always correct: PHP resolves `self` to the
+     *   class where the method body is declared).
+     * - `static::class` → `$declaringClass` (conservative). Late static binding would
+     *   resolve this to the receiver's runtime class, but the parser is keyed by the
+     *   declaring class only, so we cannot vary the result per binding without
+     *   defeating the cache. Yields a strictly better answer than leaking `'static'`.
+     * - `parent::class` → `$parentClass` (or null when the declaring class has no
+     *   parent — same path as a dynamic arg, which makes the upstream handler defer).
+     *   When the declaring class extends `Illuminate\Database\Eloquent\Model` directly,
+     *   `parent::class` legitimately resolves to that abstract base — that matches PHP's
+     *   runtime semantics; the resulting `Relation<Model, Self>` is well-formed but
+     *   semantically thin. Filtering Model out here would break faithfulness to the
+     *   user's source.
      */
-    private static function resolveClassConstFetch(PhpParser\Node\Expr $expr): ?string
+    private static function resolveClassConstFetch(PhpParser\Node\Expr $expr, string $declaringClass, ?string $parentClass): ?string
     {
         if (
             !$expr instanceof PhpParser\Node\Expr\ClassConstFetch
@@ -321,6 +376,14 @@ final class RelationMethodParser
             || $expr->name->name !== 'class'
         ) {
             return null;
+        }
+
+        if ($expr->class->isSpecialClassName()) {
+            return match ($expr->class->toLowerString()) {
+                'self', 'static' => $declaringClass,
+                'parent' => $parentClass,
+                default => null,
+            };
         }
 
         // Prefer the FQCN resolved by Psalm's name-resolution pass

--- a/tests/Application/app/Models/PartReplacement.php
+++ b/tests/Application/app/Models/PartReplacement.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+/**
+ * Pivot recording when one {@see Part} replaced another (e.g., brake pads swapped
+ * during a {@see WorkOrder}). Used to exercise `->using(self::class)` on a
+ * BelongsToMany — when a pivot model declares its own many-to-many relation and
+ * passes itself as the pivot via `using(self::class)`, the parser must substitute
+ * the keyword rather than leaking the literal `'self'` into TPivotModel.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/879
+ */
+final class PartReplacement extends Pivot
+{
+    protected $table = 'part_replacements';
+
+    /**
+     * Other replacements bundled with this one (e.g., "while replacing the brake
+     * pads, also replace the rotors"). Modeled as Part-to-Part bundle membership
+     * with this pivot acting as itself for the bundle metadata.
+     *
+     * @psalm-return BelongsToMany<Part, $this, self, 'pivot'>
+     */
+    public function bundledReplacements(): BelongsToMany
+    {
+        return $this->belongsToMany(Part::class)->using(self::class);
+    }
+}

--- a/tests/Application/app/Models/PowerTool.php
+++ b/tests/Application/app/Models/PowerTool.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+
+/**
+ * Power-driven specialty {@see Tool} (drills, impact wrenches, etc.). Exists to
+ * exercise `parent::class` resolution on a relation factory — `parent::class`
+ * inside a method on this class must resolve to the {@see Tool} FQCN, not leak
+ * the literal `'parent'` keyword.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/879
+ */
+final class PowerTool extends Tool
+{
+    /**
+     * The non-powered ancestor tools this power tool replaced. `parent::class`
+     * resolves to {@see Tool}, so the relation reads `HasMany<Tool, PowerTool>`.
+     */
+    public function ancestorTools(): HasMany
+    {
+        return $this->hasMany(parent::class, 'replaced_id');
+    }
+
+    /**
+     * Mechanics who used the lineage of non-powered tools this power tool replaced.
+     * `parent::class` at the through intermediate slot (positionalIndex=1) plus the
+     * named-arg form together exercise both branches of `extractClassStringArg`.
+     */
+    public function lineageMechanics(): HasManyThrough
+    {
+        return $this->hasManyThrough(related: Mechanic::class, through: parent::class);
+    }
+}

--- a/tests/Application/app/Models/Tool.php
+++ b/tests/Application/app/Models/Tool.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+/**
+ * Equipment kept by the shop and checked out to mechanics. Concrete (not abstract)
+ * because {@see \Psalm\LaravelPlugin\Handlers\Eloquent\ModelRegistrationHandler}
+ * skips abstract classes — an abstract base would never reach the relation provider.
+ *
+ * Acts as the base class for the {@see PowerTool} subclass so `parent::class` in
+ * relation factories on PowerTool can be exercised; concurrently exercises
+ * `self::class` and `static::class` substitution in factories on this class itself.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/879
+ */
+class Tool extends Model
+{
+    protected $table = 'tools';
+
+    /**
+     * Replacement tool kept on the same shelf — modeled with `self::class` so the
+     * parser must substitute the keyword with the declaring class FQCN.
+     */
+    public function replacementTool(): HasOne
+    {
+        return $this->hasOne(self::class);
+    }
+
+    /**
+     * Same shape but using `static::class` — pinned conservatively to the declaring
+     * class (see {@see \Psalm\LaravelPlugin\Handlers\Eloquent\RelationMethodParser::resolveClassConstFetch}).
+     */
+    public function lateBoundReplacement(): HasOne
+    {
+        return $this->hasOne(static::class);
+    }
+
+    /**
+     * Mechanics who have used a successor tool of this one. Through-relation with the
+     * intermediate slot at `self::class` — exercises the parser's positionalIndex=1
+     * threading. The semantics are intentionally sparse; the relation's value is in
+     * pinning the through-slot keyword substitution.
+     */
+    public function successorMechanics(): HasManyThrough
+    {
+        return $this->hasManyThrough(Mechanic::class, self::class);
+    }
+}

--- a/tests/Application/app/Models/WorkOrderNote.php
+++ b/tests/Application/app/Models/WorkOrderNote.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * Service note left on a {@see WorkOrder}, optionally replying to another note.
+ * Forms a threaded discussion (mechanic asks the customer, customer replies, etc.),
+ * so the table is self-referential through `reply_to_id`.
+ *
+ * Exercises relation factories called with `self::class` —
+ * see {@see https://github.com/psalm/psalm-plugin-laravel/issues/879}.
+ */
+final class WorkOrderNote extends Model
+{
+    protected $table = 'work_order_notes';
+
+    public function replies(): HasMany
+    {
+        return $this->hasMany(self::class, 'reply_to_id');
+    }
+
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'reply_to_id');
+    }
+}

--- a/tests/Type/tests/Relation/Issue879SelfStaticParentClassTest.phpt
+++ b/tests/Type/tests/Relation/Issue879SelfStaticParentClassTest.phpt
@@ -1,0 +1,125 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Mechanic;
+use App\Models\Part;
+use App\Models\PartReplacement;
+use App\Models\PowerTool;
+use App\Models\Tool;
+use App\Models\WorkOrderNote;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+/**
+ * Regression for https://github.com/psalm/psalm-plugin-laravel/issues/879.
+ *
+ * Relation factories called with self::class / static::class / parent::class
+ * must resolve the keyword to the declaring (or parent) class FQCN. Without
+ * the fix, the literal keyword leaks as TRelatedModel and Psalm substitutes
+ * `self` with the call site's enclosing class — producing nonsensical
+ * "expects MergeTagsAction" errors on save() / associate() at the consumer.
+ *
+ * Same root cause hits ->using(self::class) on BelongsToMany / MorphToMany.
+ *
+ * The supporting fixtures live on disk so the plugin's
+ * {@see \Psalm\LaravelPlugin\Handlers\Eloquent\ModelRegistrationHandler}
+ * (which guards on `class_exists()` via the autoloader) registers the
+ * relation provider for them. Inline-defined models in PHPT bodies are
+ * not autoloadable and bypass the registration path, so they cannot
+ * exercise the handler under test.
+ */
+
+// --- Reproducer 1: hasMany(self::class) → ->save() ---
+
+function issue879_hasMany_self_class_resolves_to_declaring(WorkOrderNote $parent): HasMany
+{
+    $relation = $parent->replies();
+    /** @psalm-check-type-exact $relation = HasMany<WorkOrderNote, WorkOrderNote> */
+    return $relation;
+}
+
+function issue879_hasMany_self_class_save_accepts_same_model(WorkOrderNote $parent, WorkOrderNote $reply): WorkOrderNote|false
+{
+    return $parent->replies()->save($reply);
+}
+
+// --- Reproducer 2: belongsTo(self::class) → ->associate() ---
+
+function issue879_belongsTo_self_class_resolves_to_declaring(WorkOrderNote $reply): BelongsTo
+{
+    $relation = $reply->parent();
+    /** @psalm-check-type-exact $relation = BelongsTo<WorkOrderNote, WorkOrderNote> */
+    return $relation;
+}
+
+function issue879_belongsTo_self_class_associate_accepts_same_model(WorkOrderNote $reply, WorkOrderNote $parent): WorkOrderNote
+{
+    return $reply->parent()->associate($parent);
+}
+
+// --- self::class on a base class resolves to the declaring class ---
+
+function issue879_self_class_on_base_resolves_to_declaring(Tool $tool): HasOne
+{
+    $relation = $tool->replacementTool();
+    /** @psalm-check-type-exact $relation = HasOne<Tool, Tool> */
+    return $relation;
+}
+
+// static::class is conservatively resolved to the declaring class — strictly better
+// than leaking the literal `'static'` keyword. Late-static-binding-correct resolution
+// would require the binding class threaded into the parser cache; that's out of scope
+// for the issue, but pinned here so a future "fix" cannot silently regress.
+
+function issue879_static_class_resolves_to_declaring_conservatively(Tool $tool): HasOne
+{
+    $relation = $tool->lateBoundReplacement();
+    /** @psalm-check-type-exact $relation = HasOne<Tool, Tool> */
+    return $relation;
+}
+
+// --- parent::class resolves to the immediate parent FQCN ---
+
+function issue879_parent_class_resolves_to_parent_fqcn(PowerTool $powerTool): HasMany
+{
+    $relation = $powerTool->ancestorTools();
+    /** @psalm-check-type-exact $relation = HasMany<Tool, PowerTool> */
+    return $relation;
+}
+
+// --- self::class / parent::class at the through-relation intermediate slot ---
+// extractClassStringArg(positionalIndex: 1, paramName: 'through', ...) is reachable
+// only via hasOneThrough / hasManyThrough. Without these tests, a refactor that
+// silently dropped $declaringClass / $parentClass at index 1 would go undetected.
+
+function issue879_through_intermediate_self_class(Tool $tool): HasManyThrough
+{
+    $relation = $tool->successorMechanics();
+    /** @psalm-check-type-exact $relation = HasManyThrough<Mechanic, Tool, Tool> */
+    return $relation;
+}
+
+// Named-arg form (`through: parent::class`) hits the named-arg branch of
+// extractClassStringArg in addition to the through index — pinning that the
+// fix threads the resolution context through both branches.
+
+function issue879_through_intermediate_parent_class_named_arg(PowerTool $powerTool): HasManyThrough
+{
+    $relation = $powerTool->lineageMechanics();
+    /** @psalm-check-type-exact $relation = HasManyThrough<Mechanic, Tool, PowerTool> */
+    return $relation;
+}
+
+// --- ->using(self::class) on a BelongsToMany threads through firstClassStringArg ---
+
+function issue879_using_self_class_resolves_pivot(PartReplacement $replacement): BelongsToMany
+{
+    $relation = $replacement->bundledReplacements();
+    /** @psalm-check-type-exact $relation = BelongsToMany<Part, PartReplacement, PartReplacement, 'pivot'> */
+    return $relation;
+}
+?>
+--EXPECTF--

--- a/tests/Unit/Handlers/Eloquent/RelationMethodParserTest.php
+++ b/tests/Unit/Handlers/Eloquent/RelationMethodParserTest.php
@@ -209,6 +209,48 @@ final class RelationMethodParserTest extends TestCase
         $this->assertSame('', $this->callPrivate('extractNamespace', 'User'));
     }
 
+    // --- resolveClassConstFetch ---
+
+    /**
+     * @see https://github.com/psalm/psalm-plugin-laravel/issues/879
+     */
+    #[Test]
+    #[DataProvider('classConstFetchProvider')]
+    public function resolve_class_const_fetch(string $classKeyword, string $declaringClass, ?string $parentClass, ?string $expected): void
+    {
+        $expr = new \PhpParser\Node\Expr\ClassConstFetch(
+            new \PhpParser\Node\Name($classKeyword),
+            new \PhpParser\Node\Identifier('class'),
+        );
+
+        $result = $this->callPrivate('resolveClassConstFetch', $expr, $declaringClass, $parentClass);
+
+        $this->assertSame($expected, $result);
+    }
+
+    /** @return iterable<string, array{string, string, ?string, ?string}> */
+    public static function classConstFetchProvider(): iterable
+    {
+        yield 'self resolves to declaring class' => [
+            'self', 'App\\Models\\WorkOrderNote', 'Illuminate\\Database\\Eloquent\\Model', 'App\\Models\\WorkOrderNote',
+        ];
+        yield 'self is case-insensitive' => [
+            'SELF', 'App\\Models\\WorkOrderNote', null, 'App\\Models\\WorkOrderNote',
+        ];
+        yield 'static resolves to declaring class (conservative — see resolveClassConstFetch docblock)' => [
+            'static', 'App\\Models\\Tool', 'Illuminate\\Database\\Eloquent\\Model', 'App\\Models\\Tool',
+        ];
+        yield 'parent resolves to parent class FQCN' => [
+            'parent', 'App\\Models\\PowerTool', 'App\\Models\\Tool', 'App\\Models\\Tool',
+        ];
+        yield 'parent returns null when no parent class is known' => [
+            'parent', 'App\\Models\\Tool', null, null,
+        ];
+        yield 'regular FQCN falls back to toString (no resolvedName attribute)' => [
+            'App\\Models\\Vehicle', 'App\\Models\\Customer', null, 'App\\Models\\Vehicle',
+        ];
+    }
+
     /**
      * Call a private static method on RelationMethodParser via reflection.
      */


### PR DESCRIPTION
## Issue to Solve

Relation factories called with `self::class` / `static::class` / `parent::class` were leaking the literal keyword as `TRelatedModel`. PhpParser leaves these keywords unresolved (they're context-sensitive), so the parser stored the string `'self'` / `'static'` / `'parent'` as the related-model template parameter. At the call site, Psalm then substituted `self` with the enclosing class, producing nonsensical errors like `expects MergeTagsAction` on `->save()` / `->associate()`.

```php
final class Tag extends Model {
    /** @return BelongsTo<Tag, self> */
    public function parentTag(): BelongsTo {
        return $this->belongsTo(self::class, 'parent_tag_id');
    }
}

// elsewhere:
$alias->parentTag()->associate($keep);
// ImplicitToStringCast: Argument 1 expects App\Actions\MergeTagsAction|int|null|string,
// but App\Models\Tag provided
```

Affects every relation factory that takes a class-string (`hasMany`, `hasOne`, `belongsTo`, `belongsToMany`, `morphMany`, `morphOne`, `morphToMany`, `morphedByMany`, `hasOneThrough`, `hasManyThrough`) plus `->using(self::class)` on `BelongsToMany` / `MorphToMany`.

Regression introduced in `fb49d583` (#760). Before that commit, relation accessors collapsed to `Rel<Model, Model>` and the keyword never reached the template slot.

## Related

Closes #879.

## Solution Description

Thread the declaring class FQCN (and a pre-resolved parent FQCN for `parent::class`) through the parser pipeline (`parse` -> `doParse` -> `parseMethodBody` -> `findRelationCallInExpr` -> `extractClassStringArg` / `firstClassStringArg` -> `resolveClassConstFetch`). In `resolveClassConstFetch`, gate on `PhpParser\Node\Name::isSpecialClassName()` and substitute:

- `self::class` -> declaring class
- `static::class` -> declaring class (conservative; the parser cache is keyed on declaring class only, so late-static-binding-correct resolution is out of scope; documented in the docblock and pinned by a regression test)
- `parent::class` -> parent class FQCN (or `null` when no parent, matching the dynamic-arg path so the upstream handler defers)

The parent FQCN is resolved once in `doParse` via `$codebase->classlike_storage_provider->get($className)->parent_class`, with `InvalidArgumentException` caught and a debug message logged (matching the surrounding fail-soft style).

### Tests

PHPT regression at `tests/Type/tests/Relation/Issue879SelfStaticParentClassTest.phpt` covering:

- Both reproducers from the issue (`HasMany::save()` after `hasMany(self::class)`, `BelongsTo::associate()` after `belongsTo(self::class)`)
- `static::class` resolves to the declaring class (pinned conservative behavior)
- `parent::class` from a subclass resolves to the parent FQCN
- `hasManyThrough(Mechanic::class, self::class)` (intermediate at positionalIndex=1)
- `hasManyThrough(related: Mechanic::class, through: parent::class)` (named-arg branch)
- `->using(self::class)` on a `BelongsToMany` (`firstClassStringArg` path)

Plus DataProvider unit tests for `resolveClassConstFetch` covering `self`, case-insensitive `SELF`, `static`, `parent` (with and without parent), and a regular `Foo::class`.

Disk fixtures (`tests/Application/app/Models/WorkOrderNote.php`, `Tool.php`, `PowerTool.php`, `PartReplacement.php`) live in the existing car repair shop domain and are required because `ModelRegistrationHandler::class_exists()` skips models not loadable by the autoloader. `WorkOrderNote` covers the `self::class` self-referential pattern (threaded service notes); `Tool` / `PowerTool extends Tool` covers `parent::class`; `PartReplacement extends Pivot` covers `->using(self::class)`.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and unit test in `tests/Unit/`)
