### PR TITLE
Skip `PropertyNotSetInConstructor` on Laravel testing lifecycle properties

### DIFF
--- a/src/Handlers/SuppressHandler.php
+++ b/src/Handlers/SuppressHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Psalm\LaravelPlugin\Handlers;
 
 use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
+use Psalm\Internal\Provider\ClassLikeStorageProvider;
 use Psalm\Plugin\EventHandler\AfterClassLikeVisitInterface;
 use Psalm\Plugin\EventHandler\AfterCodebasePopulatedInterface;
 use Psalm\Plugin\EventHandler\Event\AfterClassLikeVisitEvent;
@@ -101,8 +102,44 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
             ],
             'Illuminate\View\Component' => ['componentName'],
         ],
-        'PropertyNotSetInConstructor' => [
-            'Illuminate\Foundation\Testing\TestCase' => ['callbackException', 'app'],
+    ];
+
+    /**
+     * Properties that Laravel populates during a framework-driven lifecycle hook (e.g. testing
+     * setUp(), createApplication()) rather than from any constructor. Listing them by the class
+     * the user typically extends; the entry is resolved to the actual declaring class storage
+     * (trait or parent) at codebase-populated time.
+     *
+     * Marking a property as "initialized" on its declaring class storage is what Psalm itself
+     * does for properties with a default value or promoted constructor params (see
+     * ClassLikeNodeScanner / FunctionLikeNodeScanner). The PropertyNotSetInConstructor check
+     * keys off `$declaring_class_storage->initialized_properties[$property_name]`, so writing
+     * there cleanly skips the un-init check for every subclass without touching their
+     * `$storage->suppressed_issues` — the user's own un-initialized properties still get
+     * flagged. A property-level entry in PROPERTY_LEVEL_BY_PARENT_CLASS does NOT achieve this
+     * because ClassAnalyzer's PropertyNotSetInConstructor report does not consult
+     * `$property_storage->suppressed_issues`.
+     *
+     * @var array<string, list<string>>
+     */
+    private const FRAMEWORK_INITIALIZED_PROPERTIES_BY_FQCN = [
+        // `app` and `callbackException` are declared in the
+        // `Illuminate\Foundation\Testing\Concerns\InteractsWithTestCaseLifecycle` trait used by
+        // TestCase. `traitsUsedByTest` is declared on TestCase itself and assigned inside
+        // `createApplication()`. See psalm/psalm-plugin-laravel#912.
+        'Illuminate\Foundation\Testing\TestCase' => [
+            'app',
+            'callbackException',
+            'traitsUsedByTest',
+        ],
+        // `faker` is declared on the `WithFaker` trait and assigned by `setUpFaker()`, called from
+        // the trait's `setUpFakerHelpers()` lifecycle hook. Any TestCase subclass that does
+        // `use WithFaker;` trips the same false positive as the entries above. Resolving by trait
+        // FQCN works because the trait's own ClassLikeStorage has `declaring_property_ids['faker']`
+        // pointing back to itself (set during scanning), so the mutation lands on the trait
+        // storage and propagates to every user class that composes it.
+        'Illuminate\Foundation\Testing\WithFaker' => [
+            'faker',
         ],
     ];
 
@@ -213,7 +250,9 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
     #[\Override]
     public static function afterCodebasePopulated(AfterCodebasePopulatedEvent $event): void
     {
-        foreach ($event->getCodebase()->classlike_storage_provider::getAll() as $classStorage) {
+        $provider = $event->getCodebase()->classlike_storage_provider;
+
+        foreach ($provider::getAll() as $classStorage) {
             if (!$classStorage->user_defined) {
                 continue;
             }
@@ -226,6 +265,47 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
             self::suppressByUsedTraits($classStorage);
             self::suppressByInterface($classStorage);
         }
+
+        self::markFrameworkInitializedProperties($provider);
+    }
+
+    /**
+     * Mark framework-initialized properties as initialized on the class that declares them.
+     *
+     * `declaring_property_ids` is populated by Psalm's Populator after inheritance resolution,
+     * so a property inherited via a trait points at the trait's storage and a property declared
+     * on the parent class points at the parent. Writing `initialized_properties[$name] = true`
+     * there is the same signal Psalm emits for properties with a default value, which the
+     * PropertyNotSetInConstructor check honours without further configuration. The user's own
+     * declared (and genuinely un-initialised) properties are unaffected.
+     */
+    private static function markFrameworkInitializedProperties(ClassLikeStorageProvider $provider): void
+    {
+        foreach (self::FRAMEWORK_INITIALIZED_PROPERTIES_BY_FQCN as $className => $propertyNames) {
+            if (!$provider->has($className)) {
+                continue;
+            }
+
+            $classStorage = $provider->get($className);
+
+            foreach ($propertyNames as $propertyName) {
+                $declaringClass = $classStorage->declaring_property_ids[$propertyName] ?? null;
+                if ($declaringClass === null) {
+                    continue;
+                }
+
+                if (!$provider->has($declaringClass)) {
+                    continue;
+                }
+
+                self::markPropertyInitialized($provider->get($declaringClass), $propertyName);
+            }
+        }
+    }
+
+    private static function markPropertyInitialized(ClassLikeStorage $storage, string $propertyName): void
+    {
+        $storage->initialized_properties[$propertyName] = true;
     }
 
     private static function suppressByParentClass(ClassLikeStorage $classStorage): void

--- a/tests/Type/tests/Foundation/TestCasePropertyNotSetInConstructorNegativeTest.phpt
+++ b/tests/Type/tests/Foundation/TestCasePropertyNotSetInConstructorNegativeTest.phpt
@@ -1,0 +1,57 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Tests;
+
+use Illuminate\Foundation\Testing\TestCase;
+
+/**
+ * Negative-path guard for psalm/psalm-plugin-laravel#912.
+ *
+ * The fix must NOT hide user-declared properties on a TestCase subclass — only the four
+ * Laravel-managed properties ($app, $callbackException, $traitsUsedByTest, $faker) should be
+ * silently treated as initialized. User-declared properties with no default value and no
+ * constructor assignment must still raise PropertyNotSetInConstructor.
+ *
+ * Tightens the contract from the issue's "property-level approach is preferable" preference:
+ * if a future refactor accidentally regresses to a class-level suppression, this test fails.
+ *
+ * Visibility matters for the emitted error string: Psalm appends "private or final " to the
+ * message when any uninitialized property is private. Both branches are exercised below to
+ * guard against a regression that narrows by visibility.
+ */
+final class UnInitializedPrivatePropertyTest extends TestCase
+{
+    private int $privateField;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function it_uses_field(): int
+    {
+        return $this->privateField;
+    }
+}
+
+final class UnInitializedProtectedPropertyTest extends TestCase
+{
+    protected int $protectedField;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function it_uses_field(): int
+    {
+        return $this->protectedField;
+    }
+}
+?>
+--EXPECTF--
+PropertyNotSetInConstructor on line %d: Property App\Tests\UnInitializedPrivatePropertyTest::$privateField is not defined in constructor of App\Tests\UnInitializedPrivatePropertyTest or in any private or final methods called in the constructor
+PropertyNotSetInConstructor on line %d: Property App\Tests\UnInitializedProtectedPropertyTest::$protectedField is not defined in constructor of App\Tests\UnInitializedProtectedPropertyTest or in any methods called in the constructor

--- a/tests/Type/tests/Foundation/TestCasePropertyNotSetInConstructorTest.phpt
+++ b/tests/Type/tests/Foundation/TestCasePropertyNotSetInConstructorTest.phpt
@@ -1,0 +1,73 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Tests;
+
+use Illuminate\Foundation\Testing\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+
+/**
+ * Regression guard for psalm/psalm-plugin-laravel#912.
+ *
+ * Subclasses of `Illuminate\Foundation\Testing\TestCase` should NOT trigger
+ * `PropertyNotSetInConstructor` for the framework-managed properties Laravel populates through
+ * its testing lifecycle (setUp() / createApplication() / setUpFaker()):
+ *
+ *   - $app                — declared in the `InteractsWithTestCaseLifecycle` trait
+ *   - $callbackException  — declared in the `InteractsWithTestCaseLifecycle` trait
+ *   - $traitsUsedByTest   — declared on TestCase itself, assigned in createApplication()
+ *   - $faker              — declared on the `WithFaker` trait, assigned in setUpFaker()
+ *
+ * The fix marks these properties as initialized on their actual declaring class storage
+ * (trait or parent) so the un-init check skips them for every subclass without hiding genuine
+ * un-initialized properties the user might declare.
+ */
+abstract class ApplicationTestCase extends TestCase
+{
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+}
+
+final class DirectSubclassTest extends ApplicationTestCase
+{
+    public function it_does_something(): void
+    {
+        // ...
+    }
+}
+
+/**
+ * Multi-level inheritance check. Mid sits between the abstract base and the leaf test class,
+ * so a regression that only walks one level of the parent chain (e.g., looking at
+ * `parent_classes[0]` instead of writing to the declaring storage) would fail this case.
+ */
+abstract class IntermediateTestCase extends ApplicationTestCase
+{
+    protected function helper(): int
+    {
+        return 1;
+    }
+}
+
+final class DeeplyNestedSubclassTest extends IntermediateTestCase
+{
+    public function it_extends_deeper(): int
+    {
+        return $this->helper();
+    }
+}
+
+final class WithFakerSubclassTest extends ApplicationTestCase
+{
+    use WithFaker;
+
+    public function it_uses_faker(): void
+    {
+        // ...
+    }
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

Subclasses of `Illuminate\Foundation\Testing\TestCase` were reporting `PropertyNotSetInConstructor` for three framework-managed properties (`$app`, `$callbackException`, `$traitsUsedByTest`). The same false positive surfaced for `$faker` whenever a test composes the `WithFaker` trait. Laravel initialises these in its testing lifecycle hooks (`setUp()`, `createApplication()`, `setUpFaker()`), not in any constructor.

## Related

Fixes #912

## Solution Description

The previous `PROPERTY_LEVEL_BY_PARENT_CLASS` entry for `Illuminate\Foundation\Testing\TestCase` was dead code: Psalm's `PropertyNotSetInConstructor` check reads from the analysed class's `$storage->suppressed_issues`, not `$property_storage->suppressed_issues`. Walking the parent chain to suppress on the declaring class's `PropertyStorage` (the path the issue suggested) would have hit the same dead end.

Instead, mark these properties as initialised on the declaring class storage (trait or parent), mirroring the signal Psalm itself emits for properties with a default value or promoted constructor parameters. `ClassAnalyzer` keys the un-init check off `$declaring_class_storage->initialized_properties[$property_name]`, so the entry propagates to every subclass through Psalm's existing inheritance resolution. User-declared un-initialised properties are unaffected, so genuine bugs still surface.

### Tests

- `tests/Type/tests/Foundation/TestCasePropertyNotSetInConstructorTest.phpt`: positive cases for a direct subclass, a 3-level inheritance chain, and a `use WithFaker;` leaf.
- `tests/Type/tests/Foundation/TestCasePropertyNotSetInConstructorNegativeTest.phpt`: user-declared `private` and `protected` un-initialised properties still raise `PropertyNotSetInConstructor`, guarding against any future drift into a class-level suppression.

## Checklist

- [x] Tests cover the change (type tests in `tests/Type/tests/Foundation/`)
