### PR TITLE
Narrow `Rules\Enum` and `Rules\In` object forms in `validated()`

### DIFF
--- a/src/Handlers/Validation/ValidationRuleAnalyzer.php
+++ b/src/Handlers/Validation/ValidationRuleAnalyzer.php
@@ -372,8 +372,18 @@ final class ValidationRuleAnalyzer
     private static function ruleToRemovedTaints(string $rule): int
     {
         return match ($rule) {
-            // Strictly character-constrained — values cannot contain any meta-characters
-            // that matter to known input sinks, so we escape every INPUT_* kind.
+            // Safe across every INPUT_* kind. Two distinct rationales feed
+            // into this same arm:
+            //   1. Character-constrained rules (integer, numeric, boolean,
+            //      uuid, alpha*, hex_color, date*, timezone, …) — values
+            //      cannot contain any meta-characters that matter to known
+            //      input sinks.
+            //   2. Whitelist / provenance rules ('in', 'enum') — the
+            //      validated value is one of a fixed set of developer-
+            //      authored whitelist values (source-code constants), so it
+            //      is trusted by provenance regardless of content. The
+            //      per-rule inline comments below spell the rationale out
+            //      where it's non-obvious.
             'integer', 'numeric', 'boolean',
             'decimal', 'digits', 'digits_between',
             'accepted', 'accepted_if',

--- a/src/Handlers/Validation/ValidationRuleAnalyzer.php
+++ b/src/Handlers/Validation/ValidationRuleAnalyzer.php
@@ -68,6 +68,16 @@ final class ValidationRuleAnalyzer
         // before/after/before_or_equal/after_or_equal constraints — all of
         // which are themselves ALL_INPUT-escaped in ruleToRemovedTaints().
         'illuminate\\validation\\rules\\date' => TaintKind::ALL_INPUT,
+        // Mirrors the 'enum' synthetic segment: when validation succeeds, the
+        // validated value is necessarily a developer-declared case backing
+        // value (a source-code constant — same trust model as Rule::in([...])).
+        // UnitEnum scalar input is rejected outright by Enum::passes() because
+        // the rule short-circuits when the enum has no `tryFrom`, so no value
+        // reaches the sink either way for pure UnitEnums. The escape is
+        // therefore sound for both branches. Covers the fallback class: path
+        // when the enum class argument isn't statically resolvable (e.g.
+        // `new Enum($variable)`).
+        'illuminate\\validation\\rules\\enum' => TaintKind::ALL_INPUT,
     ];
 
     /**
@@ -335,6 +345,7 @@ final class ValidationRuleAnalyzer
                 new TNamedObject(\Illuminate\Http\UploadedFile::class),
             ]),
             'in' => self::inRuleToLiteralUnion($param),
+            'enum' => self::enumRuleToType($param),
             'uuid', 'ulid',
             'alpha', 'alpha_num', 'alpha_dash',
             'hex_color', 'mac_address',
@@ -375,7 +386,14 @@ final class ValidationRuleAnalyzer
             'after', 'after_or_equal',
             'date_equals',
             'timezone',
-            'in' => TaintKind::ALL_INPUT,
+            'in',
+            // Enum rule (synthetic `enum:FQN` segment): only developer-declared
+            // case backing values reach validated() output (source-code
+            // constants), none of which contain input-sink meta-characters.
+            // Pure UnitEnums are out of reach via scalar input — Enum::passes()
+            // short-circuits without `tryFrom`, so no value flows to a sink.
+            // Mirrors the 'in' escape.
+            'enum' => TaintKind::ALL_INPUT,
 
             // IP literals: restricted to digits / dots / colons / hex letters.
             // Safe everywhere except SSRF — a syntactically valid IP can still
@@ -404,6 +422,105 @@ final class ValidationRuleAnalyzer
             // string, json, regex, required, max, min, etc. → keep all taint
             default => 0,
         };
+    }
+
+    /**
+     * Resolve the synthetic `enum:FQN` rule segment to the literal-union type
+     * the enum's backing values produce in validated() output.
+     *
+     * Laravel's `Rules\Enum::passes()` accepts a raw scalar and runs it through
+     * `BackingEnum::tryFrom()` without mutating the validator's data, so the
+     * value stored in validated() is the original scalar — *not* an enum
+     * instance — and its type is exactly the enum's backing type. We narrow
+     * further to the literal union of the case backing values, mirroring how
+     * `'in:a,b,c'` already narrows whitelist string rules.
+     *
+     * Unit enums (no `tryFrom`) intentionally fall back to `mixed`: Laravel's
+     * `passes()` short-circuits to `false` for any scalar input when
+     * `method_exists($type, 'tryFrom')` is false, so the only way a UnitEnum
+     * field survives validation is via programmatic `$request->merge(...)`
+     * with an instance — that's an enum object, not a `string` case name as
+     * the `__toString()` form suggests. Returning `mixed` keeps us sound for
+     * both paths until Laravel grows real UnitEnum name-matching.
+     *
+     * Soundness escapes (return `mixed` or the base backing type):
+     *   - Class not resolvable in the codebase (mistyped FQN, scan order race) → mixed.
+     *   - Class is not an enum (no `enum_cases`)                                → mixed.
+     *   - `enum_type` is set but a case's value can't be resolved (deferred
+     *     constant expression, unresolvable docblock)                          → fall back
+     *     to the base backing type (`int` or `string`) so we never over-narrow.
+     */
+    private static function enumRuleToType(?string $param): Union
+    {
+        if ($param === null || $param === '') {
+            return Type::getMixed();
+        }
+
+        $enumFqn = \ltrim($param, '\\');
+
+        try {
+            $codebase = ProjectAnalyzer::getInstance()->getCodebase();
+        } catch (\RuntimeException|\Error) {
+            return Type::getMixed();
+        }
+
+        try {
+            $storage = $codebase->classlike_storage_provider->get(\strtolower($enumFqn));
+        } catch (\InvalidArgumentException) {
+            return Type::getMixed();
+        }
+
+        if ($storage->enum_cases === []) {
+            // Either not an enum at all, or an enum with no cases declared yet
+            // (rare; the rule is degenerate but harmless — leave as mixed).
+            return Type::getMixed();
+        }
+
+        $atomics = [];
+
+        if ($storage->enum_type === 'int') {
+            foreach ($storage->enum_cases as $case) {
+                try {
+                    $value = $case->getValue($codebase->classlikes);
+                } catch (\UnexpectedValueException) {
+                    return Type::getInt();
+                }
+
+                if (!$value instanceof TLiteralInt) {
+                    return Type::getInt();
+                }
+
+                $atomics[] = $value;
+            }
+
+            // $atomics is guaranteed non-empty here: enum_cases was verified
+            // non-empty above, every loop iteration either returns early or
+            // pushes one atomic, so reaching this line means at least one push.
+            return new Union($atomics);
+        }
+
+        if ($storage->enum_type === 'string') {
+            foreach ($storage->enum_cases as $case) {
+                try {
+                    $value = $case->getValue($codebase->classlikes);
+                } catch (\UnexpectedValueException) {
+                    return Type::getString();
+                }
+
+                if (!$value instanceof TLiteralString) {
+                    return Type::getString();
+                }
+
+                $atomics[] = $value;
+            }
+
+            return new Union($atomics);
+        }
+
+        // Pure UnitEnum (enum_type === null): see the soundness note in the
+        // docblock — Laravel's Enum rule rejects all scalar UnitEnum input, so
+        // any narrowing here would be wrong for one of the runtime paths.
+        return Type::getMixed();
     }
 
     /**
@@ -849,16 +966,29 @@ final class ValidationRuleAnalyzer
                         continue;
                     }
 
-                    // Rule::in(...) / Rule::notIn(...) with statically-extractable
-                    // string literals — emit the equivalent 'in:a,b,c' / 'not_in:a,b,c'
-                    // segment so resolveRuleSegments narrows the type via the existing
-                    // string-rule path. Falls through to the class: segment when the
-                    // arguments aren't statically resolvable (variables, enums,
-                    // Arrayable, spread, comma-bearing values, …).
+                    // Rule::in(...) / Rule::notIn(...) / `new In([...])` / `new NotIn([...])`
+                    // with statically-extractable string literals — emit the equivalent
+                    // 'in:a,b,c' / 'not_in:a,b,c' segment so resolveRuleSegments narrows
+                    // the type via the existing string-rule path. Falls through to the
+                    // class: segment when the arguments aren't statically resolvable
+                    // (variables, enum cases, Arrayable, spread, comma-bearing values, …).
                     $inLikeSegment = self::tryExtractInLikeRuleSegment($ruleItem->value);
 
                     if ($inLikeSegment !== null) {
                         $segments[] = $inLikeSegment;
+
+                        continue;
+                    }
+
+                    // `Rule::enum(EnumClass::class)` / `new Enum(EnumClass::class)` —
+                    // emit a synthetic `enum:FQN` segment so resolveRuleSegments can
+                    // narrow validated() output to the enum's backing-type literal union
+                    // via {@see enumRuleToType()}. Falls through to the class: segment
+                    // when the constructor argument is not a static `::class` literal.
+                    $enumSegment = self::tryExtractEnumRuleSegment($ruleItem->value);
+
+                    if ($enumSegment !== null) {
+                        $segments[] = $enumSegment;
 
                         continue;
                     }
@@ -886,13 +1016,15 @@ final class ValidationRuleAnalyzer
     }
 
     /**
-     * If the expression is a `Rule::in(...)` or `Rule::notIn(...)` static call
-     * (optionally wrapped in fluent method calls) whose arguments are all
-     * string literals, return the equivalent `in:a,b,c` / `not_in:a,b,c`
-     * rule segment. Returns null for any unsupported argument shape.
+     * If the expression is one of:
+     *   - `Rule::in(...)`  / `Rule::notIn(...)` static call
+     *   - `new \Illuminate\Validation\Rules\In(...)`  / `new NotIn(...)`
+     * (optionally wrapped in outer fluent method calls), and the arguments
+     * are all string literals, return the equivalent `in:a,b,c` /
+     * `not_in:a,b,c` rule segment. Returns null for any unsupported shape.
      *
-     * Reusing the string-rule segment funnels the fluent form through the
-     * same {@see inRuleToLiteralUnion()} narrowing and {@see ruleToRemovedTaints()}
+     * Reusing the string-rule segment funnels both forms through the same
+     * {@see inRuleToLiteralUnion()} narrowing and {@see ruleToRemovedTaints()}
      * escape path that `'in:a,b,c'` already takes. Identical taint contribution
      * for `in` (`TaintKind::ALL_INPUT` from both the class table and the rule
      * table) and `not_in` (0 from both) means swapping segment forms cannot
@@ -902,6 +1034,10 @@ final class ValidationRuleAnalyzer
      *   - `Rule::in('a', 'b')`         variadic
      *   - `Rule::in('a')`              single
      *   - `Rule::in(['a', 'b'])`       array literal
+     *   - `new In(['a', 'b'])`         constructor with array literal
+     *   - `new In('a', 'b')`           constructor with variadic-style args
+     *     (Laravel's In falls back to `func_get_args()` when the first
+     *     argument isn't an array — see Rules\In::__construct).
      *
      * Bails (returns null) for:
      *   - Any non-string-literal argument (variables, enum cases, method calls,
@@ -925,9 +1061,188 @@ final class ValidationRuleAnalyzer
             $expr = $expr->var;
         }
 
-        if (!$expr instanceof Node\Expr\StaticCall
-            || !$expr->class instanceof Node\Name
+        $detected = self::detectInLikeRuleRoot($expr);
+
+        if ($detected === null) {
+            return null;
+        }
+
+        [$ruleName, $args] = $detected;
+
+        $values = self::extractStringLiteralArgs($args);
+
+        if ($values === null) {
+            return null;
+        }
+
+        return $ruleName . ':' . \implode(',', $values);
+    }
+
+    /**
+     * Inspect an already-fluent-unwrapped expression and detect whether it is
+     * an `in` / `not_in` rule construct in either the `Rule::in(...)` static
+     * call form or the `new \Illuminate\Validation\Rules\In(...)` constructor
+     * form. Returns the canonical rule name (`'in'` or `'not_in'`) together
+     * with the construct's positional argument list, or null when the
+     * expression doesn't match either shape.
+     *
+     * Keeping detection in one place means a future `Rule::between(...)` /
+     * `new Between(...)` extension only has to extend two short maps below
+     * (the facade-method map and the constructor-FQN map), not duplicate the
+     * AST walk.
+     *
+     * @return array{0: 'in'|'not_in', 1: list<Node\Arg|Node\VariadicPlaceholder>}|null
+     */
+    private static function detectInLikeRuleRoot(Node\Expr $expr): ?array
+    {
+        if ($expr instanceof Node\Expr\StaticCall
+            && $expr->class instanceof Node\Name
+            && $expr->name instanceof Node\Identifier
+        ) {
+            /** @var string|null $resolved */
+            $resolved = $expr->class->getAttribute('resolvedName');
+
+            if (\is_string($resolved)
+                && \strtolower($resolved) === self::RULE_FACADE_LOWER_FQN
+            ) {
+                $ruleName = match (\strtolower($expr->name->name)) {
+                    'in' => 'in',
+                    'notin' => 'not_in',
+                    default => null,
+                };
+
+                if ($ruleName !== null) {
+                    return [$ruleName, \array_values($expr->args)];
+                }
+            }
+        }
+
+        if ($expr instanceof Node\Expr\New_ && $expr->class instanceof Node\Name) {
+            /** @var string|null $resolved */
+            $resolved = $expr->class->getAttribute('resolvedName');
+
+            if (\is_string($resolved)) {
+                $ruleName = match (\strtolower($resolved)) {
+                    'illuminate\\validation\\rules\\in' => 'in',
+                    'illuminate\\validation\\rules\\notin' => 'not_in',
+                    default => null,
+                };
+
+                if ($ruleName !== null) {
+                    return [$ruleName, \array_values($expr->args)];
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * If the expression is `Rule::enum(EnumClass::class)` or
+     * `new \Illuminate\Validation\Rules\Enum(EnumClass::class)` (optionally
+     * wrapped in outer fluent method calls) whose first argument is a
+     * resolvable `::class` literal, return the synthetic `enum:FQN` rule
+     * segment. The {@see enumRuleToType()} resolver then narrows the
+     * validated() output to the enum's backing-type literal union.
+     *
+     * The outer fluent unwrap collapses `Rule::enum(X)->only(...)` /
+     * `->except(...)` to its `Rule::enum(X)` root, so the emitted segment
+     * narrows to the full case set rather than the runtime subset. That's a
+     * sound superset (the runtime subset is contained in the full case set,
+     * so no false positives reach downstream consumers) and a deliberate
+     * trade-off in favour of zero false positives over peak precision.
+     *
+     * Bails (returns null) for:
+     *   - First argument is not a `Class::class` literal (variable, string,
+     *     method call, …) → fall through to the class: segment so taint
+     *     still escapes via {@see FIRST_PARTY_RULE_ESCAPES}.
+     *   - Class reference is not statically resolvable (`$class::class`,
+     *     dynamic `::class`).
+     */
+    private static function tryExtractEnumRuleSegment(Node\Expr $expr): ?string
+    {
+        // Unwrap fluent calls so `Rule::enum(...)->only(...)` resolves to its
+        // `Rule::enum(...)` root. Mirrors tryExtractInLikeRuleSegment().
+        while ($expr instanceof Node\Expr\MethodCall
+            || $expr instanceof Node\Expr\NullsafeMethodCall
+        ) {
+            $expr = $expr->var;
+        }
+
+        $args = self::detectEnumRuleArgs($expr);
+
+        if ($args === null || $args === []) {
+            return null;
+        }
+
+        $firstArg = $args[0];
+
+        if (!$firstArg instanceof Node\Arg || $firstArg->unpack) {
+            return null;
+        }
+
+        $enumFqn = self::resolveClassConstLiteral($firstArg->value);
+
+        if ($enumFqn === null) {
+            return null;
+        }
+
+        return 'enum:' . $enumFqn;
+    }
+
+    /**
+     * Inspect an already-fluent-unwrapped expression and return the positional
+     * argument list iff the expression is one of the two Enum-rule construct
+     * shapes (`Rule::enum(...)` or `new Illuminate\Validation\Rules\Enum(...)`).
+     * Returns null when the expression isn't an enum-rule root.
+     *
+     * @return list<Node\Arg|Node\VariadicPlaceholder>|null
+     */
+    private static function detectEnumRuleArgs(Node\Expr $expr): ?array
+    {
+        if ($expr instanceof Node\Expr\StaticCall
+            && $expr->class instanceof Node\Name
+            && $expr->name instanceof Node\Identifier
+        ) {
+            /** @var string|null $resolved */
+            $resolved = $expr->class->getAttribute('resolvedName');
+
+            if (\is_string($resolved)
+                && \strtolower($resolved) === self::RULE_FACADE_LOWER_FQN
+                && \strtolower($expr->name->name) === 'enum'
+            ) {
+                return \array_values($expr->args);
+            }
+        }
+
+        if ($expr instanceof Node\Expr\New_ && $expr->class instanceof Node\Name) {
+            /** @var string|null $resolved */
+            $resolved = $expr->class->getAttribute('resolvedName');
+
+            if (\is_string($resolved)
+                && \strtolower($resolved) === 'illuminate\\validation\\rules\\enum'
+            ) {
+                return \array_values($expr->args);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolve a `ClassName::class` literal to its FQN. Returns null for any
+     * other expression (variable `::class`, method call result, plain string).
+     *
+     * Not `@psalm-mutation-free` because `Node\Name::getAttribute()` reads
+     * mutable attribute state on the AST node — same reason
+     * {@see resolveRuleObjectClassName()} isn't annotated as pure.
+     */
+    private static function resolveClassConstLiteral(Node\Expr $expr): ?string
+    {
+        if (!$expr instanceof Node\Expr\ClassConstFetch
             || !$expr->name instanceof Node\Identifier
+            || \strtolower($expr->name->name) !== 'class'
+            || !$expr->class instanceof Node\Name
         ) {
             return null;
         }
@@ -935,29 +1250,7 @@ final class ValidationRuleAnalyzer
         /** @var string|null $resolved */
         $resolved = $expr->class->getAttribute('resolvedName');
 
-        if (!\is_string($resolved)
-            || \strtolower($resolved) !== self::RULE_FACADE_LOWER_FQN
-        ) {
-            return null;
-        }
-
-        $ruleName = match (\strtolower($expr->name->name)) {
-            'in' => 'in',
-            'notin' => 'not_in',
-            default => null,
-        };
-
-        if ($ruleName === null) {
-            return null;
-        }
-
-        $values = self::extractStringLiteralArgs(\array_values($expr->args));
-
-        if ($values === null) {
-            return null;
-        }
-
-        return $ruleName . ':' . \implode(',', $values);
+        return \is_string($resolved) ? \ltrim($resolved, '\\') : null;
     }
 
     /**

--- a/src/Handlers/Validation/ValidationRuleAnalyzer.php
+++ b/src/Handlers/Validation/ValidationRuleAnalyzer.php
@@ -387,12 +387,16 @@ final class ValidationRuleAnalyzer
             'date_equals',
             'timezone',
             'in',
-            // Enum rule (synthetic `enum:FQN` segment): only developer-declared
-            // case backing values reach validated() output (source-code
-            // constants), none of which contain input-sink meta-characters.
-            // Pure UnitEnums are out of reach via scalar input — Enum::passes()
-            // short-circuits without `tryFrom`, so no value flows to a sink.
-            // Mirrors the 'in' escape.
+            // Enum rule (synthetic `enum:FQN` segment): the validated value is
+            // necessarily one of the developer-declared case backing values —
+            // i.e. a source-code constant. Same trust model as Rule::in([...]):
+            // we treat developer-authored whitelist values as trusted, even
+            // when an individual case happens to spell something risky like
+            // `case Evil = "'; DROP TABLE--"`. The escape is about provenance
+            // (source code, not user input), not a character-level guarantee.
+            // Pure UnitEnums never reach a sink via scalar input — passes()
+            // short-circuits without `tryFrom` — so the escape is vacuous for
+            // that branch and sound on both. Mirrors the 'in' escape.
             'enum' => TaintKind::ALL_INPUT,
 
             // IP literals: restricted to digits / dots / colons / hex letters.

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestRuleEnumNoTaint.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestRuleEnumNoTaint.phpt
@@ -1,0 +1,50 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Enum;
+
+/**
+ * Issue #908: `new Enum(BackedEnum::class)` and `Rule::enum(BackedEnum::class)`
+ * must escape ALL_INPUT taint at sinks. The accepted set is bounded by the
+ * developer-declared case backing values (source-code constants), so the trust
+ * model matches `Rule::in([$whitelist])` which is already at ALL_INPUT.
+ *
+ * Sibling of {@see SafeFormRequestRuleInFluentNoTaint.phpt}.
+ */
+enum SafeRole: string
+{
+    case Admin = 'admin';
+    case User = 'user';
+}
+
+final class EnumRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['role' => ['required', new Enum(SafeRole::class)]];
+    }
+}
+
+function renderEnum(EnumRequest $request): void {
+    echo $request->string('role');
+}
+
+final class FluentEnumRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['role' => ['required', Rule::enum(SafeRole::class)]];
+    }
+}
+
+function renderFluentEnum(FluentEnumRequest $request): void {
+    echo $request->string('role');
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/ValidationRuleEnumNarrowingTest.phpt
+++ b/tests/Type/tests/ValidationRuleEnumNarrowingTest.phpt
@@ -219,7 +219,7 @@ function testNewInArrayLiteral(NewInArrayLiteralRequest $request): void
     /** @psalm-check-type-exact $_workday = 'full'|'half' */
 }
 
-class NewNotInVariadicRequest extends FormRequest
+class NewNotInArrayLiteralRequest extends FormRequest
 {
     public function rules(): array
     {
@@ -234,7 +234,7 @@ class NewNotInVariadicRequest extends FormRequest
     }
 }
 
-function testNewNotInVariadic(NewNotInVariadicRequest $request): void
+function testNewNotInArrayLiteral(NewNotInArrayLiteralRequest $request): void
 {
     $_role = $request->validated('role');
     /** @psalm-check-type-exact $_role = string */

--- a/tests/Type/tests/ValidationRuleEnumNarrowingTest.phpt
+++ b/tests/Type/tests/ValidationRuleEnumNarrowingTest.phpt
@@ -1,0 +1,279 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Enum;
+use Illuminate\Validation\Rules\In;
+use Illuminate\Validation\Rules\NotIn;
+
+/**
+ * Issue #908: `new Enum(BackedEnum::class)` and `Rule::enum(BackedEnum::class)`
+ * must narrow validated() output to the enum's backing-type literal union, not
+ * leave it as `mixed`. `new In([...])` / `new NotIn([...])` must narrow on a
+ * par with the `Rule::in(...)` fluent form already covered by
+ * ValidationRuleInFluentNarrowingTest.
+ *
+ * Sibling tests live next to fluent narrowing so the two object-form entry
+ * points stay symmetrical.
+ */
+enum IssueStatus: int
+{
+    case Active = 1;
+    case Inactive = 0;
+}
+
+enum IssueRole: string
+{
+    case Admin = 'admin';
+    case User = 'user';
+}
+
+enum IssueColour
+{
+    case Red;
+    case Green;
+    case Blue;
+}
+
+class EnumBackedIntRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'status' => ['required', new Enum(IssueStatus::class)],
+        ];
+    }
+}
+
+function testEnumBackedInt(EnumBackedIntRequest $request): void
+{
+    // BackedEnum:int → literal-int union of case values
+    $_status = $request->validated('status');
+    /** @psalm-check-type-exact $_status = 0|1 */
+
+    $_all = $request->validated();
+    /** @psalm-check-type-exact $_all = array{status: 0|1} */
+}
+
+class EnumBackedStringRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'role' => ['required', new Enum(IssueRole::class)],
+        ];
+    }
+}
+
+function testEnumBackedString(EnumBackedStringRequest $request): void
+{
+    // BackedEnum:string → literal-string union of case backing values
+    $_role = $request->validated('role');
+    /** @psalm-check-type-exact $_role = 'admin'|'user' */
+}
+
+class EnumUnitRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'colour' => ['required', new Enum(IssueColour::class)],
+        ];
+    }
+}
+
+function testEnumUnit(EnumUnitRequest $request): void
+{
+    // Pure UnitEnum (no `tryFrom`): Laravel's Enum::passes() returns false for
+    // every scalar input, so any narrowing would be wrong for the only path
+    // through which a UnitEnum field could reach validated() (programmatic
+    // `$request->merge(SomeUnit::Case)`, which produces an enum *instance*,
+    // not a string). Stay at `mixed` until Laravel grows real UnitEnum
+    // name-matching at runtime.
+    $_colour = $request->validated('colour');
+    /** @psalm-check-type-exact $_colour = mixed */
+}
+
+class FluentEnumBackedIntRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'status' => ['required', Rule::enum(IssueStatus::class)],
+        ];
+    }
+}
+
+function testFluentEnumBackedInt(FluentEnumBackedIntRequest $request): void
+{
+    // Rule::enum(...) routes through the same synthetic `enum:FQN` segment
+    // as the `new Enum(...)` constructor form. Locked in so the fluent /
+    // constructor entry points cannot diverge.
+    $_status = $request->validated('status');
+    /** @psalm-check-type-exact $_status = 0|1 */
+}
+
+class FluentEnumOnlySubsetRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            // ->only([...]) further restricts the accepted cases at runtime,
+            // but the analyzer's fluent unwrap collapses the chain to its
+            // root, so we emit the full-case-set union. That's a sound
+            // superset (no false positives, just less peak precision), and
+            // a deliberate trade-off documented in tryExtractEnumRuleSegment.
+            'status' => ['required', Rule::enum(IssueStatus::class)->only([IssueStatus::Active])],
+        ];
+    }
+}
+
+function testFluentEnumOnlySubsetUsesFullUnion(FluentEnumOnlySubsetRequest $request): void
+{
+    $_status = $request->validated('status');
+    /** @psalm-check-type-exact $_status = 0|1 */
+}
+
+class EnumWithStringRuleRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            // 'first wins' for type-bearing rules — mirrors the
+            // FluentInWithStringRuleRequest case in the In sibling test.
+            // The 'string' segment resolves before the enum segment, so the
+            // inferred type stays `string`.
+            'role' => ['required', 'string', new Enum(IssueRole::class)],
+        ];
+    }
+}
+
+function testEnumWithStringRule(EnumWithStringRuleRequest $request): void
+{
+    $_role = $request->validated('role');
+    /** @psalm-check-type-exact $_role = string */
+}
+
+class EnumWithVariableArgRequest extends FormRequest
+{
+    /**
+     * @return array<string, list<string|\Illuminate\Validation\Rules\Enum>>
+     */
+    public function rules(): array
+    {
+        /** @var class-string<\UnitEnum> $enumClass */
+        $enumClass = IssueStatus::class;
+
+        return [
+            'status' => ['required', new Enum($enumClass)],
+        ];
+    }
+}
+
+function testEnumWithVariableArgFallsBackToMixed(EnumWithVariableArgRequest $request): void
+{
+    // Variable arg: the analyzer cannot statically resolve the enum class, so
+    // it falls back to the class: segment path. Type stays mixed; taint still
+    // escapes via FIRST_PARTY_RULE_ESCAPES['…\\rules\\enum'].
+    $_status = $request->validated('status');
+    /** @psalm-check-type-exact $_status = mixed */
+}
+
+class EnumOptionalRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            // Missing 'required' → field is optional in validated() shape.
+            'status' => [new Enum(IssueStatus::class)],
+        ];
+    }
+}
+
+function testEnumOptional(EnumOptionalRequest $request): void
+{
+    $_all = $request->validated();
+    /** @psalm-check-type-exact $_all = array{status?: 0|1} */
+}
+
+class NewInArrayLiteralRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            // `new In(...)` mirrors `Rule::in(...)` — both must narrow to the
+            // same literal-string union for the same statically-resolvable
+            // whitelist. Locked in here so the constructor form does not
+            // silently regress to `mixed`.
+            'workday' => ['required', new In(['half', 'full'])],
+        ];
+    }
+}
+
+function testNewInArrayLiteral(NewInArrayLiteralRequest $request): void
+{
+    $_workday = $request->validated('workday');
+    /** @psalm-check-type-exact $_workday = 'full'|'half' */
+}
+
+class NewNotInVariadicRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            // not_in is a blocklist — no value-shape narrowing. Locked in here
+            // so the constructor form behaves identically to the static-call
+            // form (FluentNotInVariadicRequest) and to the `not_in:a,b`
+            // string-rule form: the explicit `'string'` rule wins, type =
+            // string.
+            'role' => ['required', 'string', new NotIn(['banned', 'blocked'])],
+        ];
+    }
+}
+
+function testNewNotInVariadic(NewNotInVariadicRequest $request): void
+{
+    $_role = $request->validated('role');
+    /** @psalm-check-type-exact $_role = string */
+}
+
+class EnumNullableRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            // The 'nullable' modifier wraps every type-bearing rule's union
+            // with `|null` via resolveRuleSegments(). Locking this in for the
+            // enum path so a future refactor of the nullable handling can't
+            // silently drop the null branch off enum narrowings.
+            'status' => ['nullable', new Enum(IssueStatus::class)],
+        ];
+    }
+}
+
+function testEnumNullable(EnumNullableRequest $request): void
+{
+    $_status = $request->validated('status');
+    /** @psalm-check-type-exact $_status = 0|1|null */
+}
+
+/**
+ * Inline validate([...]) routes through the same extractRulePairsFromArrayNode
+ * → tryExtractEnumRuleSegment / tryExtractInLikeRuleSegment path as the
+ * FormRequest::rules() entry point. Locked in so the inline-validate call
+ * shape stays in sync.
+ */
+function testInlineValidateWithEnumAndNewIn(\Illuminate\Http\Request $request): void
+{
+    $_data = $request->validate([
+        'status' => ['required', new Enum(IssueStatus::class)],
+        'role' => ['required', Rule::enum(IssueRole::class)],
+        'workday' => ['required', new In(['half', 'full'])],
+    ]);
+    /** @psalm-check-type-exact $_data = array{role: 'admin'|'user', status: 0|1, workday: 'full'|'half'} */
+}
+?>
+--EXPECTF--

--- a/tests/Unit/Handlers/Validation/ValidationRuleAnalyzerTest.php
+++ b/tests/Unit/Handlers/Validation/ValidationRuleAnalyzerTest.php
@@ -501,6 +501,21 @@ final class ValidationRuleAnalyzerTest extends TestCase
     }
 
     #[Test]
+    public function class_segment_for_rules_enum_removes_all_input_taint(): void
+    {
+        // Issue #908 follow-on: the `Rules\Enum` class segment is the fallback
+        // path used when the analyzer can't statically resolve the enum-class
+        // argument (e.g. `new Enum($variable)`). The synthetic `enum:FQN`
+        // segment already escapes via ruleToRemovedTaints, so the class:
+        // fallback must match for parity — see FIRST_PARTY_RULE_ESCAPES entry.
+        $rule = ValidationRuleAnalyzer::resolveRuleSegments(
+            ['required', 'class:Illuminate\\Validation\\Rules\\Enum'],
+        );
+
+        $this->assertSame(TaintKind::ALL_INPUT, $rule->removedTaints);
+    }
+
+    #[Test]
     public function class_segment_for_rules_notin_removes_no_taint(): void
     {
         // NotIn is deliberately not in FIRST_PARTY_RULE_ESCAPES: rejecting a
@@ -517,17 +532,17 @@ final class ValidationRuleAnalyzerTest extends TestCase
     /**
      * Defensive guard: these classes are mapped in RULE_FACADE_METHOD_RETURN_CLASS
      * but deliberately omitted from FIRST_PARTY_RULE_ESCAPES. File/ImageFile
-     * carry user-controlled filename/mime/contents; Enum is a plausible
-     * candidate for a future escape (backing values are developer-defined
-     * string literals) but is intentionally out of scope for the initial PR.
-     * If a future refactor added any of them, this test would flip to a
+     * carry user-controlled filename/mime/contents — no value-shape guarantee
+     * that would justify a blanket escape. Enum used to live here; #908 added
+     * an explicit escape entry (enum cases are character-constrained), so it
+     * moves to the positive-assertion test above.
+     * If a future refactor added either of these, this test would flip to a
      * non-zero expectation and fail, forcing a deliberate decision.
      *
      * @return iterable<string, array{string}>
      */
     public static function provideNonEscapingMappedRuleClasses(): iterable
     {
-        yield 'Enum' => ['Illuminate\\Validation\\Rules\\Enum'];
         yield 'File' => ['Illuminate\\Validation\\Rules\\File'];
         yield 'ImageFile' => ['Illuminate\\Validation\\Rules\\ImageFile'];
     }

--- a/tests/Unit/Handlers/Validation/ValidationRuleAnalyzerTest.php
+++ b/tests/Unit/Handlers/Validation/ValidationRuleAnalyzerTest.php
@@ -534,8 +534,10 @@ final class ValidationRuleAnalyzerTest extends TestCase
      * but deliberately omitted from FIRST_PARTY_RULE_ESCAPES. File/ImageFile
      * carry user-controlled filename/mime/contents — no value-shape guarantee
      * that would justify a blanket escape. Enum used to live here; #908 added
-     * an explicit escape entry (enum cases are character-constrained), so it
-     * moves to the positive-assertion test above.
+     * an explicit escape entry (the validated value is always one of the
+     * developer-declared case backing values — a source-code constant, same
+     * provenance / whitelist trust model as Rule::in([...])), so it moves to
+     * the positive-assertion test above.
      * If a future refactor added either of these, this test would flip to a
      * non-zero expectation and fail, forcing a deliberate decision.
      *


### PR DESCRIPTION
## Issue to Solve

`FormRequest::validated()` inferred fields validated by `new Enum(BackedEnum::class)`, `Rule::enum(...)`, or `new In([...])` / `new NotIn([...])` constructor forms as `mixed`. Downstream code typed against the actual backing type (e.g. `array<string, string|int>`) was rejected with `InvalidArgument`, forcing every caller to assert the type by hand.

## Related

Fixes #908.

## Solution Description

`ValidationRuleAnalyzer` now recognises four new rule construct shapes during rule extraction:

- `new Enum(BackedEnum::class)` and `Rule::enum(BackedEnum::class)` emit a synthetic `enum:FQN` segment.
- `new In([...])` / `new NotIn([...])` emit the same `in:a,b,c` / `not_in:a,b,c` segments that `Rule::in(...)` / `Rule::notIn(...)` already produce.

`enumRuleToType()` resolves `enum:FQN` to the literal union of the enum's backing case values:

- `BackedEnum:int` (e.g. `enum Status: int { case Active = 1; case Inactive = 0; }`) narrows to `0|1`.
- `BackedEnum:string` narrows to the literal-string union of backing values.
- Pure `UnitEnum` stays at `mixed`. Laravel's `Enum::passes()` rejects all scalar `UnitEnum` input (it requires `tryFrom`), so the only way a `UnitEnum` field reaches `validated()` is programmatic `$request->merge(EnumCase)`, which produces an instance, not a string. Narrowing to `string` (case names) would be unsound; the issue text's suggested fallback to `string` is not adopted.

When a constructor argument is not statically resolvable (e.g. `new Enum($variable)`), the analyzer falls through to the existing `class:FQN` segment. `Illuminate\Validation\Rules\Enum` is added to `FIRST_PARTY_RULE_ESCAPES` so the fallback path still escapes `ALL_INPUT` taint, matching the synthetic segment's behaviour.

`Rule::enum(X)->only(...)` / `->except(...)` chains collapse to the `Rule::enum(X)` root via the existing fluent-unwrap loop, so the emitted segment narrows to the full case set rather than the runtime subset. This is a sound superset (the runtime subset is contained in the full case set) and a deliberate trade-off in favour of zero false positives over peak precision.

### Verification

- New PHPT `tests/Type/tests/ValidationRuleEnumNarrowingTest.phpt` covers backed-int, backed-string, UnitEnum, `Rule::enum`, `->only(...)` superset behaviour, `'string'` before-enum first-wins, variable-arg fallback, `nullable` modifier (`0|1|null`), optional (`array{status?: 0|1}`), `new In(...)` array form, `new NotIn(...)`, and inline `validate([...])` call shape.
- New taint PHPT `tests/Type/tests/TaintAnalysis/SafeFormRequestRuleEnumNoTaint.phpt` exercises both `new Enum(...)` and `Rule::enum(...)` against an HTML header sink and confirms no taint flows.
- Unit test in `ValidationRuleAnalyzerTest.php` adds a positive assertion that the `class:Illuminate\Validation\Rules\Enum` fallback segment escapes `ALL_INPUT` and removes `Enum` from the "non-escaping mapped classes" provider.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)
