### PR TITLE
CI: verify the plugin works under psalm.phar

### DIFF
--- a/.github/workflows/test-laravel-app-phar.yml
+++ b/.github/workflows/test-laravel-app-phar.yml
@@ -1,0 +1,193 @@
+name: Test Laravel app (psalm.phar)
+
+# Validates the plugin works when Psalm is run as a standalone phar (not
+# vendor/bin/psalm). This is the "phar class-loading" gate referenced in
+# docs/contributing/decisions.md → "Handler files are loaded with explicit
+# require_once". A passing run here is the empirical evidence that unblocks
+# collapsing src/Plugin.php::registerHandlers() into a foreach loop.
+# See https://github.com/psalm/psalm-plugin-laravel/issues/895.
+#
+# Triggers are deliberately narrow: manual + on a new release (post-tag smoke
+# test) + a weekly schedule (catches drift between releases). We do NOT run
+# this on every PR/push because the matrix is heavy and the failure modes are
+# slow-moving (Psalm's plugin loader and our require_once block both change
+# rarely).
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+  schedule:
+    # Weekly on Friday at 06:00 UTC, matching test-laravel-app.yml.
+    - cron: "0 6 * * 5"
+
+# Cancel superseded runs on the same ref (mostly relevant for manual dispatch).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Test Laravel ${{ matrix.laravel-installer-version }} under psalm.phar (PHP ${{ matrix.php-version }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - '8.2'
+          - '8.3'
+          - '8.4'
+          - '8.5'
+        laravel-installer-version:
+          - '12.12.2'
+          - 'dev-master'
+        exclude:
+          - php-version: '8.2'
+            laravel-installer-version: 'dev-master'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+          tools: composer:v2
+
+      - name: Create Laravel app and install plugin (no Psalm run)
+        run: |
+          LARAVEL_INSTALLER_VERSION=${{ matrix.laravel-installer-version }} \
+            ./tests/Application/laravel-test.sh --verbose --setup-only
+
+      - name: Download psalm.phar matching the resolved Psalm version
+        working-directory: tests-app/laravel-example
+        run: |
+          # Read the exact Psalm version composer resolved in the test project.
+          # jq is preinstalled on GitHub-hosted ubuntu runners. Parsing JSON is
+          # more robust than text-parsing `composer show`.
+          PSALM_VERSION=$(composer show -f json vimeo/psalm | jq -r '.versions[0]')
+          if [ -z "$PSALM_VERSION" ] || [ "$PSALM_VERSION" = "null" ]; then
+            echo "::error::Could not resolve installed vimeo/psalm version"
+            composer show vimeo/psalm
+            exit 1
+          fi
+          echo "Resolved Psalm version: $PSALM_VERSION"
+          # Restrict to a proper semver tag. This rejects both `dev-master`
+          # (no phar published) and Composer's path-repo aliases like
+          # `9999999-dev`, where building a GitHub release URL would 404 with
+          # a less actionable message.
+          if [[ ! "$PSALM_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "::error::Resolved Psalm version '$PSALM_VERSION' is not a tagged semver release; no phar artifact is published for dev refs."
+            echo "::error::Pin vimeo/psalm to a tagged release in composer.json before running this workflow."
+            exit 1
+          fi
+          PHAR_URL="https://github.com/vimeo/psalm/releases/download/${PSALM_VERSION}/psalm.phar"
+          curl -fL --retry 3 -o psalm.phar "$PHAR_URL"
+          # Integrity check: a TCP reset can leave curl with exit 0 but a
+          # truncated phar. `--version` alone would still pass on a truncated
+          # phar that happens to print a parse error before crashing, so we
+          # gate on the version line actually starting with `Psalm`.
+          if ! php psalm.phar --version | tee /dev/stderr | grep -q '^Psalm'; then
+            echo "::error::psalm.phar appears truncated or corrupt (--version did not print a 'Psalm ...' line)"
+            ls -la psalm.phar
+            exit 1
+          fi
+
+      - name: Run plugin under psalm.phar (baseline check)
+        working-directory: tests-app/laravel-example
+        run: |
+          # Mirrors what laravel-test.sh does on the vendor/bin path, but via
+          # psalm.phar. failOnInternalError=true in the config means a plugin
+          # init failure makes psalm exit non-zero, and pipefail propagates
+          # that out of the `tee`. The positive-assertion step (next) is what
+          # actually proves handlers registered — this step only catches
+          # regressions in the absorbed-by-baseline issue set.
+          php psalm.phar \
+            --config=../../tests/Application/laravel-test-psalm.xml \
+            --use-baseline=../../tests/Application/laravel-test-psalm-baseline.xml \
+            --no-cache --no-progress --no-suggestions --output-format=compact
+
+      - name: Positive assertion (NoEnvOutsideConfig fires under psalm.phar)
+        working-directory: tests-app/laravel-example
+        run: |
+          # Drop a tiny fixture into the Laravel app that calls env() outside a
+          # config directory. The NoEnvOutsideConfigHandler should flag it.
+          # If the handler silently didn't register (e.g. a refactor that broke
+          # the require_once defense), the diagnostic won't appear and this
+          # step fails. That is the load-bearing assertion of the whole job.
+          mkdir -p app/PharCheck
+          cat > app/PharCheck/PharCheckEnvFixture.php <<'PHP'
+          <?php
+
+          declare(strict_types=1);
+
+          namespace App\PharCheck;
+
+          final class PharCheckEnvFixture
+          {
+              public function call(): void
+              {
+                  env('PSALM_PLUGIN_LARAVEL_PHAR_CHECK');
+              }
+          }
+          PHP
+          # Minimal config: only the fixture file is in scope, no baseline, no
+          # noise filters. Both Psalm's exit code AND the diagnostic must
+          # appear; see the three-way gate below.
+          cat > psalm-phar-fixture.xml <<'XML'
+          <?xml version="1.0"?>
+          <psalm errorLevel="1"
+              findUnusedBaselineEntry="false"
+              findUnusedCode="false"
+              resolveFromConfigFile="false"
+              xmlns="https://getpsalm.org/schema/config">
+              <projectFiles>
+                  <file name="app/PharCheck/PharCheckEnvFixture.php"/>
+              </projectFiles>
+              <plugins>
+                  <pluginClass class="Psalm\LaravelPlugin\Plugin">
+                      <failOnInternalError value="true"/>
+                  </pluginClass>
+              </plugins>
+          </psalm>
+          XML
+          # The diagnostic causes a non-zero psalm exit, which is expected.
+          # We capture the psalm exit code separately via PIPESTATUS so we can
+          # distinguish three outcomes:
+          #   exit == 0  -> psalm ran clean (BAD: diagnostic should have fired)
+          #   exit != 0  + diagnostic in output -> PASS
+          #   exit != 0  + no diagnostic       -> psalm crashed before handlers ran
+          set +e
+          php psalm.phar --config=psalm-phar-fixture.xml --no-cache --no-progress --no-suggestions --output-format=compact 2>&1 | tee positive.log
+          PSALM_EXIT=${PIPESTATUS[0]}
+          set -e
+          # Init-failure marker. We match either of the two stable strings the
+          # plugin's InternalErrorReporter emits, so a reword of one of them
+          # does not silently disable this gate.
+          if grep -qE 'Laravel plugin (error on initialisation|has been disabled)' positive.log; then
+            echo "::error::Plugin emitted init warning under psalm.phar (positive run)"
+            exit 1
+          fi
+          if [ "$PSALM_EXIT" -eq 0 ]; then
+            echo "::error::psalm.phar exited 0 on the bad-env fixture; NoEnvOutsideConfig should have caused a non-zero exit. Output may be empty or the handler is misregistered."
+            echo "--- positive.log ---"
+            cat positive.log
+            exit 1
+          fi
+          if ! grep -q 'NoEnvOutsideConfig' positive.log; then
+            echo "::error::psalm.phar exited $PSALM_EXIT but NoEnvOutsideConfig diagnostic was NOT in the output. Plugin handlers may have failed to register, or psalm crashed before the rule fired."
+            echo "--- positive.log ---"
+            cat positive.log
+            exit 1
+          fi
+          echo "Positive assertion passed: NoEnvOutsideConfig fired under psalm.phar (psalm exit $PSALM_EXIT)"
+
+      - name: Diagnostics on failure
+        if: ${{ failure() }}
+        run: |
+          echo "Psalm analysis failed under psalm.phar."
+          echo "If the baseline step regressed, consider: ./tests/Application/laravel-test.sh --update"
+          echo "If the positive-assertion step failed, the plugin's class-loading flow is broken under psalm.phar."
+          echo "See https://github.com/psalm/psalm-plugin-laravel/issues/895."

--- a/docs/contributing/decisions.md
+++ b/docs/contributing/decisions.md
@@ -88,7 +88,7 @@ In practice, the plugin also boots a real Laravel app via Testbench, which requi
 
 **Sister plugins follow the same pattern:** `psalm-plugin-symfony` keeps `require_once` for every handler. `psalm-plugin-phpunit` and `Lctrs/psalm-psr-container-plugin` use `class_exists($fqcn, true)` instead, but each has only one handler — the failure mode is harder to miss.
 
-**How to remove this constraint:** add a CI job that installs `psalm.phar` and runs the plugin against a sample Laravel project ([#895](https://github.com/psalm/psalm-plugin-laravel/issues/895)). Once that job exists and passes consistently, this decision can be revisited and the `require_once` block collapsed.
+**How to remove this constraint:** [#895](https://github.com/psalm/psalm-plugin-laravel/issues/895) tracks the cleanup. A CI job (`.github/workflows/test-laravel-app-phar.yml`) now exercises the plugin under `psalm.phar` and asserts that a known plugin diagnostic (`NoEnvOutsideConfig`) fires. That gives positive evidence handlers actually register, not just absence of errors. The job runs on `workflow_dispatch`, on new releases, and weekly on Fridays. It does not run on every PR or push, because the failure modes here are slow-moving and the matrix is heavy. Once that job has accumulated consistent green runs, this decision can be revisited and the `require_once` block collapsed.
 
 **Until then:** every new handler added to `Plugin::registerHandlers()` MUST keep its paired `require_once` line.
 

--- a/tests/Application/laravel-test.sh
+++ b/tests/Application/laravel-test.sh
@@ -26,7 +26,13 @@ NC='\033[0m' # No Color
 UPDATE_BASELINE=false
 VERBOSE=false
 REMOVE=false
+SETUP_ONLY=false
 PSALM_PASSED=false
+
+# Path (or filename, resolved relative to the Laravel app dir) of the Psalm binary
+# to invoke. Defaults to the composer-installed binstub. The phar CI job
+# (test-laravel-app-phar.yml) overrides this to ./psalm.phar.
+PSALM_BINARY="${PSALM_BINARY:-./vendor/bin/psalm}"
 
 # Function to display script usage
 show_help() {
@@ -39,10 +45,16 @@ Options:
     -h, --help                          Show this help message
     -u, --update                        Update Psalm baseline
     -v, --verbose                       Enable verbose output
-    -r, --remove   Remove Laravel project directory after execution
+    -r, --remove                        Remove Laravel project directory after execution
+    --setup-only                        Create the Laravel app + install the plugin, then exit
+                                        before running Psalm. Lets the caller swap the binary
+                                        (e.g. psalm.phar) before invoking analysis.
 
 Environment variables:
-    LARAVEL_INSTALLER_VERSION    Laravel version to install (default: 12.12.2)
+    LARAVEL_INSTALLER_VERSION    Laravel version to install (default: dev-master)
+    PSALM_BINARY                 Psalm binary path, relative to the Laravel app dir
+                                 (default: ./vendor/bin/psalm). The phar CI job sets
+                                 this to ./psalm.phar.
     COMPOSER_MEMORY_LIMIT        Memory limit for Composer (default: -1)
 EOF
 }
@@ -118,6 +130,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         -v|--verbose)
             VERBOSE=true
+            shift
+            ;;
+        --setup-only)
+            SETUP_ONLY=true
             shift
             ;;
         *)
@@ -225,14 +241,24 @@ quiet_run "composer require psalm/plugin-laravel" \
 PSALM_CONFIG="../../tests/Application/laravel-test-psalm.xml"
 PSALM_BASELINE="../../tests/Application/laravel-test-psalm-baseline.xml"
 
+if [ "$SETUP_ONLY" = true ]; then
+    info "Setup complete (--setup-only). Skipping Psalm run; Laravel app preserved at $APP_INSTALLATION_PATH"
+    # Skip the EXIT-trap cleanup: callers (e.g. the phar CI job) need the app dir
+    # intact to download psalm.phar into it and run analysis as a follow-up step.
+    trap - EXIT
+    exit 0
+fi
+
+# Invoke via `php` so PSALM_BINARY works for both ./vendor/bin/psalm (executable
+# binstub) and ./psalm.phar (downloaded artifact without +x bit).
 if [ "$UPDATE_BASELINE" = true ]; then
-    info "Updating Psalm baseline"
-    ./vendor/bin/psalm --config="$PSALM_CONFIG" --set-baseline="$PSALM_BASELINE" --no-progress --no-suggestions
+    info "Updating Psalm baseline (using $PSALM_BINARY)"
+    php "$PSALM_BINARY" --config="$PSALM_CONFIG" --set-baseline="$PSALM_BASELINE" --no-progress --no-suggestions
     info "Baseline file $PSALM_BASELINE is updated, please check the changes and commit them."
 else
-    info "Running Psalm analysis"
+    info "Running Psalm analysis (using $PSALM_BINARY)"
     # set -e ensures script exits on failure, so cleanup below only runs on success
-    ./vendor/bin/psalm --config="$PSALM_CONFIG" --use-baseline="$PSALM_BASELINE" --no-progress --no-suggestions --output-format=compact
+    php "$PSALM_BINARY" --config="$PSALM_CONFIG" --use-baseline="$PSALM_BASELINE" --no-progress --no-suggestions --output-format=compact
 fi
 
 echo


### PR DESCRIPTION
Closes #895. **First run revealed a category-wide latent bug; see #910.**

## Summary

Adds `.github/workflows/test-laravel-app-phar.yml`. The job downloads the Psalm version composer resolves in a freshly-built Laravel project, runs the plugin under `psalm.phar` (not `vendor/bin/psalm`), and asserts that `NoEnvOutsideConfig` fires on a tiny bad-env fixture. The diagnostic firing is positive evidence that handlers actually registered, not just absence of errors.

This is the empirical gate that was meant to unblock collapsing `Plugin::registerHandlers()`'s 41 `require_once` + `registerHooksFromClass` pairs into a `foreach` loop over a `HANDLERS` constant (see `docs/contributing/decisions.md` → "Handler files are loaded with explicit `require_once`"). **That cleanup is now gated on #910 instead.**

## Empirical finding (first run)

I triggered the new workflow on this PR via a throwaway `pull_request` trigger (since `gh workflow run` cannot dispatch a workflow that does not yet exist on master). Every matrix cell failed with the same fatal:

```
PHP Fatal error: Cannot redeclare class Psalm\Internal\ErrorHandler
  (previously declared in phar:///.../psalm.phar/src/Psalm/Internal/ErrorHandler.php:20)
  in /.../vendor/vimeo/psalm/src/Psalm/Internal/ErrorHandler.php on line 24
```

Full logs: https://github.com/psalm/psalm-plugin-laravel/actions/runs/25658024029

This is a **dual-Psalm collision**, not the autoloader-not-registered scenario the `require_once` defense was guarding against. When the plugin is composer-installed, `vimeo/psalm` comes along as a hard dependency (declared in `require`). Then when `psalm.phar` runs, the phar's bundled Psalm and the composer-installed Psalm fight in PHP's class table. Sister plugin `psalm-plugin-symfony` has the identical composer.json shape and only tests via `vendor/bin/psalm` in its CI; the bug is presumably category-wide. Filed as #910.

The throwaway trigger commit was then dropped (force-push-with-lease), so the diff in this PR matches the original spec: triggers are `workflow_dispatch` + `release: published` + weekly Friday cron.

## Triggers (per maintainer spec)

- `workflow_dispatch` (manual)
- `release: types: [published]` (post-tag smoke test)
- `schedule: "0 6 * * 5"` (weekly Friday, matches `test-laravel-app.yml`)

Intentionally NOT on PR/push: the matrix is heavy (7 cells) and the failure modes here are slow-moving.

## Job structure

1. **Create Laravel app + install plugin** — reuses `tests/Application/laravel-test.sh` with the new `--setup-only` flag (exits before Psalm runs).
2. **Download psalm.phar** matching the composer-resolved Psalm version. Includes a semver guard that rejects `dev-master` and Composer path-repo aliases (`9999999-dev`), plus an integrity check via `php psalm.phar --version | grep -q '^Psalm'` to catch truncated downloads.
3. **Baseline check** — runs `psalm.phar` against the existing `laravel-test-psalm.xml` config.
4. **Positive assertion** — drops `app/PharCheck/PharCheckEnvFixture.php` (calls `env()` outside `config/`) into the test app, runs `psalm.phar` with a stripped-down config, and three-way-gates on (a) non-zero psalm exit, (b) no init-failure warning in output, (c) `NoEnvOutsideConfig` appears in output. Distinct error messages per failure mode so a crash before output is not misreported as "handler failed to register".

## Companion changes

- `tests/Application/laravel-test.sh`: adds `PSALM_BINARY` env var (default `./vendor/bin/psalm`) and `--setup-only` flag. Existing `composer test:app` path is unchanged.
- `docs/contributing/decisions.md`: updates the "How to remove this constraint" paragraph to note the new CI job exists, with the caveat that it does not run on every PR.

## Recommended path forward

**Land this PR as proof-of-discovery.** The workflow correctly identifies that the plugin is broken under `psalm.phar` (first run, every cell). That's exactly what #895 asked for. Until #910 is fixed:

- The post-merge `gh workflow run test-laravel-app-phar.yml --ref master` will fail; the failure is the deliverable.
- The weekly Friday cron and release-trigger runs will keep failing as a visible reminder.
- The `require_once` cleanup contemplated in `docs/contributing/decisions.md` stays gated.

If you'd rather not merge a workflow that fails on first run, the alternative is to keep this PR open until #910 is fixed and the workflow can produce a green signal.

## Validation

- `actionlint` passes on the new workflow.
- `bash -n` passes on the modified script.
- Two rounds of `/psalm-review` (code, architecture, docs, tests, errors agents) before push.
- Workflow ran end-to-end on the PR via a throwaway `pull_request` trigger (since reverted) and behaved as designed: the three-way gate correctly identifies the dual-Psalm collision as a non-init-warning, psalm-exited-non-zero, no-NoEnvOutsideConfig-in-output failure mode and surfaces it cleanly.