### PR TITLE
Extract `Arg` helper to dedupe per-call-arg type/node access in handlers

### DIFF
--- a/src/Handlers/Collections/CollectionFlattenHandler.php
+++ b/src/Handlers/Collections/CollectionFlattenHandler.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Enumerable;
 use Illuminate\Support\LazyCollection;
 use PhpParser\Node\Scalar\Int_;
+use Psalm\LaravelPlugin\Util\Arg;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
 use Psalm\Type;
@@ -87,12 +88,8 @@ final class CollectionFlattenHandler implements MethodReturnTypeProviderInterfac
      */
     private static function extractLiteralDepth(MethodReturnTypeProviderEvent $event): ?int
     {
-        $args = $event->getCallArgs();
-        if ($args === []) {
-            return null; // no argument = INF depth, can't narrow
-        }
-
-        $depthArg = $args[0]->value;
+        // Missing arg means INF depth — can't narrow.
+        $depthArg = Arg::nodeAt($event->getCallArgs(), 0);
 
         if ($depthArg instanceof Int_) {
             return $depthArg->value;

--- a/src/Handlers/Console/CommandArgumentHandler.php
+++ b/src/Handlers/Console/CommandArgumentHandler.php
@@ -8,6 +8,7 @@ use Psalm\CodeLocation;
 use Psalm\IssueBuffer;
 use Psalm\LaravelPlugin\Issues\InvalidConsoleArgumentName;
 use Psalm\LaravelPlugin\Issues\InvalidConsoleOptionName;
+use Psalm\LaravelPlugin\Util\Arg;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
 use Psalm\Type;
@@ -49,18 +50,13 @@ final class CommandArgumentHandler implements MethodReturnTypeProviderInterface
             return null;
         }
 
-        // argument(null) / option(null) or no args — returns the full array, fall through
-        $callArgs = $event->getCallArgs();
-
-        if ($callArgs === []) {
-            return null;
-        }
-
-        // Extract the literal string key from the first argument
-        $firstArgType = $event->getSource()->getNodeTypeProvider()->getType($callArgs[0]->value);
+        // Extract the literal string key from the first argument.
+        // argument(null) / option(null) or no args fall through here too — typeAt
+        // returns null for missing args, and a literal-null arg is not a string literal.
+        $firstArgType = Arg::typeAt($event->getCallArgs(), $event->getSource(), 0);
 
         if (!$firstArgType instanceof \Psalm\Type\Union || !$firstArgType->isSingleStringLiteral()) {
-            return null; // dynamic key — cannot narrow
+            return null; // dynamic key, no arg, or null literal — cannot narrow
         }
 
         $key = $firstArgType->getSingleStringLiteral()->value;

--- a/src/Handlers/Helpers/CacheHandler.php
+++ b/src/Handlers/Helpers/CacheHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Handlers\Helpers;
 
+use Psalm\LaravelPlugin\Util\Arg;
 use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
 use Psalm\Type;
@@ -34,7 +35,7 @@ final class CacheHandler implements FunctionReturnTypeProviderInterface
             ]);
         }
 
-        $first_arg_type = $event->getStatementsSource()->getNodeTypeProvider()->getType($call_args[0]->value);
+        $first_arg_type = Arg::typeAt($call_args, $event->getStatementsSource(), 0);
 
         /** @see \Illuminate\Contracts\Cache\Store::put() */
         if ($first_arg_type && $first_arg_type->isArray()) {

--- a/src/Handlers/Helpers/EnvHandler.php
+++ b/src/Handlers/Helpers/EnvHandler.php
@@ -53,7 +53,7 @@ final class EnvHandler implements FunctionReturnTypeProviderInterface
         //   - default has unknown type
         //   - default explicitly includes null
         //   - default is mixed (implicitly includes null)
-        if ($second_arg_type === null
+        if (!$second_arg_type instanceof \Psalm\Type\Union
             || $second_arg_type->isNullable()
             || $second_arg_type->hasMixed()
         ) {

--- a/src/Handlers/Helpers/EnvHandler.php
+++ b/src/Handlers/Helpers/EnvHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Handlers\Helpers;
 
+use Psalm\LaravelPlugin\Util\Arg;
 use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
 use Psalm\Type;
@@ -45,20 +46,14 @@ final class EnvHandler implements FunctionReturnTypeProviderInterface
     #[\Override]
     public static function getFunctionReturnType(FunctionReturnTypeProviderEvent $event): Type\Union
     {
-        $call_args = $event->getCallArgs();
+        $second_arg_type = Arg::typeAt($event->getCallArgs(), $event->getStatementsSource(), 1);
 
-        // No default argument — env var may not be set → null
-        if (\count($call_args) < 2) {
-            return new Type\Union([new TString(), new TNull()]);
-        }
-
-        $second_arg_type = $event->getStatementsSource()
-            ->getNodeTypeProvider()
-            ->getType($call_args[1]->value);
-
-        // Unknown type, default includes null, or default is mixed (implicitly includes null):
-        // fall back to string|null
-        if (!$second_arg_type instanceof \Psalm\Type\Union
+        // Fall back to string|null when:
+        //   - no default argument supplied (env var may not be set → null)
+        //   - default has unknown type
+        //   - default explicitly includes null
+        //   - default is mixed (implicitly includes null)
+        if ($second_arg_type === null
             || $second_arg_type->isNullable()
             || $second_arg_type->hasMixed()
         ) {

--- a/src/Handlers/Helpers/PathHandler.php
+++ b/src/Handlers/Helpers/PathHandler.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Psalm\LaravelPlugin\Handlers\Helpers;
 
 use Closure;
-use PhpParser\Node\Arg;
 use PhpParser\Node\Scalar\String_;
 use Psalm\LaravelPlugin\Providers\ApplicationProvider;
+use Psalm\LaravelPlugin\Util\Arg;
 use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
@@ -98,12 +98,9 @@ final class PathHandler implements FunctionReturnTypeProviderInterface, MethodRe
         // so that we can inform psalm of where the files live.
         $argument = '';
 
-        $first_argument = $call_args[0] ?? null;
-        if ($first_argument instanceof Arg) {
-            $argumentType = $first_argument->value;
-            if ($argumentType instanceof String_) {
-                $argument = $argumentType->value;
-            }
+        $first_argument = Arg::nodeAt($call_args, 0);
+        if ($first_argument instanceof String_) {
+            $argument = $first_argument->value;
         }
 
         $result = $closure([$argument]);

--- a/src/Handlers/Translations/TranslationKeyHandler.php
+++ b/src/Handlers/Translations/TranslationKeyHandler.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Scalar\String_;
 use Psalm\CodeLocation;
 use Psalm\IssueBuffer;
 use Psalm\LaravelPlugin\Issues\MissingTranslation;
+use Psalm\LaravelPlugin\Util\Arg as ArgUtil;
 use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
 use Psalm\Type;
@@ -103,7 +104,7 @@ final class TranslationKeyHandler implements FunctionReturnTypeProviderInterface
 
         // Dynamic keys (variables, sprintf, concatenation) or missing literal keys:
         // return string to avoid PossiblyInvalidCast noise from string|array union
-        $firstArgType = $event->getStatementsSource()->getNodeTypeProvider()->getType($callArgs[0]->value);
+        $firstArgType = ArgUtil::typeAt($callArgs, $event->getStatementsSource(), 0);
 
         if ($firstArgType instanceof \Psalm\Type\Union) {
             if ($firstArgType->isString()) {

--- a/src/Handlers/Validation/ValidatedTypeHandler.php
+++ b/src/Handlers/Validation/ValidatedTypeHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Handlers\Validation;
 
+use Psalm\LaravelPlugin\Util\Arg;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
 use Psalm\Type;
@@ -110,7 +111,7 @@ final class ValidatedTypeHandler implements MethodReturnTypeProviderInterface
         }
 
         // safe(['key1', 'key2']) → extract literal string keys from the array argument
-        $argType = $event->getSource()->getNodeTypeProvider()->getType($callArgs[0]->value);
+        $argType = Arg::typeAt($callArgs, $event->getSource(), 0);
 
         if (!$argType instanceof Union) {
             return null;

--- a/src/Util/Arg.php
+++ b/src/Util/Arg.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Util;
+
+use PhpParser\Node\Expr;
+use Psalm\StatementsSource;
+use Psalm\Type\Union;
+
+/**
+ * Tiny accessors for `getCallArgs()` lists from {@see \Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent}
+ * and {@see \Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent}.
+ *
+ * Use the helper when a handler reads a single argument node or its inferred
+ * type by index. When a handler passes the whole arg list down to a resolver,
+ * or branches on more than missing-vs-present (e.g. count-aware empty checks
+ * with literal-null handling), inline the access — the helper has no answer
+ * for those shapes and would only obscure the intent.
+ *
+ * The class name shadows {@see \PhpParser\Node\Arg}. When a handler also imports
+ * the PhpParser symbol (e.g. as a parameter type), import this helper aliased
+ * as `ArgUtil` to keep both names usable.
+ *
+ * @internal
+ */
+final class Arg
+{
+    /**
+     * Return the AST expression of the argument at $index, or null if the
+     * index is out of range.
+     *
+     * @param list<\PhpParser\Node\Arg> $args
+     * @psalm-mutation-free
+     */
+    public static function nodeAt(array $args, int $index): ?Expr
+    {
+        return $args[$index]->value ?? null;
+    }
+
+    /**
+     * Return the inferred Psalm type of the argument at $index, or null if
+     * the argument is missing or its type is unknown.
+     *
+     * Both null cases collapse intentionally: callers that need to distinguish
+     * "no arg" from "arg of unknown type" should fetch the node via
+     * {@see self::nodeAt()} and call `getNodeTypeProvider()->getType()` themselves.
+     *
+     * @param list<\PhpParser\Node\Arg> $args
+     */
+    public static function typeAt(array $args, StatementsSource $source, int $index): ?Union
+    {
+        $node = $args[$index]->value ?? null;
+
+        if ($node === null) {
+            return null;
+        }
+
+        return $source->getNodeTypeProvider()->getType($node);
+    }
+}


### PR DESCRIPTION
## Issue to Solve

`src/Handlers/**/*.php` accumulated repeated boilerplate for fetching the N-th call argument's AST node or inferred type from a Psalm event:

```php
$args = $event->getCallArgs();
if ($args === []) { return null; }
$argNode = $args[$index]->value;
$type = $event->getSource()->getNodeTypeProvider()->getType($argNode);
```

Inspired by [`php-standard-library/psalm-plugin/src/Argument.php`](https://github.com/php-standard-library/psalm-plugin/blob/main/src/Argument.php), which collapses the same shape into a single helper used by every handler in that plugin.

## Solution Description

Adds `src/Util/Arg.php` with two static methods:

- `Arg::nodeAt(array $args, int $index): ?\PhpParser\Node\Expr` — returns the AST expression at the given index, or `null` if missing.
- `Arg::typeAt(array $args, \Psalm\StatementsSource $source, int $index): ?\Psalm\Type\Union` — returns the inferred type, or `null` if the argument is missing or its type is unknown.

Migrates 7 handler sites:
- `src/Handlers/Collections/CollectionFlattenHandler.php`
- `src/Handlers/Console/CommandArgumentHandler.php`
- `src/Handlers/Helpers/CacheHandler.php`
- `src/Handlers/Helpers/EnvHandler.php`
- `src/Handlers/Helpers/PathHandler.php`
- `src/Handlers/Translations/TranslationKeyHandler.php`
- `src/Handlers/Validation/ValidatedTypeHandler.php`

`EnvHandler` and `CommandArgumentHandler` get an additional simplification: they previously had separate branches for "no arg" and "unknown type" that both led to the same fallback. With `Arg::typeAt` returning `null` for both cases, those branches collapse into one nullability check.

`typeAt` intentionally collapses missing-arg and unknown-type into a single `null` return; the docblock points callers at `nodeAt` plus a manual `getType()` call when the distinction matters.

### Intentionally NOT migrated

- **Bulk-passthrough sites** that pass the whole `$args` list to a downstream resolver: `BuilderPluckHandler`, `ModelMethodHandler`, `ContainerHandler`, `OffsetHandler`, `CollectionPluckHandler`. These wouldn't benefit from the helper.
- **`src/Handlers/Eloquent/Schema/*`** — parses migration AST through `MethodCall->args[]` directly, not via `getCallArgs()`.
- **`CollectionFilterHandler::isCalledWithoutArgOrNull`** — does count-aware empty checks plus literal-null detection, more than the helper covers.
- **`MissingViewHandler`** — extracts the whole `Arg` (not its `->value`) before calling a private literal-string extractor; migrating would require refactoring that private method. Reasonable follow-up.

### Naming note

`Arg` shadows `PhpParser\Node\Arg`. `TranslationKeyHandler` already imported the PhpParser symbol as a parameter type, so it imports the helper as `use Psalm\LaravelPlugin\Util\Arg as ArgUtil;`. The class docblock documents the convention for future contributors.

### Net diff

`src/Handlers/`: -12 lines (27 insertions, 39 deletions). `src/Util/Arg.php`: +61 lines. No new `psalm-baseline.xml` entries.

### Validation

- `composer cs` clean
- `composer psalm` exits 0
- `composer test:unit` 572 pass / 1 skipped
- `composer test:type` 380 pass

## Checklist
- [x] Tests cover the change (existing handler tests cover the migrated sites; the helper itself is too thin to warrant standalone tests, per the task spec)
