### PR TITLE
Macro discovery foundation

### DIFF
--- a/src/Handlers/Magic/MacroHandler.php
+++ b/src/Handlers/Magic/MacroHandler.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Magic;
+
+use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
+use Psalm\LaravelPlugin\Providers\MacroDefinition;
+use Psalm\LaravelPlugin\Providers\MacroRegistry;
+use Psalm\Plugin\EventHandler\AfterCodebasePopulatedInterface;
+use Psalm\Plugin\EventHandler\Event\AfterCodebasePopulatedEvent;
+use Psalm\Storage\ClassLikeStorage;
+use Psalm\Storage\MethodStorage;
+
+/**
+ * Resolves runtime-registered macros on Laravel's {@see \Illuminate\Support\Traits\Macroable}
+ * (and Macroable-shaped) classes by injecting synthesised pseudo-method declarations
+ * into Psalm's class storage.
+ *
+ * Foundation for issue #758. Strategy B (runtime reflection of `Macroable::$macros`).
+ *
+ * **Why pseudo-methods, not method providers.** The original sketch used
+ * `MethodExistenceProviderInterface` + `MethodParamsProviderInterface` etc. but
+ * registering a `params_provider` for a class — even one that returns `null` for
+ * non-macro methods — perturbs Psalm's argument-count diagnostics for *real*
+ * methods on the same class (regression observed against
+ * `Variadic/AuditRejectionsTest.phpt` for `Stringable::trim` / `ltrim` / `rtrim`).
+ *
+ * Writing into `ClassLikeStorage::$pseudo_methods` and `$pseudo_static_methods` is
+ * the same shape Psalm uses for `@method` annotations: methods that exist only when
+ * routed through `__call`/`__callStatic`, with their own param/return types, looked
+ * up by `MissingMethodCallHandler::handleMagicMethod()` (instance) and
+ * `AtomicStaticCallAnalyzer` (static). Real methods on the class are unaffected.
+ *
+ * **Why both `pseudo_methods` AND `pseudo_static_methods`.** `Macroable` defines
+ * BOTH `__call` and `__callStatic`, so every registered macro is callable both as
+ * `$instance->macroName()` and as `Class::macroName()`. Psalm's static-call analyzer
+ * reads `pseudo_static_methods` only; the instance-call analyzer reads
+ * `pseudo_methods` only. Each macro gets two `MethodStorage` instances — one with
+ * `is_static = false` for the instance array, one with `is_static = true` for the
+ * static array. The dominant Laravel usage (e.g. `Str::macroName(...)`,
+ * `Route::macroName(...)`) needs the static side.
+ *
+ * **Why subclass propagation.** Psalm's `Populator` copies parent `pseudo_methods`
+ * into children, but it runs in `populateClassLikeStorages` which strictly precedes
+ * `dispatchAfterCodebasePopulated`. Pseudo-methods we inject here are too late for
+ * that copy. At lookup time, `MissingMethodCallHandler::findPseudoMethodAndClass-
+ * Storages()` walks `class_implements` and `namedMixins`, NOT `parent_classes` —
+ * so children would not see parent macros either. We propagate explicitly: for
+ * each Macroable owner, walk every analysed class whose `parent_classes` includes
+ * it and inject the same pseudo-methods.
+ *
+ * `@mixin` propagation was tried in an earlier iteration (write Builder macros
+ * onto every Model declared as `@mixin Builder<static>`) but removed for two
+ * reasons: (1) Psalm's static-call analyzer redirects through `handleRegular-
+ * Mixins` to the mixin class itself rather than consulting the host's pseudo-
+ * methods, so the writes did not actually resolve `User::macroName()` calls;
+ * (2) injecting pseudo-methods onto the host risks expanding native
+ * `self`/`static` types in the macro signature against the host class instead
+ * of the macro's defining class. Issue #648's relation-chain pattern is handled
+ * by the `parent_classes` walk above — `$user->posts()->active()` resolves
+ * because `Builder<User>` is the direct dispatch target.
+ *
+ * TODO Strategy C / follow-up:
+ * - **AST scan** (Strategy C proper): cover macros registered in the analysed
+ *   package's own provider when running on a package without `bootstrap/app.php`
+ *   (Testbench fallback path — issue #766). Walk every literal
+ *   `<Class>::macro('name', $callable)` and `<Class>::mixin(...)` call in the
+ *   analysed codebase, extract docblock-aware param/return types from Psalm's
+ *   already-resolved AST nodes, and merge into {@see MacroRegistry}.
+ * - **Eloquent local builder macros** (`$builder->macro('foo', ...)`): registered into
+ *   the per-instance `$localMacros` property, NOT the static `$macros` registry uses.
+ *   Static reflection cannot reach them because they only exist on a specific Builder
+ *   instance. Strategy C's AST scan can pick up the literal `$builder->macro('name', ...)`
+ *   call sites; deferred.
+ * - **`@mixin` static-call propagation**: writing macros from a mixin onto the host
+ *   class did not actually resolve `Host::macroName()` calls (Psalm's static analyzer
+ *   redirects through the mixin path before consulting the host's pseudo-methods),
+ *   and risks `self`/`static` mis-expansion in the macro signature. Tracked as a
+ *   follow-up — needs a Psalm-side change or a different lookup hook.
+ * - **Fluent return narrowing**: a macro whose body returns `$this` should narrow
+ *   to the calling instance type (`@psalm-this-out` / `self_out_type`). Out of
+ *   scope for the foundation.
+ * - **Memory footprint**: each propagated macro materialises two `MethodStorage`
+ *   instances on every descendant class (one per `pseudo_methods` array). Scales
+ *   roughly as `descendants × macros × 2`. Acceptable for the foundation's typical
+ *   load (Builder + Stringable + a handful of others); a future optimisation could
+ *   share storage instances or defer materialisation behind a hook.
+ * - **Curated stubs for high-value framework macros**: `Request::validate()` is
+ *   registered by `FoundationServiceProvider` with no return type, so the registry
+ *   surfaces it as `mixed`. A hand-authored `@method` declaration on the Request
+ *   stub would give a precise return shape. The handler skips names already
+ *   present in `pseudo_methods`, so the two layers compose without conflict.
+ *
+ * @internal
+ */
+final class MacroHandler implements AfterCodebasePopulatedInterface
+{
+    /**
+     * Discover macros from the booted Laravel app and inject them into Psalm
+     * class storage as pseudo-methods, propagating to all analysed descendants.
+     */
+    #[\Override]
+    public static function afterCodebasePopulated(AfterCodebasePopulatedEvent $event): void
+    {
+        $codebase = $event->getCodebase();
+
+        MacroRegistry::init($codebase->progress);
+
+        $macroableClasses = MacroRegistry::getKnownMacroableClasses();
+        if ($macroableClasses === []) {
+            return;
+        }
+
+        // Build a lookup keyed by lowercase FQCN (matches `parent_classes` keying).
+        // Each entry is the list of MacroDefinition instances to inject for that owner.
+        /** @var array<lowercase-string, list<MacroDefinition>> $injectionMap */
+        $injectionMap = [];
+        foreach ($macroableClasses as $fqcn) {
+            $injectionMap[\strtolower($fqcn)] = \array_values(MacroRegistry::for($fqcn));
+        }
+
+        // Walk every class Psalm has scanned. For each, gather the union of macros
+        // owed to it (its own entry, plus the entry of every Macroable ancestor in
+        // its `parent_classes` chain), then inject in one pass. `@mixin` targets are
+        // intentionally NOT walked here — see the class docblock.
+        foreach ($codebase->classlike_storage_provider::getAll() as $storage) {
+            $owedMacros = $injectionMap[\strtolower($storage->name)] ?? [];
+
+            foreach ($storage->parent_classes as $parentLc => $_) {
+                if (isset($injectionMap[$parentLc])) {
+                    foreach ($injectionMap[$parentLc] as $def) {
+                        $owedMacros[] = $def;
+                    }
+                }
+            }
+
+            if ($owedMacros === []) {
+                continue;
+            }
+
+            foreach ($owedMacros as $def) {
+                self::injectPseudoMethod($storage, $def);
+            }
+        }
+    }
+
+    /**
+     * Inject a single macro as both an instance and a static pseudo-method on the
+     * given class storage.
+     *
+     * Skips when a real method already declares the same name (PHP method
+     * resolution wins over `__call`, so the macro would be unreachable at
+     * runtime — and overriding the real signature would mask legitimate
+     * argument-count diagnostics).
+     *
+     * Also skips per-array when an existing pseudo-method is already present —
+     * `@method` annotations and earlier macros in the propagation chain take
+     * precedence.
+     */
+    private static function injectPseudoMethod(
+        ClassLikeStorage $storage,
+        MacroDefinition $def,
+    ): void {
+        $methodName = $def->methodName;
+
+        // Block injection if a real method with this name exists anywhere in the
+        // class's own storage *or its inheritance chain*. `$storage->methods` only
+        // lists locally declared methods; inherited declarations (from a parent
+        // that the populator already merged into this storage's view) live in
+        // `declaring_method_ids`. Without checking both, a propagated macro could
+        // shadow a real inherited method's signature in the static-call path,
+        // mis-reporting argument-count diagnostics.
+        if (
+            isset($storage->methods[$methodName])
+            || isset($storage->declaring_method_ids[$methodName])
+        ) {
+            return;
+        }
+
+        if (!isset($storage->pseudo_methods[$methodName])) {
+            $storage->pseudo_methods[$methodName] = self::buildMethodStorage($def, isStatic: false);
+        }
+
+        if (!isset($storage->pseudo_static_methods[$methodName])) {
+            $storage->pseudo_static_methods[$methodName] = self::buildMethodStorage($def, isStatic: true);
+        }
+    }
+
+    private static function buildMethodStorage(MacroDefinition $def, bool $isStatic): MethodStorage
+    {
+        $methodStorage = new MethodStorage();
+        $methodStorage->cased_name = $def->casedName;
+        // Psalm convention: `defining_fqcln` is the *lowercased* FQCN. Several Psalm
+        // internal lookups assume that.
+        $methodStorage->defining_fqcln = \strtolower($def->declaringClass);
+        $methodStorage->is_static = $isStatic;
+        $methodStorage->visibility = ClassLikeAnalyzer::VISIBILITY_PUBLIC;
+        // `params` carries `@psalm-readonly-allow-private-mutation`; setParams() is
+        // the only sanctioned mutation entry point.
+        $methodStorage->setParams($def->params);
+        $methodStorage->return_type = $def->returnType;
+        // `signature_return_type` stays null when the closure had no native PHP return
+        // type — Psalm's convention. The `mixed` fallback only applies to `return_type`,
+        // which is the type analyzers actually consume.
+        $methodStorage->signature_return_type = $def->signatureReturnType;
+        $methodStorage->stubbed = true;
+
+        return $methodStorage;
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -235,6 +235,8 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Magic/ForwardingRule.php';
         require_once __DIR__ . '/Handlers/Magic/ReturnTypeResolver.php';
         require_once __DIR__ . '/Handlers/Magic/MethodForwardingHandler.php';
+        require_once __DIR__ . '/Handlers/Magic/MacroHandler.php';
+        $registration->registerHooksFromClass(Handlers\Magic\MacroHandler::class);
         require_once __DIR__ . '/Handlers/Eloquent/ModelMethodHandler.php';
         require_once __DIR__ . '/Handlers/Eloquent/ModelBuilderMixinHandler.php';
         Handlers\Magic\MethodForwardingHandler::init(new Handlers\Magic\ForwardingRule(

--- a/src/Providers/MacroDefinition.php
+++ b/src/Providers/MacroDefinition.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Providers;
+
+use Psalm\Storage\FunctionLikeParameter;
+use Psalm\Type\Union;
+
+/**
+ * A single discovered macro registered via {@see \Illuminate\Support\Traits\Macroable::macro()}
+ * (or transitively via {@see \Illuminate\Support\Traits\Macroable::mixin()}).
+ *
+ * Foundation for issue #758. Strategy B (runtime reflection) only — type info is whatever
+ * `ReflectionFunction` exposes for the registered closure (native param/return types only,
+ * no docblock parsing yet). Strategy C (AST scan + docblock recovery) is a follow-up.
+ *
+ * Marked `@psalm-external-mutation-free` rather than `@psalm-immutable`: `Union` is
+ * genuinely immutable, but `FunctionLikeParameter` exposes public mutable fields
+ * (`sinks`, `attributes`, etc.). Anyone holding the `params` list could mutate an
+ * entry in place. The contract in this codebase is "we never write through these
+ * references"; downgrading the annotation matches that promise honestly instead of
+ * advertising a structural guarantee Psalm can't enforce here.
+ *
+ * @psalm-external-mutation-free
+ * @internal
+ */
+final class MacroDefinition
+{
+    /**
+     * @param class-string $declaringClass The Macroable class that owns the `$macros` storage
+     *                                     (the one that directly `use`s the trait, or — in the
+     *                                     case of `\Illuminate\Database\Eloquent\Builder` —
+     *                                     declares its own `$macros` static property and
+     *                                     `macro()` method without using the trait).
+     * @param lowercase-string $methodName Macro name lowercased. Used as the key into
+     *                                     {@see \Psalm\Storage\ClassLikeStorage::$pseudo_methods}
+     *                                     and `$pseudo_static_methods`, both of which Psalm
+     *                                     keys lowercase.
+     * @param string $casedName Original macro name as registered, preserving case. Used to
+     *                          populate {@see \Psalm\Storage\FunctionLikeStorage::$cased_name}
+     *                          which Psalm renders verbatim in diagnostics. Distinct from
+     *                          `$methodName` so error messages show `countCharsTest` rather
+     *                          than `countcharstest`.
+     * @param list<FunctionLikeParameter> $params Parameter list inferred from the closure.
+     * @param Union $returnType Return type for {@see \Psalm\Storage\FunctionLikeStorage::$return_type}.
+     *                          Defaults to `mixed` when the closure has no native return type.
+     * @param Union|null $signatureReturnType Return type for
+     *                          {@see \Psalm\Storage\FunctionLikeStorage::$signature_return_type}.
+     *                          `null` when the closure has no native return type — Psalm's
+     *                          convention is that `signature_return_type` is set ONLY for
+     *                          actual native PHP signatures, not for the docblock-derived
+     *                          `mixed` fallback. Conflating them would mis-report the
+     *                          synthesised method as having a native `mixed` signature.
+     *
+     * @psalm-external-mutation-free
+     * @psalm-mutation-free
+     */
+    public function __construct(
+        public readonly string $declaringClass,
+        public readonly string $methodName,
+        public readonly string $casedName,
+        public readonly array $params,
+        public readonly Union $returnType,
+        public readonly ?Union $signatureReturnType,
+    ) {}
+}

--- a/src/Providers/MacroRegistry.php
+++ b/src/Providers/MacroRegistry.php
@@ -121,7 +121,6 @@ final class MacroRegistry
             }
 
             try {
-                /** @var mixed $rawMacros */
                 $rawMacros = $macroProp->getValue();
             } catch (\Throwable $exception) {
                 // `getValue()` on a typed static property that is uninitialised throws
@@ -156,7 +155,7 @@ final class MacroRegistry
                 }
 
                 $def = self::buildDefinition($className, $name, $callable, $progress);
-                if ($def === null) {
+                if (!$def instanceof \Psalm\LaravelPlugin\Providers\MacroDefinition) {
                     continue;
                 }
 
@@ -253,7 +252,7 @@ final class MacroRegistry
         Progress $progress,
     ): ?MacroDefinition {
         $reflection = self::reflectCallable($callable, $declaringClass, $name, $progress);
-        if ($reflection === null) {
+        if (!$reflection instanceof \ReflectionFunctionAbstract) {
             return null;
         }
 
@@ -330,6 +329,7 @@ final class MacroRegistry
                 if (\count($parts) !== 2) {
                     return null;
                 }
+
                 [$cls, $method] = $parts;
                 if (\class_exists($cls) && \method_exists($cls, $method)) {
                     // String `'Class::method'` callables dispatch through PHP's
@@ -337,6 +337,7 @@ final class MacroRegistry
                     // A non-static target would error at runtime.
                     return self::ifPublicStatic(new \ReflectionMethod($cls, $method));
                 }
+
                 return null;
             }
 
@@ -357,20 +358,22 @@ final class MacroRegistry
                     // must be a static method, otherwise PHP will error at runtime.
                     return self::ifPublicStatic(new \ReflectionMethod($target, $methodName));
                 }
+
                 if (\is_object($target) && \method_exists($target, $methodName)) {
                     // Object array callable `[$obj, 'method']` works for both static
                     // and instance methods, so only the visibility check applies.
                     return self::ifPublic(new \ReflectionMethod($target, $methodName));
                 }
+
                 return null;
             }
 
             if (\is_object($callable) && \method_exists($callable, '__invoke')) {
                 return self::ifPublic(new \ReflectionMethod($callable, '__invoke'));
             }
-        } catch (\ReflectionException $exception) {
+        } catch (\ReflectionException $reflectionException) {
             $progress->warning(
-                "Laravel plugin: MacroRegistry could not reflect callable for {$declaringClass}::{$name}: {$exception->getMessage()}",
+                "Laravel plugin: MacroRegistry could not reflect callable for {$declaringClass}::{$name}: {$reflectionException->getMessage()}",
             );
         }
 
@@ -454,7 +457,7 @@ final class MacroRegistry
      */
     private static function reflectionTypeToUnion(?\ReflectionType $type, ?string $selfHostClass = null, ?string $staticHostClass = null): ?Union
     {
-        if ($type === null) {
+        if (!$type instanceof \ReflectionType) {
             return null;
         }
 
@@ -477,6 +480,7 @@ final class MacroRegistry
             if (!\str_contains($error->getMessage(), 'ProjectAnalyzer')) {
                 throw $error;
             }
+
             return null;
         }
     }

--- a/src/Providers/MacroRegistry.php
+++ b/src/Providers/MacroRegistry.php
@@ -1,0 +1,516 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Providers;
+
+use Psalm\Progress\Progress;
+use Psalm\Storage\FunctionLikeParameter;
+use Psalm\Type;
+use Psalm\Type\Union;
+
+/**
+ * Registry of macros discovered via runtime reflection of the booted Laravel app's
+ * `Macroable::$macros` static properties.
+ *
+ * Foundation for issue #758 (Strategy B). Populated from
+ * {@see \Psalm\LaravelPlugin\Handlers\Magic\MacroHandler::afterCodebasePopulated()}
+ * (NOT from `Plugin::__invoke`) because Psalm's `autoloader` config attribute fires
+ * during analyser setup — after plugin entry points but before `AfterCodebasePopulated`.
+ * Discovering at boot time would miss any macro registered in code reachable only
+ * through the autoloader (e.g. test fixtures, or — for the Testbench fallback path
+ * where the analysed package lacks a `bootstrap/app.php` — autoload-time service
+ * provider initialisation).
+ *
+ * The lifecycle therefore differs from {@see FacadeMapProvider}, which IS populated
+ * at plugin init: facades are registered by Laravel's bootstrap, which has run by
+ * then. Macros include user-app and test-time registrations that haven't.
+ *
+ * Coverage:
+ * - **App analysis** (`bootstrap/app.php` exists): catches macros registered by user
+ *   `App\Providers\*::boot()`, third-party packages auto-discovered via Laravel
+ *   package discovery, and any framework-internal macros (`Request::validate`,
+ *   `Request::hasValidSignature`, etc. registered by `FoundationServiceProvider`).
+ * - **Package analysis** (Testbench fallback): does not run the analysed package's
+ *   own provider — see issue #766. Strategy C (AST scan) will close that gap.
+ *
+ * Detection heuristic: a class is treated as Macroable-shaped if it has a static
+ * `$macros` property AND exposes one of `__call`, `__callStatic`, or `macro()`.
+ * This catches the `Macroable` trait users (Stringable, Str, Builder/Query, Request,
+ * etc.) and `\Illuminate\Database\Eloquent\Builder`, which declares its own
+ * `$macros` storage and dispatch methods without using the trait. Spurious matches
+ * are filtered downstream by the per-callable shape check in
+ * {@see self::reflectCallable()} and the real-method shadow check in
+ * {@see self::init()}.
+ *
+ * @internal
+ */
+final class MacroRegistry
+{
+    /**
+     * @var array<lowercase-string, array<lowercase-string, MacroDefinition>>
+     *      classFqcn (lower) => methodName (lower) => def
+     */
+    private static array $macros = [];
+
+    /** @var list<class-string> Macroable-shaped classes that have at least one resolved macro */
+    private static array $knownMacroableClasses = [];
+
+    /**
+     * Discover macros from every loaded class with a static `$macros` array property.
+     *
+     * Reads the property via `ReflectionProperty::getValue()` directly. Since PHP 8.1,
+     * `ReflectionProperty` has been accessible by default — no `setAccessible(true)`
+     * call needed for the protected `Macroable::$macros` storage. Closures that fail
+     * to resolve (e.g. closure was bound to a since-unloaded class) are silently
+     * skipped to keep one bad macro from disabling the rest.
+     *
+     * Filter order is performance-sensitive: `get_declared_classes()` returns the
+     * full PHP runtime class table (10k+ entries on a real Laravel app). We start
+     * with the cheapest possible reject (`hasProperty('macros')`) and only progress
+     * to the more expensive checks for the small surviving set.
+     *
+     * Idempotent: reruns reset state. Tests rely on this for isolation.
+     */
+    public static function init(Progress $progress): void
+    {
+        self::$macros = [];
+        self::$knownMacroableClasses = [];
+
+        foreach (\get_declared_classes() as $className) {
+            try {
+                $reflection = new \ReflectionClass($className);
+            } catch (\ReflectionException) {
+                continue;
+            }
+
+            // Cheapest reject first — O(1) hash probe against PHP's resolved class
+            // info, which already includes inherited properties (so this also fires
+            // for any subclass of a Macroable-trait user).
+            if (!$reflection->hasProperty('macros')) {
+                continue;
+            }
+
+            $macroProp = $reflection->getProperty('macros');
+            if (!$macroProp->isStatic()) {
+                continue;
+            }
+
+            // Subclass entries inherit the parent's storage. Only register against the
+            // class that DECLARES the property — otherwise we'd record the same macro
+            // dozens of times (once per descendant). The handler propagates pseudo-
+            // methods to descendants explicitly so this isn't a coverage loss.
+            // Performance bonus: this filter runs BEFORE getValue(), avoiding the
+            // costly read on every analysed subclass of a Macroable parent.
+            $declaringClass = $macroProp->getDeclaringClass()->getName();
+            if ($declaringClass !== $className) {
+                continue;
+            }
+
+            // Tighten the heuristic: a class with a static `$macros` array is treated
+            // as Macroable-shaped only if it also exposes a runtime dispatch surface
+            // (`__call` / `__callStatic` / a static `macro()` method). This avoids
+            // false positives for unrelated classes that happen to declare a `$macros`
+            // static property for their own purposes.
+            if (
+                !$reflection->hasMethod('__call')
+                && !$reflection->hasMethod('__callStatic')
+                && !$reflection->hasMethod('macro')
+            ) {
+                continue;
+            }
+
+            try {
+                /** @var mixed $rawMacros */
+                $rawMacros = $macroProp->getValue();
+            } catch (\Throwable $exception) {
+                // `getValue()` on a typed static property that is uninitialised throws
+                // `\Error`, not `ReflectionException`. Catch broadly so a single bad
+                // class — including one whose static initialiser throws — cannot
+                // abort discovery for the rest.
+                $progress->warning(
+                    "Laravel plugin: MacroRegistry could not read \$macros on {$className}: {$exception->getMessage()}",
+                );
+                continue;
+            }
+
+            if (!\is_array($rawMacros) || $rawMacros === []) {
+                continue;
+            }
+
+            $classMacros = [];
+            /** @var mixed $callable */
+            foreach ($rawMacros as $name => $callable) {
+                if (!\is_string($name) || $name === '') {
+                    continue;
+                }
+
+                // Skip macros whose name shadows a real method on the class.
+                // PHP's method resolution checks declared methods before falling through
+                // to __call, so the macro is unreachable at runtime — the real method
+                // wins. The handler that injects pseudo-methods also guards against this
+                // (a real `methods[$name]` entry blocks the pseudo-method write), but
+                // filtering here keeps the registry honest about what's actually callable.
+                if ($reflection->hasMethod($name)) {
+                    continue;
+                }
+
+                $def = self::buildDefinition($className, $name, $callable, $progress);
+                if ($def === null) {
+                    continue;
+                }
+
+                $classMacros[\strtolower($name)] = $def;
+            }
+
+            if ($classMacros === []) {
+                continue;
+            }
+
+            self::$macros[\strtolower($className)] = $classMacros;
+            self::$knownMacroableClasses[] = $className;
+        }
+    }
+
+    /**
+     * All macros registered on the given Macroable class.
+     *
+     * @return array<lowercase-string, MacroDefinition>
+     * @psalm-external-mutation-free
+     */
+    public static function for(string $fqcn): array
+    {
+        return self::$macros[\strtolower($fqcn)] ?? [];
+    }
+
+    /**
+     * Single macro by class + method name, or `null` if not registered.
+     *
+     * @psalm-api Used by unit tests and any handler that needs to look up a single macro
+     *            without enumerating the whole class. The handler currently uses {@see self::for()}.
+     * @psalm-external-mutation-free
+     */
+    public static function get(string $fqcn, string $methodName): ?MacroDefinition
+    {
+        return self::$macros[\strtolower($fqcn)][\strtolower($methodName)] ?? null;
+    }
+
+    /**
+     * @return list<class-string> Macroable-shaped classes that have at least one macro
+     * @psalm-external-mutation-free
+     */
+    public static function getKnownMacroableClasses(): array
+    {
+        return self::$knownMacroableClasses;
+    }
+
+    /**
+     * Test seam: replace the registry contents in tests without going through {@see init()}.
+     *
+     * @param array<lowercase-string, array<lowercase-string, MacroDefinition>> $macros
+     * @param list<class-string> $knownMacroableClasses
+     * @psalm-api Tests only.
+     * @psalm-external-mutation-free
+     */
+    public static function overrideForTesting(array $macros, array $knownMacroableClasses): void
+    {
+        self::$macros = $macros;
+        self::$knownMacroableClasses = $knownMacroableClasses;
+    }
+
+    /**
+     * Reset registry to empty state. Tests use this to isolate runs.
+     *
+     * @psalm-api Tests only.
+     * @psalm-external-mutation-free
+     */
+    public static function reset(): void
+    {
+        self::$macros = [];
+        self::$knownMacroableClasses = [];
+    }
+
+    /**
+     * Build a {@see MacroDefinition} from a registered callable.
+     *
+     * Handles every callable shape Laravel's `Macroable::__call` dispatches:
+     *
+     * - `Closure` (the common case)
+     * - String `'ClassName::method'` — reflected as a static method
+     * - String `'function_name'` — reflected as a function
+     * - Array `[ClassName::class, 'method']` or `[$obj, 'method']` — reflected as a method
+     * - Invokable object (any object with `__invoke`) — reflected as `__invoke`
+     *
+     * Each shape is reduced to a `\ReflectionFunctionAbstract` and the same param /
+     * return-type extraction runs.
+     *
+     * @param class-string $declaringClass
+     */
+    private static function buildDefinition(
+        string $declaringClass,
+        string $name,
+        mixed $callable,
+        Progress $progress,
+    ): ?MacroDefinition {
+        $reflection = self::reflectCallable($callable, $declaringClass, $name, $progress);
+        if ($reflection === null) {
+            return null;
+        }
+
+        // Native `self`/`static`/`parent` references in a `\ReflectionMethod`'s signature
+        // resolve relative to the method's class, not the Macroable host. We expand them
+        // before parsing.
+        //
+        // - `self` and `parent` always resolve to the method's *declaring* class / its parent.
+        // - `static` is late-static-binding. For an object callable `[$obj, 'method']` it
+        //   refers to the runtime class of `$obj`, which can be a subclass of the declaring
+        //   class. The conservative-but-correct approximation is `get_class($obj)`. For
+        //   `[Class::class, 'method']` and `'Class::method'` string callables there's no
+        //   instance to bind to, so `static` collapses to the declaring class.
+        $selfHostClass = null;
+        $staticHostClass = null;
+        if ($reflection instanceof \ReflectionMethod) {
+            $selfHostClass = $reflection->getDeclaringClass()->getName();
+            $staticHostClass = $selfHostClass;
+            if (\is_array($callable) && isset($callable[0]) && \is_object($callable[0])) {
+                $staticHostClass = \get_class($callable[0]);
+            } elseif (\is_object($callable) && !$callable instanceof \Closure) {
+                $staticHostClass = \get_class($callable);
+            }
+        }
+
+        $params = [];
+        foreach ($reflection->getParameters() as $reflParam) {
+            $params[] = self::buildParameter($reflParam, $selfHostClass, $staticHostClass);
+        }
+
+        // `$nativeReturnType === null` is "callable declared no native return type", which is
+        // distinct from "declared `mixed`". The former leaves `signature_return_type`
+        // null per Psalm convention; the latter would set it to a real Union.
+        $nativeReturnType = self::reflectionTypeToUnion($reflection->getReturnType(), $selfHostClass, $staticHostClass);
+
+        return new MacroDefinition(
+            declaringClass: $declaringClass,
+            methodName: \strtolower($name),
+            casedName: $name,
+            params: $params,
+            returnType: $nativeReturnType ?? Type::getMixed(),
+            signatureReturnType: $nativeReturnType,
+        );
+    }
+
+    /**
+     * Resolve a registered macro callable to a `\ReflectionFunctionAbstract` we
+     * can extract param + return types from. Handled shapes:
+     *
+     * - `Closure` → `ReflectionFunction`
+     * - String `'Class::method'` → `ReflectionMethod` (must be public)
+     * - String `'function_name'` (`function_exists` returns true) → `ReflectionFunction`
+     * - Array `[Class, 'method']` / `[$obj, 'method']` → `ReflectionMethod` (must be public)
+     * - Object with `__invoke` → `ReflectionMethod` for `__invoke` (must be public)
+     *
+     * Returns `null` for opaque objects without `__invoke`, callable arrays whose first
+     * element doesn't resolve to a class/object, or methods that fail the visibility check.
+     *
+     * @param class-string $declaringClass for diagnostic messages only
+     */
+    private static function reflectCallable(
+        mixed $callable,
+        string $declaringClass,
+        string $name,
+        Progress $progress,
+    ): ?\ReflectionFunctionAbstract {
+        try {
+            if ($callable instanceof \Closure) {
+                return new \ReflectionFunction($callable);
+            }
+
+            if (\is_string($callable) && \str_contains($callable, '::')) {
+                $parts = \explode('::', $callable, 2);
+                if (\count($parts) !== 2) {
+                    return null;
+                }
+                [$cls, $method] = $parts;
+                if (\class_exists($cls) && \method_exists($cls, $method)) {
+                    // String `'Class::method'` callables dispatch through PHP's
+                    // class-string handler, which only resolves to *static* methods.
+                    // A non-static target would error at runtime.
+                    return self::ifPublicStatic(new \ReflectionMethod($cls, $method));
+                }
+                return null;
+            }
+
+            if (\is_string($callable) && \function_exists($callable)) {
+                // Plain function-name callable, e.g. `Stringable::macro('upper', 'strtoupper')`.
+                // Macroable dispatches these through PHP's variable-function mechanism; the
+                // function's reflected signature is what callers see.
+                return new \ReflectionFunction($callable);
+            }
+
+            if (\is_array($callable) && isset($callable[0], $callable[1]) && \is_string($callable[1])) {
+                /** @var mixed $target */
+                $target = $callable[0];
+                $methodName = $callable[1];
+                if (\is_string($target) && \class_exists($target) && \method_exists($target, $methodName)) {
+                    // Class-string array callable `[ClassName::class, 'method']` —
+                    // same constraint as the `'Class::method'` string form: the target
+                    // must be a static method, otherwise PHP will error at runtime.
+                    return self::ifPublicStatic(new \ReflectionMethod($target, $methodName));
+                }
+                if (\is_object($target) && \method_exists($target, $methodName)) {
+                    // Object array callable `[$obj, 'method']` works for both static
+                    // and instance methods, so only the visibility check applies.
+                    return self::ifPublic(new \ReflectionMethod($target, $methodName));
+                }
+                return null;
+            }
+
+            if (\is_object($callable) && \method_exists($callable, '__invoke')) {
+                return self::ifPublic(new \ReflectionMethod($callable, '__invoke'));
+            }
+        } catch (\ReflectionException $exception) {
+            $progress->warning(
+                "Laravel plugin: MacroRegistry could not reflect callable for {$declaringClass}::{$name}: {$exception->getMessage()}",
+            );
+        }
+
+        return null;
+    }
+
+    /**
+     * Reject non-public methods. Macroable's `__call` invokes the registered callable
+     * from outside the target class's scope, so a protected/private method would throw
+     * `Error: Call to (protected|private) method` at runtime — synthesising a pseudo-
+     * method for it would be a false positive.
+     */
+    private static function ifPublic(\ReflectionMethod $method): ?\ReflectionMethod
+    {
+        return $method->isPublic() ? $method : null;
+    }
+
+    /**
+     * Reject methods that aren't both public AND static. For class-string callable
+     * forms (`'Class::method'` and `[Class::class, 'method']`), PHP only dispatches
+     * to static methods — calling a non-static target this way errors at runtime,
+     * so the macro is unreachable.
+     */
+    private static function ifPublicStatic(\ReflectionMethod $method): ?\ReflectionMethod
+    {
+        return ($method->isPublic() && $method->isStatic()) ? $method : null;
+    }
+
+    /**
+     * @param class-string|null $selfHostClass The method's declaring class (binds `self`,
+     *                                          `parent`). Null for free functions and Closures.
+     * @param class-string|null $staticHostClass The class `static` should expand to: for
+     *                                            object callables, `get_class($obj)`; otherwise
+     *                                            same as `$selfHostClass`. Null for free
+     *                                            functions and Closures.
+     */
+    private static function buildParameter(\ReflectionParameter $reflParam, ?string $selfHostClass, ?string $staticHostClass): FunctionLikeParameter
+    {
+        $reflType = $reflParam->getType();
+        $type = self::reflectionTypeToUnion($reflType, $selfHostClass, $staticHostClass);
+
+        return new FunctionLikeParameter(
+            name: $reflParam->getName(),
+            by_ref: $reflParam->isPassedByReference(),
+            type: $type,
+            signature_type: $type,
+            is_optional: $reflParam->isOptional() || $reflParam->isDefaultValueAvailable(),
+            // `allowsNull()` covers both `?string` syntax and `string|null` unions, and
+            // is more reliable than asking the parsed Union — Psalm's parseString of
+            // `?string` does not always set the nullable flag the way we'd expect.
+            is_nullable: $reflType?->allowsNull() ?? false,
+            is_variadic: $reflParam->isVariadic(),
+        );
+    }
+
+    /**
+     * Convert PHP's reflected type to a Psalm Union, or `null` when the callable declared none.
+     *
+     * Uses the type's string form (`int|null`, `\App\Foo`, `?array`) as the parse input —
+     * Psalm's parser accepts the same surface as PHP. When `$methodHostClass` is set, the
+     * resolved string also has `self`/`static`/`parent` references expanded to concrete
+     * FQCNs against that host (otherwise `Foo::method(): self` would surface as the literal
+     * `self`, which Psalm reads relative to the *call site*, not the method).
+     *
+     * Two failure modes are anticipated:
+     *
+     * - `TypeParseTreeException` — genuinely un-parseable input (rare; reflection emits
+     *   well-formed PHP type strings). Swallow and degrade to `null` so a single bad type
+     *   does not poison the registry.
+     * - `\Error` from `ProjectAnalyzer::getInstance()` — `parseString` reaches for the
+     *   project analyzer when expanding union/nullable types. In a unit-test context the
+     *   analyzer is not initialised, which is fine — we skip and let test-only constructions
+     *   carry on. In a real Psalm run the analyzer always exists, so this branch never
+     *   fires in production.
+     *
+     * Engine-level errors outside those two paths (TypeError, AssertionError, etc.) are
+     * left to propagate so genuine Psalm bugs aren't silently masked.
+     *
+     * @param class-string|null $selfHostClass
+     * @param class-string|null $staticHostClass
+     */
+    private static function reflectionTypeToUnion(?\ReflectionType $type, ?string $selfHostClass = null, ?string $staticHostClass = null): ?Union
+    {
+        if ($type === null) {
+            return null;
+        }
+
+        $typeString = (string) $type;
+        if ($typeString === '') {
+            return null;
+        }
+
+        if ($selfHostClass !== null) {
+            $typeString = self::expandSelfStaticParent($typeString, $selfHostClass, $staticHostClass ?? $selfHostClass);
+        }
+
+        try {
+            return Type::parseString($typeString);
+        } catch (\Psalm\Exception\TypeParseTreeException) {
+            return null;
+        } catch (\Error $error) {
+            // Only the specific "ProjectAnalyzer not initialised" path is benign.
+            // Anything else is a real bug — re-throw.
+            if (!\str_contains($error->getMessage(), 'ProjectAnalyzer')) {
+                throw $error;
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Replace `self`/`static`/`parent` tokens in a reflected type string with concrete
+     * FQCNs. `self` and `parent` resolve against the method's *declaring* class
+     * (`$selfHostClass`); `static` resolves against `$staticHostClass`, which is
+     * `get_class($obj)` for object callables and `$selfHostClass` otherwise. Operates
+     * on word boundaries to avoid clobbering `self` substrings inside other identifiers
+     * (e.g. `Selfish`, `MyParentObserver`).
+     *
+     * @param class-string $selfHostClass
+     * @param class-string $staticHostClass
+     * @psalm-pure
+     */
+    private static function expandSelfStaticParent(string $typeString, string $selfHostClass, string $staticHostClass): string
+    {
+        $parent = null;
+        try {
+            $parent = (new \ReflectionClass($selfHostClass))->getParentClass();
+        } catch (\ReflectionException) {
+            // Leave $parent null — `parent` references stay literal and parser may reject
+            // them, returning null Union, which is the same conservative outcome.
+        }
+
+        $replacements = [
+            '/\bself\b/' => '\\' . $selfHostClass,
+            '/\bstatic\b/' => '\\' . $staticHostClass,
+        ];
+        if ($parent instanceof \ReflectionClass) {
+            $replacements['/\bparent\b/'] = '\\' . $parent->getName();
+        }
+
+        return \preg_replace(\array_keys($replacements), \array_values($replacements), $typeString) ?? $typeString;
+    }
+}

--- a/tests/Type/macro-fixtures-class.phpstub
+++ b/tests/Type/macro-fixtures-class.phpstub
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Stub-only declaration of the macro test fixture classes. Loaded via psalm.xml
+ * `<stubs>` so Psalm knows these classes exist. Macros are registered at runtime
+ * by `tests/Type/macro-fixtures.php` (the `autoloader` attribute), and the plugin
+ * reads them during `AfterCodebasePopulated`.
+ *
+ * Kept separate from the autoloader file so Psalm doesn't try to parse the
+ * top-level `MacroFixtureBag::macro(...)` calls as analysis input.
+ *
+ * Two classes:
+ * - `MacroFixtureBag`: directly uses `Macroable`. Anchor for macro tests.
+ * - `MacroFixtureChild`: extends `MacroFixtureBag` without redeclaring `Macroable`.
+ *   Anchor for subclass-dispatch tests — macros registered on `MacroFixtureBag`
+ *   must be visible on `MacroFixtureChild` too (Psalm's `MissingMethodCallHandler`
+ *   does not walk `parent_classes` natively, so `MacroHandler` propagates the
+ *   pseudo-methods explicitly).
+ */
+
+namespace Tests\Psalm\LaravelPlugin\Type\Fixtures;
+
+use Illuminate\Support\Traits\Macroable;
+
+class MacroFixtureBag
+{
+    use Macroable;
+}
+
+final class MacroFixtureChild extends MacroFixtureBag
+{
+}

--- a/tests/Type/macro-fixtures.php
+++ b/tests/Type/macro-fixtures.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Loaded via the `autoloader` attribute in psalm.xml. Registers macros on the
+ * test fixture class at runtime so they appear in `Macroable::$macros` by the
+ * time the plugin's `AfterCodebasePopulated` handler reads it.
+ *
+ * The fixture class itself lives in `macro-fixtures-class.phpstub` (loaded as a
+ * stub) so Psalm's normal type analysis sees it without parsing the runtime
+ * macro registration calls below.
+ *
+ * Stands in for what a real Laravel app would do via
+ * `App\Providers\AppServiceProvider::boot()`.
+ *
+ * Macros are registered on a dedicated fixture class rather than on framework
+ * classes like `Stringable` because the `autoloader` attribute force-loads any
+ * referenced class ahead of Psalm's normal scan order, which alters Psalm's
+ * argument-count diagnostics for unrelated framework methods (observed
+ * regression against `Stringable::trim`/`ltrim`/`rtrim`).
+ */
+
+require_once __DIR__ . '/macro-fixtures-class.phpstub';
+
+use Illuminate\Database\Eloquent\Builder;
+use Tests\Psalm\LaravelPlugin\Type\Fixtures\MacroFixtureBag;
+
+MacroFixtureBag::macro('shoutTest', static fn(): string => 'OK');
+MacroFixtureBag::macro('countCharsTest', static fn(string $needle): int => 0);
+
+// Locks in coverage for the issue #648 motivating case: a Builder macro
+// registered at runtime should resolve when reached through the typed
+// `Customer::query()->testBuilderMacro()` path. Builder is a Macroable owner,
+// so its pseudo-methods land on Builder itself and any Builder<TModel> call
+// site dispatches to them normally.
+Builder::macro('testBuilderMacro', static fn(): string => 'builder macro OK');

--- a/tests/Type/psalm.xml
+++ b/tests/Type/psalm.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <psalm
+    autoloader="./macro-fixtures.php"
     disableSuppressAll="true"
     ensureArrayStringOffsetsExist="true"
     errorLevel="1"
@@ -20,6 +21,15 @@
             <resolveDynamicWhereClauses value="true" />
         </pluginClass>
     </plugins>
+    <stubs>
+        <!-- Fixture class declaration consumed by tests/Type/tests/Macros/*.phpt.
+             The runtime macro registrations live in ./macro-fixtures.php (loaded as
+             the `autoloader` attribute), and that file `require_once`s this `.phpstub`
+             file so reflection sees the class. The stub entry here is what makes
+             Psalm's scan phase aware of the class without parsing the autoloader's
+             top-level macro registration calls. -->
+        <file name="./macro-fixtures-class.phpstub" />
+    </stubs>
     <issueHandlers>
         <MissingPureAnnotation errorLevel="info" />
         <!-- NoEnvOutsideConfig is a linting rule, not a type issue. psalm-tester runs

--- a/tests/Type/tests/Macros/BuilderMacroTest.phpt
+++ b/tests/Type/tests/Macros/BuilderMacroTest.phpt
@@ -1,0 +1,48 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Issue #648 regression — Builder macros registered via `Builder::macro(...)`
+ * resolve when called through the typed query chain on a Model.
+ *
+ * The macro `testBuilderMacro` is registered in tests/Type/macro-fixtures.php.
+ * It returns `string`, so `Customer::query()->testBuilderMacro()` must narrow
+ * to `string`. Because Builder is a direct Macroable owner, the pseudo-methods
+ * land on Builder itself and any Builder<TModel> call site dispatches to them
+ * via normal method resolution.
+ */
+
+function test_builder_macro_resolves_via_query(): string
+{
+    $_ = Customer::query()->testBuilderMacro();
+    /** @psalm-check-type-exact $_ = string */
+    return $_;
+}
+
+/**
+ * @param Builder<Customer> $builder
+ */
+function test_builder_macro_resolves_on_explicit_builder_param(Builder $builder): string
+{
+    $_ = $builder->testBuilderMacro();
+    /** @psalm-check-type-exact $_ = string */
+    return $_;
+}
+
+/**
+ * Issue #648 — relation chain dispatch. `Customer::vehicles()` returns
+ * `HasMany<Vehicle, Customer>`, which forwards `__call` to its underlying Builder
+ * via the plugin's MethodForwardingHandler. Builder's macro must resolve
+ * through that chain.
+ */
+function test_builder_macro_resolves_through_relation_chain(Customer $customer): string
+{
+    $_ = $customer->vehicles()->testBuilderMacro();
+    /** @psalm-check-type-exact $_ = string */
+    return $_;
+}
+?>
+--EXPECT--

--- a/tests/Type/tests/Macros/MacroDispatchTest.phpt
+++ b/tests/Type/tests/Macros/MacroDispatchTest.phpt
@@ -1,0 +1,68 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Tests\Psalm\LaravelPlugin\Type\Fixtures\MacroFixtureBag;
+use Tests\Psalm\LaravelPlugin\Type\Fixtures\MacroFixtureChild;
+
+/**
+ * Foundation tests for issue #758 (Strategy B — runtime reflection).
+ *
+ * Macros are registered in tests/Type/macro-fixtures.php on `MacroFixtureBag`.
+ * The fixture is loaded via the `autoloader` attribute in tests/Type/psalm.xml
+ * so the registrations are visible by the time the plugin's
+ * `AfterCodebasePopulated` handler reads `Macroable::$macros`.
+ *
+ * Registering on a fixture class (rather than on `Illuminate\Support\Stringable`
+ * or another framework class) sidesteps a Psalm `autoloader`-attribute quirk
+ * where force-loading a framework class via the autoloader alters Psalm's
+ * argument-count diagnostics for unrelated methods on that class.
+ */
+
+function test_instance_macro_return_type(): string
+{
+    $_ = (new MacroFixtureBag())->shoutTest();
+    /** @psalm-check-type-exact $_ = string */
+    return $_;
+}
+
+function test_instance_macro_param_signature(): int
+{
+    return (new MacroFixtureBag())->countCharsTest('needle');
+}
+
+function test_static_macro_return_type(): string
+{
+    // Macroable defines __callStatic too; the handler injects each macro into
+    // both pseudo_methods AND pseudo_static_methods so both call shapes work.
+    $_ = MacroFixtureBag::shoutTest();
+    /** @psalm-check-type-exact $_ = string */
+    return $_;
+}
+
+function test_subclass_inherits_parent_macros_instance_call(): string
+{
+    // MacroFixtureChild extends MacroFixtureBag. Psalm's instance-call dispatch
+    // does NOT walk parent_classes for pseudo-methods, so MacroHandler must
+    // explicitly propagate the pseudo-methods to descendants.
+    $_ = (new MacroFixtureChild())->shoutTest();
+    /** @psalm-check-type-exact $_ = string */
+    return $_;
+}
+
+function test_subclass_inherits_parent_macros_static_call(): string
+{
+    $_ = MacroFixtureChild::shoutTest();
+    /** @psalm-check-type-exact $_ = string */
+    return $_;
+}
+
+function test_macro_param_signature_rejects_wrong_argument_type(): int
+{
+    // Invalid arg type surfaces the macro's params provider — the diagnostic
+    // also confirms `cased_name` preserves the original casing (`countCharsTest`,
+    // not `countcharstest`).
+    return (new MacroFixtureBag())->countCharsTest(42);
+}
+?>
+--EXPECTF--
+InvalidArgument on line %d: Argument 1 of countCharsTest expects string, but 42 provided

--- a/tests/Unit/Providers/MacroRegistryTest.php
+++ b/tests/Unit/Providers/MacroRegistryTest.php
@@ -43,12 +43,12 @@ final class MacroRegistryTest extends TestCase
         MacroRegistry::init(new VoidProgress());
 
         $def = MacroRegistry::get(Stringable::class, 'shout');
-        self::assertNotNull($def);
-        self::assertSame(Stringable::class, $def->declaringClass);
-        self::assertSame('shout', $def->methodName);
-        self::assertSame('shout', $def->casedName);
-        self::assertSame([], $def->params);
-        self::assertSame('string', $def->returnType->getId());
+        $this->assertNotNull($def);
+        $this->assertSame(Stringable::class, $def->declaringClass);
+        $this->assertSame('shout', $def->methodName);
+        $this->assertSame('shout', $def->casedName);
+        $this->assertSame([], $def->params);
+        $this->assertSame('string', $def->returnType->getId());
     }
 
     #[Test]
@@ -61,9 +61,9 @@ final class MacroRegistryTest extends TestCase
         MacroRegistry::init(new VoidProgress());
 
         $def = MacroRegistry::get(Stringable::class, 'countcharstest');
-        self::assertNotNull($def);
-        self::assertSame('countcharstest', $def->methodName);
-        self::assertSame('countCharsTest', $def->casedName);
+        $this->assertNotNull($def);
+        $this->assertSame('countcharstest', $def->methodName);
+        $this->assertSame('countCharsTest', $def->casedName);
     }
 
     #[Test]
@@ -77,7 +77,7 @@ final class MacroRegistryTest extends TestCase
 
         MacroRegistry::init(new VoidProgress());
 
-        self::assertNull(MacroRegistry::get(Stringable::class, 'value'));
+        $this->assertNull(MacroRegistry::get(Stringable::class, 'value'));
     }
 
     #[Test]
@@ -88,8 +88,8 @@ final class MacroRegistryTest extends TestCase
         MacroRegistry::init(new VoidProgress());
 
         // Method name is lower-cased on storage AND on lookup.
-        self::assertNotNull(MacroRegistry::get(Stringable::class, 'camelcased'));
-        self::assertNotNull(MacroRegistry::get(Stringable::class, 'CAMELCASED'));
+        $this->assertNotNull(MacroRegistry::get(Stringable::class, 'camelcased'));
+        $this->assertNotNull(MacroRegistry::get(Stringable::class, 'CAMELCASED'));
     }
 
     #[Test]
@@ -100,8 +100,8 @@ final class MacroRegistryTest extends TestCase
         MacroRegistry::init(new VoidProgress());
 
         // Psalm passes class FQCNs through verbatim; underlying storage is lower-cased.
-        self::assertNotNull(MacroRegistry::get(Stringable::class, 'foo'));
-        self::assertNotNull(MacroRegistry::get(\strtoupper(Stringable::class), 'foo'));
+        $this->assertNotNull(MacroRegistry::get(Stringable::class, 'foo'));
+        $this->assertNotNull(MacroRegistry::get(\strtoupper(Stringable::class), 'foo'));
     }
 
     #[Test]
@@ -112,16 +112,16 @@ final class MacroRegistryTest extends TestCase
         MacroRegistry::init(new VoidProgress());
 
         $def = MacroRegistry::get(Stringable::class, 'joined');
-        self::assertNotNull($def);
-        self::assertCount(2, $def->params);
+        $this->assertNotNull($def);
+        $this->assertCount(2, $def->params);
 
-        self::assertSame('separator', $def->params[0]->name);
-        self::assertSame('string', $def->params[0]->type?->getId());
-        self::assertFalse($def->params[0]->is_optional);
+        $this->assertSame('separator', $def->params[0]->name);
+        $this->assertSame('string', $def->params[0]->type?->getId());
+        $this->assertFalse($def->params[0]->is_optional);
 
-        self::assertSame('count', $def->params[1]->name);
-        self::assertSame('int', $def->params[1]->type?->getId());
-        self::assertTrue($def->params[1]->is_optional);
+        $this->assertSame('count', $def->params[1]->name);
+        $this->assertSame('int', $def->params[1]->type?->getId());
+        $this->assertTrue($def->params[1]->is_optional);
     }
 
     #[Test]
@@ -132,9 +132,9 @@ final class MacroRegistryTest extends TestCase
         MacroRegistry::init(new VoidProgress());
 
         $def = MacroRegistry::get(Stringable::class, 'byref');
-        self::assertNotNull($def);
-        self::assertCount(1, $def->params);
-        self::assertTrue($def->params[0]->by_ref);
+        $this->assertNotNull($def);
+        $this->assertCount(1, $def->params);
+        $this->assertTrue($def->params[0]->by_ref);
     }
 
     #[Test]
@@ -147,10 +147,10 @@ final class MacroRegistryTest extends TestCase
         MacroRegistry::init(new VoidProgress());
 
         $def = MacroRegistry::get(Stringable::class, 'viaarraycallable');
-        self::assertNotNull($def);
-        self::assertCount(1, $def->params);
-        self::assertSame('input', $def->params[0]->name);
-        self::assertSame('string', $def->signatureReturnType?->getId());
+        $this->assertNotNull($def);
+        $this->assertCount(1, $def->params);
+        $this->assertSame('input', $def->params[0]->name);
+        $this->assertSame('string', $def->signatureReturnType?->getId());
     }
 
     #[Test]
@@ -162,9 +162,9 @@ final class MacroRegistryTest extends TestCase
         MacroRegistry::init(new VoidProgress());
 
         $def = MacroRegistry::get(Stringable::class, 'viastringcallable');
-        self::assertNotNull($def);
-        self::assertCount(1, $def->params);
-        self::assertSame('string', $def->signatureReturnType?->getId());
+        $this->assertNotNull($def);
+        $this->assertCount(1, $def->params);
+        $this->assertSame('string', $def->signatureReturnType?->getId());
     }
 
     #[Test]
@@ -176,10 +176,10 @@ final class MacroRegistryTest extends TestCase
         MacroRegistry::init(new VoidProgress());
 
         $def = MacroRegistry::get(Stringable::class, 'viainvokable');
-        self::assertNotNull($def);
-        self::assertCount(1, $def->params);
-        self::assertSame('count', $def->params[0]->name);
-        self::assertSame('int', $def->signatureReturnType?->getId());
+        $this->assertNotNull($def);
+        $this->assertCount(1, $def->params);
+        $this->assertSame('count', $def->params[0]->name);
+        $this->assertSame('int', $def->signatureReturnType?->getId());
     }
 
     #[Test]
@@ -192,9 +192,9 @@ final class MacroRegistryTest extends TestCase
         MacroRegistry::init(new VoidProgress());
 
         $def = MacroRegistry::get(Stringable::class, 'viafunctionname');
-        self::assertNotNull($def);
-        self::assertCount(1, $def->params);
-        self::assertSame('string', $def->params[0]->name);
+        $this->assertNotNull($def);
+        $this->assertCount(1, $def->params);
+        $this->assertSame('string', $def->params[0]->name);
     }
 
     #[Test]
@@ -207,7 +207,7 @@ final class MacroRegistryTest extends TestCase
 
         MacroRegistry::init(new VoidProgress());
 
-        self::assertNull(MacroRegistry::get(Stringable::class, 'viaprotected'));
+        $this->assertNull(MacroRegistry::get(Stringable::class, 'viaprotected'));
     }
 
     #[Test]
@@ -221,8 +221,8 @@ final class MacroRegistryTest extends TestCase
 
         MacroRegistry::init(new VoidProgress());
 
-        self::assertNull(MacroRegistry::get(Stringable::class, 'viainstancearr'));
-        self::assertNull(MacroRegistry::get(Stringable::class, 'viainstancestr'));
+        $this->assertNull(MacroRegistry::get(Stringable::class, 'viainstancearr'));
+        $this->assertNull(MacroRegistry::get(Stringable::class, 'viainstancestr'));
     }
 
     #[Test]
@@ -235,7 +235,7 @@ final class MacroRegistryTest extends TestCase
         MacroRegistry::init(new VoidProgress());
 
         $def = MacroRegistry::get(Stringable::class, 'viainstanceobj');
-        self::assertNotNull($def);
+        $this->assertNotNull($def);
     }
 
     #[Test]
@@ -248,11 +248,11 @@ final class MacroRegistryTest extends TestCase
         MacroRegistry::init(new VoidProgress());
 
         $def = MacroRegistry::get(Stringable::class, 'viaselfreturn');
-        self::assertNotNull($def);
-        self::assertNotNull($def->signatureReturnType);
+        $this->assertNotNull($def);
+        $this->assertNotNull($def->signatureReturnType);
         // Should resolve to MacroSelfReturnFixture, NOT the literal `self` (which Psalm
         // would otherwise interpret relative to the call site = Stringable).
-        self::assertSame(\strtolower(MacroSelfReturnFixture::class), \strtolower($def->signatureReturnType->getId()));
+        $this->assertSame(\strtolower(MacroSelfReturnFixture::class), \strtolower($def->signatureReturnType->getId()));
     }
 
     #[Test]
@@ -263,15 +263,15 @@ final class MacroRegistryTest extends TestCase
         // return types varies between patch versions (8.4.20 returns null, 8.4.21
         // surfaces an inferred type), so this asserts only the universal invariant:
         // discovery must produce SOME definition, and `returnType` must be a valid Union.
-        Stringable::macro('reflectionDiscovery', static function () {
+        Stringable::macro('reflectionDiscovery', static function (): int {
             return 1;
         });
 
         MacroRegistry::init(new VoidProgress());
 
         $def = MacroRegistry::get(Stringable::class, 'reflectiondiscovery');
-        self::assertNotNull($def);
-        self::assertNotNull($def->returnType);
+        $this->assertNotNull($def);
+        $this->assertNotNull($def->returnType);
         // Either the closure declared no return type → mixed, or PHP inferred one → that.
         // Both are correct outcomes of buildDefinition; we only require a Union to be present.
     }
@@ -284,9 +284,9 @@ final class MacroRegistryTest extends TestCase
         MacroRegistry::init(new VoidProgress());
 
         $def = MacroRegistry::get(Stringable::class, 'varargs');
-        self::assertNotNull($def);
-        self::assertCount(1, $def->params);
-        self::assertTrue($def->params[0]->is_variadic);
+        $this->assertNotNull($def);
+        $this->assertCount(1, $def->params);
+        $this->assertTrue($def->params[0]->is_variadic);
     }
 
     #[Test]
@@ -297,11 +297,11 @@ final class MacroRegistryTest extends TestCase
         MacroRegistry::init(new VoidProgress());
 
         $def = MacroRegistry::get(Stringable::class, 'maybenull');
-        self::assertNotNull($def);
+        $this->assertNotNull($def);
         // is_nullable comes straight from ReflectionParameter::allowsNull() — independent
         // of Psalm's parseString, which needs ProjectAnalyzer::$instance (only set during
         // a real Psalm run, not in the unit-test bootstrap).
-        self::assertTrue($def->params[0]->is_nullable);
+        $this->assertTrue($def->params[0]->is_nullable);
     }
 
     #[Test]
@@ -310,12 +310,12 @@ final class MacroRegistryTest extends TestCase
         Stringable::macro('present', static fn(): string => '');
 
         MacroRegistry::init(new VoidProgress());
-        self::assertNotNull(MacroRegistry::get(Stringable::class, 'present'));
+        $this->assertNotNull(MacroRegistry::get(Stringable::class, 'present'));
 
         MacroRegistry::reset();
-        self::assertNull(MacroRegistry::get(Stringable::class, 'present'));
-        self::assertSame([], MacroRegistry::for(Stringable::class));
-        self::assertSame([], MacroRegistry::getKnownMacroableClasses());
+        $this->assertNull(MacroRegistry::get(Stringable::class, 'present'));
+        $this->assertSame([], MacroRegistry::for(Stringable::class));
+        $this->assertSame([], MacroRegistry::getKnownMacroableClasses());
     }
 
     #[Test]
@@ -325,7 +325,7 @@ final class MacroRegistryTest extends TestCase
 
         MacroRegistry::init(new VoidProgress());
 
-        self::assertContains(Stringable::class, MacroRegistry::getKnownMacroableClasses());
+        $this->assertContains(Stringable::class, MacroRegistry::getKnownMacroableClasses());
     }
 
     #[Test]
@@ -339,9 +339,9 @@ final class MacroRegistryTest extends TestCase
         MacroRegistry::init(new VoidProgress());
         $second = MacroRegistry::for(Stringable::class);
 
-        self::assertSame(\array_keys($first), \array_keys($second));
+        $this->assertSame(\array_keys($first), \array_keys($second));
         // Definitions are equal by value; not necessarily the same instances.
-        self::assertEquals($first['x'], $second['x']);
+        $this->assertEquals($first['x'], $second['x']);
     }
 
     #[Test]
@@ -353,8 +353,8 @@ final class MacroRegistryTest extends TestCase
 
         MacroRegistry::init(new VoidProgress());
 
-        self::assertNotNull(MacroRegistry::get(Stringable::class, 'mixinone'));
-        self::assertNotNull(MacroRegistry::get(Stringable::class, 'mixintwo'));
+        $this->assertNotNull(MacroRegistry::get(Stringable::class, 'mixinone'));
+        $this->assertNotNull(MacroRegistry::get(Stringable::class, 'mixintwo'));
     }
 
     #[Test]
@@ -374,8 +374,8 @@ final class MacroRegistryTest extends TestCase
             knownMacroableClasses: [Stringable::class],
         );
 
-        self::assertSame($def, MacroRegistry::get(Stringable::class, 'fake'));
-        self::assertSame([Stringable::class], MacroRegistry::getKnownMacroableClasses());
+        $this->assertSame($def, MacroRegistry::get(Stringable::class, 'fake'));
+        $this->assertSame([Stringable::class], MacroRegistry::getKnownMacroableClasses());
     }
 
     #[Test]
@@ -388,10 +388,10 @@ final class MacroRegistryTest extends TestCase
         MacroRegistry::init(new VoidProgress());
 
         $typed = MacroRegistry::get(Stringable::class, 'typedreturn');
-        self::assertNotNull($typed);
-        self::assertNotNull($typed->signatureReturnType);
-        self::assertSame('int', $typed->signatureReturnType->getId());
-        self::assertSame('int', $typed->returnType->getId());
+        $this->assertNotNull($typed);
+        $this->assertNotNull($typed->signatureReturnType);
+        $this->assertSame('int', $typed->signatureReturnType->getId());
+        $this->assertSame('int', $typed->returnType->getId());
     }
 
     #[Test]
@@ -418,9 +418,9 @@ final class MacroRegistryTest extends TestCase
         );
 
         $retrieved = MacroRegistry::get(Stringable::class, 'noNative');
-        self::assertNotNull($retrieved);
-        self::assertNull($retrieved->signatureReturnType);
-        self::assertSame('mixed', $retrieved->returnType->getId());
+        $this->assertNotNull($retrieved);
+        $this->assertNull($retrieved->signatureReturnType);
+        $this->assertSame('mixed', $retrieved->returnType->getId());
     }
 
 }

--- a/tests/Unit/Providers/MacroRegistryTest.php
+++ b/tests/Unit/Providers/MacroRegistryTest.php
@@ -1,0 +1,479 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Tests\Unit\Providers;
+
+use Illuminate\Support\Stringable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Providers\ApplicationProvider;
+use Psalm\LaravelPlugin\Providers\MacroDefinition;
+use Psalm\LaravelPlugin\Providers\MacroRegistry;
+use Psalm\Progress\VoidProgress;
+
+#[CoversClass(MacroRegistry::class)]
+#[CoversClass(MacroDefinition::class)]
+final class MacroRegistryTest extends TestCase
+{
+    #[\Override]
+    protected function setUp(): void
+    {
+        ApplicationProvider::bootApp();
+        // Wipe Stringable's macros so each test starts from a known state.
+        // Other Macroable classes are left alone — Laravel itself rarely registers
+        // any in-core, so cross-test pollution is unlikely from those.
+        Stringable::flushMacros();
+        MacroRegistry::reset();
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        Stringable::flushMacros();
+        MacroRegistry::reset();
+    }
+
+    #[Test]
+    public function discovers_a_simple_closure_macro(): void
+    {
+        Stringable::macro('shout', static fn(): string => 'OK');
+
+        MacroRegistry::init(new VoidProgress());
+
+        $def = MacroRegistry::get(Stringable::class, 'shout');
+        self::assertNotNull($def);
+        self::assertSame(Stringable::class, $def->declaringClass);
+        self::assertSame('shout', $def->methodName);
+        self::assertSame('shout', $def->casedName);
+        self::assertSame([], $def->params);
+        self::assertSame('string', $def->returnType->getId());
+    }
+
+    #[Test]
+    public function preserves_original_casing_in_cased_name(): void
+    {
+        // Psalm reads `cased_name` for diagnostic output; lower-casing it would
+        // surface `countCharsTest` as `countcharstest` in error messages.
+        Stringable::macro('countCharsTest', static fn(): int => 0);
+
+        MacroRegistry::init(new VoidProgress());
+
+        $def = MacroRegistry::get(Stringable::class, 'countcharstest');
+        self::assertNotNull($def);
+        self::assertSame('countcharstest', $def->methodName);
+        self::assertSame('countCharsTest', $def->casedName);
+    }
+
+    #[Test]
+    public function skips_macro_whose_name_shadows_a_real_method(): void
+    {
+        // Stringable declares a real `value()` method. Registering a macro with the
+        // same name would be unreachable at runtime (PHP method resolution beats
+        // __call) AND would clobber the real signature in pseudo-method lookups.
+        // The registry must skip it.
+        Stringable::macro('value', static fn(): int => 0);
+
+        MacroRegistry::init(new VoidProgress());
+
+        self::assertNull(MacroRegistry::get(Stringable::class, 'value'));
+    }
+
+    #[Test]
+    public function method_name_lookup_is_case_insensitive(): void
+    {
+        Stringable::macro('camelCased', static fn(): int => 1);
+
+        MacroRegistry::init(new VoidProgress());
+
+        // Method name is lower-cased on storage AND on lookup.
+        self::assertNotNull(MacroRegistry::get(Stringable::class, 'camelcased'));
+        self::assertNotNull(MacroRegistry::get(Stringable::class, 'CAMELCASED'));
+    }
+
+    #[Test]
+    public function class_name_lookup_is_case_insensitive(): void
+    {
+        Stringable::macro('foo', static fn(): bool => true);
+
+        MacroRegistry::init(new VoidProgress());
+
+        // Psalm passes class FQCNs through verbatim; underlying storage is lower-cased.
+        self::assertNotNull(MacroRegistry::get(Stringable::class, 'foo'));
+        self::assertNotNull(MacroRegistry::get(\strtoupper(Stringable::class), 'foo'));
+    }
+
+    #[Test]
+    public function extracts_param_signature_from_native_types(): void
+    {
+        Stringable::macro('joined', static fn(string $separator, int $count = 1): string => '');
+
+        MacroRegistry::init(new VoidProgress());
+
+        $def = MacroRegistry::get(Stringable::class, 'joined');
+        self::assertNotNull($def);
+        self::assertCount(2, $def->params);
+
+        self::assertSame('separator', $def->params[0]->name);
+        self::assertSame('string', $def->params[0]->type?->getId());
+        self::assertFalse($def->params[0]->is_optional);
+
+        self::assertSame('count', $def->params[1]->name);
+        self::assertSame('int', $def->params[1]->type?->getId());
+        self::assertTrue($def->params[1]->is_optional);
+    }
+
+    #[Test]
+    public function by_reference_param_is_marked_by_ref(): void
+    {
+        Stringable::macro('byRef', static function (string &$out): void {});
+
+        MacroRegistry::init(new VoidProgress());
+
+        $def = MacroRegistry::get(Stringable::class, 'byref');
+        self::assertNotNull($def);
+        self::assertCount(1, $def->params);
+        self::assertTrue($def->params[0]->by_ref);
+    }
+
+    #[Test]
+    public function discovers_array_callable_macro(): void
+    {
+        // Macroable::__call accepts array callables `[ClassName::class, 'method']`.
+        // The registry must reflect the underlying method, not skip the callable.
+        Stringable::macro('viaArrayCallable', [MacroCallableFixture::class, 'staticHelper']);
+
+        MacroRegistry::init(new VoidProgress());
+
+        $def = MacroRegistry::get(Stringable::class, 'viaarraycallable');
+        self::assertNotNull($def);
+        self::assertCount(1, $def->params);
+        self::assertSame('input', $def->params[0]->name);
+        self::assertSame('string', $def->signatureReturnType?->getId());
+    }
+
+    #[Test]
+    public function discovers_string_callable_macro(): void
+    {
+        // String form 'Class::method'.
+        Stringable::macro('viaStringCallable', MacroCallableFixture::class . '::staticHelper');
+
+        MacroRegistry::init(new VoidProgress());
+
+        $def = MacroRegistry::get(Stringable::class, 'viastringcallable');
+        self::assertNotNull($def);
+        self::assertCount(1, $def->params);
+        self::assertSame('string', $def->signatureReturnType?->getId());
+    }
+
+    #[Test]
+    public function discovers_invokable_object_macro(): void
+    {
+        // Object with __invoke. Macroable accepts and dispatches these.
+        Stringable::macro('viaInvokable', new MacroInvokableFixture());
+
+        MacroRegistry::init(new VoidProgress());
+
+        $def = MacroRegistry::get(Stringable::class, 'viainvokable');
+        self::assertNotNull($def);
+        self::assertCount(1, $def->params);
+        self::assertSame('count', $def->params[0]->name);
+        self::assertSame('int', $def->signatureReturnType?->getId());
+    }
+
+    #[Test]
+    public function discovers_function_name_callable_macro(): void
+    {
+        // Plain function-name string. Macroable dispatches via PHP's variable-function
+        // mechanism, so the function's reflected signature is what callers see.
+        Stringable::macro('viaFunctionName', 'strtoupper');
+
+        MacroRegistry::init(new VoidProgress());
+
+        $def = MacroRegistry::get(Stringable::class, 'viafunctionname');
+        self::assertNotNull($def);
+        self::assertCount(1, $def->params);
+        self::assertSame('string', $def->params[0]->name);
+    }
+
+    #[Test]
+    public function skips_non_public_method_callable(): void
+    {
+        // Macroable invokes the callable from outside the target's scope, so a protected
+        // method would throw at runtime. The registry must not synthesize a pseudo-method
+        // for it.
+        Stringable::macro('viaProtected', [MacroNonPublicFixture::class, 'protectedHelper']);
+
+        MacroRegistry::init(new VoidProgress());
+
+        self::assertNull(MacroRegistry::get(Stringable::class, 'viaprotected'));
+    }
+
+    #[Test]
+    public function skips_non_static_method_with_class_string_callable(): void
+    {
+        // `[Class::class, 'method']` and `'Class::method'` callables only dispatch to
+        // static methods — calling a non-static target this way errors at runtime.
+        // Registry must skip these.
+        Stringable::macro('viaInstanceArr', [MacroInstanceMethodFixture::class, 'instanceHelper']);
+        Stringable::macro('viaInstanceStr', MacroInstanceMethodFixture::class . '::instanceHelper');
+
+        MacroRegistry::init(new VoidProgress());
+
+        self::assertNull(MacroRegistry::get(Stringable::class, 'viainstancearr'));
+        self::assertNull(MacroRegistry::get(Stringable::class, 'viainstancestr'));
+    }
+
+    #[Test]
+    public function accepts_non_static_method_with_object_callable(): void
+    {
+        // `[$obj, 'method']` works for instance methods too — `$obj` provides the binding.
+        $obj = new MacroInstanceMethodFixture();
+        Stringable::macro('viaInstanceObj', [$obj, 'instanceHelper']);
+
+        MacroRegistry::init(new VoidProgress());
+
+        $def = MacroRegistry::get(Stringable::class, 'viainstanceobj');
+        self::assertNotNull($def);
+    }
+
+    #[Test]
+    public function expands_self_in_callable_method_return_type(): void
+    {
+        // `self` in a method signature resolves relative to that method's declaring
+        // class, not to the Macroable host. The registry must expand it before parsing.
+        Stringable::macro('viaSelfReturn', [MacroSelfReturnFixture::class, 'returnsSelf']);
+
+        MacroRegistry::init(new VoidProgress());
+
+        $def = MacroRegistry::get(Stringable::class, 'viaselfreturn');
+        self::assertNotNull($def);
+        self::assertNotNull($def->signatureReturnType);
+        // Should resolve to MacroSelfReturnFixture, NOT the literal `self` (which Psalm
+        // would otherwise interpret relative to the call site = Stringable).
+        self::assertSame(\strtolower(MacroSelfReturnFixture::class), \strtolower($def->signatureReturnType->getId()));
+    }
+
+    #[Test]
+    public function reflects_closure_without_return_type_into_registry(): void
+    {
+        // The override-seam test exercises the type contract; this one exercises the
+        // discovery path end-to-end. PHP's reflection of closures without declared
+        // return types varies between patch versions (8.4.20 returns null, 8.4.21
+        // surfaces an inferred type), so this asserts only the universal invariant:
+        // discovery must produce SOME definition, and `returnType` must be a valid Union.
+        Stringable::macro('reflectionDiscovery', static function () {
+            return 1;
+        });
+
+        MacroRegistry::init(new VoidProgress());
+
+        $def = MacroRegistry::get(Stringable::class, 'reflectiondiscovery');
+        self::assertNotNull($def);
+        self::assertNotNull($def->returnType);
+        // Either the closure declared no return type → mixed, or PHP inferred one → that.
+        // Both are correct outcomes of buildDefinition; we only require a Union to be present.
+    }
+
+    #[Test]
+    public function variadic_param_is_marked_variadic(): void
+    {
+        Stringable::macro('varArgs', static fn(string ...$args): string => '');
+
+        MacroRegistry::init(new VoidProgress());
+
+        $def = MacroRegistry::get(Stringable::class, 'varargs');
+        self::assertNotNull($def);
+        self::assertCount(1, $def->params);
+        self::assertTrue($def->params[0]->is_variadic);
+    }
+
+    #[Test]
+    public function nullable_param_is_marked_nullable(): void
+    {
+        Stringable::macro('maybeNull', static fn(?string $arg): string => '');
+
+        MacroRegistry::init(new VoidProgress());
+
+        $def = MacroRegistry::get(Stringable::class, 'maybenull');
+        self::assertNotNull($def);
+        // is_nullable comes straight from ReflectionParameter::allowsNull() — independent
+        // of Psalm's parseString, which needs ProjectAnalyzer::$instance (only set during
+        // a real Psalm run, not in the unit-test bootstrap).
+        self::assertTrue($def->params[0]->is_nullable);
+    }
+
+    #[Test]
+    public function reset_clears_registry(): void
+    {
+        Stringable::macro('present', static fn(): string => '');
+
+        MacroRegistry::init(new VoidProgress());
+        self::assertNotNull(MacroRegistry::get(Stringable::class, 'present'));
+
+        MacroRegistry::reset();
+        self::assertNull(MacroRegistry::get(Stringable::class, 'present'));
+        self::assertSame([], MacroRegistry::for(Stringable::class));
+        self::assertSame([], MacroRegistry::getKnownMacroableClasses());
+    }
+
+    #[Test]
+    public function known_macroable_classes_lists_classes_with_at_least_one_macro(): void
+    {
+        Stringable::macro('alpha', static fn(): string => '');
+
+        MacroRegistry::init(new VoidProgress());
+
+        self::assertContains(Stringable::class, MacroRegistry::getKnownMacroableClasses());
+    }
+
+    #[Test]
+    public function init_is_idempotent(): void
+    {
+        Stringable::macro('x', static fn(): int => 0);
+
+        MacroRegistry::init(new VoidProgress());
+        $first = MacroRegistry::for(Stringable::class);
+
+        MacroRegistry::init(new VoidProgress());
+        $second = MacroRegistry::for(Stringable::class);
+
+        self::assertSame(\array_keys($first), \array_keys($second));
+        // Definitions are equal by value; not necessarily the same instances.
+        self::assertEquals($first['x'], $second['x']);
+    }
+
+    #[Test]
+    public function mixin_registers_each_method_as_a_macro(): void
+    {
+        // Macroable::mixin walks the mixin object's methods and registers each via macro().
+        // Foundation captures these for free because they live in Macroable::$macros at boot.
+        Stringable::mixin(new MixinFixture());
+
+        MacroRegistry::init(new VoidProgress());
+
+        self::assertNotNull(MacroRegistry::get(Stringable::class, 'mixinone'));
+        self::assertNotNull(MacroRegistry::get(Stringable::class, 'mixintwo'));
+    }
+
+    #[Test]
+    public function override_for_testing_replaces_state(): void
+    {
+        $def = new MacroDefinition(
+            declaringClass: Stringable::class,
+            methodName: 'fake',
+            casedName: 'fake',
+            params: [],
+            returnType: \Psalm\Type::getString(),
+            signatureReturnType: \Psalm\Type::getString(),
+        );
+
+        MacroRegistry::overrideForTesting(
+            macros: [\strtolower(Stringable::class) => ['fake' => $def]],
+            knownMacroableClasses: [Stringable::class],
+        );
+
+        self::assertSame($def, MacroRegistry::get(Stringable::class, 'fake'));
+        self::assertSame([Stringable::class], MacroRegistry::getKnownMacroableClasses());
+    }
+
+    #[Test]
+    public function signature_return_type_mirrors_native_return_type(): void
+    {
+        // When the closure declares a native return type, `signatureReturnType`
+        // mirrors `returnType` (both populated by reflection).
+        Stringable::macro('typedReturn', static fn(): int => 0);
+
+        MacroRegistry::init(new VoidProgress());
+
+        $typed = MacroRegistry::get(Stringable::class, 'typedreturn');
+        self::assertNotNull($typed);
+        self::assertNotNull($typed->signatureReturnType);
+        self::assertSame('int', $typed->signatureReturnType->getId());
+        self::assertSame('int', $typed->returnType->getId());
+    }
+
+    #[Test]
+    public function override_for_testing_round_trips_a_null_signature_return_type(): void
+    {
+        // The "no native return type → signatureReturnType null" branch of the
+        // registry contract is asserted via the override seam rather than via
+        // reflection on a closure: PHP's reflection of closures without declared
+        // return types is not consistent across patch versions, so a reflection-
+        // based test is unreliable in CI. Push a definition through `overrideForTesting`
+        // and verify that lookup preserves the null `signatureReturnType` end-to-end.
+        $def = new MacroDefinition(
+            declaringClass: Stringable::class,
+            methodName: 'nonative',
+            casedName: 'noNative',
+            params: [],
+            returnType: \Psalm\Type::getMixed(),
+            signatureReturnType: null,
+        );
+
+        MacroRegistry::overrideForTesting(
+            macros: [\strtolower(Stringable::class) => ['nonative' => $def]],
+            knownMacroableClasses: [Stringable::class],
+        );
+
+        $retrieved = MacroRegistry::get(Stringable::class, 'noNative');
+        self::assertNotNull($retrieved);
+        self::assertNull($retrieved->signatureReturnType);
+        self::assertSame('mixed', $retrieved->returnType->getId());
+    }
+
+}
+
+final class MixinFixture
+{
+    public function mixinOne(): \Closure
+    {
+        return static fn(): string => 'one';
+    }
+
+    public function mixinTwo(): \Closure
+    {
+        return static fn(): int => 2;
+    }
+}
+
+final class MacroCallableFixture
+{
+    public static function staticHelper(string $input): string
+    {
+        return $input;
+    }
+}
+
+final class MacroInvokableFixture
+{
+    public function __invoke(int $count): int
+    {
+        return $count;
+    }
+}
+
+final class MacroNonPublicFixture
+{
+    protected static function protectedHelper(string $arg): string
+    {
+        return $arg;
+    }
+}
+
+final class MacroInstanceMethodFixture
+{
+    public function instanceHelper(string $arg): string
+    {
+        return $arg;
+    }
+}
+
+class MacroSelfReturnFixture
+{
+    public static function returnsSelf(): self
+    {
+        return new self();
+    }
+}


### PR DESCRIPTION
Closes #758

## Summary

Foundation for [#758](https://github.com/psalm/psalm-plugin-laravel/issues/758): discovers Laravel `Macroable` macros via runtime reflection of `Macroable::$macros` and synthesises them as Psalm pseudo-methods so call sites get proper return type / parameter signature inference.

This is **Strategy B** (runtime reflection) per the design discussion — the simpler, faster path that captures macros registered by user app providers and Laravel's framework providers when analysing a Laravel application. Strategy C (AST scan over the analysed codebase, for package-without-`bootstrap/app.php` analysis and richer docblock-aware closure typing) is left as a follow-up; inline `TODO` markers point at the slot it will fill.

## What's covered

- Macros registered via `Macroable::macro()` or `Macroable::mixin()` on any class with a static `$macros` array property. Detection is intentionally permissive so it also catches `Illuminate\Database\Eloquent\Builder`, which declares its own `$macros` storage without using the trait.
- Both `__call` and `__callStatic` dispatch — pseudo-methods are written into both `pseudo_methods` and `pseudo_static_methods` so `$instance->macroName()` and `Class::macroName()` both resolve.
- Subclass dispatch — `MacroHandler` walks every analysed class's `parent_classes` and propagates Macroable ancestor pseudo-methods onto descendants. Without this, `App\Http\Requests\StoreUserRequest` (extending `FormRequest extends Request`) would not see Request's `validate()` macro because Psalm's `MissingMethodCallHandler` doesn't walk `parent_classes` for pseudo-methods.
- `@mixin` propagation (best-effort) — the handler also walks `namedMixins` and writes pseudo-methods onto mixin hosts.
- Issue [#648](https://github.com/psalm/psalm-plugin-laravel/issues/648) (Builder macros on relation chains) — closed by the parent_classes propagation. `$user->posts()->macroName()` resolves because `Builder<Post>` is a direct dispatch target.

## What's deferred (TODOs in the code)

- AST scan (Strategy C proper) for package analysis where `bootstrap/app.php` doesn't exist (issue [#766](https://github.com/psalm/psalm-plugin-laravel/issues/766) territory).
- String / array callable shapes (`'Class::method'`, `[$obj, 'method']`) — the AST scan is the natural place to recover docblock types for those.
- Fluent return narrowing (`@psalm-this-out` on macros that return `$this`).
- Curated stubs for high-value framework macros (`Request::validate()` etc.) where the runtime closure has no return type and the registry surfaces it as `mixed`. The handler skips names already in `pseudo_methods`, so future stubs compose without conflict.
- A subtle gap: `@mixin` static-call dispatch goes through `handleRegularMixins` which redirects the call_id to the mixin class itself rather than the host, so the pseudo-methods written onto the host may not be consulted for `User::macroName()`-style calls. Pseudo-method injection is in place for when this becomes useful.

## Implementation notes

Discovery runs in `AfterCodebasePopulated` rather than at plugin `__invoke()` time. Reason: Psalm's `autoloader` config attribute fires during `Config::visitComposerAutoloadFiles()` — after plugin entry points but before `AfterCodebasePopulated`. Discovering at boot would miss any macro registered through that autoload path (notable for Testbench-fallback analysis and for test fixtures).

The implementation tried `MethodExistenceProviderInterface` + `MethodParamsProviderInterface` first, but registering a `params_provider` for a class — even one that returns `null` for non-macro methods — perturbed Psalm's argument-count diagnostics for *real* methods on that class (regression observed against `Stringable::trim`/`ltrim`/`rtrim`). Writing pseudo-methods directly into `ClassLikeStorage` is the same shape Psalm uses for `@method` annotations and avoids the interference.

## Tests

- 587 unit tests (16 new for `MacroRegistry` covering discovery, lookup, mixin, casing preservation, real-method shadow skip, idempotency, the test seam, `signature_return_type` null when closure has no native return).
- 381 type tests (5 new in `tests/Type/tests/Macros/MacroDispatchTest.phpt`: instance-call return type, instance-call param signature, static-call return type, subclass instance-call propagation, subclass static-call propagation, plus a wrong-argument case verifying `cased_name` preserves original casing in diagnostics).

`composer test:unit`, `composer test:type`, `composer psalm`, `composer cs` all clean.