### PR TITLE
Fix `Model::query()` flattening `static` for plain models

### DIFF
--- a/src/Handlers/Eloquent/ModelMethodHandler.php
+++ b/src/Handlers/Eloquent/ModelMethodHandler.php
@@ -37,8 +37,13 @@ use Psalm\Type\Union;
  * provider lookup requires exact class name matching — a handler registered for Model::class
  * is not consulted for concrete subclasses like App\Models\User.
  *
- * The getClassLikeNames() registration for Model::class still handles Model::query()
- * and the __callStatic proxy for methods resolvable through the single-hop mixin chain.
+ * The getClassLikeNames() registration for Model::class handles `Model::query()` only when
+ * a custom Eloquent builder is registered for the called model. For plain models (base
+ * `Builder`), `query()` is intentionally deferred to the stub at
+ * `stubs/common/Database/Eloquent/Model.stubphp` whose `@return Builder<static>` is the only
+ * way to preserve the `&static` intersection through Psalm's template binding (see #799).
+ * `__callStatic` is similarly proxied for methods resolvable through the single-hop mixin
+ * chain.
  *
  * Builder-instance handlers (trait methods and scopes on custom builders) are in
  * {@see CustomBuilderMethodHandler}.
@@ -386,6 +391,16 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
         // Model::query()
         if ($event->getMethodNameLowercase() === 'query') {
             $builderClass = self::getBuilderClassForModel($called_fq_classlike_name);
+
+            // For models without a custom builder, defer to the stub's
+            // `@return Builder<static>` annotation. Returning `Builder<ConcreteModel>`
+            // here flattens `static`, which then breaks return-type inference inside
+            // methods declared `: static` (e.g. `static::query()->firstOrCreate(...)`)
+            // because the `&static` intersection is lost across the template binding.
+            // See https://github.com/psalm/psalm-plugin-laravel/issues/799.
+            if ($builderClass === Builder::class) {
+                return null;
+            }
 
             return new Union([self::builderType($builderClass, $called_fq_classlike_name, $codebase)]);
         }

--- a/stubs/common/Database/Eloquent/Model.stubphp
+++ b/stubs/common/Database/Eloquent/Model.stubphp
@@ -69,6 +69,11 @@ abstract class Model implements ArrayAccess, Arrayable, CanBeEscapedWhenCastToSt
     public static function with($relations) {}
 
     /**
+     * The `<static>` template argument MUST stay literal. Replacing it with `<self>` or any
+     * concrete class collapses the `&static` intersection that `: static`-returning callers
+     * depend on, and `ModelMethodHandler::getMethodReturnType` deliberately defers to this
+     * annotation for plain models (see #799).
+     *
      * @return \Illuminate\Database\Eloquent\Builder<static>
      */
     public static function query() {}

--- a/tests/Type/tests/Model/StaticReturnFromQueryTest.phpt
+++ b/tests/Type/tests/Model/StaticReturnFromQueryTest.phpt
@@ -1,0 +1,49 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+
+/**
+ * Regression for https://github.com/psalm/psalm-plugin-laravel/issues/799
+ *
+ * Methods declared `: static` that return `static::query()->firstOrCreate(...)`
+ * (or sibling write methods) must propagate the `&static` intersection through
+ * the Builder template parameter. Otherwise Psalm reports MoreSpecificReturnType
+ * because `firstOrCreate()` returns `Customer` while the declared type is
+ * `Customer&static`.
+ */
+// Intentionally non-final: the `: static` template propagation only matters when
+// `static` is genuinely deferred. A final class collapses `static` to `self`,
+// hiding the regression.
+class StaticReturnFromQueryRegression extends Customer
+{
+    public static function viaFirstOrCreate(): static
+    {
+        return static::query()->firstOrCreate(['id' => '1']);
+    }
+
+    public static function viaUpdateOrCreate(): static
+    {
+        return static::query()->updateOrCreate(['id' => '1'], ['first_name' => 'x']);
+    }
+
+    public static function viaFirstOrNew(): static
+    {
+        return static::query()->firstOrNew(['id' => '1']);
+    }
+
+    public static function viaCreate(): static
+    {
+        return static::query()->create(['id' => '1']);
+    }
+
+    // Contrast case: `: self` already worked before the fix (returning Customer
+    // for `: self` is fine). Kept to make the `: static` vs `: self` asymmetry
+    // explicit for future readers; it is not a control for the regression.
+    public static function viaFirstOrCreateSelfReturn(): self
+    {
+        return static::query()->firstOrCreate(['id' => '1']);
+    }
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

`Model::query()` was overridden by `ModelMethodHandler::getMethodReturnType` to always return `Builder<ConcreteModel>`, flattening the `&static` intersection that the stub's `@return Builder<static>` carries. This broke return-type inference for any method declared `: static` that chained a write method on the result, e.g.:

```php
class Album extends Model
{
    public static function getOrCreate(Artist $artist, string $name): static
    {
        return static::query()->firstOrCreate([
            'artist_id' => $artist->id,
            'name' => $name,
        ]); // MoreSpecificReturnType / LessSpecificReturnStatement
    }
}
```

The same pattern affected `firstOrCreate`, `updateOrCreate`, `firstOrNew`, and `create` chained on `static::query()`. Most other items from #799 (return type of `firstOrCreate` itself, `findMany` with concrete annotations, `: self` callers) had already been fixed by prior stub work; the remaining gap was the `: static` propagation.

## Related

Fixes #799.

## Solution Description

For models without a custom Eloquent builder, `ModelMethodHandler::getMethodReturnType` now returns `null` for `Model::query()`, deferring to the stub's `@return Builder<static>`. Psalm preserves the `&static` intersection through the template binding, so the chained `TModel`-returning methods correctly produce `Album&static` instead of `Album`.

Custom-builder models keep the existing override because no stub binds their template.

The handler's class docblock and the stub's `query()` annotation now cross-reference each other so the responsibility split is explicit and a future stub-sync cannot silently flatten `<static>` without surfacing the regression.

A non-final regression test covers all four affected write methods. A final-class test would silently pass because Psalm collapses `static` to `self` for final classes; the test docblock notes this.

Verification: `composer test:type` (380 tests), `composer test:unit` (572 tests), `composer psalm`, `composer test:app` all pass. The empirical reproducer from the issue body produces no MoreSpecificReturnType / LessSpecificReturnStatement diagnostics with the fix applied.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
