### PR TITLE
Detect Octane-incompatible singleton bindings

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,3 +34,4 @@ Each one links to detailed documentation with examples and fix guidance.
 - [MissingTranslation](issues/MissingTranslation.md)
 - [MissingView](issues/MissingView.md)
 - [ModelMakeDiscouraged](issues/ModelMakeDiscouraged.md)
+- [OctaneIncompatibleBinding](issues/OctaneIncompatibleBinding.md)

--- a/docs/config.md
+++ b/docs/config.md
@@ -127,11 +127,14 @@ See [MissingView](issues/MissingView.md) for details.
 
 ## `findOctaneIncompatibleBinding`
 
-**default**: auto (enabled when `laravel/octane` is installed in the project)
+**default**: omit the element. The plugin then auto-detects: the rule registers if the project depends on `laravel/octane`, and stays off otherwise.
 
 The plugin flags `singleton()` and `singletonIf()` binding closures that resolve request-scoped Laravel services (Request, Session, Auth, Cookie, Config, UrlGenerator, Redirector). Under Laravel Octane the application instance is reused across requests, so these captures leak state from the first resolving request into every subsequent one. `scoped()` / `scopedIf()` bindings are not flagged: Octane flushes them between requests.
 
-Detection runs automatically when `laravel/octane` is present in the project (the rule is only relevant to Octane users). Set the flag explicitly to `true` for projects that don't install the package directly but still want the check (e.g. shared libraries that aim to stay Octane-safe).
+To override the auto-detect:
+
+- `value="true"`: force the rule on. Useful for projects that don't install `laravel/octane` directly but still want the check (e.g. shared libraries that aim to stay Octane-safe).
+- `value="false"`: force the rule off, even when `laravel/octane` is installed.
 
 See [OctaneIncompatibleBinding](issues/OctaneIncompatibleBinding.md) for details.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -24,6 +24,7 @@ Full config example:
         <resolveDynamicWhereClauses value="false" />
         <findMissingTranslations value="true" />
         <findMissingViews value="true" />
+        <findOctaneIncompatibleBinding value="true" />
         <failOnInternalError value="true" />
         <configDirectory name="app/Config" />
     </pluginClass>
@@ -122,6 +123,22 @@ See [MissingView](issues/MissingView.md) for details.
 
 ```xml
 <findMissingViews value="true" />
+```
+
+## `findOctaneIncompatibleBinding`
+
+**default**: auto (enabled when `laravel/octane` is installed in the project)
+
+The plugin flags `singleton()` and `singletonIf()` binding closures that resolve request-scoped Laravel services (Request, Session, Auth, Cookie, Config, UrlGenerator, Redirector). Under Laravel Octane the application instance is reused across requests, so these captures leak state from the first resolving request into every subsequent one. `scoped()` / `scopedIf()` bindings are not flagged: Octane flushes them between requests.
+
+Detection runs automatically when `laravel/octane` is present in the project (the rule is only relevant to Octane users). Set the flag explicitly to `true` for projects that don't install the package directly but still want the check (e.g. shared libraries that aim to stay Octane-safe).
+
+See [OctaneIncompatibleBinding](issues/OctaneIncompatibleBinding.md) for details.
+
+### Example
+
+```xml
+<findOctaneIncompatibleBinding value="true" />
 ```
 
 ## Cache directory

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -35,7 +35,7 @@ flowchart TD
         Helpers — CacheHandler, PathHandler, TransHandler
         Translations — TranslationKeyHandler
         Views — MissingViewHandler
-        Rules — NoEnvOutsideConfigHandler, ModelMakeHandler
+        Rules — NoEnvOutsideConfigHandler, ModelMakeHandler, OctaneIncompatibleBindingHandler
         Validation — ValidatedTypeHandler, ValidationTaintHandler
         SuppressHandler
     "]
@@ -208,6 +208,13 @@ flowchart LR
         expression AST, codebase
         ----
         ModelMakeHandler"]
+
+        A7["AfterMethodCallAnalysis
+        on each resolved method call
+        ----
+        expression, declaring method id
+        ----
+        OctaneIncompatibleBindingHandler"]
     end
 
     scanning --> populated --> analysis

--- a/docs/issues/OctaneIncompatibleBinding.md
+++ b/docs/issues/OctaneIncompatibleBinding.md
@@ -1,0 +1,94 @@
+---
+title: OctaneIncompatibleBinding
+parent: Custom Issues
+nav_order: 7
+---
+
+# OctaneIncompatibleBinding
+
+Emitted when a `singleton()` or `singletonIf()` binding closure resolves a request-scoped Laravel service such as `Request`, `Session`, or `Auth`.
+
+**Auto-enabled when `laravel/octane` is installed.** Projects that don't depend on the package directly can still opt in via `<findOctaneIncompatibleBinding value="true" />` in `psalm.xml`. See [Configuration](../config.md#findoctaneincompatiblebinding).
+
+`bind()`, `bindIf()`, `scoped()`, and `scopedIf()` are NOT flagged:
+
+- `bind()` / `bindIf()` re-execute the closure on every resolution.
+- `scoped()` / `scopedIf()` are flushed between requests under Octane (via `Container::forgetScopedInstances()`), so captured state does not leak across requests. These are the Octane-safe alternative to `singleton()`.
+
+## Why this is a problem
+
+Under traditional PHP-FPM, every request boots a fresh application instance, so even a "shared" binding is really re-created per request.
+
+Under [Laravel Octane](https://laravel.com/docs/octane), the application instance is **reused across requests**. A shared binding closure runs once and the result is kept for the rest of the worker's lifetime. If that closure captures request-scoped state (a `Request`, the current `Auth` user, a `Session`), every subsequent request sees stale state from the first resolution.
+
+This is a [documented Octane caveat](https://laravel.com/docs/octane#dependency-injection-and-octane):
+
+> You should avoid injecting the application container or HTTP request into the constructor of any object you register as a singleton.
+
+## Examples
+
+```php
+// Bad. The Request is captured once and reused for every future request.
+class AppServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->singleton(MyService::class, function ($app) {
+            return new MyService($app->make(Request::class)); // OctaneIncompatibleBinding
+        });
+    }
+}
+```
+
+```php
+// Also bad. Same issue, facade variant.
+$this->app->singleton(MyService::class, function () {
+    return new MyService(App::make(Request::class)); // OctaneIncompatibleBinding
+});
+```
+
+```php
+// Good. Use bind() so the closure re-runs on every resolution.
+$this->app->bind(MyService::class, function ($app) {
+    return new MyService($app->make(Request::class));
+});
+```
+
+```php
+// Also good. Keep the singleton, but resolve the request-scoped service at the
+// point of use instead of constructor injection.
+class MyService
+{
+    public function __construct(private \Illuminate\Contracts\Container\Container $container) {}
+
+    public function handle(): void
+    {
+        $request = $this->container->make(Request::class);
+        // ...
+    }
+}
+```
+
+## Detected services
+
+The following abstracts are treated as request-scoped:
+
+- `Illuminate\Http\Request` and its Symfony parent `Symfony\Component\HttpFoundation\Request`, alias `'request'`
+- `Illuminate\Session\Store`, `Illuminate\Session\SessionManager`, `Illuminate\Contracts\Session\Session`, aliases `'session'`, `'session.store'`
+- `Illuminate\Auth\AuthManager`, `Illuminate\Contracts\Auth\Factory`, `Illuminate\Contracts\Auth\Guard`, `Illuminate\Contracts\Auth\Authenticatable`, aliases `'auth'`, `'auth.driver'`
+- `Illuminate\Cookie\CookieJar` (and contracts `Illuminate\Contracts\Cookie\Factory`, `Illuminate\Contracts\Cookie\QueueingFactory`), alias `'cookie'`
+- `Illuminate\Config\Repository`, `Illuminate\Contracts\Config\Repository`, alias `'config'` (Octane clones config per request)
+- `Illuminate\Routing\UrlGenerator`, `Illuminate\Contracts\Routing\UrlGenerator`, alias `'url'`
+- `Illuminate\Routing\Redirector`, alias `'redirect'`
+
+## Known gaps
+
+- `Container::getInstance()->make(...)` inside a closure is not detected.
+- The rule does not trace transitive dependencies. Singleton A that depends on singleton B which captures `Request` is flagged only at B.
+- Named arguments are not normalized: if the closure is not the second source-order argument of `singleton()`, the call is missed (e.g. `singleton(concrete: fn() => ..., abstract: X::class)` puts the closure at source position 0).
+
+## How to fix
+
+- Change `singleton()` to `scoped()`. Octane flushes scoped instances between requests, so the closure runs once per request instead of once per worker.
+- Or change `singleton()` to `bind()`. The closure will re-run on every resolution (simpler but no intra-request caching).
+- Or keep the singleton and move the request-scoped resolution out of the constructor: inject the container and resolve lazily inside the method that actually uses it.

--- a/docs/issues/OctaneIncompatibleBinding.md
+++ b/docs/issues/OctaneIncompatibleBinding.md
@@ -8,7 +8,7 @@ nav_order: 7
 
 Emitted when a `singleton()` or `singletonIf()` binding closure resolves a request-scoped Laravel service such as `Request`, `Session`, or `Auth`.
 
-**Auto-enabled when `laravel/octane` is installed.** Projects that don't depend on the package directly can still opt in via `<findOctaneIncompatibleBinding value="true" />` in `psalm.xml`. See [Configuration](../config.md#findoctaneincompatiblebinding).
+**Auto-enabled when `laravel/octane` is installed.** Projects that don't depend on the package directly can opt in via `<findOctaneIncompatibleBinding value="true" />` in `psalm.xml`. To opt out even when `laravel/octane` is installed, set `<findOctaneIncompatibleBinding value="false" />`. See [Configuration](../config.md#findoctaneincompatiblebinding).
 
 `bind()`, `bindIf()`, `scoped()`, and `scopedIf()` are NOT flagged:
 

--- a/docs/issues/index.md
+++ b/docs/issues/index.md
@@ -14,5 +14,6 @@ The plugin ships advanced Laravel-aware static analysis checks that extend Psalm
 - [MissingView](MissingView.md) — `view()` references a non-existent Blade template (opt-in)
 - [MissingTranslation](MissingTranslation.md) — `__()` or `trans()` references an undefined translation key (opt-in)
 - [ModelMakeDiscouraged](ModelMakeDiscouraged.md) — `Model::make()` used instead of `new Model()`
+- [OctaneIncompatibleBinding](OctaneIncompatibleBinding.md) — `singleton()` closure resolves a request-scoped service such as Request, Session, or Auth (auto-enabled when `laravel/octane` is installed)
 
 Each issue page explains what it detects, why it matters, and how to fix it.

--- a/rector.php
+++ b/rector.php
@@ -14,6 +14,13 @@ use Rector\ValueObject\PhpVersion;
 return RectorConfig::configure()
     ->withPaths(['src', 'tests'])
     ->withSkipPath('tests/Unit/Handlers/Eloquent/Schema/migrations')
+    // UNSAFE_METHOD_IDS uses intentionally-lowercased "class::method" strings so we can
+    // match strtolower(getDeclaringMethodId()) without runtime normalization. Rector
+    // keeps "upgrading" them to \Class::class concatenation, which silently breaks the
+    // lookup: ::class preserves source-code casing, so a mis-cased FQN produces a key
+    // that never matches the lowercase method id. (::class IS valid in const arrays on
+    // PHP 8.3+; the problem is the casing, not the const-context.)
+    ->withSkipPath('src/Handlers/Rules/OctaneIncompatibleBindingHandler.php')
     ->withPhpVersion(PhpVersion::PHP_82)
     ->withSets([PHPUnitSetList::PHPUNIT_120])
     ->withPreparedSets(deadCode: true, codingStyle: true, typeDeclarations: true, codeQuality: true, phpunitCodeQuality: true)

--- a/src/Handlers/Rules/OctaneIncompatibleBindingHandler.php
+++ b/src/Handlers/Rules/OctaneIncompatibleBindingHandler.php
@@ -1,0 +1,514 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Enum_;
+use PhpParser\Node\Stmt\Interface_;
+use PhpParser\Node\Stmt\Trait_;
+use Psalm\CodeLocation;
+use Psalm\IssueBuffer;
+use Psalm\LaravelPlugin\Issues\OctaneIncompatibleBinding;
+use Psalm\Plugin\EventHandler\AfterMethodCallAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterMethodCallAnalysisEvent;
+
+/**
+ * Flags request-scoped service resolutions inside long-lived binding closures
+ * (singleton, singletonIf).
+ *
+ * Under Laravel Octane, the application instance is reused across requests, so a
+ * closure that resolves Request/Session/Auth during the first resolution keeps
+ * that instance alive for every subsequent request.
+ *
+ * scoped()/scopedIf() bindings are NOT flagged: Octane calls
+ * {@see \Illuminate\Container\Container::forgetScopedInstances()} between requests,
+ * so scoped captures are re-created per request. They are the Octane-safe
+ * alternative to singleton() and are out of scope for this rule.
+ *
+ * Handler is auto-registered when the project depends on laravel/octane, and
+ * also registered when findOctaneIncompatibleBinding is set in psalm.xml. When
+ * registered, the hook fires for every resolved MethodCall and StaticCall; we
+ * reject StaticCall immediately (facade-form bindings like `App::singleton(...)`
+ * are out of scope) and match remaining calls in O(1) via an isset() lookup on
+ * the declaring method id.
+ *
+ * @see https://laravel.com/docs/octane#dependency-injection-and-octane
+ * @see https://github.com/larastan/larastan/blob/3.x/src/Rules/OctaneCompatibilityRule.php
+ */
+final class OctaneIncompatibleBindingHandler implements AfterMethodCallAnalysisInterface
+{
+    /**
+     * Method IDs (declaring-class::method, lowercased) for container bindings that
+     * register a single shared instance reused across requests.
+     *
+     *  - bind()/bindIf() are safe: they re-execute the closure per resolution.
+     *  - scoped()/scopedIf() are safe under Octane: flushed between requests via
+     *    Container::forgetScopedInstances(). Not flagged.
+     *
+     * Covers both the concrete Container and the contract, because declaring_method_id
+     * points at whichever one is in scope for the receiver type. Users who type
+     * $this->app as the contract hit the contract rows; users typing the concrete
+     * class hit the Container rows.
+     *
+     * Keys are hard-coded lowercase strings. ::class is allowed in const arrays on
+     * PHP 8.3+, but it preserves the source-code casing verbatim: a mis-cased
+     * `\Illuminate\container\Container::class` at the declaration site would silently
+     * produce a key that never matches strtolower(getDeclaringMethodId()). Literal
+     * lowercase strings eliminate that trap.
+     */
+    private const UNSAFE_METHOD_IDS = [
+        'illuminate\\container\\container::singleton' => true,
+        'illuminate\\container\\container::singletonif' => true,
+        'illuminate\\contracts\\container\\container::singleton' => true,
+        'illuminate\\contracts\\container\\container::singletonif' => true,
+    ];
+
+    /**
+     * Core request-scoped Laravel services. Resolving any of these inside a shared
+     * binding closure captures state from the first resolving request and leaks it
+     * into every subsequent request under Octane.
+     *
+     * Sources:
+     *  - {@see \Illuminate\Foundation\Application::registerCoreContainerAliases()}
+     *    for the alias -> class mapping (request, session, cookie, auth, config, url).
+     *  - {@see \Illuminate\Auth\AuthServiceProvider::register()} for Authenticatable,
+     *    which is bound at register time, not via the alias table.
+     *
+     * Illuminate\Routing\Route is intentionally NOT listed: it is a plain data object,
+     * not a container-bound service. The "current route" is accessed via the Router
+     * or facade, not by resolving Route::class.
+     *
+     * Maintenance: revisit on every Laravel major bump by re-reading
+     * {@see \Illuminate\Foundation\Application::registerCoreContainerAliases()}.
+     * If a new alias resolves to a request-scoped service, add the concrete class
+     * (and any sibling contracts that share the alias) here, plus the alias key in
+     * REQUEST_SCOPED_ALIASES.
+     */
+    private const REQUEST_SCOPED_CLASSES = [
+        \Illuminate\Http\Request::class => true,
+        \Symfony\Component\HttpFoundation\Request::class => true,
+        \Illuminate\Session\Store::class => true,
+        \Illuminate\Session\SessionManager::class => true,
+        \Illuminate\Contracts\Session\Session::class => true,
+        \Illuminate\Cookie\CookieJar::class => true,
+        // Cookie contract siblings: `cookie` alias maps to all three of these in
+        // registerCoreContainerAliases(); resolving any of them returns the same
+        // shared CookieJar instance.
+        \Illuminate\Contracts\Cookie\Factory::class => true,
+        \Illuminate\Contracts\Cookie\QueueingFactory::class => true,
+        \Illuminate\Auth\AuthManager::class => true,
+        \Illuminate\Contracts\Auth\Factory::class => true,
+        \Illuminate\Contracts\Auth\Guard::class => true,
+        \Illuminate\Contracts\Auth\Authenticatable::class => true,
+        \Illuminate\Config\Repository::class => true,
+        \Illuminate\Contracts\Config\Repository::class => true,
+        \Illuminate\Routing\UrlGenerator::class => true,
+        \Illuminate\Contracts\Routing\UrlGenerator::class => true,
+        \Illuminate\Routing\Redirector::class => true,
+    ];
+
+    /**
+     * String aliases for request-scoped services (keys Laravel registers in
+     * registerCoreContainerAliases()). Resolving via alias string is equivalent to
+     * resolving via class-string.
+     */
+    private const REQUEST_SCOPED_ALIASES = [
+        'request' => true,
+        'auth' => true,
+        'auth.driver' => true,
+        'session' => true,
+        'session.store' => true,
+        'cookie' => true,
+        'config' => true,
+        'url' => true,
+        'redirect' => true,
+    ];
+
+    /**
+     * Container resolution methods that take an abstract name as their first arg.
+     */
+    private const RESOLVER_METHODS = [
+        'make' => true,
+        'makewith' => true,
+        'get' => true,
+        'resolve' => true,
+    ];
+
+    /** @inheritDoc */
+    #[\Override]
+    public static function afterMethodCallAnalysis(AfterMethodCallAnalysisEvent $event): void
+    {
+        $expr = $event->getExpr();
+
+        // The event also fires for StaticCall. Facade-form bindings like
+        // `App::singleton(...)` are intentionally out of scope for this rule
+        // (they're much rarer than the `$this->app->singleton(...)` pattern).
+        if (!$expr instanceof MethodCall) {
+            return;
+        }
+
+        // Hot path: the handler fires for every resolved MethodCall. Reject on
+        // the short, pre-parsed method-name token before allocating the lowercased
+        // FQN id, so the >99% non-singleton calls don't pay for the strtolower
+        // copy of "Long\Namespace\Class::method".
+        if (!$expr->name instanceof Identifier) {
+            return;
+        }
+
+        $methodName = $expr->name->name;
+        $methodNameLower = \strtolower($methodName);
+
+        if ($methodNameLower !== 'singleton' && $methodNameLower !== 'singletonif') {
+            return;
+        }
+
+        if (!isset(self::UNSAFE_METHOD_IDS[\strtolower($event->getDeclaringMethodId())])) {
+            return;
+        }
+
+        $args = $expr->getArgs();
+
+        if (\count($args) < 2) {
+            return;
+        }
+
+        $closure = $args[1]->value;
+
+        if (!$closure instanceof Closure && !$closure instanceof ArrowFunction) {
+            return;
+        }
+
+        $containerParamName = self::getFirstParamName($closure);
+
+        foreach (self::findResolutions($closure, $containerParamName) as [$abstract, $node]) {
+            self::emitIssue($event, $methodName, $abstract, $node);
+        }
+    }
+
+    /**
+     * The name of the closure's first parameter (Laravel passes the container here).
+     * Returns null when the closure takes no parameters or the name is dynamic.
+     *
+     * @psalm-mutation-free
+     */
+    private static function getFirstParamName(Closure|ArrowFunction $closure): ?string
+    {
+        $params = $closure->getParams();
+
+        if ($params === []) {
+            return null;
+        }
+
+        $firstParam = $params[0];
+
+        if (!$firstParam->var instanceof Variable || !\is_string($firstParam->var->name)) {
+            return null;
+        }
+
+        return $firstParam->var->name;
+    }
+
+    /**
+     * Yield each (abstract, node) violation found inside the closure body.
+     *
+     * We deliberately do not descend into nested closures / arrow functions. In the
+     * common case, resolutions performed inside them happen only when the inner
+     * closure is invoked later, not during the outer shared-binding closure's
+     * one-and-only execution, so attributing them to the outer binding would be a
+     * false positive.
+     *
+     * Known limitation: immediately-invoked closures / arrow functions (IIFEs) are
+     * also skipped by this traversal, so resolutions inside them can be missed
+     * (false negatives). Detecting IIFEs reliably is an AST-pattern problem we
+     * consider out of scope for this rule.
+     *
+     * @return \Generator<int, array{class-string|string, Node}>
+     */
+    private static function findResolutions(Closure|ArrowFunction $closure, ?string $containerParamName): \Generator
+    {
+        $body = $closure instanceof Closure ? $closure->stmts : [$closure->expr];
+
+        foreach (self::walkWithoutNestedClosures($body) as $node) {
+            $violation = self::classifyResolution($node, $containerParamName);
+
+            if ($violation !== null) {
+                yield $violation;
+            }
+        }
+    }
+
+    /**
+     * Match one of the patterns we care about:
+     *   - $app->make(X::class)            / $app->make('request')
+     *   - $app[X::class]                  / $app['request']
+     *   - $this->app->make(X::class)      / $this->app['request']
+     *   - app(X::class)                   / resolve(X::class)
+     *   - App::make(X::class)             (facade)
+     *
+     * Returns the resolved abstract (class-string or alias) plus the AST node to
+     * report at, or null if the node is unrelated.
+     *
+     * Known gap: `Container::getInstance()->make(...)` is not detected. Rare enough
+     * that the added complexity would not pay off.
+     *
+     * @return array{class-string|string, Node}|null
+     */
+    private static function classifyResolution(Node $node, ?string $containerParamName): ?array
+    {
+        // $app->make(...), $this->app->make(...), app()->make(...), etc.
+        if ($node instanceof MethodCall
+            && $node->name instanceof Identifier
+            && isset(self::RESOLVER_METHODS[\strtolower($node->name->name)])
+            && self::looksLikeContainer($node->var, $containerParamName)
+        ) {
+            $abstract = self::extractAbstract($node->getArgs());
+
+            if ($abstract !== null) {
+                return [$abstract, $node];
+            }
+
+            return null;
+        }
+
+        // $app[X::class], $this->app['request']
+        if ($node instanceof ArrayDimFetch
+            && self::looksLikeContainer($node->var, $containerParamName)
+        ) {
+            $abstract = self::literalAbstractFrom($node->dim);
+
+            if ($abstract !== null) {
+                return [$abstract, $node];
+            }
+
+            return null;
+        }
+
+        // app(X::class), resolve(X::class)
+        if ($node instanceof FuncCall
+            && $node->name instanceof Name
+            && \in_array($node->name->toLowerString(), ['app', 'resolve'], true)
+        ) {
+            $abstract = self::extractAbstract($node->getArgs());
+
+            if ($abstract !== null) {
+                return [$abstract, $node];
+            }
+
+            return null;
+        }
+
+        // App::make(X::class). The facade resolves from the globally-bound container,
+        // which in a typical application is the same instance we are binding into.
+        if ($node instanceof StaticCall
+            && $node->name instanceof Identifier
+            && isset(self::RESOLVER_METHODS[\strtolower($node->name->name)])
+            && $node->class instanceof Name
+            && self::isAppFacade($node->class)
+        ) {
+            $abstract = self::extractAbstract($node->getArgs());
+
+            if ($abstract !== null) {
+                return [$abstract, $node];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Does $expr look like the container inside the closure scope?
+     * True for: the declared container param ($app), $this->app, and app()/resolve().
+     */
+    private static function looksLikeContainer(Node $expr, ?string $containerParamName): bool
+    {
+        if ($containerParamName !== null
+            && $expr instanceof Variable
+            && $expr->name === $containerParamName
+        ) {
+            return true;
+        }
+
+        if ($expr instanceof PropertyFetch
+            && $expr->var instanceof Variable
+            && $expr->var->name === 'this'
+            && $expr->name instanceof Identifier
+            && $expr->name->name === 'app'
+        ) {
+            return true;
+        }
+
+        return $expr instanceof FuncCall
+            && $expr->name instanceof Name
+            && \in_array($expr->name->toLowerString(), ['app', 'resolve'], true)
+            && $expr->getArgs() === [];
+    }
+
+    private static function isAppFacade(Name $class): bool
+    {
+        /** @psalm-var mixed $resolved */
+        $resolved = $class->getAttribute('resolvedName');
+
+        if (\is_string($resolved)) {
+            return $resolved === \Illuminate\Support\Facades\App::class;
+        }
+
+        // Fallback for root-namespace alias. The generated
+        // `class App extends \Illuminate\Support\Facades\App {}` alias stub means
+        // unqualified `App::make(...)` in application code resolves to the facade.
+        return $class->toString() === 'App';
+    }
+
+    /**
+     * From the args of make() / get() / app() / resolve(), extract the first
+     * positional argument only, which is the "abstract" in Laravel's container API.
+     * Extra arguments (parameters for makeWith) are not relevant to this rule.
+     *
+     * @param array<array-key, Arg> $args
+     * @return class-string|string|null
+     */
+    private static function extractAbstract(array $args): ?string
+    {
+        foreach ($args as $arg) {
+            return self::literalAbstractFrom($arg->value);
+        }
+
+        return null;
+    }
+
+    /**
+     * Extract a known request-scoped abstract from a literal expression node
+     * (class-const-fetch or a known-alias string literal). The string branch is
+     * deliberately restricted to Laravel's alias keys; arbitrary strings do not
+     * match.
+     *
+     * @return class-string|string|null
+     */
+    private static function literalAbstractFrom(?Node $node): ?string
+    {
+        if ($node instanceof ClassConstFetch
+            && $node->class instanceof Name
+            && $node->name instanceof Identifier
+            && \strtolower($node->name->name) === 'class'
+        ) {
+            /** @psalm-var mixed $resolved */
+            $resolved = $node->class->getAttribute('resolvedName');
+
+            if (\is_string($resolved) && isset(self::REQUEST_SCOPED_CLASSES[$resolved])) {
+                /** @psalm-var class-string */
+                return $resolved;
+            }
+
+            return null;
+        }
+
+        if ($node instanceof String_ && isset(self::REQUEST_SCOPED_ALIASES[$node->value])) {
+            return $node->value;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return \Generator<Node>
+     *
+     * @param iterable<Node> $nodes
+     */
+    private static function walkWithoutNestedClosures(iterable $nodes): \Generator
+    {
+        foreach ($nodes as $node) {
+            yield from self::walkNode($node);
+        }
+    }
+
+    /**
+     * @return \Generator<Node>
+     */
+    private static function walkNode(Node $node): \Generator
+    {
+        yield $node;
+
+        foreach ($node->getSubNodeNames() as $name) {
+            /** @psalm-var mixed $sub */
+            $sub = $node->$name;
+
+            if (self::isScopeBoundary($sub)) {
+                // Do not descend into nested execution scopes. See findResolutions() docblock.
+                continue;
+            }
+
+            if ($sub instanceof Node) {
+                yield from self::walkNode($sub);
+                continue;
+            }
+
+            if (\is_array($sub)) {
+                /** @psalm-var mixed $item */
+                foreach ($sub as $item) {
+                    if (self::isScopeBoundary($item)) {
+                        continue;
+                    }
+
+                    if ($item instanceof Node) {
+                        yield from self::walkNode($item);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Nodes whose bodies form a separate execution scope: their statements do not
+     * run during the outer shared-binding closure's resolution.
+     *
+     *   - FunctionLike covers Closure, ArrowFunction, Function_, ClassMethod.
+     *   - Class_, Trait_, Interface_, Enum_ cover anonymous / nested class-like
+     *     declarations inside the closure; method bodies inside them are lazy.
+     *
+     * @psalm-pure
+     * @psalm-assert-if-true FunctionLike|Class_|Trait_|Interface_|Enum_ $node
+     */
+    private static function isScopeBoundary(mixed $node): bool
+    {
+        return $node instanceof FunctionLike
+            || $node instanceof Class_
+            || $node instanceof Trait_
+            || $node instanceof Interface_
+            || $node instanceof Enum_;
+    }
+
+    private static function emitIssue(
+        AfterMethodCallAnalysisEvent $event,
+        string $methodName,
+        string $abstract,
+        Node $node,
+    ): void {
+        IssueBuffer::accepts(
+            new OctaneIncompatibleBinding(
+                \sprintf(
+                    "Request-scoped '%s' resolved inside %s() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.",
+                    $abstract,
+                    $methodName,
+                ),
+                new CodeLocation($event->getStatementsSource(), $node),
+            ),
+            $event->getStatementsSource()->getSuppressedIssues(),
+        );
+    }
+}

--- a/src/Handlers/Rules/OctaneIncompatibleBindingHandler.php
+++ b/src/Handlers/Rules/OctaneIncompatibleBindingHandler.php
@@ -42,12 +42,12 @@ use Psalm\Plugin\EventHandler\Event\AfterMethodCallAnalysisEvent;
  * so scoped captures are re-created per request. They are the Octane-safe
  * alternative to singleton() and are out of scope for this rule.
  *
- * Handler is auto-registered when the project depends on laravel/octane, and
- * also registered when findOctaneIncompatibleBinding is set in psalm.xml. When
- * registered, the hook fires for every resolved MethodCall and StaticCall; we
- * reject StaticCall immediately (facade-form bindings like `App::singleton(...)`
- * are out of scope) and match remaining calls in O(1) via an isset() lookup on
- * the declaring method id.
+ * Handler registration is tri-state: auto-detected when laravel/octane is
+ * installed; `<findOctaneIncompatibleBinding value="true|false" />` in psalm.xml
+ * forces it on or off. When registered, the hook fires for every resolved
+ * MethodCall and StaticCall; we reject StaticCall immediately (facade-form
+ * bindings like `App::singleton(...)` are out of scope) and match remaining
+ * calls in O(1) via an isset() lookup on the declaring method id.
  *
  * @see https://laravel.com/docs/octane#dependency-injection-and-octane
  * @see https://github.com/larastan/larastan/blob/3.x/src/Rules/OctaneCompatibilityRule.php

--- a/src/Issues/OctaneIncompatibleBinding.php
+++ b/src/Issues/OctaneIncompatibleBinding.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Issues;
+
+use Psalm\Issue\PluginIssue;
+
+/**
+ * Reported when a singleton() / singletonIf() binding closure resolves a
+ * request-scoped Laravel service (Request, Session, Auth, etc.). Under Laravel
+ * Octane, the application instance is reused across requests, so such captures
+ * leak state from the first resolving request into every subsequent request.
+ *
+ * scoped() / scopedIf() bindings are NOT reported: Octane flushes them between
+ * requests via Container::forgetScopedInstances().
+ */
+final class OctaneIncompatibleBinding extends PluginIssue
+{
+    public const DOCUMENTATION_URL = 'https://psalm.github.io/psalm-plugin-laravel/issues/OctaneIncompatibleBinding/';
+
+    public const ERROR_LEVEL = 1;
+}

--- a/src/Issues/OctaneIncompatibleBinding.php
+++ b/src/Issues/OctaneIncompatibleBinding.php
@@ -19,5 +19,8 @@ final class OctaneIncompatibleBinding extends PluginIssue
 {
     public const DOCUMENTATION_URL = 'https://psalm.github.io/psalm-plugin-laravel/issues/OctaneIncompatibleBinding/';
 
-    public const ERROR_LEVEL = 1;
+    // No ERROR_LEVEL override: a request-scoped capture in a singleton closure is a
+    // real correctness bug under Octane (state leaks across requests), not a strictness
+    // preference. Inherit CodeIssue::ERROR_LEVEL = -1 so the issue is reported as
+    // ERROR at every project level, not downgraded to INFO when level > 1.
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -338,6 +338,18 @@ final class Plugin implements PluginEntryPointInterface
 
         require_once __DIR__ . '/Handlers/Rules/ModelMakeHandler.php';
         $registration->registerHooksFromClass(Handlers\Rules\ModelMakeHandler::class);
+        // Auto-enable when the project depends on laravel/octane (the rule is only
+        // relevant under long-lived workers); allow manual opt-in via
+        // `<findOctaneIncompatibleBinding value="true" />` for projects that don't
+        // install the package directly but still want the check (e.g. shared
+        // libraries that aim to stay Octane-safe).
+        // class_exists() triggers the project autoloader, which is already active
+        // here because ApplicationProvider booted the Laravel app earlier.
+        if ($pluginConfig->findOctaneIncompatibleBinding || \class_exists('Laravel\\Octane\\Octane')) {
+            require_once __DIR__ . '/Handlers/Rules/OctaneIncompatibleBindingHandler.php';
+            $registration->registerHooksFromClass(Handlers\Rules\OctaneIncompatibleBindingHandler::class);
+        }
+
         // NoEnvOutsideConfigHandler must be registered BEFORE EnvHandler.
         // Both handle 'env()' via FunctionReturnTypeProviderInterface; Psalm dispatches handlers
         // in registration order and stops at the first non-null return. NoEnvOutsideConfigHandler

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -338,14 +338,17 @@ final class Plugin implements PluginEntryPointInterface
 
         require_once __DIR__ . '/Handlers/Rules/ModelMakeHandler.php';
         $registration->registerHooksFromClass(Handlers\Rules\ModelMakeHandler::class);
-        // Auto-enable when the project depends on laravel/octane (the rule is only
-        // relevant under long-lived workers); allow manual opt-in via
-        // `<findOctaneIncompatibleBinding value="true" />` for projects that don't
-        // install the package directly but still want the check (e.g. shared
-        // libraries that aim to stay Octane-safe).
-        // class_exists() triggers the project autoloader, which is already active
-        // here because ApplicationProvider booted the Laravel app earlier.
-        if ($pluginConfig->findOctaneIncompatibleBinding || \class_exists('Laravel\\Octane\\Octane')) {
+        // Tri-state gate for the OctaneIncompatibleBinding rule:
+        //   findOctaneIncompatibleBinding === null  → auto-detect via class_exists()
+        //   findOctaneIncompatibleBinding === true  → force enabled
+        //   findOctaneIncompatibleBinding === false → force disabled (opt-out, even if laravel/octane is installed)
+        // Auto-detect uses class_exists(), which triggers the project autoloader. The
+        // autoloader is already active here because ApplicationProvider booted the
+        // Laravel app earlier in __invoke().
+        $shouldRegisterOctaneRule = $pluginConfig->findOctaneIncompatibleBinding
+            ?? \class_exists('Laravel\\Octane\\Octane');
+
+        if ($shouldRegisterOctaneRule) {
             require_once __DIR__ . '/Handlers/Rules/OctaneIncompatibleBindingHandler.php';
             $registration->registerHooksFromClass(Handlers\Rules\OctaneIncompatibleBindingHandler::class);
         }

--- a/src/PluginConfig.php
+++ b/src/PluginConfig.php
@@ -27,6 +27,7 @@ final readonly class PluginConfig
         public bool $resolveDynamicWhereClauses,
         public bool $findMissingTranslations,
         public bool $findMissingViews,
+        public bool $findOctaneIncompatibleBinding,
         public string $cachePath,
         public bool $failOnInternalError,
     ) {}
@@ -50,6 +51,7 @@ final readonly class PluginConfig
         $failOnInternalError = self::xmlBoolAttr($config?->failOnInternalError, 'failOnInternalError');
         $findMissingTranslations = self::xmlBoolAttr($config?->findMissingTranslations, 'findMissingTranslations');
         $findMissingViews = self::xmlBoolAttr($config?->findMissingViews, 'findMissingViews');
+        $findOctaneIncompatibleBinding = self::xmlBoolAttr($config?->findOctaneIncompatibleBinding, 'findOctaneIncompatibleBinding');
         $resolveDynamicWhereClauses = self::xmlBoolAttr($config?->resolveDynamicWhereClauses, 'resolveDynamicWhereClauses', true);
         $configDirectories = self::xmlNameList($config, 'configDirectory');
 
@@ -59,6 +61,7 @@ final readonly class PluginConfig
             resolveDynamicWhereClauses: $resolveDynamicWhereClauses,
             findMissingTranslations: $findMissingTranslations,
             findMissingViews: $findMissingViews,
+            findOctaneIncompatibleBinding: $findOctaneIncompatibleBinding,
             cachePath: self::resolveCachePath(),
             failOnInternalError: $failOnInternalError,
         );
@@ -151,7 +154,7 @@ final readonly class PluginConfig
         // the automatic Psalm cache directory instead
         $env = \getenv('PSALM_LARAVEL_PLUGIN_CACHE_PATH');
 
-        if (is_string($env) && $env !== '') {
+        if (\is_string($env) && $env !== '') {
             \trigger_error(
                 'PSALM_LARAVEL_PLUGIN_CACHE_PATH is deprecated and will be removed in v5. '
                     . "The plugin now uses Psalm's cache directory automatically.",

--- a/src/PluginConfig.php
+++ b/src/PluginConfig.php
@@ -27,7 +27,14 @@ final readonly class PluginConfig
         public bool $resolveDynamicWhereClauses,
         public bool $findMissingTranslations,
         public bool $findMissingViews,
-        public bool $findOctaneIncompatibleBinding,
+        /**
+         * Tri-state opt-in/out for the OctaneIncompatibleBinding rule.
+         *
+         *  - null  → auto-detect (rule registers when laravel/octane is installed)
+         *  - true  → force enabled (useful for shared libraries that aim to stay Octane-safe)
+         *  - false → force disabled (override even when laravel/octane is installed)
+         */
+        public ?bool $findOctaneIncompatibleBinding,
         public string $cachePath,
         public bool $failOnInternalError,
     ) {}
@@ -51,7 +58,7 @@ final readonly class PluginConfig
         $failOnInternalError = self::xmlBoolAttr($config?->failOnInternalError, 'failOnInternalError');
         $findMissingTranslations = self::xmlBoolAttr($config?->findMissingTranslations, 'findMissingTranslations');
         $findMissingViews = self::xmlBoolAttr($config?->findMissingViews, 'findMissingViews');
-        $findOctaneIncompatibleBinding = self::xmlBoolAttr($config?->findOctaneIncompatibleBinding, 'findOctaneIncompatibleBinding');
+        $findOctaneIncompatibleBinding = self::xmlOptionalBoolAttr($config?->findOctaneIncompatibleBinding, 'findOctaneIncompatibleBinding');
         $resolveDynamicWhereClauses = self::xmlBoolAttr($config?->resolveDynamicWhereClauses, 'resolveDynamicWhereClauses', true);
         $configDirectories = self::xmlNameList($config, 'configDirectory');
 
@@ -138,6 +145,40 @@ final readonly class PluginConfig
         }
 
         $value = (string) ($element['value'] ?? ($default ? 'true' : 'false'));
+
+        if (!\in_array($value, ['true', 'false'], true)) {
+            throw new \InvalidArgumentException(
+                "Invalid {$name} value '{$value}'. Valid values: 'true', 'false'.",
+            );
+        }
+
+        return $value === 'true';
+    }
+
+    /**
+     * Tri-state variant of {@see self::xmlBoolAttr()} for flags that auto-detect
+     * when unset. Returns null when the element is absent so callers can fall back
+     * to runtime detection (e.g. `class_exists()`); returns true/false when the
+     * user explicitly opts in or out via XML.
+     *
+     * @psalm-pure
+     */
+    private static function xmlOptionalBoolAttr(?\SimpleXMLElement $element, string $name): ?bool
+    {
+        if (!$element instanceof \SimpleXMLElement) {
+            return null;
+        }
+
+        // SimpleXMLElement returns an empty proxy when accessing a non-existent
+        // child via dynamic property syntax, so the instanceof check above does
+        // not distinguish "absent" from "present". Use the value attribute as
+        // the absence signal: a present element without a value attribute is
+        // treated as auto-detect, same as a missing element.
+        if (!isset($element['value'])) {
+            return null;
+        }
+
+        $value = (string) $element['value'];
 
         if (!\in_array($value, ['true', 'false'], true)) {
             throw new \InvalidArgumentException(

--- a/src/Util/ContainerResolver.php
+++ b/src/Util/ContainerResolver.php
@@ -32,8 +32,8 @@ final class ContainerResolver
 
         // dynamic analysis to resolve the actual type from the container
         try {
+            /** @psalm-var mixed $concrete */
             $concrete = ApplicationProvider::getApp()->make($abstract);
-            assert(\is_object($concrete) || \is_string($concrete));
         } catch (\Throwable) {
             return null;
         }
@@ -41,9 +41,15 @@ final class ContainerResolver
         if (\is_string($concrete)) {
             // some path-helpers actually return a string when being resolved
             $concreteClass = $concrete;
-        } else {
+        } elseif (\is_object($concrete)) {
             // normally we have an object resolved
             $concreteClass = $concrete::class;
+        } else {
+            // Some Laravel bindings (e.g. Authenticatable on a fresh Testbench app
+            // with no authenticated user) resolve to null. The previous assert-based
+            // check was a no-op in production, letting `$concrete::class` crash on
+            // null. Return null so the caller falls back to mixed inference.
+            return null;
         }
 
         self::$cache[$abstract] = $concreteClass;

--- a/src/Util/IssueUrlGenerator.php
+++ b/src/Util/IssueUrlGenerator.php
@@ -87,7 +87,7 @@ final class IssueUrlGenerator
             '- resolveDynamicWhereClauses: ' . self::formatBool($pluginConfig->resolveDynamicWhereClauses),
             '- findMissingTranslations: ' . self::formatBool($pluginConfig->findMissingTranslations),
             '- findMissingViews: ' . self::formatBool($pluginConfig->findMissingViews),
-            '- findOctaneIncompatibleBinding: ' . self::formatBool($pluginConfig->findOctaneIncompatibleBinding),
+            '- findOctaneIncompatibleBinding: ' . self::formatOctaneFlag($pluginConfig->findOctaneIncompatibleBinding),
             '- cachePath: ' . self::sanitizeCachePath($pluginConfig->cachePath),
             '- failOnInternalError: ' . self::formatBool($pluginConfig->failOnInternalError),
             '- configDirectories: ' . self::formatConfigDirectories($pluginConfig->configDirectories),
@@ -119,6 +119,25 @@ final class IssueUrlGenerator
     private static function formatBool(bool $value): string
     {
         return $value ? 'true' : 'false';
+    }
+
+    /**
+     * Render the tri-state findOctaneIncompatibleBinding flag for the bug-report body.
+     *
+     * Plain `auto` is ambiguous for triagers because it does not say whether the
+     * handler actually ran on this project. We resolve `null` (the auto-detect
+     * sentinel) the same way Plugin::registerHandlers() does, and surface the
+     * resolution alongside the user's intent.
+     */
+    private static function formatOctaneFlag(?bool $configured): string
+    {
+        if ($configured !== null) {
+            return self::formatBool($configured);
+        }
+
+        $octaneInstalled = \class_exists('Laravel\\Octane\\Octane');
+
+        return 'auto (laravel/octane installed: ' . self::formatBool($octaneInstalled) . ')';
     }
 
     /**

--- a/src/Util/IssueUrlGenerator.php
+++ b/src/Util/IssueUrlGenerator.php
@@ -87,6 +87,7 @@ final class IssueUrlGenerator
             '- resolveDynamicWhereClauses: ' . self::formatBool($pluginConfig->resolveDynamicWhereClauses),
             '- findMissingTranslations: ' . self::formatBool($pluginConfig->findMissingTranslations),
             '- findMissingViews: ' . self::formatBool($pluginConfig->findMissingViews),
+            '- findOctaneIncompatibleBinding: ' . self::formatBool($pluginConfig->findOctaneIncompatibleBinding),
             '- cachePath: ' . self::sanitizeCachePath($pluginConfig->cachePath),
             '- failOnInternalError: ' . self::formatBool($pluginConfig->failOnInternalError),
             '- configDirectories: ' . self::formatConfigDirectories($pluginConfig->configDirectories),

--- a/tests/Type/psalm-with-optin-custom-issues.xml
+++ b/tests/Type/psalm-with-optin-custom-issues.xml
@@ -19,6 +19,7 @@
             <failOnInternalError value="true" />
             <findMissingViews value="true" />
             <findMissingTranslations value="true" />
+            <findOctaneIncompatibleBinding value="true" />
         </pluginClass>
     </plugins>
     <issueHandlers>

--- a/tests/Type/tests/OctaneIncompatibleBindingTest.phpt
+++ b/tests/Type/tests/OctaneIncompatibleBindingTest.phpt
@@ -1,0 +1,295 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm-with-optin-custom-issues.xml
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Providers;
+
+use App\Services\MyService;
+use Illuminate\Auth\AuthManager;
+use Illuminate\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\Factory as AuthFactory;
+use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Contracts\Config\Repository as ConfigRepositoryContract;
+use Illuminate\Contracts\Cookie\Factory as CookieFactory;
+use Illuminate\Contracts\Cookie\QueueingFactory as CookieQueueingFactory;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Routing\UrlGenerator as UrlGeneratorContract;
+use Illuminate\Contracts\Session\Session as SessionContract;
+use Illuminate\Cookie\CookieJar;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Redirector;
+use Illuminate\Routing\UrlGenerator;
+use Illuminate\Session\SessionManager;
+use Illuminate\Session\Store as SessionStore;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\ServiceProvider;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+
+class AppServiceProvider extends ServiceProvider
+{
+    #[\Override]
+    public function register(): void
+    {
+        // Bad. $app->make() of a request-scoped class inside singleton.
+        $this->app->singleton(MyService::class, function (Application $app): MyService {
+            return new MyService($app->make(Request::class));
+        });
+
+        // Bad. Array access with class-string.
+        $this->app->singleton('svc.1', function (Application $app): MyService {
+            return new MyService($app[Request::class]);
+        });
+
+        // Bad. Array access with string alias.
+        $this->app->singleton('svc.2', function (Application $app): MyService {
+            return new MyService($app['request']);
+        });
+
+        // Bad. $this->app inside closure (closure bound to ServiceProvider).
+        $this->app->singleton('svc.3', function (): MyService {
+            return new MyService($this->app->make(SessionStore::class));
+        });
+
+        // Bad. app() helper.
+        $this->app->singleton('svc.4', function (): MyService {
+            return new MyService(app(Authenticatable::class));
+        });
+
+        // Bad. resolve() helper.
+        $this->app->singleton('svc.5', function (): MyService {
+            return new MyService(resolve(AuthFactory::class));
+        });
+
+        // Bad. App facade.
+        $this->app->singleton('svc.6', function (): MyService {
+            return new MyService(App::make(Request::class));
+        });
+
+        // Bad. singletonIf() (case-insensitive method name).
+        $this->app->singletonIf('svc.8', function (Application $app): MyService {
+            return new MyService($app->make(Request::class));
+        });
+
+        // Bad. Arrow function form.
+        $this->app->singleton(
+            'svc.10',
+            fn(Application $app): MyService => new MyService($app->make(Request::class)),
+        );
+
+        // Bad. makeWith resolver method (defined on the concrete Container, not on the
+        // Application contract, so type the closure param accordingly).
+        $this->app->singleton('svc.11', function (\Illuminate\Foundation\Application $app): MyService {
+            return new MyService($app->makeWith(Request::class, []));
+        });
+
+        // Bad. PSR-11 get() resolver.
+        $this->app->singleton('svc.12', function (Application $app): MyService {
+            return new MyService($app->get(Request::class));
+        });
+
+        // Bad. Symfony Request (alias target of 'request').
+        $this->app->singleton('svc.13', function (Application $app): MyService {
+            return new MyService($app->make(SymfonyRequest::class));
+        });
+
+        // Bad. Chained app()->make(...) inside singleton (looksLikeContainer FuncCall branch).
+        $this->app->singleton('svc.14', function (): MyService {
+            return new MyService(app()->make(Request::class));
+        });
+
+        // Bad. Remaining request-scoped classes (coverage for REQUEST_SCOPED_CLASSES).
+        $this->app->singleton('svc.15', function (Application $app): MyService {
+            return new MyService($app->make(CookieJar::class));
+        });
+        $this->app->singleton('svc.16', function (Application $app): MyService {
+            return new MyService($app->make(AuthManager::class));
+        });
+        $this->app->singleton('svc.17', function (Application $app): MyService {
+            return new MyService($app->make(Guard::class));
+        });
+        $this->app->singleton('svc.18', function (Application $app): MyService {
+            return new MyService($app->make(SessionManager::class));
+        });
+        $this->app->singleton('svc.19', function (Application $app): MyService {
+            return new MyService($app->make(SessionContract::class));
+        });
+        $this->app->singleton('svc.20', function (Application $app): MyService {
+            return new MyService($app->make(ConfigRepository::class));
+        });
+        $this->app->singleton('svc.21', function (Application $app): MyService {
+            return new MyService($app->make(UrlGenerator::class));
+        });
+        $this->app->singleton('svc.22', function (Application $app): MyService {
+            return new MyService($app->make(Redirector::class));
+        });
+        $this->app->singleton('svc.23', function (Application $app): MyService {
+            return new MyService($app->make(ConfigRepositoryContract::class));
+        });
+        $this->app->singleton('svc.24', function (Application $app): MyService {
+            return new MyService($app->make(UrlGeneratorContract::class));
+        });
+        $this->app->singleton('svc.25.cookieFactory', function (Application $app): MyService {
+            return new MyService($app->make(CookieFactory::class));
+        });
+        $this->app->singleton('svc.26.cookieQueueing', function (Application $app): MyService {
+            return new MyService($app->make(CookieQueueingFactory::class));
+        });
+
+        // Bad. Remaining aliases (coverage for REQUEST_SCOPED_ALIASES).
+        $this->app->singleton('svc.25', function (Application $app): MyService {
+            return new MyService($app['auth']);
+        });
+        $this->app->singleton('svc.26', function (Application $app): MyService {
+            return new MyService($app['auth.driver']);
+        });
+        $this->app->singleton('svc.27', function (Application $app): MyService {
+            return new MyService($app['session']);
+        });
+        $this->app->singleton('svc.28', function (Application $app): MyService {
+            return new MyService($app['session.store']);
+        });
+        $this->app->singleton('svc.29', function (Application $app): MyService {
+            return new MyService($app['cookie']);
+        });
+        $this->app->singleton('svc.30', function (Application $app): MyService {
+            return new MyService($app['config']);
+        });
+        $this->app->singleton('svc.31', function (Application $app): MyService {
+            return new MyService($app['url']);
+        });
+        $this->app->singleton('svc.32', function (Application $app): MyService {
+            return new MyService($app['redirect']);
+        });
+
+        // Good. bind() re-executes per resolution, so request-scoped resolution is fine.
+        $this->app->bind('svc.ok1', function (Application $app): MyService {
+            return new MyService($app->make(Request::class));
+        });
+
+        // Good. Facade-form bindings (StaticCall) are out of scope: the hook receives
+        // both MethodCall and StaticCall but we filter the StaticCall branch out.
+        // This is a regression guard after the AfterExpressionAnalysis -> AfterMethodCallAnalysis refactor.
+        App::singleton('svc.ok.facade', function (Application $app): MyService {
+            return new MyService($app->make(Request::class));
+        });
+
+        // Good. bindIf() has the same per-resolution semantics as bind().
+        $this->app->bindIf('svc.ok2', function (Application $app): MyService {
+            return new MyService($app->make(Request::class));
+        });
+
+        // Good. scoped() bindings are flushed between requests by Octane via
+        // Container::forgetScopedInstances(), so request-scoped captures do not leak.
+        // scoped() is the Octane-safe alternative to singleton().
+        $this->app->scoped('svc.ok.scoped', function (Application $app): MyService {
+            return new MyService($app->make(Request::class));
+        });
+
+        // Good. scopedIf() has the same per-request semantics as scoped().
+        $this->app->scopedIf('svc.ok.scopedIf', function (Application $app): MyService {
+            return new MyService($app->make(Request::class));
+        });
+
+        // Good. singleton with no request-scoped resolution.
+        $this->app->singleton('svc.ok3', function (): MyService {
+            return new MyService(null);
+        });
+
+        // Good. singleton resolving a non-request-scoped class (regression guard
+        // for REQUEST_SCOPED_CLASSES whitelist being consulted).
+        $this->app->singleton('svc.ok4', function (Application $app): MyService {
+            return new MyService($app->make(\Illuminate\Log\LogManager::class));
+        });
+
+        // Good. Nested closure body does NOT belong to the outer singleton's scope.
+        // The outer singleton's closure returns another closure; the inner one runs
+        // later on each invocation, not during the singleton resolve.
+        $this->app->singleton('svc.ok5', function (Application $app): \Closure {
+            return function () use ($app): Request {
+                return $app->make(Request::class);
+            };
+        });
+
+        // Good. Non-literal abstract is not detected (we only match literals).
+        $class = Request::class;
+        $this->app->singleton('svc.ok6', function (Application $app) use ($class): MyService {
+            return new MyService($app->make($class));
+        });
+
+        // Good. Anonymous class methods form a separate execution scope: the
+        // $app->make(Request::class) call inside handle() runs on method invocation,
+        // not during singleton resolution. The outer singleton's constructor line
+        // creates the anonymous class instance without resolving Request.
+        $this->app->singleton('svc.ok7', function (Application $app): object {
+            return new class ($app) {
+                public function __construct(private Application $app) {}
+
+                public function handle(): Request
+                {
+                    return $this->app->make(Request::class);
+                }
+            };
+        });
+
+        // Good. Documented known-gap regression guard: nested IIFE bodies are
+        // skipped by the walker (FunctionLike scope boundary) even when the IIFE
+        // captures $app via use(). A future change that accidentally descends
+        // into nested closures would flag this and break the documented gap.
+        $this->app->singleton('svc.ok.iife', function (Application $app): MyService {
+            return (function () use ($app): MyService {
+                return new MyService($app->make(Request::class));
+            })();
+        });
+
+        // Good. Documented known-gap regression guard: Container::getInstance()
+        // is not recognized as the resolver receiver. classifyResolution() only
+        // matches a parameter variable, $this->app, or the helper functions.
+        $this->app->singleton('svc.ok.getinstance', function (): MyService {
+            return new MyService(\Illuminate\Container\Container::getInstance()->make(Request::class));
+        });
+    }
+}
+
+namespace App\Services;
+
+class MyService
+{
+    public function __construct(mixed $dep) {}
+}
+?>
+--EXPECTF--
+OctaneIncompatibleBinding on line %d: Request-scoped 'Illuminate\Http\Request' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'Illuminate\Http\Request' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'request' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'Illuminate\Session\Store' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'Illuminate\Contracts\Auth\Authenticatable' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'Illuminate\Contracts\Auth\Factory' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'Illuminate\Http\Request' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'Illuminate\Http\Request' resolved inside singletonIf() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'Illuminate\Http\Request' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'Illuminate\Http\Request' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'Illuminate\Http\Request' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'Symfony\Component\HttpFoundation\Request' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'Illuminate\Http\Request' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'Illuminate\Cookie\CookieJar' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'Illuminate\Auth\AuthManager' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'Illuminate\Contracts\Auth\Guard' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'Illuminate\Session\SessionManager' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'Illuminate\Contracts\Session\Session' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'Illuminate\Config\Repository' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'Illuminate\Routing\UrlGenerator' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'Illuminate\Routing\Redirector' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'Illuminate\Contracts\Config\Repository' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'Illuminate\Contracts\Routing\UrlGenerator' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'Illuminate\Contracts\Cookie\Factory' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'Illuminate\Contracts\Cookie\QueueingFactory' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'auth' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'auth.driver' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'session' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'session.store' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'cookie' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'config' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'url' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.
+OctaneIncompatibleBinding on line %d: Request-scoped 'redirect' resolved inside singleton() closure. State leaks across Octane requests. Use scoped(), bind(), or resolve at call site.

--- a/tests/Unit/PluginConfigTest.php
+++ b/tests/Unit/PluginConfigTest.php
@@ -43,6 +43,7 @@ final class PluginConfigTest extends TestCase
         $this->assertFalse($config->failOnInternalError);
         $this->assertFalse($config->findMissingTranslations);
         $this->assertFalse($config->findMissingViews);
+        $this->assertFalse($config->findOctaneIncompatibleBinding);
         $this->assertTrue($config->resolveDynamicWhereClauses);
         $this->assertSame([], $config->configDirectories);
     }
@@ -231,6 +232,37 @@ final class PluginConfigTest extends TestCase
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage("Invalid findMissingViews value 'yes'");
+
+        PluginConfig::fromXml($xml);
+    }
+
+    #[Test]
+    public function find_octane_incompatible_binding_true(): void
+    {
+        $xml = new \SimpleXMLElement('<pluginClass><findOctaneIncompatibleBinding value="true" /></pluginClass>');
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertTrue($config->findOctaneIncompatibleBinding);
+    }
+
+    #[Test]
+    public function find_octane_incompatible_binding_false(): void
+    {
+        $xml = new \SimpleXMLElement('<pluginClass><findOctaneIncompatibleBinding value="false" /></pluginClass>');
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertFalse($config->findOctaneIncompatibleBinding);
+    }
+
+    #[Test]
+    public function invalid_find_octane_incompatible_binding_throws(): void
+    {
+        $xml = new \SimpleXMLElement('<pluginClass><findOctaneIncompatibleBinding value="yes" /></pluginClass>');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid findOctaneIncompatibleBinding value 'yes'");
 
         PluginConfig::fromXml($xml);
     }

--- a/tests/Unit/PluginConfigTest.php
+++ b/tests/Unit/PluginConfigTest.php
@@ -43,7 +43,9 @@ final class PluginConfigTest extends TestCase
         $this->assertFalse($config->failOnInternalError);
         $this->assertFalse($config->findMissingTranslations);
         $this->assertFalse($config->findMissingViews);
-        $this->assertFalse($config->findOctaneIncompatibleBinding);
+        // null = auto-detect via class_exists('Laravel\Octane\Octane') at runtime;
+        // explicit true/false in XML overrides the auto-detection.
+        $this->assertNull($config->findOctaneIncompatibleBinding);
         $this->assertTrue($config->resolveDynamicWhereClauses);
         $this->assertSame([], $config->configDirectories);
     }
@@ -237,6 +239,18 @@ final class PluginConfigTest extends TestCase
     }
 
     #[Test]
+    public function find_octane_incompatible_binding_absent_yields_null(): void
+    {
+        // null is the auto-detect sentinel — Plugin::registerHandlers() falls
+        // back to class_exists('Laravel\Octane\Octane') when this is null.
+        $xml = new \SimpleXMLElement('<pluginClass />');
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertNull($config->findOctaneIncompatibleBinding);
+    }
+
+    #[Test]
     public function find_octane_incompatible_binding_true(): void
     {
         $xml = new \SimpleXMLElement('<pluginClass><findOctaneIncompatibleBinding value="true" /></pluginClass>');
@@ -249,6 +263,7 @@ final class PluginConfigTest extends TestCase
     #[Test]
     public function find_octane_incompatible_binding_false(): void
     {
+        // Explicit false overrides auto-detect even when laravel/octane is installed.
         $xml = new \SimpleXMLElement('<pluginClass><findOctaneIncompatibleBinding value="false" /></pluginClass>');
 
         $config = PluginConfig::fromXml($xml);

--- a/tests/Unit/Util/IssueUrlGeneratorTest.php
+++ b/tests/Unit/Util/IssueUrlGeneratorTest.php
@@ -156,7 +156,14 @@ final class IssueUrlGeneratorTest extends TestCase
         $this->assertStringContainsString('- resolveDynamicWhereClauses: true', $body);
         $this->assertStringContainsString('- findMissingTranslations: false', $body);
         $this->assertStringContainsString('- findMissingViews: false', $body);
-        $this->assertStringContainsString('- findOctaneIncompatibleBinding: false', $body);
+        // Tri-state default (null) renders as "auto (...)" with the resolved
+        // class_exists() outcome so triagers know whether the handler actually ran.
+        // The plugin's own composer.json does not depend on laravel/octane, so the
+        // resolution is "false" in the test environment.
+        $this->assertStringContainsString(
+            '- findOctaneIncompatibleBinding: auto (laravel/octane installed: false)',
+            $body,
+        );
         $this->assertStringContainsString('- cachePath:', $body);
         $this->assertStringContainsString('- failOnInternalError: false', $body);
     }

--- a/tests/Unit/Util/IssueUrlGeneratorTest.php
+++ b/tests/Unit/Util/IssueUrlGeneratorTest.php
@@ -156,6 +156,7 @@ final class IssueUrlGeneratorTest extends TestCase
         $this->assertStringContainsString('- resolveDynamicWhereClauses: true', $body);
         $this->assertStringContainsString('- findMissingTranslations: false', $body);
         $this->assertStringContainsString('- findMissingViews: false', $body);
+        $this->assertStringContainsString('- findOctaneIncompatibleBinding: false', $body);
         $this->assertStringContainsString('- cachePath:', $body);
         $this->assertStringContainsString('- failOnInternalError: false', $body);
     }
@@ -169,6 +170,7 @@ final class IssueUrlGeneratorTest extends TestCase
             . '<resolveDynamicWhereClauses value="false" />'
             . '<findMissingTranslations value="true" />'
             . '<findMissingViews value="true" />'
+            . '<findOctaneIncompatibleBinding value="true" />'
             . '<failOnInternalError value="true" />'
             . '</pluginClass>',
         );
@@ -180,6 +182,7 @@ final class IssueUrlGeneratorTest extends TestCase
         $this->assertStringContainsString('- resolveDynamicWhereClauses: false', $body);
         $this->assertStringContainsString('- findMissingTranslations: true', $body);
         $this->assertStringContainsString('- findMissingViews: true', $body);
+        $this->assertStringContainsString('- findOctaneIncompatibleBinding: true', $body);
         $this->assertStringContainsString('- failOnInternalError: true', $body);
     }
 


### PR DESCRIPTION
## Summary

Adds a new handler `OctaneIncompatibleBindingHandler` that flags `singleton()` / `singletonIf()` binding closures resolving request-scoped Laravel services (Request, Session, Auth, Cookie, Config, UrlGenerator, Redirector). Under Octane, these captures leak state across requests.

Re-creation of #743 (closed without merge) on the latest master, with the following improvements applied during review:

1. **Auto-enabled** when `laravel/octane` is present in the project. Manual opt-in `<findOctaneIncompatibleBinding value=\"true\" />` is also supported for projects that want the check without depending on the package directly.
2. **Hot-path optimization**: per-call cost is two cheap rejections (an `instanceof` check on the AST node, then a short method-name comparison on a pre-parsed identifier) before any AST walk or FQN allocation.
3. **Cookie contracts coverage**: added `Illuminate\Contracts\Cookie\Factory` and `Illuminate\Contracts\Cookie\QueueingFactory` to the request-scoped class set (the `cookie` alias maps to all three).
4. **Issue message** now suggests `scoped()` (the Octane-safe drop-in) before `bind()`.
5. **Regression tests** for documented known gaps: nested IIFE bodies and `Container::getInstance()->make(...)` are confirmed-skipped.

Closes #703.

## Detection scope

Flagged inside `singleton()` / `singletonIf()` closures:

- `$app->make(X::class)` / `makeWith` / `get` / `resolve`
- `$app[X::class]` / `$app['request']`
- `$this->app->make(...)` / `$this->app[...]`
- `app(X::class)` / `resolve(X::class)`
- `App::make(X::class)` (facade)

Request-scoped targets: `Illuminate\Http\Request` (+ Symfony parent), `Session\Store`, `Session\SessionManager`, `Contracts\Session\Session`, `Cookie\CookieJar` (+ contracts `Factory` and `QueueingFactory`), `Auth\AuthManager`, `Contracts\Auth\{Factory,Guard,Authenticatable}`, `Config\Repository` (+ contract), `Routing\UrlGenerator` (+ contract), `Routing\Redirector`. Plus alias strings: `request`, `auth`, `auth.driver`, `session`, `session.store`, `cookie`, `config`, `url`, `redirect`.

## Why these are NOT flagged

- `bind()` / `bindIf()`: the closure re-executes on every resolution.
- `scoped()` / `scopedIf()`: Octane flushes them via `Container::forgetScopedInstances()` between requests.
- `App::singleton(...)` (StaticCall facade form): out of scope, much rarer than `$this->app->singleton(...)`.

## Known gaps (intentional non-goals)

- **Transitive detection.** Singleton A captures singleton B which captures Request. One level deep only.
- **Helper-method flow.** Closure calls `$this->resolveRequest()` that internally resolves `Request`. No inter-procedural analysis.
- **`use (...)` captured variables.** Pre-resolved `Request` via `use ($request)` is not traced.
- **Named-argument `singleton()` call.** When the closure is not the second source-order argument (e.g. `singleton(concrete: fn() => ..., abstract: X::class)`), the call is missed.
- **Nested IIFEs.** Skipped to avoid the common nested-closure false-positive case. Regression-tested.
- **`Container::getInstance()->make(...)`** inside a closure. Regression-tested.

## Implementation notes

- Uses `AfterMethodCallAnalysisInterface` (not `AfterExpressionAnalysis`). Psalm pre-resolves the declaring class via `getDeclaringMethodId()`, so the handler matches in O(1) via an isset() lookup on a lowercased \"class::method\" key.
- Inner-closure walker treats `FunctionLike` and `Class_`/`Trait_`/`Interface_`/`Enum_` as scope boundaries, so nested closures, anonymous classes, and inner methods do not contribute violations to the outer binding.
- `class_exists('Laravel\\Octane\\Octane')` runs once at plugin init. The user's Composer autoloader is already active because `ApplicationProvider` boots the Laravel app earlier in `__invoke()`.

## Incidental fix bundled in this PR

`src/Util/ContainerResolver::resolveAbstract` previously called `assert(is_object($concrete) || is_string($concrete))` after `$app->make()`. The assert is a no-op outside `assert.exception=1`, so a null concrete (e.g. `Authenticatable` on a Testbench app with no authenticated user) would crash on `null::class`. The fix returns null in that branch so the caller falls back to mixed inference. This change arrived with the original PR branch and is preserved here.