### PR TITLE
Add regression guards for relation and `Builder` template-arg invariants

### DIFF
--- a/tests/Application/app/Models/Shop.php
+++ b/tests/Application/app/Models/Shop.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 
 /**
  * Test model for non-generic relationship accessor resolution (#497).
@@ -114,5 +115,51 @@ final class Shop extends Model
     public function defaultCustomer(): BelongsTo
     {
         return $this->belongsTo(Customer::class)->withDefault();
+    }
+
+    // --- Helper-delegation pattern (regression for #882) ---
+    //
+    // A public relation method whose body delegates to a private helper that
+    // builds the relation. Without parser support for following helper calls,
+    // RelationMethodParser bails on `$this->workOrdersByStatus(...)` (not a
+    // factory name) and the handler returns null, causing Psalm to fall back
+    // to the untemplated stub default `HasMany<Model, Model>`.
+
+    /** @psalm-return HasMany<WorkOrder, self> */
+    public function activeWorkOrders(): HasMany
+    {
+        return $this->workOrdersByStatus('active');
+    }
+
+    /** @psalm-return HasMany<WorkOrder, self> */
+    public function completedWorkOrders(): HasMany
+    {
+        return $this->workOrdersByStatus('completed');
+    }
+
+    private function workOrdersByStatus(string $status): HasMany
+    {
+        return $this->hasMany(WorkOrder::class)
+            ->where('status', $status);
+    }
+
+    // --- Wrapper-method-on-this pattern (regression for #884) ---
+    //
+    // The wrapper body re-enters the chain via `$this->parts()->wherePivot(...)`.
+    // The Relation stubs return `$this` from `wherePivot`/`where`, so Psalm
+    // attaches `&static` to the outer atomic. If the wrapper's declaration is
+    // a concrete-class form like `@psalm-return BelongsToMany<Part, self, Pivot, 'pivot'>`,
+    // the outer `&static` must NOT block the assignment.
+
+    /** @psalm-return BelongsToMany<Part, self, Pivot, 'pivot'> */
+    public function suggestedParts(): BelongsToMany
+    {
+        return $this->parts()->wherePivot('priority', 'high');
+    }
+
+    /** @psalm-return HasMany<WorkOrder, self> */
+    public function recentWorkOrders(): HasMany
+    {
+        return $this->workOrders()->where('created_at', '>=', '2025-01-01');
     }
 }

--- a/tests/Type/tests/Builder/Issue777BuilderChainTest.phpt
+++ b/tests/Type/tests/Builder/Issue777BuilderChainTest.phpt
@@ -1,0 +1,67 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use App\Models\Vehicle;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Regression for https://github.com/psalm/psalm-plugin-laravel/issues/777.
+ *
+ * `Customer::query()->select(...)->leftJoin(...)->where(Closure)->groupBy(...)`
+ * was reported (plugin 3.8.4 / Psalm 6.16.1) to infer as
+ * `Builder<Eloquent>&static|Builder<Model>&static` instead of `Builder<Customer>`,
+ * breaking concrete-class `@return Builder<Customer>` declarations. Likely root
+ * cause: one of the chained methods (most plausibly `where(Closure)` whose
+ * closure parameter is typed `Builder` without a template) drops `TModel`.
+ *
+ * Each function below carries a function-level `@return Builder<Customer>` (or
+ * `Builder<Vehicle>`) — combined with the empty `--EXPECTF--` block, that is the
+ * regression oracle. A regression that drops `TModel` mid-chain trips
+ * `LessSpecificReturnStatement` / `InvalidReturnStatement` against the function
+ * signature and the test fails.
+ */
+
+/** @return Builder<Customer> */
+function issue777_builder_chain_keeps_tmodel_through_select_and_join(): Builder
+{
+    return Customer::query()
+        ->select('customers.*')
+        ->leftJoin('vehicles', 'vehicles.customer_id', '=', 'customers.id');
+}
+
+/** @return Builder<Customer> */
+function issue777_builder_chain_keeps_tmodel_through_where_closure(): Builder
+{
+    return Customer::query()
+        ->select('customers.*')
+        ->leftJoin('vehicles', 'vehicles.customer_id', '=', 'customers.id')
+        ->where(function (Builder $b): void { $b->where('email', 'x@example.com'); });
+}
+
+/** @return Builder<Customer> */
+function issue777_builder_chain_keeps_tmodel_through_groupBy(): Builder
+{
+    return Customer::query()
+        ->select('customers.*')
+        ->leftJoin('vehicles', 'vehicles.customer_id', '=', 'customers.id')
+        ->where(function (Builder $b): void { $b->where('email', 'x@example.com'); })
+        ->groupBy('customers.id');
+}
+
+// Pterodactyl-style reproducer (issue's real-world example):
+// User::accessibleServers() returns Builder<Server> after a 4-step chain.
+
+/** @return Builder<Vehicle> */
+function issue777_pterodactyl_style_query(Customer $customer): Builder
+{
+    return Vehicle::query()
+        ->select('vehicles.*')
+        ->leftJoin('customers', 'customers.id', '=', 'vehicles.customer_id')
+        ->where(function (Builder $b) use ($customer): void {
+            $b->where('customer_id', $customer->id);
+        })
+        ->groupBy('vehicles.id');
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Relation/Issue882HelperDelegationTest.phpt
+++ b/tests/Type/tests/Relation/Issue882HelperDelegationTest.phpt
@@ -1,0 +1,41 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Shop;
+use App\Models\WorkOrder;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * Regression for https://github.com/psalm/psalm-plugin-laravel/issues/882.
+ *
+ * When a public relation method delegates to a private helper that builds the
+ * relation (`return $this->workOrdersByStatus('active')`),
+ * {@see \Psalm\LaravelPlugin\Handlers\Eloquent\RelationMethodParser::findRelationCallInExpr}
+ * used to bail at the helper call (not in `FACTORY_TO_RELATION`) and the handler
+ * returned null. Psalm then fell back to the untemplated stub default,
+ * collapsing the inferred type to `HasMany<Model, Model>` and triggering
+ * `MoreSpecificReturnType` / `LessSpecificReturnStatement` against the public
+ * method's `@psalm-return HasMany<WorkOrder, self>` declaration.
+ *
+ * The fixture lives on disk in {@see Shop::activeWorkOrders()} so the
+ * registration handler picks it up. Inline-defined models bypass the
+ * `class_exists`-gated registration path and would not exercise this handler.
+ *
+ * Empty `--EXPECTF--` is the regression oracle.
+ */
+
+function issue882_helper_delegation_resolves_relation(Shop $shop): HasMany
+{
+    $relation = $shop->activeWorkOrders();
+    /** @psalm-check-type-exact $relation = HasMany<WorkOrder, Shop> */
+    return $relation;
+}
+
+function issue882_second_delegation_resolves_relation(Shop $shop): HasMany
+{
+    $relation = $shop->completedWorkOrders();
+    /** @psalm-check-type-exact $relation = HasMany<WorkOrder, Shop> */
+    return $relation;
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Relation/Issue884StaticConstraintScopeTest.phpt
+++ b/tests/Type/tests/Relation/Issue884StaticConstraintScopeTest.phpt
@@ -1,0 +1,75 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use App\Models\Part;
+use App\Models\Shop;
+use App\Models\Vehicle;
+use App\Models\WorkOrder;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+/**
+ * Regression for https://github.com/psalm/psalm-plugin-laravel/issues/884.
+ *
+ * A wrapper relation method whose body re-enters the chain via
+ * `$this->existingRelation()->wherePivot(...)` (or any fluent chained method that
+ * returns `$this`) currently produces an outer `Rel<...>&static`. The issue
+ * thread argued this would block concrete-class declarations like
+ * `@psalm-return BelongsToMany<Part, self, Pivot, 'pivot'>`. On current master
+ * concrete declarations DO match the `&static`-on-outer form (Psalm absorbs the
+ * intersection through the assignment), so this is a regression-guard test
+ * pinning the user-visible contract: declaring a concrete-class return type on a
+ * wrapper that chains off `$this->relation()` must not raise
+ * `InvalidReturnStatement` / `LessSpecificReturnStatement`.
+ *
+ * The wrapper-on-`$this` shape is exercised by autoloaded fixtures
+ * {@see Shop::suggestedParts()} (BelongsToMany + wherePivot) and
+ * {@see Shop::recentWorkOrders()} (HasMany + where). Inline-defined classes
+ * would bypass {@see \Psalm\LaravelPlugin\Handlers\Eloquent\ModelRegistrationHandler}'s
+ * `class_exists`-gated registration, so the on-disk fixture is required.
+ *
+ * The external-caller cases below (free functions taking a Model instance)
+ * cover a sibling shape: same chain shape but starting from `$workOrder->...`
+ * rather than `$this->...`.
+ *
+ * Empty `--EXPECTF--` is the regression oracle for both shapes.
+ */
+
+// --- Wrapper-on-$this shape: invoke the Shop fixtures so the docblock-vs-body
+//     match is actually exercised. The `@psalm-check-type-exact` pins the
+//     handler-emitted Union (without `&static` on the outer) because the handler
+//     emits the relation type for the outermost call before `wherePivot()`/
+//     `where()` returns `$this` and adds the intersection.
+
+function issue884_wrapper_on_this_belongsToMany_concrete_decl(Shop $shop): BelongsToMany
+{
+    $relation = $shop->suggestedParts();
+    /** @psalm-check-type-exact $relation = BelongsToMany<Part, Shop, Pivot, 'pivot'> */
+    return $relation;
+}
+
+function issue884_wrapper_on_this_hasMany_concrete_decl(Shop $shop): HasMany
+{
+    $relation = $shop->recentWorkOrders();
+    /** @psalm-check-type-exact $relation = HasMany<WorkOrder, Shop> */
+    return $relation;
+}
+
+// --- External-caller shape: declared concrete-class return must still hold
+//     against the chain's `&static`-on-outer inferred form.
+
+/** @return BelongsToMany<Part, WorkOrder, Pivot, 'pivot'> */
+function issue884_concrete_class_declaration_after_wherePivot(WorkOrder $workOrder): BelongsToMany
+{
+    return $workOrder->parts()->wherePivot('quantity', 1);
+}
+
+/** @return HasMany<Vehicle, Customer> */
+function issue884_concrete_class_declaration_after_where(Customer $customer): HasMany
+{
+    return $customer->vehicles()->where('active', true);
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
> **Plans and upstream connection.** This PR is regression-guards-only. Deeper fix work is gated on a `vimeo/psalm` tag containing vimeo/psalm#11768 (merged on `vimeo/psalm` master 2026-05-04, no Psalm 7 tag yet). Once that tag ships and the plugin bumps its constraint, PR #870 ("Bind `TDeclaringModel` to `static` on `$this` relation dispatch") becomes the natural follow-up: it needs the `&static`-on-outer issue corrected before merging, and the regression guards added here will catch that exact shape.

## Issue to Solve

Bundle investigation of four reports (#764, #882, #884, #777), all of which describe generic-template loss in Eloquent relation/builder return types. Empirically verified on current `master` (Psalm `7.0.0-beta19` + plugin 4.x): only #764 actively reproduces, and that one is fixed on `vimeo/psalm` dev-master. The other three pass on plugin master, so this PR ships **regression guards only** to lock in the expected behavior.

## Related

Closes #764
Closes #882
Closes #884
Closes #777

## Solution Description

### Per-issue upstream verdict

**#764, pure-upstream (fixed on `vimeo/psalm` master).** The stub `$this` template-arg collapse is fixed by vimeo/psalm#11768 (merged 2026-05-04). That fix is not yet in a tagged Psalm release (`7.0.0-beta19`, 2026-04-15), so a fresh `composer install` against the plugin's `^7.0.0-beta19 || dev-master` constraint will only see the fix once the next Psalm 7 tag ships (or with an explicit `dev-master` pin). Per project preference, no plugin-side workaround is shipped here. Re-landing #620 (stub `$this` to `static`) is explicitly skipped: the user's own 2026-05-06 comment on #764 states it is no longer needed.

**#882, pure-plugin (not currently reproducing on master).** The helper-method-delegation pattern works on current master because `ModelRelationReturnTypeHandler` is registered per-class for **all** methods (including private), so the handler fires on the helper too and emits the right `HasMany<WorkOrder, Shop>`. Likely already mitigated by sibling fixes since the `d181797` environment in the issue. A regression guard is added so future changes that break this path are caught at the type-test layer.

**#884, pure-plugin (regression precondition not on master).** The reported `&static`-on-outer regression was introduced by `cc78e94f` ("Bind TDeclaringModel to static on `$this` relation dispatch") on PR #870, which is **open and not merged** to `master`. Without it, master's chain results do carry `&static` on the outer (Psalm's natural `$this` resolution on chained methods returning `$this`), but Psalm correctly matches that against concrete-class declared returns. A regression guard pins both the wrapper-on-`$this` shape and the external-caller shape, so a future iteration of PR #870 that reintroduces the outer-`&static` shape is caught.

**#777, pure-plugin (not currently reproducing on master).** The Builder generic collapse reported on plugin 3.8.4 / Psalm 6.16.1 does not reproduce on plugin 4.x with Psalm 7.0.0-beta19, presumably resolved by intervening Builder rework. A regression guard covers each progressive step of the chain (`select` and `leftJoin`, then `where(Closure)`, then `groupBy`) plus the Pterodactyl-style real-world reproducer.

### Why #620's revert is no longer a blocker

#620 was reverted in `514a033` because the `$this` to `static` stub workaround interacted poorly with assertions in `EloquentRelationGenericsTest.phpt`. The user's own #764 comment from 2026-05-06 records the post-revert decision: vimeo/psalm#11768 fixes the underlying type-system issue at the right layer, so re-landing the workaround is unnecessary. This PR follows that decision and does not touch any stub.

### New regression tests

- `tests/Type/tests/Relation/Issue882HelperDelegationTest.phpt`
- `tests/Type/tests/Relation/Issue884StaticConstraintScopeTest.phpt`
- `tests/Type/tests/Builder/Issue777BuilderChainTest.phpt`

Each oracle is load-bearing (mutation-verified during the `psalm-review` round). Function-level `@return Builder<T>` is the oracle for the chain tests; `@psalm-check-type-exact` pins the wrapper-on-`$this` assignments. Empty `--EXPECTF--` blocks act as the no-error oracle.

### Supporting fixtures

`tests/Application/app/Models/Shop.php` gains five fixture methods supporting #882 and #884:

- Helper-delegation pattern (#882): `activeWorkOrders` / `completedWorkOrders` (public, declared) delegate to `workOrdersByStatus(string)` (private). Exercises both the per-method handler cache hit and the helper's own factory-chain parse.
- Wrapper-on-`$this` pattern (#884): `suggestedParts` (declared `BelongsToMany<Part, self, Pivot, 'pivot'>`) and `recentWorkOrders` (declared `HasMany<WorkOrder, self>`) chain off `$this->parts()` / `$this->workOrders()` so a concrete-class declared return is matched against an `&static`-on-outer chain result. The `Pivot` import is added to the `use` block so the docblock reference resolves correctly.

Inline-class fixtures cannot exercise these paths because `ModelRegistrationHandler` is `class_exists`-gated; the on-disk fixture approach matches the existing `Issue879SelfStaticParentClassTest` convention.

## Checklist

- [x] Tests cover the change (three new PHPT regression guards under `tests/Type/tests/Relation/` and `tests/Type/tests/Builder/`)
