### PR TITLE
fix(stubs): make Request::route() nullable in $param-is-null branch #918

### DIFF
--- a/stubs/common/Http/Request.phpstub
+++ b/stubs/common/Http/Request.phpstub
@@ -27,11 +27,21 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     /**
      * Get the route handling the request.
      *
+     * Intentionally more precise than Laravel's own PHPDoc. Laravel declares
+     * `@return ($param is null ? \Illuminate\Routing\Route : object|string|null)`,
+     * but the body returns the unresolved resolver result directly:
+     * `if (is_null($route) || is_null($param)) { return $route; }`. The route
+     * resolver is `null` before routing matches (early middleware, console
+     * context, exception handler), so the `$param is null` branch can return
+     * `null` too. Laravel's own `Request::fingerprint()` guards on this with
+     * `if (! $route = $this->route())`. Upstream Laravel PHPDoc fix tracked
+     * separately; this stub fixes the plugin-level false positive (#918).
+     *
      * @template TDefault of object
      *
      * @param string|null $param
      * @param TDefault $default
-     * @psalm-return ($param is null ? \Illuminate\Routing\Route : TDefault|string|null)
+     * @psalm-return ($param is null ? \Illuminate\Routing\Route|null : TDefault|string|null)
      *
      * @psalm-taint-source input
      */

--- a/tests/Type/tests/Http/RequestTest.phpt
+++ b/tests/Type/tests/Http/RequestTest.phpt
@@ -9,8 +9,27 @@ function it_returns_one_header(\Illuminate\Http\Request $request): ?string {
     return $request->header('Accept');
 };
 
-function it_returns_route(\Illuminate\Http\Request $request): \Illuminate\Routing\Route {
-    return $request->route();
+function it_returns_route(\Illuminate\Http\Request $request): void {
+    $_result = $request->route();
+    /** @psalm-check-type-exact $_result = \Illuminate\Routing\Route|null */
+};
+
+function it_supports_null_safe_route_chain(\Illuminate\Http\Request $request): ?string {
+    return $request->route()?->getName();
+};
+
+function it_supports_null_safe_route_chain_via_helper(): ?string {
+    return request()->route()?->getName();
+};
+
+function it_returns_route_parameter(\Illuminate\Http\Request $request): void {
+    $_result = $request->route('user');
+    /** @psalm-check-type-exact $_result = string|null */
+};
+
+function it_returns_route_parameter_with_default(\Illuminate\Http\Request $request): void {
+    $_result = $request->route('user', new \stdClass());
+    /** @psalm-check-type-exact $_result = stdClass|string|null */
 };
 ?>
 --EXPECTF--


### PR DESCRIPTION
## Summary

Fixes #918.

`Illuminate\Http\Request::route()` can return `null` even when `$param` is `null`. The body returns the unresolved route resolver value directly:

```php
if (is_null($route) || is_null($param)) {
    return $route;
}
```

The resolver is `null` before routing matches (early middleware, console context, exception handler). Laravel's own `Request::fingerprint()` already guards on this with `if (! $route = $this->route())`.

The stub previously claimed `\Illuminate\Routing\Route` (non-null) in that branch, which mirrored Laravel's own optimistic PHPDoc and caused Psalm to flag legitimate null-safe usage as `DocblockTypeContradiction`:

```php
'route' => request()->route()?->getName();
// DocblockTypeContradiction: Illuminate\Routing\Route does not contain null
```

## Change

```diff
-@psalm-return ($param is null ? \Illuminate\Routing\Route : TDefault|string|null)
+@psalm-return ($param is null ? \Illuminate\Routing\Route|null : TDefault|string|null)
```

Plus an explanatory docblock so future maintainers do not "sync back to Laravel" and accidentally revert.

## Upstream

Laravel's own PHPDoc has the same gap (the conditional true branch omits `null`). The durable long-term fix is an upstream PR to `laravel/framework`. This stub change is the plugin-level workaround until that lands. Per CLAUDE.md "Upstream commits" rule, calling this out explicitly.

## Tests

Pin the regression durably:

- `it_returns_route`: `@psalm-check-type-exact $_result = Route|null` (not covariance-permissive)
- `it_supports_null_safe_route_chain`: `request->route()?->getName()` returns `?string`
- `it_supports_null_safe_route_chain_via_helper`: same via `request()` helper (the exact reproducer in the issue)
- `it_returns_route_parameter`: `request->route('user')` returns `string|null`
- `it_returns_route_parameter_with_default`: `request->route('user', new \stdClass())` returns `stdClass|string|null`

Reverting the stub now breaks 3 of the 5 tests (verified empirically).

All checks green: `composer test:type` (393/393), `composer psalm`, `composer cs`.