### PR TITLE
Align `Collection::random()` with Laravel's actual signature

### DIFF
--- a/stubs/common/Support/Collection.phpstub
+++ b/stubs/common/Support/Collection.phpstub
@@ -138,12 +138,13 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * @psalm-mutation-free
      *
-     * @param  (callable(TValue): int)|int|null  $number
+     * @param  (callable(self<TKey, TValue>): int)|int|null  $number
+     * @param  bool  $preserveKeys
      * @return ($number is null ? TValue : static<int, TValue>)
      *
      * @throws \InvalidArgumentException
      */
-    public function random($number = null) {}
+    public function random($number = null, $preserveKeys = false) {}
 
     /**
      * @psalm-mutation-free

--- a/tests/Type/tests/Collection/CollectionRandomTest.phpt
+++ b/tests/Type/tests/Collection/CollectionRandomTest.phpt
@@ -1,0 +1,68 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Collection as BaseCollection;
+
+/**
+ * Collection::random() stub alignment with Laravel's actual signature.
+ *
+ * Covers:
+ *  - `random()` with no argument returns a single TValue (works correctly today).
+ *  - `random(callable)` accepts a closure receiving the whole collection
+ *    (callable(self<TKey, TValue>): int), matching Laravel's
+ *    `Illuminate\Collections\Collection::random` where `$number($this)` is called.
+ *    Before this stub change the param was `callable(TValue): int`, which produced
+ *    a spurious `InvalidArgument` on callers like
+ *    `$collection->random(fn (Collection $items): int => ...)`.
+ *  - `random(int, bool)` compiles without TooManyArguments — the `$preserveKeys`
+ *    second parameter was missing from the stub.
+ *
+ * NOT covered here: the conditional return type `($number is null ? TValue :
+ * static<int, TValue>)` does not currently narrow correctly when `$number` is
+ * non-null. That is tracked separately in
+ * https://github.com/psalm/psalm-plugin-laravel/issues/903 and is out of scope
+ * for this stub-signature fix.
+ */
+final class CollectionRandomTest
+{
+    /** @return EloquentCollection<int, Customer> */
+    public function getCustomers(): EloquentCollection
+    {
+        return Customer::all();
+    }
+
+    /**
+     * No argument: returns a single Customer.
+     *
+     * @psalm-check-type-exact $result = Customer
+     */
+    public function randomNoArg(): Customer
+    {
+        $result = $this->getCustomers()->random();
+
+        return $result;
+    }
+
+    /**
+     * Closure argument typed against the parent Support\Collection: no InvalidArgument.
+     * This reproduces the monicahq/monica pattern in VaultIndexViewHelper.
+     */
+    public function randomCallable(): void
+    {
+        $this->getCustomers()->random(
+            fn (BaseCollection $items): int => min(5, $items->count()),
+        );
+    }
+
+    /**
+     * preserveKeys positional argument compiles without TooManyArguments.
+     */
+    public function randomWithPreserveKeys(): void
+    {
+        $this->getCustomers()->random(3, true);
+    }
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

The plugin's stub for `Illuminate\Support\Collection::random()` does not match Laravel's actual signature in two ways:

1. **Callable parameter:** stubbed as `callable(TValue): int` (closure receives a single element), but Laravel calls the closure with the whole collection at `Illuminate\Collections\Collection::random` (`$number($this)`). The correct shape is `callable(self<TKey, TValue>): int`.
2. **Missing second parameter:** the real signature is `random($number = null, $preserveKeys = false)`. The stub omitted `$preserveKeys`.

This emitted spurious `InvalidArgument` (and `TooManyArguments` when `$preserveKeys` was passed) on caller code that matched Laravel's real API, e.g. monicahq/monica `app/Domains/Vault/.../VaultIndexViewHelper.php:135`:

```php
$vault->contacts
    ->random(fn (Collection $items): int => min(5, count($items)))
    ->map(fn (Contact $c) => ['id' => $c->id, ...]);
```

## Related

Filed during a benchmark audit of `UndefinedMagicMethod` findings across the v4.10.0 corpus.

This PR fixes the `InvalidArgument` half of the surface. A separate (and harder) bug remains: the conditional return type `($number is null ? TValue : static<int, TValue>)` collapses to `TValue` even for non-null arguments on the concrete `Illuminate\Support\Collection`. That interacts with the parent `Enumerable` interface's looser annotation. Filed and scoped out of this PR: #903.

## Solution Description

- `stubs/common/Support/Collection.phpstub:138-147`
  - `@param` callable arm updated from `callable(TValue): int` to `callable(self<TKey, TValue>): int`, matching Laravel's `Illuminate\Collections\Collection.php:1127` docblock and the runtime behaviour (`$number($this)`).
  - Method signature gains `$preserveKeys = false` (Laravel's second parameter).
- `tests/Type/tests/Collection/CollectionRandomTest.phpt`
  - Regression test for the closure-typed-as-`Support\Collection` pattern (monica).
  - Regression test for `random(int, bool)` not emitting `TooManyArguments`.
  - Documents what is intentionally out of scope (the conditional bug) with a link to #903 so future readers know why the test does not assert the int / callable branches of the return type.

Verified: `composer test:type -- --filter=Collection` passes (20/20). Self-analysis (`composer psalm`) clean.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
