### PR TITLE
Extract collaborators from Plugin.php

### DIFF
--- a/src/Handlers/Eloquent/Schema/MigrationSchemaBuilder.php
+++ b/src/Handlers/Eloquent/Schema/MigrationSchemaBuilder.php
@@ -1,0 +1,263 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Eloquent\Schema;
+
+use Illuminate\Foundation\Application;
+use Psalm\Codebase;
+use Psalm\Progress\Progress;
+
+/**
+ * Builds the {@see SchemaAggregator} for the booted Laravel app.
+ *
+ * Discovers SQL schema dumps and PHP migration files, parses them through
+ * {@see SqlSchemaParser} and {@see SchemaAggregator}, and serves results
+ * through a {@see MigrationCache} so subsequent runs skip re-parsing when
+ * neither the migrations nor the plugin version have changed.
+ *
+ * @internal
+ */
+final class MigrationSchemaBuilder
+{
+    /** @psalm-mutation-free */
+    public function __construct(
+        private readonly Application $app,
+        private readonly Codebase $codebase,
+        private readonly MigrationCache $cache,
+    ) {}
+
+    public function build(): SchemaAggregator
+    {
+        $progress = $this->codebase->progress;
+
+        // Discover all files first — needed for cache fingerprinting
+        $sqlDumpFiles = $this->discoverSqlDumpFiles($progress);
+        $migrationFiles = $this->discoverMigrationFiles($progress);
+
+        $tables = $this->cache->remember(
+            $migrationFiles,
+            $sqlDumpFiles,
+            fn(): array => $this->parse($sqlDumpFiles, $migrationFiles, $progress),
+        );
+
+        $this->reportCacheStatus($progress);
+
+        $aggregator = new SchemaAggregator();
+        $aggregator->tables = $tables;
+        return $aggregator;
+    }
+
+    /**
+     * @param list<string> $sqlDumpFiles
+     * @param list<string> $migrationFiles
+     * @return array<string, SchemaTable>
+     */
+    private function parse(array $sqlDumpFiles, array $migrationFiles, Progress $progress): array
+    {
+        $aggregator = new SchemaAggregator();
+
+        // Parse SQL schema dumps first — they represent the base state from
+        // squashed migrations (php artisan schema:dump)
+        $this->parseSqlDumps($sqlDumpFiles, $aggregator, $progress);
+
+        // Then parse PHP migrations — they modify the base state
+        foreach ($migrationFiles as $file) {
+            try {
+                $aggregator->addStatements($this->codebase->getStatementsForFile($file));
+            } catch (\InvalidArgumentException|\UnexpectedValueException $e) {
+                $progress->warning(
+                    "Laravel plugin: skipping migration '{$file}': {$e->getMessage()}",
+                );
+            }
+        }
+
+        return $aggregator->tables;
+    }
+
+    private function reportCacheStatus(Progress $progress): void
+    {
+        if ($this->cache->wasCacheHit()) {
+            $progress->debug("Laravel plugin: loaded migration schema from cache\n");
+        } elseif ($this->cache->wasCacheWritten()) {
+            $progress->debug("Laravel plugin: parsed migration schema (cached for next run)\n");
+        } else {
+            $writeFailure = $this->cache->getWriteFailureReason();
+            $detail = $writeFailure !== null ? ": {$writeFailure}" : ' — check directory permissions';
+            $progress->warning("Laravel plugin: parsed migration schema (cache write failed{$detail})");
+        }
+
+        $readFailure = $this->cache->getReadFailureReason();
+        if ($readFailure !== null) {
+            $progress->warning("Laravel plugin: {$readFailure}");
+        }
+    }
+
+    /**
+     * Discover SQL schema dump files from the database/schema/ directory.
+     *
+     * @return list<string>
+     */
+    private function discoverSqlDumpFiles(Progress $progress): array
+    {
+        $schemaDir = $this->app->databasePath('schema');
+
+        if (!\is_dir($schemaDir)) {
+            return [];
+        }
+
+        return $this->findSqlDumpFiles($schemaDir, $progress);
+    }
+
+    /**
+     * Discover PHP migration files from all registered migration directories.
+     *
+     * @return list<string>
+     */
+    private function discoverMigrationFiles(Progress $progress): array
+    {
+        $files = [];
+
+        foreach ($this->getMigrationDirectories() as $directory) {
+            \array_push($files, ...$this->findPhpFilesRecursive($directory, $progress));
+        }
+
+        // Sort by basename to match Laravel's migrator ordering (timestamp prefixes
+        // ensure chronological order). Without sorting, RecursiveIteratorIterator
+        // returns files in filesystem order (not alphabetical on ext4/Linux), causing
+        // Schema::table() to run before the corresponding Schema::create().
+        \usort($files, static fn(string $a, string $b): int => \basename($a) <=> \basename($b));
+
+        return $files;
+    }
+
+    /**
+     * Parse SQL schema dump files into the aggregator.
+     *
+     * Laravel's `php artisan schema:dump` creates these files using mysqldump/pg_dump.
+     * They represent squashed migrations and should be parsed before PHP migrations.
+     *
+     * @param list<string> $sqlDumpFiles
+     */
+    private function parseSqlDumps(
+        array $sqlDumpFiles,
+        SchemaAggregator $schemaAggregator,
+        Progress $progress,
+    ): void {
+        if ($sqlDumpFiles === []) {
+            return;
+        }
+
+        $sqlParser = new SqlSchemaParser();
+
+        foreach ($sqlDumpFiles as $file) {
+            try {
+                $sql = \file_get_contents($file);
+
+                if ($sql === false) {
+                    $progress->warning("Laravel plugin: could not read SQL schema dump '{$file}'");
+                    continue;
+                }
+
+                $sqlParser->addToAggregator($sql, $schemaAggregator);
+            } catch (\RuntimeException $exception) {
+                // SqlSchemaParser is pure string processing and shouldn't throw.
+                // This catch is a safety net for unexpected runtime issues (e.g. memory).
+                $progress->warning("Laravel plugin: skipping SQL schema dump '{$file}': {$exception->getMessage()}");
+            }
+        }
+    }
+
+    /**
+     * Find SQL schema dump files in a directory (non-recursive — schema dumps are flat).
+     *
+     * The .dump extension is supported for backward compatibility with schema dumps
+     * created by older Laravel versions. Both extensions contain plain-text SQL.
+     *
+     * @return list<string>
+     */
+    private function findSqlDumpFiles(string $directory, Progress $progress): array
+    {
+        try {
+            $iterator = new \DirectoryIterator($directory);
+        } catch (\UnexpectedValueException $unexpectedValueException) {
+            $progress->warning("Laravel plugin: could not read schema directory '{$directory}': {$unexpectedValueException->getMessage()}");
+            return [];
+        }
+
+        $files = [];
+
+        foreach ($iterator as $fileInfo) {
+            if (!$fileInfo->isFile() || !\in_array($fileInfo->getExtension(), ['sql', 'dump'], true)) {
+                continue;
+            }
+
+            $realPath = $fileInfo->getRealPath();
+
+            if (\is_string($realPath)) {
+                $files[] = $realPath;
+            }
+        }
+
+        // Sort for deterministic loading order — later files can overwrite tables from earlier ones
+        \sort($files);
+
+        return $files;
+    }
+
+    /**
+     * Resolve migration directories the same way Laravel does:
+     * extra paths registered via loadMigrationsFrom() + the default database/migrations directory.
+     *
+     * @return non-empty-list<string>
+     */
+    private function getMigrationDirectories(): array
+    {
+        /** @var \Illuminate\Database\Migrations\Migrator $migrator */
+        $migrator = $this->app->make('migrator');
+
+        return \array_values(\array_merge($migrator->paths(), [$this->app->databasePath('migrations')]));
+    }
+
+    /**
+     * Recursively find all .php files in a directory.
+     *
+     * @return list<string>
+     */
+    private function findPhpFilesRecursive(string $directory, Progress $progress): array
+    {
+        if (!\is_dir($directory)) {
+            return [];
+        }
+
+        try {
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),
+            );
+        } catch (\UnexpectedValueException $unexpectedValueException) {
+            $progress->warning("Laravel plugin: could not read migration directory '{$directory}': {$unexpectedValueException->getMessage()}");
+            return [];
+        }
+
+        $files = [];
+
+        try {
+            /** @var \SplFileInfo $file */
+            foreach ($iterator as $file) {
+                if ($file->getExtension() !== 'php') {
+                    continue;
+                }
+
+                $realPath = $file->getRealPath();
+                if (\is_string($realPath)) {
+                    $files[] = $realPath;
+                }
+            }
+        } catch (\UnexpectedValueException $unexpectedValueException) {
+            // RecursiveIteratorIterator can throw during iteration on unreadable subdirectories
+            $progress->warning("Laravel plugin: error scanning migration directory '{$directory}': {$unexpectedValueException->getMessage()}");
+        }
+
+        return $files;
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -6,13 +6,13 @@ namespace Psalm\LaravelPlugin;
 
 use Illuminate\Foundation\Application;
 use Psalm\Internal\Analyzer\ProjectAnalyzer;
-use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaAggregator;
-use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SqlSchemaParser;
+use Psalm\LaravelPlugin\Providers\AliasStubProvider;
 use Psalm\LaravelPlugin\Providers\ApplicationProvider;
 use Psalm\LaravelPlugin\Providers\CarbonStubProvider;
 use Psalm\LaravelPlugin\Providers\FacadeMapProvider;
 use Psalm\LaravelPlugin\Providers\SchemaStateProvider;
-use Psalm\LaravelPlugin\Util\IssueUrlGenerator;
+use Psalm\LaravelPlugin\Util\InternalErrorReporter;
+use Psalm\LaravelPlugin\Util\StubFileFinder;
 use Psalm\Plugin\PluginEntryPointInterface;
 use Psalm\Plugin\RegistrationInterface;
 
@@ -36,8 +36,6 @@ final class Plugin implements PluginEntryPointInterface
                 $this->buildSchema($pluginConfig);
             }
 
-            $this->generateAliasStubs($pluginConfig);
-
             // Build facade → service class map before registering handlers.
             // Handlers use FacadeMapProvider::getFacadeClasses() in getClassLikeNames()
             // to also register for facade/alias classes that proxy to their service.
@@ -56,146 +54,24 @@ final class Plugin implements PluginEntryPointInterface
             $this->registerHandlers($registration, $pluginConfig);
             $this->registerStubs($registration, $pluginConfig, $output);
         } catch (\Throwable $throwable) {
-            $this->handleInternalError($throwable, $output, $pluginConfig);
+            InternalErrorReporter::report($throwable, $output, $pluginConfig);
         }
-    }
-
-    /** @return list<string> */
-    private function getCommonStubs(\Psalm\Progress\Progress $output): array
-    {
-        return $this->findStubFiles(\dirname(__DIR__) . '/stubs/common', $output);
-    }
-
-    /**
-     * Collect stubs from all version directories that are <= the installed Laravel version.
-     *
-     * Supports both major-only directories (e.g. "12/", "13/") and patch-level directories
-     * (e.g. "12.20.0/", "12.42.0/"). Directories are sorted in ascending version order so
-     * that later versions override earlier ones for same-named stubs.
-     *
-     * @see https://www.php.net/version_compare — treats "12" as "12.0.0"
-     *
-     * @return list<string>
-     */
-    private function getStubsForLaravelVersion(string $version, \Psalm\Progress\Progress $output): array
-    {
-        $stubsRoot = \dirname(__DIR__) . '/stubs';
-
-        // Collect version directories (names starting with a digit, e.g. "12", "12.20.0", "13")
-        $candidates = [];
-
-        foreach (new \DirectoryIterator($stubsRoot) as $entry) {
-            if (! $entry->isDir() || $entry->isDot()) {
-                continue;
-            }
-
-            $dirName = $entry->getFilename();
-
-            // Skip non-version directories (e.g. "common")
-            if (\ctype_digit($dirName[0])) {
-                $candidates[] = $dirName;
-            }
-        }
-
-        $stubGroups = [];
-
-        foreach (self::filterVersionDirectories($candidates, $version) as $dir) {
-            $stubGroups[] = $this->findStubFiles($stubsRoot . '/' . $dir, $output);
-        }
-
-        return $stubGroups === [] ? [] : \array_merge(...$stubGroups);
-    }
-
-    /**
-     * Filter and sort version directory names, keeping only those <= the target version.
-     *
-     * @param list<string> $candidates directory names (e.g. ["13", "12", "12.20.0"])
-     *
-     * @return list<string> sorted ascending by version (e.g. ["12", "12.20.0"])
-     *
-     * @psalm-pure
-     *
-     * @internal used by tests
-     */
-    public static function filterVersionDirectories(array $candidates, string $targetVersion): array
-    {
-        $matched = \array_filter(
-            $candidates,
-            static fn(string $dir): bool => \version_compare($dir, $targetVersion, '<='),
-        );
-
-        \usort($matched, static fn(string $a, string $b): int => \version_compare($a, $b));
-
-        return $matched;
-    }
-
-    /**
-     * Recursively find all .phpstub files in a directory.
-     *
-     * Results are sorted to ensure deterministic stub registration order.
-     * RecursiveDirectoryIterator returns files in filesystem order, which
-     * varies across OSes (alphabetical on APFS/HFS+, inode order on ext4).
-     *
-     * Stub loading order matters: when multiple stubs declare the same method
-     * on the same class, Psalm reuses the MethodStorage and re-applies docblock
-     * parsing. Type annotations (`@return`, `@param`) use `=` so the last-loaded
-     * stub wins; taint annotations (`@psalm-taint-*`) use `|=` and accumulate.
-     * Without sorting, moving or renaming stub files can silently change types.
-     * See docs/contributing/README.md "Stub merging" for details.
-     *
-     * @return list<string>
-     */
-    private function findStubFiles(string $directory, \Psalm\Progress\Progress $output): array
-    {
-        if (!\is_dir($directory)) {
-            return [];
-        }
-
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),
-        );
-
-        $stubs = [];
-
-        try {
-            /** @var \SplFileInfo $file */
-            foreach ($iterator as $file) {
-                if ($file->getExtension() !== 'phpstub') {
-                    continue;
-                }
-
-                $realPath = $file->getRealPath();
-
-                if (!\is_string($realPath)) {
-                    continue;
-                }
-
-                $stubs[] = $realPath;
-            }
-        } catch (\UnexpectedValueException $unexpectedValueException) {
-            // RecursiveIteratorIterator can throw during iteration on unreadable subdirectories.
-            // Return whatever stubs were collected before the error — partial results from
-            // readable subdirectories are better than none.
-            $output->warning("Laravel plugin: error scanning stub directory '{$directory}': {$unexpectedValueException->getMessage()}");
-        }
-
-        \sort($stubs);
-
-        return $stubs;
     }
 
     private function registerStubs(RegistrationInterface $registration, PluginConfig $pluginConfig, \Psalm\Progress\Progress $output): void
     {
+        $stubsRoot = \dirname(__DIR__) . '/stubs';
+
         $stubs = \array_merge(
-            $this->getCommonStubs($output),
-            $this->getStubsForLaravelVersion(Application::VERSION, $output),
+            StubFileFinder::commonStubs($stubsRoot, $output),
+            StubFileFinder::stubsForLaravelVersion($stubsRoot, Application::VERSION, $output),
         );
 
         foreach ($stubs as $stubFilePath) {
             $registration->addStubFile($stubFilePath);
         }
 
-        $registration->addStubFile(self::getAliasStubLocation($pluginConfig));
+        AliasStubProvider::register($registration, self::getAliasStubLocation($pluginConfig));
 
         CarbonStubProvider::register($registration, $output);
     }
@@ -480,259 +356,20 @@ final class Plugin implements PluginEntryPointInterface
     {
         $app = ApplicationProvider::getApp();
 
+        // Defensive guard: getApp() is typed as Illuminate\Foundation\Application, but
+        // alternative bootstraps (e.g. trimmed-down Testbench builds) may return an
+        // implementation that lacks databasePath(). Skip the migration build rather
+        // than fatal-erroring inside MigrationSchemaBuilder.
         if (!\method_exists($app, 'databasePath')) {
             return;
         }
 
-        $projectAnalyzer = ProjectAnalyzer::getInstance();
-        $codebase = $projectAnalyzer->getCodebase();
-        $progress = $codebase->progress;
-
-        // Discover all files first — needed for cache fingerprinting
-        $sqlDumpFiles = $this->discoverSqlDumpFiles($app, $progress);
-        $migrationFiles = $this->discoverMigrationFiles($app, $progress);
-
+        $codebase = ProjectAnalyzer::getInstance()->getCodebase();
         $cache = new Handlers\Eloquent\Schema\MigrationCache(self::getCacheLocation($pluginConfig));
 
-        $tables = $cache->remember(
-            $migrationFiles,
-            $sqlDumpFiles,
-            function () use ($sqlDumpFiles, $migrationFiles, $codebase, $progress): array {
-                $schemaAggregator = new Handlers\Eloquent\Schema\SchemaAggregator();
+        $aggregator = (new Handlers\Eloquent\Schema\MigrationSchemaBuilder($app, $codebase, $cache))->build();
 
-                // Parse SQL schema dumps first — they represent the base state from
-                // squashed migrations (php artisan schema:dump)
-                $this->parseSqlDumps($sqlDumpFiles, $schemaAggregator, $progress);
-
-                // Then parse PHP migrations — they modify the base state
-                foreach ($migrationFiles as $file) {
-                    try {
-                        $schemaAggregator->addStatements($codebase->getStatementsForFile($file));
-                    } catch (\InvalidArgumentException|\UnexpectedValueException $e) {
-                        $progress->warning(
-                            "Laravel plugin: skipping migration '{$file}': {$e->getMessage()}",
-                        );
-                    }
-                }
-
-                return $schemaAggregator->tables;
-            },
-        );
-
-        if ($cache->wasCacheHit()) {
-            $progress->debug("Laravel plugin: loaded migration schema from cache\n");
-        } elseif ($cache->wasCacheWritten()) {
-            $progress->debug("Laravel plugin: parsed migration schema (cached for next run)\n");
-        } else {
-            $writeFailure = $cache->getWriteFailureReason();
-            $detail = $writeFailure !== null ? ": {$writeFailure}" : ' — check directory permissions';
-            $progress->warning("Laravel plugin: parsed migration schema (cache write failed{$detail})");
-        }
-
-        $readFailure = $cache->getReadFailureReason();
-        if ($readFailure !== null) {
-            $progress->warning("Laravel plugin: {$readFailure}");
-        }
-
-        $schemaAggregator = new Handlers\Eloquent\Schema\SchemaAggregator();
-        $schemaAggregator->tables = $tables;
-        SchemaStateProvider::setSchema($schemaAggregator);
-    }
-
-    /**
-     * Discover SQL schema dump files from the database/schema/ directory.
-     *
-     * @return list<string>
-     */
-    private function discoverSqlDumpFiles(Application $app, \Psalm\Progress\Progress $progress): array
-    {
-        $schemaDir = $app->databasePath('schema');
-
-        if (!\is_dir($schemaDir)) {
-            return [];
-        }
-
-        return $this->findSqlDumpFiles($schemaDir, $progress);
-    }
-
-    /**
-     * Discover PHP migration files from all registered migration directories.
-     * @return list<string>
-     */
-    private function discoverMigrationFiles(Application $app, \Psalm\Progress\Progress $progress): array
-    {
-        $files = [];
-
-        foreach ($this->getMigrationDirectories($app) as $directory) {
-            \array_push($files, ...$this->findPhpFilesRecursive($directory, $progress));
-        }
-
-        // Sort by basename to match Laravel's migrator ordering (timestamp prefixes
-        // ensure chronological order). Without sorting, RecursiveIteratorIterator
-        // returns files in filesystem order (not alphabetical on ext4/Linux), causing
-        // Schema::table() to run before the corresponding Schema::create().
-        \usort($files, static fn(string $a, string $b): int => \basename($a) <=> \basename($b));
-
-        return $files;
-    }
-
-    /**
-     * Parse SQL schema dump files into the aggregator.
-     *
-     * Laravel's `php artisan schema:dump` creates these files using mysqldump/pg_dump.
-     * They represent squashed migrations and should be parsed before PHP migrations.
-     *
-     * @param list<string> $sqlDumpFiles
-     */
-    private function parseSqlDumps(
-        array $sqlDumpFiles,
-        SchemaAggregator $schemaAggregator,
-        \Psalm\Progress\Progress $progress,
-    ): void {
-        if ($sqlDumpFiles === []) {
-            return;
-        }
-
-        $sqlParser = new SqlSchemaParser();
-
-        foreach ($sqlDumpFiles as $file) {
-            try {
-                $sql = \file_get_contents($file);
-
-                if ($sql === false) {
-                    $progress->warning("Laravel plugin: could not read SQL schema dump '{$file}'");
-                    continue;
-                }
-
-                $sqlParser->addToAggregator($sql, $schemaAggregator);
-            } catch (\RuntimeException $exception) {
-                // SqlSchemaParser is pure string processing and shouldn't throw.
-                // This catch is a safety net for unexpected runtime issues (e.g. memory).
-                $progress->warning("Laravel plugin: skipping SQL schema dump '{$file}': {$exception->getMessage()}");
-            }
-        }
-    }
-
-    /**
-     * Find SQL schema dump files in a directory (non-recursive — schema dumps are flat).
-     *
-     * The .dump extension is supported for backward compatibility with schema dumps
-     * created by older Laravel versions. Both extensions contain plain-text SQL.
-     *
-     * @return list<string>
-     */
-    private function findSqlDumpFiles(string $directory, \Psalm\Progress\Progress $progress): array
-    {
-        try {
-            $iterator = new \DirectoryIterator($directory);
-        } catch (\UnexpectedValueException $unexpectedValueException) {
-            $progress->warning("Laravel plugin: could not read schema directory '{$directory}': {$unexpectedValueException->getMessage()}");
-            return [];
-        }
-
-        $files = [];
-
-        foreach ($iterator as $fileInfo) {
-            if (!$fileInfo->isFile() || !\in_array($fileInfo->getExtension(), ['sql', 'dump'], true)) {
-                continue;
-            }
-
-            $realPath = $fileInfo->getRealPath();
-
-            if (\is_string($realPath)) {
-                $files[] = $realPath;
-            }
-        }
-
-        // Sort for deterministic loading order — later files can overwrite tables from earlier ones
-        \sort($files);
-
-        return $files;
-    }
-
-    /**
-     * Resolve migration directories the same way Laravel does:
-     * extra paths registered via loadMigrationsFrom() + the default database/migrations directory.
-     *
-     * @return non-empty-list<string>
-     */
-    private function getMigrationDirectories(Application $app): array
-    {
-        /** @var \Illuminate\Database\Migrations\Migrator $migrator */
-        $migrator = $app->make('migrator');
-
-        return \array_values(\array_merge($migrator->paths(), [$app->databasePath('migrations')]));
-    }
-
-    /**
-     * Recursively find all .php files in a directory.
-     * @return list<string>
-     */
-    private function findPhpFilesRecursive(string $directory, \Psalm\Progress\Progress $progress): array
-    {
-        if (!\is_dir($directory)) {
-            return [];
-        }
-
-        try {
-            $iterator = new \RecursiveIteratorIterator(
-                new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),
-            );
-        } catch (\UnexpectedValueException $unexpectedValueException) {
-            $progress->warning("Laravel plugin: could not read migration directory '{$directory}': {$unexpectedValueException->getMessage()}");
-            return [];
-        }
-
-        $files = [];
-
-        try {
-            /** @var \SplFileInfo $file */
-            foreach ($iterator as $file) {
-                if ($file->getExtension() !== 'php') {
-                    continue;
-                }
-
-                $realPath = $file->getRealPath();
-                if (\is_string($realPath)) {
-                    $files[] = $realPath;
-                }
-            }
-        } catch (\UnexpectedValueException $unexpectedValueException) {
-            // RecursiveIteratorIterator can throw during iteration on unreadable subdirectories
-            $progress->warning("Laravel plugin: error scanning migration directory '{$directory}': {$unexpectedValueException->getMessage()}");
-        }
-
-        return $files;
-    }
-
-    private function generateAliasStubs(PluginConfig $pluginConfig): void
-    {
-        // Read aliases from the booted app's AliasLoader — this reflects the actual
-        // aliases registered for this project (config app.aliases + package discovery),
-        // not just Laravel's hardcoded defaults.
-        /** @var array<string, class-string> $aliases */
-        $aliases = \Illuminate\Foundation\AliasLoader::getInstance()->getAliases();
-        $stub = "<?php\n\n";
-
-        foreach ($aliases as $alias => $fqcn) {
-            // Skip namespaced aliases — `class Some\Name extends ...` is invalid PHP
-            // without a namespace block
-            if (\str_contains($alias, '\\')) {
-                continue;
-            }
-
-            $stub .= "class {$alias} extends \\{$fqcn} {}\n";
-        }
-
-        $location = self::getAliasStubLocation($pluginConfig);
-        $result = \file_put_contents($location, $stub);
-
-        if ($result === false) {
-            throw new \RuntimeException(
-                "Failed to write alias stub file to '{$location}'. "
-                . 'Check that the directory exists and is writable.',
-            );
-        }
+        SchemaStateProvider::setSchema($aggregator);
     }
 
     public static function getAliasStubLocation(PluginConfig $pluginConfig): string
@@ -749,31 +386,6 @@ final class Plugin implements PluginEntryPointInterface
         }
 
         return $dir;
-    }
-
-    /** @throws \Throwable */
-    private function handleInternalError(\Throwable $throwable, \Psalm\Progress\Progress $output, PluginConfig $pluginConfig): void
-    {
-        $output->warning("Laravel plugin error on initialisation: {$throwable->getMessage()}");
-
-        // URL generation is best-effort — a secondary failure here (e.g. a
-        // throwable with a broken __toString(), a corrupt composer installed.php)
-        // must never shadow the original init error that the user actually cares
-        // about, so we fall back to a plain issue-tracker link. The secondary
-        // error is still surfaced as a separate warning so plugin maintainers can
-        // spot regressions in the URL generator during self-analysis.
-        try {
-            $url = IssueUrlGenerator::generate($throwable, $pluginConfig);
-        } catch (\Throwable $urlGenerationFailure) {
-            $output->warning("Laravel plugin failed to build a detailed report URL: {$urlGenerationFailure->getMessage()}");
-            $url = 'https://github.com/psalm/psalm-plugin-laravel/issues';
-        }
-
-        $output->warning('Laravel plugin has been disabled for this run, please report about this issue: ' . $url);
-
-        if ($pluginConfig->failOnInternalError) {
-            throw $throwable;
-        }
     }
 
     /** @psalm-mutation-free */

--- a/src/Providers/AliasStubProvider.php
+++ b/src/Providers/AliasStubProvider.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Providers;
+
+use Illuminate\Foundation\AliasLoader;
+use Psalm\Plugin\RegistrationInterface;
+
+/**
+ * Generates and registers a `class <Alias> extends <FQCN> {}` stub file for each alias
+ * declared by the booted Laravel app's {@see AliasLoader}.
+ *
+ * Reflects the actual aliases for the project (`config/app.php` aliases plus package
+ * discovery), not just Laravel's hardcoded defaults, so plugin support follows whatever
+ * the application has registered at runtime.
+ *
+ * Mirrors the {@see CarbonStubProvider} shape: one `register()` call writes any
+ * derived files and adds them to the Psalm registration in a single step.
+ *
+ * @internal
+ */
+final class AliasStubProvider
+{
+    public static function register(RegistrationInterface $registration, string $location): void
+    {
+        /** @var array<string, class-string> $aliases */
+        $aliases = AliasLoader::getInstance()->getAliases();
+        $stub = "<?php\n\n";
+
+        foreach ($aliases as $alias => $fqcn) {
+            // Skip namespaced aliases — `class Some\Name extends ...` is invalid PHP
+            // without a namespace block
+            if (\str_contains($alias, '\\')) {
+                continue;
+            }
+
+            $stub .= "class {$alias} extends \\{$fqcn} {}\n";
+        }
+
+        $result = \file_put_contents($location, $stub);
+
+        if ($result === false) {
+            throw new \RuntimeException(
+                "Failed to write alias stub file to '{$location}'. "
+                . 'Check that the directory exists and is writable.',
+            );
+        }
+
+        $registration->addStubFile($location);
+    }
+}

--- a/src/Util/InternalErrorClassifier.php
+++ b/src/Util/InternalErrorClassifier.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Util;
+
+/**
+ * Classifies a {@see \Throwable} raised during plugin initialisation by walking
+ * its stack trace and emitting a hint that points at the most likely fix site:
+ * the user's application, the plugin's own bridge code, the Laravel framework,
+ * Orchestra Testbench, or another vendor package.
+ *
+ * The hint is best-effort. When no frame matches a known category, we return
+ * null and the caller falls back to the generic "report it upstream" link from
+ * {@see InternalErrorReporter}.
+ *
+ * Inspired by Larastan's `BootstrapErrorHandler` (3.9+); see issue #897.
+ *
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final class InternalErrorClassifier
+{
+    /** @psalm-mutation-free */
+    public static function hint(\Throwable $throwable): ?string
+    {
+        foreach (self::frameFiles($throwable) as $file) {
+            $hint = self::hintForFile($file);
+            if ($hint !== null) {
+                return $hint;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Classify a single frame's file path. Returns null when the frame is
+     * plugin-internal error machinery (so the caller skips it and inspects the
+     * next frame).
+     *
+     * Public for unit testing — production callers should use {@see hint()}.
+     *
+     * @internal
+     *
+     * @psalm-pure
+     */
+    public static function hintForFile(string $file): ?string
+    {
+        if ($file === '') {
+            return null;
+        }
+
+        // Normalise Windows separators so substring matches work the same everywhere
+        $normalized = \str_replace('\\', '/', $file);
+
+        // Skip plugin-internal error reporting frames — they appear on every
+        // failure path and would otherwise classify every error as "plugin bug"
+        if (
+            \str_contains($normalized, '/Util/InternalErrorReporter.php')
+            || \str_contains($normalized, '/Util/InternalErrorClassifier.php')
+        ) {
+            return null;
+        }
+
+        if (\str_contains($normalized, '/vendor/orchestra/testbench')) {
+            return 'The failure originated inside Orchestra Testbench. The plugin falls back to Testbench when '
+                . 'ApplicationProvider cannot boot your application directly. Check that your project exposes a '
+                . 'runnable bootstrap/app.php or that your Laravel version is supported by the Testbench pin.';
+        }
+
+        if (
+            \str_contains($normalized, '/vendor/laravel/framework')
+            || \str_contains($normalized, '/vendor/illuminate/')
+        ) {
+            return 'The failure originated inside Laravel framework code. Try reproducing it with a plain '
+                . '`php artisan` command. If it fails there too, the bug is upstream rather than in the plugin.';
+        }
+
+        if (
+            \str_contains($normalized, '/psalm-plugin-laravel/src/')
+            || \str_contains($normalized, '/vendor/psalm/plugin-laravel/src/')
+        ) {
+            return 'The failure originated inside the Laravel plugin itself. This is likely a plugin bug. '
+                . 'Please attach the full stack trace to the report linked below.';
+        }
+
+        if (\str_contains($normalized, '/vendor/')) {
+            return "The failure originated inside a third-party package ({$file}). Check whether the package "
+                . 'supports the Laravel and PHP versions you are running.';
+        }
+
+        // Anything else is presumed to be user application code (bootstrap/app.php,
+        // app/Providers/*, custom bindings, etc.). The plugin boots the user's real
+        // Laravel kernel, so service-provider crashes surface here.
+        return "The failure originated inside your application code ({$file}). The plugin boots your real "
+            . 'Laravel kernel, so service-provider or bootstrap errors surface during plugin initialisation.';
+    }
+
+    /**
+     * Collect the throw site followed by every frame's file from the trace, in order.
+     *
+     * @return list<string>
+     *
+     * @psalm-mutation-free
+     */
+    private static function frameFiles(\Throwable $throwable): array
+    {
+        $files = [];
+
+        $throwSite = $throwable->getFile();
+        if ($throwSite !== '') {
+            $files[] = $throwSite;
+        }
+
+        foreach ($throwable->getTrace() as $frame) {
+            if (isset($frame['file'])) {
+                $files[] = $frame['file'];
+            }
+        }
+
+        return $files;
+    }
+}

--- a/src/Util/InternalErrorReporter.php
+++ b/src/Util/InternalErrorReporter.php
@@ -24,6 +24,14 @@ final class InternalErrorReporter
     {
         $output->warning("Laravel plugin error on initialisation: {$throwable->getMessage()}");
 
+        // Best-effort classification: tells the user whether the failure
+        // looks like an app-level config issue, a plugin bug, a Laravel
+        // framework problem, or a Testbench fallback issue.
+        $hint = InternalErrorClassifier::hint($throwable);
+        if ($hint !== null) {
+            $output->warning("Laravel plugin: {$hint}");
+        }
+
         // URL generation is best-effort — a secondary failure here (e.g. a
         // throwable with a broken __toString(), a corrupt composer installed.php)
         // must never shadow the original init error that the user actually cares

--- a/src/Util/InternalErrorReporter.php
+++ b/src/Util/InternalErrorReporter.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Util;
+
+use Psalm\LaravelPlugin\PluginConfig;
+use Psalm\Progress\Progress;
+
+/**
+ * Surfaces a plugin-initialisation failure as a {@see Progress::warning()} pair —
+ * one for the original error, one with a pre-filled issue-tracker URL so users
+ * can report it with environment details attached.
+ *
+ * Sits next to {@see IssueUrlGenerator}: this class is the wrapper that composes
+ * URL generation with output and rethrow behaviour.
+ *
+ * @internal
+ */
+final class InternalErrorReporter
+{
+    /** @throws \Throwable when {@see PluginConfig::$failOnInternalError} is on */
+    public static function report(\Throwable $throwable, Progress $output, PluginConfig $pluginConfig): void
+    {
+        $output->warning("Laravel plugin error on initialisation: {$throwable->getMessage()}");
+
+        // URL generation is best-effort — a secondary failure here (e.g. a
+        // throwable with a broken __toString(), a corrupt composer installed.php)
+        // must never shadow the original init error that the user actually cares
+        // about, so we fall back to a plain issue-tracker link. The secondary
+        // error is still surfaced as a separate warning so plugin maintainers can
+        // spot regressions in the URL generator during self-analysis.
+        try {
+            $url = IssueUrlGenerator::generate($throwable, $pluginConfig);
+        } catch (\Throwable $urlGenerationFailure) {
+            $output->warning("Laravel plugin failed to build a detailed report URL: {$urlGenerationFailure->getMessage()}");
+            $url = 'https://github.com/psalm/psalm-plugin-laravel/issues';
+        }
+
+        $output->warning('Laravel plugin has been disabled for this run, please report about this issue: ' . $url);
+
+        if ($pluginConfig->failOnInternalError) {
+            throw $throwable;
+        }
+    }
+}

--- a/src/Util/StubFileFinder.php
+++ b/src/Util/StubFileFinder.php
@@ -10,9 +10,9 @@ use Psalm\Progress\Progress;
  * Discovers `.phpstub` files for the plugin's stub registration.
  *
  * Splits responsibility from {@see \Psalm\LaravelPlugin\Plugin}: filesystem
- * traversal and version-directory selection are pure helpers with no Psalm
- * coupling, so they live next to the other utilities and can be exercised
- * by unit tests without booting the plugin.
+ * traversal and version-directory selection live in this utility so they can
+ * be exercised by unit tests without booting the plugin, while warning
+ * reporting still uses Psalm's {@see Progress} output interface.
  *
  * @internal
  */

--- a/src/Util/StubFileFinder.php
+++ b/src/Util/StubFileFinder.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Util;
+
+use Psalm\Progress\Progress;
+
+/**
+ * Discovers `.phpstub` files for the plugin's stub registration.
+ *
+ * Splits responsibility from {@see \Psalm\LaravelPlugin\Plugin}: filesystem
+ * traversal and version-directory selection are pure helpers with no Psalm
+ * coupling, so they live next to the other utilities and can be exercised
+ * by unit tests without booting the plugin.
+ *
+ * @internal
+ */
+final class StubFileFinder
+{
+    /**
+     * Recursively find all `.phpstub` files in a directory.
+     *
+     * Results are sorted to ensure deterministic stub registration order.
+     * RecursiveDirectoryIterator returns files in filesystem order, which
+     * varies across OSes (alphabetical on APFS/HFS+, inode order on ext4).
+     *
+     * Stub loading order matters: when multiple stubs declare the same method
+     * on the same class, Psalm reuses the MethodStorage and re-applies docblock
+     * parsing. Type annotations (`@return`, `@param`) use `=` so the last-loaded
+     * stub wins; taint annotations (`@psalm-taint-*`) use `|=` and accumulate.
+     * Without sorting, moving or renaming stub files can silently change types.
+     * See docs/contributing/README.md "Stub merging" for details.
+     *
+     * @return list<string>
+     */
+    public static function findIn(string $directory, Progress $output): array
+    {
+        if (!\is_dir($directory)) {
+            return [];
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),
+        );
+
+        $stubs = [];
+
+        try {
+            /** @var \SplFileInfo $file */
+            foreach ($iterator as $file) {
+                if ($file->getExtension() !== 'phpstub') {
+                    continue;
+                }
+
+                $realPath = $file->getRealPath();
+
+                if (!\is_string($realPath)) {
+                    continue;
+                }
+
+                $stubs[] = $realPath;
+            }
+        } catch (\UnexpectedValueException $unexpectedValueException) {
+            // RecursiveIteratorIterator can throw during iteration on unreadable subdirectories.
+            // Return whatever stubs were collected before the error — partial results from
+            // readable subdirectories are better than none.
+            $output->warning("Laravel plugin: error scanning stub directory '{$directory}': {$unexpectedValueException->getMessage()}");
+        }
+
+        \sort($stubs);
+
+        return $stubs;
+    }
+
+    /** @return list<string> */
+    public static function commonStubs(string $stubsRoot, Progress $output): array
+    {
+        return self::findIn($stubsRoot . '/common', $output);
+    }
+
+    /**
+     * Collect stubs from all version directories that are <= the installed Laravel version.
+     *
+     * Supports both major-only directories (e.g. "12/", "13/") and patch-level directories
+     * (e.g. "12.20.0/", "12.42.0/"). Directories are sorted in ascending version order so
+     * that later versions override earlier ones for same-named stubs.
+     *
+     * @see https://www.php.net/version_compare — treats "12" as "12.0.0"
+     *
+     * @return list<string>
+     */
+    public static function stubsForLaravelVersion(string $stubsRoot, string $version, Progress $output): array
+    {
+        // Collect version directories (names starting with a digit, e.g. "12", "12.20.0", "13")
+        $candidates = [];
+
+        foreach (new \DirectoryIterator($stubsRoot) as $entry) {
+            if (!$entry->isDir() || $entry->isDot()) {
+                continue;
+            }
+
+            $dirName = $entry->getFilename();
+
+            // Skip non-version directories (e.g. "common")
+            if (\ctype_digit($dirName[0])) {
+                $candidates[] = $dirName;
+            }
+        }
+
+        $stubs = [];
+
+        foreach (self::filterVersionDirectories($candidates, $version) as $dir) {
+            \array_push($stubs, ...self::findIn($stubsRoot . '/' . $dir, $output));
+        }
+
+        return $stubs;
+    }
+
+    /**
+     * Filter and sort version directory names, keeping only those <= the target version.
+     *
+     * @param list<string> $candidates directory names (e.g. ["13", "12", "12.20.0"])
+     *
+     * @return list<string> sorted ascending by version (e.g. ["12", "12.20.0"])
+     *
+     * @psalm-pure
+     *
+     * @internal used by tests
+     */
+    public static function filterVersionDirectories(array $candidates, string $targetVersion): array
+    {
+        $matched = \array_filter(
+            $candidates,
+            static fn(string $dir): bool => \version_compare($dir, $targetVersion, '<='),
+        );
+
+        \usort($matched, static fn(string $a, string $b): int => \version_compare($a, $b));
+
+        return $matched;
+    }
+}

--- a/tests/Unit/Util/InternalErrorClassifierTest.php
+++ b/tests/Unit/Util/InternalErrorClassifierTest.php
@@ -23,8 +23,8 @@ final class InternalErrorClassifierTest extends TestCase
     {
         $hint = InternalErrorClassifier::hintForFile($file);
 
-        self::assertNotNull($hint, "expected a hint for {$file}");
-        self::assertStringContainsString($expectedCategory, $hint);
+        $this->assertNotNull($hint, "expected a hint for {$file}");
+        $this->assertStringContainsString($expectedCategory, $hint);
     }
 
     /** @return iterable<string, array{string, string}> */
@@ -79,8 +79,8 @@ final class InternalErrorClassifierTest extends TestCase
     #[Test]
     public function it_skips_internal_error_machinery_frames(): void
     {
-        self::assertNull(InternalErrorClassifier::hintForFile('/x/src/Util/InternalErrorReporter.php'));
-        self::assertNull(InternalErrorClassifier::hintForFile('/x/src/Util/InternalErrorClassifier.php'));
+        $this->assertNull(InternalErrorClassifier::hintForFile('/x/src/Util/InternalErrorReporter.php'));
+        $this->assertNull(InternalErrorClassifier::hintForFile('/x/src/Util/InternalErrorClassifier.php'));
     }
 
     #[Test]
@@ -89,7 +89,7 @@ final class InternalErrorClassifierTest extends TestCase
         // hint() filters empty paths before calling hintForFile, but the public
         // surface should still treat an empty path as unclassifiable rather than
         // as user code with empty parentheses
-        self::assertNull(InternalErrorClassifier::hintForFile(''));
+        $this->assertNull(InternalErrorClassifier::hintForFile(''));
     }
 
     #[Test]
@@ -100,6 +100,6 @@ final class InternalErrorClassifierTest extends TestCase
         // and the hint() loop reaches a classifiable frame.
         $hint = InternalErrorClassifier::hint(new \RuntimeException('boom'));
 
-        self::assertNotNull($hint);
+        $this->assertNotNull($hint);
     }
 }

--- a/tests/Unit/Util/InternalErrorClassifierTest.php
+++ b/tests/Unit/Util/InternalErrorClassifierTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Util;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Util\InternalErrorClassifier;
+
+#[CoversClass(InternalErrorClassifier::class)]
+final class InternalErrorClassifierTest extends TestCase
+{
+    /**
+     * Tests classify by stable category nouns only — the rest of the hint copy
+     * is user-facing prose and may be reworded without breaking these tests.
+     */
+    #[Test]
+    #[DataProvider('classificationProvider')]
+    public function it_classifies_files_by_path(string $file, string $expectedCategory): void
+    {
+        $hint = InternalErrorClassifier::hintForFile($file);
+
+        self::assertNotNull($hint, "expected a hint for {$file}");
+        self::assertStringContainsString($expectedCategory, $hint);
+    }
+
+    /** @return iterable<string, array{string, string}> */
+    public static function classificationProvider(): iterable
+    {
+        yield 'Laravel framework' => [
+            '/home/user/project/vendor/laravel/framework/src/Illuminate/Foundation/Application.php',
+            'Laravel framework',
+        ];
+
+        yield 'illuminate split package' => [
+            '/home/user/project/vendor/illuminate/container/Container.php',
+            'Laravel framework',
+        ];
+
+        yield 'Orchestra Testbench' => [
+            '/home/user/project/vendor/orchestra/testbench-core/src/Foundation/Application.php',
+            'Orchestra Testbench',
+        ];
+
+        yield 'plugin development checkout' => [
+            '/home/dev/code/psalm-plugin-laravel/src/Providers/ApplicationProvider.php',
+            'Laravel plugin',
+        ];
+
+        yield 'plugin installed via composer wins over generic vendor' => [
+            '/home/user/app/vendor/psalm/plugin-laravel/src/Providers/ApplicationProvider.php',
+            'Laravel plugin',
+        ];
+
+        yield 'third-party vendor' => [
+            '/home/user/app/vendor/symfony/console/Application.php',
+            'third-party package',
+        ];
+
+        yield 'user bootstrap/app.php' => [
+            '/home/user/app/bootstrap/app.php',
+            'application code',
+        ];
+
+        yield 'user app/Providers' => [
+            '/home/user/app/app/Providers/AppServiceProvider.php',
+            'application code',
+        ];
+
+        yield 'windows path is normalised' => [
+            'C:\\Users\\dev\\app\\vendor\\laravel\\framework\\Application.php',
+            'Laravel framework',
+        ];
+    }
+
+    #[Test]
+    public function it_skips_internal_error_machinery_frames(): void
+    {
+        self::assertNull(InternalErrorClassifier::hintForFile('/x/src/Util/InternalErrorReporter.php'));
+        self::assertNull(InternalErrorClassifier::hintForFile('/x/src/Util/InternalErrorClassifier.php'));
+    }
+
+    #[Test]
+    public function it_returns_null_for_empty_path(): void
+    {
+        // hint() filters empty paths before calling hintForFile, but the public
+        // surface should still treat an empty path as unclassifiable rather than
+        // as user code with empty parentheses
+        self::assertNull(InternalErrorClassifier::hintForFile(''));
+    }
+
+    #[Test]
+    public function it_returns_a_hint_for_a_real_throwable(): void
+    {
+        // Smoke test: a real throwable always has at least one classifiable frame
+        // (this test file itself is enough). Verifies frameFiles() is wired up
+        // and the hint() loop reaches a classifiable frame.
+        $hint = InternalErrorClassifier::hint(new \RuntimeException('boom'));
+
+        self::assertNotNull($hint);
+    }
+}

--- a/tests/Unit/Util/StubFileFinderTest.php
+++ b/tests/Unit/Util/StubFileFinderTest.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace Tests\Psalm\LaravelPlugin\Unit;
+namespace Tests\Psalm\LaravelPlugin\Unit\Util;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Psalm\LaravelPlugin\Plugin;
+use Psalm\LaravelPlugin\Util\StubFileFinder;
 
-#[CoversClass(Plugin::class)]
-final class PluginVersionStubsTest extends TestCase
+#[CoversClass(StubFileFinder::class)]
+final class StubFileFinderTest extends TestCase
 {
     /**
      * @param list<string> $candidates
@@ -24,7 +24,7 @@ final class PluginVersionStubsTest extends TestCase
         string $targetVersion,
         array $expected,
     ): void {
-        $this->assertSame($expected, Plugin::filterVersionDirectories($candidates, $targetVersion));
+        $this->assertSame($expected, StubFileFinder::filterVersionDirectories($candidates, $targetVersion));
     }
 
     /** @return iterable<string, array{list<string>, string, list<string>}> */


### PR DESCRIPTION
## Summary

Pure refactor splitting `src/Plugin.php` into four single-purpose collaborators that sit next to their domain peers, leaving `Plugin` as the orchestrator. Behaviour is byte-equivalent: no stubs, handlers, or registration order changed.

## What moved out of Plugin.php

| New class | Home | Responsibility |
| --- | --- | --- |
| `StubFileFinder` | `src/Util/` | Recursive `.phpstub` scan and version-directory filtering |
| `MigrationSchemaBuilder` | `src/Handlers/Eloquent/Schema/` | Discover, parse, cache, and report on SQL dumps + PHP migrations |
| `AliasStubProvider` | `src/Providers/` | Generate `aliases.phpstub` and add it to the registration in one call (mirrors `CarbonStubProvider`) |
| `InternalErrorReporter` | `src/Util/` | Top-level catch handler with the existing best-effort URL fallback and `failOnInternalError` rethrow |

The `databasePath()` `method_exists` guard stays in `Plugin::buildSchema` so `MigrationSchemaBuilder::build()` always returns a `SchemaAggregator` rather than a nullable. Cache-status diagnostics (hit / written / read-failure / write-failure) move with the builder so the reporting and the cache reside together.

## Tests

The lone direct unit test for the moved code (`PluginVersionStubsTest::filterVersionDirectories`) is renamed to `tests/Unit/Util/StubFileFinderTest.php` with `#[CoversClass]` retargeted. All other coverage (`AliasStubCompletenessTest`, `MigrationCacheTest`, `tests/Application`) continues to exercise the moved code unchanged.

## Verification

- `composer test:unit` (572 tests, 1 skipped) green
- `composer test:type` (383 tests) green
- `composer test:app` green
- `composer psalm`, `composer cs`, `composer rector` clean
- Two rounds of `/psalm-review` (laravel, psalm, architecture, performance, errors, types, code, tests, simplify) cleared with no Critical or Important findings.

## Out of scope

Tier 2.1 (move `init*Handler()` plumbing into the handlers themselves) and Tier 2.4 (move cache-path helpers onto `PluginConfig`) were deliberately left for follow-ups so this PR stays a single mechanical extraction.