### PR TITLE
Per-method @throws annotations on synthesised macro pseudo-methods

### DIFF
--- a/src/Handlers/Magic/MacroHandler.php
+++ b/src/Handlers/Magic/MacroHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Handlers\Magic;
 
+use Illuminate\Validation\ValidationException;
 use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
 use Psalm\LaravelPlugin\Providers\MacroDefinition;
 use Psalm\LaravelPlugin\Providers\MacroRegistry;
@@ -96,6 +97,64 @@ use Psalm\Storage\MethodStorage;
  */
 final class MacroHandler implements AfterCodebasePopulatedInterface
 {
+    /**
+     * Hardcoded `@throws` map for framework-registered macros whose closure body
+     * is known to raise a specific exception. Two-level lookup: declaring class
+     * (as the case-preserving FQCN) → macro name (lowercased per
+     * {@see MacroDefinition::$methodName}'s contract) → exception FQCN.
+     *
+     * The class-level scoping is load-bearing. A user registering an unrelated
+     * `validate` macro on a different Macroable host (e.g.
+     * `Stringable::macro('validate', ...)`) must NOT receive
+     * `ValidationException` in the synthesised throws set. Today the upstream
+     * propagation gap (below) masks the false positive, but the moment that
+     * gap closes, an unscoped map would surface `MissingThrowsDocblock` on
+     * innocent third-party macros that happen to share a name. Larastan's
+     * single-key map gets away with it because Larastan's pseudo-method
+     * synthesis is structured differently; the safer shape here is per-class.
+     *
+     * Currently covers the two `Request` macros registered by
+     * `Illuminate\Foundation\Providers\FoundationServiceProvider::registerRequestValidation()`,
+     * both of which throw `ValidationException` (the parent's `@throws`
+     * docblock declares this).
+     *
+     * **Effective scope today.** Setting `MethodStorage::$throws` documents the
+     * pseudo-method's throw set correctly, but Psalm 7 does NOT propagate it
+     * to the caller's `Context::$possibly_thrown_exceptions`:
+     * `Context::mergeFunctionExceptions()` is called only from
+     * `CallAnalyzer::checkMethodArgs()` (gated on `declaring_method_ids`, which
+     * pseudo-methods are not in) and `FunctionCallReturnTypeFetcher` (function
+     * calls only). The pseudo-method dispatch path
+     * (`MissingMethodCallHandler::handleMagicMethod` /
+     * `handleMissingOrMagicMethod`, and the static-call path through
+     * `AtomicStaticCallAnalyzer::findPseudoMethodAndClassStorages`) never
+     * consults `$throws`. Until Psalm wires throws propagation through that
+     * dispatch path, `MissingThrowsDocblock` will not fire on callers of
+     * `$request->validate(...)`. Tracked upstream at
+     * {@link https://github.com/vimeo/psalm/issues/11842}.
+     *
+     * Keeping the map populated regardless: the synthesised storage stays
+     * faithful to the actual runtime behaviour, and the moment Psalm closes
+     * the propagation gap this plugin's users gain `MissingThrowsDocblock`
+     * coverage with no further change here.
+     *
+     * **Adding new entries.** Cross-reference the closure body in Laravel's
+     * source. If the exception class is not already referenced from analysed
+     * code or stubs (`ValidationException` always is, via the existing
+     * validation paths), consider whether Psalm's scanner needs to be told
+     * about it — `FunctionLikeDocblockScanner` queues `@throws` classes for
+     * scanning; we do not, since the map is curated from already-reachable
+     * framework classes.
+     *
+     * @var array<class-string, array<lowercase-string, class-string<\Throwable>>>
+     */
+    private const FRAMEWORK_THROWS = [
+        \Illuminate\Http\Request::class => [
+            'validate' => ValidationException::class,
+            'validatewithbag' => ValidationException::class,
+        ],
+    ];
+
     /**
      * Discover macros from the booted Laravel app and inject them into Psalm
      * class storage as pseudo-methods, propagating to all analysed descendants.
@@ -205,6 +264,14 @@ final class MacroHandler implements AfterCodebasePopulatedInterface
         // which is the type analyzers actually consume.
         $methodStorage->signature_return_type = $def->signatureReturnType;
         $methodStorage->stubbed = true;
+
+        // Apply the framework throws map (see {@see self::FRAMEWORK_THROWS} for
+        // shape, scope, and the upstream propagation gap that makes this a
+        // future-effective wiring rather than an immediately observable one).
+        $throwsForClass = self::FRAMEWORK_THROWS[$def->declaringClass] ?? null;
+        if ($throwsForClass !== null && isset($throwsForClass[$def->methodName])) {
+            $methodStorage->throws[$throwsForClass[$def->methodName]] = true;
+        }
 
         return $methodStorage;
     }

--- a/tests/Unit/Handlers/Magic/MacroHandlerThrowsTest.php
+++ b/tests/Unit/Handlers/Magic/MacroHandlerThrowsTest.php
@@ -90,7 +90,7 @@ final class MacroHandlerThrowsTest extends TestCase
         $reflection = new \ReflectionMethod(MacroHandler::class, 'buildMethodStorage');
 
         $result = $reflection->invoke(null, $def, false);
-        \assert($result instanceof MethodStorage);
+        $this->assertInstanceOf(MethodStorage::class, $result);
 
         return $result;
     }

--- a/tests/Unit/Handlers/Magic/MacroHandlerThrowsTest.php
+++ b/tests/Unit/Handlers/Magic/MacroHandlerThrowsTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Magic;
+
+use Illuminate\Validation\ValidationException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Handlers\Magic\MacroHandler;
+use Psalm\LaravelPlugin\Providers\MacroDefinition;
+use Psalm\Storage\MethodStorage;
+use Psalm\Type;
+
+/**
+ * Verifies the {@see MacroHandler::FRAMEWORK_THROWS} map is applied when
+ * synthesising pseudo-method storage.
+ *
+ * `MacroHandler::buildMethodStorage()` is private, so we drive it via reflection
+ * rather than spinning up a full `AfterCodebasePopulated` lifecycle (which would
+ * require booting Psalm's analyser, populating ClassLikeStorage, etc. for what is
+ * a one-line lookup against a hardcoded map).
+ *
+ * The asserted shape (`throws[FQCN] => true`) matches what Psalm's own
+ * `FunctionLikeDocblockScanner::analyzeStorageDocblock()` writes when parsing
+ * `@throws` annotations on user code. Caller-side propagation is a Psalm-side
+ * concern (it doesn't currently run for pseudo-methods); this test pins the
+ * plugin contract regardless of that gap.
+ */
+#[CoversClass(MacroHandler::class)]
+final class MacroHandlerThrowsTest extends TestCase
+{
+    #[Test]
+    public function validate_macro_records_validation_exception_in_throws(): void
+    {
+        $storage = $this->buildStorage(\Illuminate\Http\Request::class, 'validate');
+
+        $this->assertSame([ValidationException::class => true], $storage->throws);
+    }
+
+    #[Test]
+    public function validate_with_bag_macro_records_validation_exception_in_throws(): void
+    {
+        // Macro names are stored lowercased — `MacroDefinition::$methodName` is
+        // typed `lowercase-string` and `MacroRegistry::init()` lowercases the key
+        // before storing. The throws map must match that casing.
+        $storage = $this->buildStorage(\Illuminate\Http\Request::class, 'validatewithbag');
+
+        $this->assertSame([ValidationException::class => true], $storage->throws);
+    }
+
+    #[Test]
+    public function unmapped_macro_records_no_throws(): void
+    {
+        $storage = $this->buildStorage(\Illuminate\Http\Request::class, 'whatever');
+
+        $this->assertSame([], $storage->throws);
+    }
+
+    #[Test]
+    public function validate_macro_on_non_request_class_records_no_throws(): void
+    {
+        // Pins the class-scoping invariant: a user (or third-party package)
+        // registering `Stringable::macro('validate', ...)` must not inherit
+        // the `Request::validate` throw set just because the names collide.
+        // The propagation gap masks this today, but the docblock on
+        // `MacroHandler::FRAMEWORK_THROWS` commits to the scope being correct
+        // for when Psalm closes that gap.
+        $storage = $this->buildStorage(\Illuminate\Support\Stringable::class, 'validate');
+
+        $this->assertSame([], $storage->throws);
+    }
+
+    /**
+     * @param class-string $declaringClass
+     * @param lowercase-string $methodName
+     */
+    private function buildStorage(string $declaringClass, string $methodName): MethodStorage
+    {
+        $def = new MacroDefinition(
+            declaringClass: $declaringClass,
+            methodName: $methodName,
+            casedName: $methodName,
+            params: [],
+            returnType: Type::getMixed(),
+            signatureReturnType: null,
+        );
+
+        $reflection = new \ReflectionMethod(MacroHandler::class, 'buildMethodStorage');
+
+        $result = $reflection->invoke(null, $def, false);
+        \assert($result instanceof MethodStorage);
+
+        return $result;
+    }
+}


### PR DESCRIPTION
## Summary

Implements item **3 (per-method `@throws` annotations)** from #899.

Adds a curated, **class-scoped** throws map for framework macros whose closure body raises a known exception, and wires it into `MacroHandler::buildMethodStorage()` so every synthesised pseudo-method's `MethodStorage::$throws` is populated when the (Macroable host, macro name) pair is in the map.

Initial coverage mirrors Larastan's `Macro::$methodThrowTypeMap`:

| Class | Macro | Throws |
|---|---|---|
| `\Illuminate\Http\Request` | `validate` | `\Illuminate\Validation\ValidationException` |
| `\Illuminate\Http\Request` | `validateWithBag` | `\Illuminate\Validation\ValidationException` |

Both are registered by `FoundationServiceProvider::registerRequestValidation()` and the closure bodies are byte-identical between Laravel 12 and 13.

## Why class-scoping matters

A flat name-only key would let `Stringable::macro('validate', ...)` (or any third-party `validate` macro on an unrelated Macroable host) inherit `ValidationException` in its synthesised throws set. The propagation gap (below) hides this today, but the docblock commits to the future where the gap closes — at which point an unscoped map would produce false `MissingThrowsDocblock` reports on innocent macros. The two-level `[class][methodName]` map prevents that. Test `validate_macro_on_non_request_class_records_no_throws` pins the invariant.

## Effective scope today (upstream gap)

`MethodStorage::$throws` is correctly populated, but **Psalm 7 does not propagate it from pseudo-method dispatch to the caller's `Context::$possibly_thrown_exceptions`**. `Context::mergeFunctionExceptions()` is called only from `CallAnalyzer::checkMethodArgs()` (gated on `declaring_method_ids`, which pseudo-methods are not in) and `FunctionCallReturnTypeFetcher` (function calls only). The pseudo-method dispatch path in `MissingMethodCallHandler` and `AtomicStaticCallAnalyzer` never reads `$throws`.

Filed upstream as **vimeo/psalm#11842** with a minimal reproduction and a one-line-per-site suggested fix. Once that lands, this plugin gains `MissingThrowsDocblock` coverage for `$request->validate(...)` (and any future entry in the throws map) with no further change here.

The map is shipped now regardless: it documents the synthesised storage faithfully, costs nothing at runtime (single hash probe per `buildMethodStorage` call), and avoids a second PR once upstream propagation lands.

## Tests

- `tests/Unit/Handlers/Magic/MacroHandlerThrowsTest.php` — 4 cases:
  - `validate` records `ValidationException`
  - `validateWithBag` records `ValidationException`
  - Unmapped name on a mapped class records no throws
  - Mapped name on an **unmapped class** (Stringable::validate) records no throws (regression guard for the class-scoping invariant)

A phpt type test asserting `MissingThrowsDocblock` would be vacuous in Psalm 7 today (it would silently pass for the wrong reason — the propagation gap, not stub correctness — without flipping when upstream fixes it). The reflection-driven unit test pins the plugin contract directly.

## Out of scope (intentionally deferred)

- Items **#1 (docblock-aware closure type extraction)**, **#2 (`Illuminate\Contracts\*` interface dispatch)**, and **#4 (multi-target Auth/Cache facade dispatch)** from #899 — each is a separate, independently shippable concern. Combined initial scoping notes are in the issue.
- Patching upstream Psalm — the propagation fix belongs in vimeo/psalm and is filed there.

## Verification

- `composer test:unit` — 605 tests pass (1 pre-existing skipped)
- `composer test:type` — 386 tests pass
- `composer psalm` — clean self-analysis
- `composer cs` — no violations
- `composer test:app` — clean

Closes one item of #899. Refs vimeo/psalm#11842.