### PR TITLE
Tri-state Blade safety scanner via BladeCompiler + php-parser

### DIFF
--- a/docs/issues/581-blade-taint-exploration.md
+++ b/docs/issues/581-blade-taint-exploration.md
@@ -85,9 +85,10 @@ Invoke Laravel's `BladeCompiler::compileString()` for each template, write the o
 - Bladestan's `BladeToPHPCompiler` is roughly 1 kLOC and handles `@include` expansion, component instantiation (via reflection), view composers, and shared data. Porting to Psalm is non trivial. The compiled output must then be stitched into Psalm's scanning phase so taint nodes flow through.
 - Error mapping back to `.blade.php` line numbers requires a line map, like Bladestan's.
 - Plugin startup cost: compiling every template at boot is O(templates) filesystem and CPU work.
-- Depends on Laravel's `BladeCompiler` being available at analysis time, which the plugin already has (Testbench booted), but surface area is wide.
 
-This is the long term target. C is a staging point towards D.
+`BladeCompiler::compileString()` itself is in fact available cheaply (Testbench is already booted), and walking the compiled PHP in-process via `nikic/php-parser` (already vendored by Psalm 7) covers most of what approach C's scanner needs. That partial use is incorporated into approach C's v2 backend (see "Prototype" below) — distinct from D's full Bladestan-style approach because it skips call-site bridging, synthetic stub generation, and feeding compiled PHP back to Psalm as an analyzed file.
+
+D in its full form (handler-level call-site bridging with stitched taint nodes) remains the long-term target; the C scanner is the staging point towards D.
 
 ### E. Standalone CLI tool
 
@@ -136,31 +137,35 @@ Any template whose scanner analysis is uncertain (unresolved `@include` targets,
 
 **C, then D.** Approach F (pre-compile via `view:cache`) is not a shortcut; if we ever pursue it, it should be as a v2 input to C's scanner (walk compiled PHP instead of raw `.blade.php`), not as a replacement for the call-site bridging work D requires.
 
-C delivers meaningful XSS coverage in weeks and preserves low FP behaviour on the common case. Its `template to unsafe keys` map is the same primitive D needs (for per call sink dispatch), so the work is not throwaway. The scanner can be incrementally upgraded:
+C delivers meaningful XSS coverage in weeks and preserves low FP behaviour on the common case. Its `template to unsafe keys` map is the same primitive D needs (for per call sink dispatch), so the work is not throwaway. The scanner is delivered in two stages:
 
-- **v1**: top level variables in `{!! !!}` and `@php`. Ignore includes.
-- **v2**: follow `@include('child', [...])` data flows. Propagate unsafe keys from child to parent when the parent passes a variable through. Optionally read compiled output from `view:cache` to get `@include` / `@extends` expansion for free.
-- **v3**: `@extends`, `@section`, components. At this point, compilation (D) is probably simpler than pattern extension.
+- **v1 backend (shipped in #920)**: `BladeCompiler::compileString()` + `nikic/php-parser` AST walking, in-process. Both deps are already vendored (Laravel pulls the compiler; Psalm 7 pulls the parser). A small subclass of `BladeCompiler` makes component-tag resolution non-fatal at analysis time and patches an upstream raw-block restoration quirk (see `PsalmBladeCompiler`). Cross-template constructs (`@extends`, `@yield`, `@stack`, `@include`, `<x-foo>` / `@component`) still classify UNKNOWN because the v1 scanner does not follow child templates. Inline `@php(...)`, mid-condition assignments, scope-local destructuring, `@inject` locals, `e()`/`htmlspecialchars`/`htmlentities`/`Js::from` safe-wrapper detection, and a conservative fallback for unrecognized echo shapes (`{!! request()->input(...) !!}`, variable variables, closure invocations) all work out of the box.
+- **v2 (long-term)**: full approach D with call-site bridging, line maps, and stubs for runtime-injected data (`View::share`, composers). The v1 scanner produces the same per-template safety map D needs, so it is not throwaway.
 
 D without C means shipping nothing for months. C without D means a permanent accuracy ceiling. Both together means a 2 to 4 week delivery with a credible path forward.
 
 ## Prototype
 
-`src/Blade/` contains a working spike of the C approach scanner:
+`src/Blade/` contains the C approach scanner:
 
-- `BladeEchoKind`: enum for `ESCAPED`, `RAW`, `PHP_BLOCK`.
-- `BladeVariableUsage`: `(name, line, kind)` record.
-- `BladeTemplateScanner::scan($source): list<BladeVariableUsage>`: extracts all variable references with their echo classification.
-- `BladeTemplateScanner::unsafeVariables($source): list<string>`: reduces to the set of unescaped top-level variables, excluding scope-introduced names (for example, `$item` in `@foreach (... as $item)`).
-- `BladeSafetyMap`: `array<string, list<string>>` keyed by Blade's dotted view name. Built via `BladeSafetyMap::build(array $viewPaths): self`, which walks view roots and applies first-match-wins like `FileViewFinder::findInPaths()`.
+- `BladeEchoKind`: enum for `ESCAPED`, `RAW`, `PHP_BLOCK` (the third case is reserved; the AST walker collapses `@php`-block echoes onto `RAW` because the compiled output is indistinguishable from `{!! ... !!}`).
+- `BladeVariableUsage`: `(name, line, kind)` record. Line numbers reflect the compiled PHP, not the original Blade source.
+- `BladeViewSafetyKind`: tri-state enum `SAFE` / `UNSAFE_KEYS` / `UNKNOWN`.
+- `BladeUncertaintyReason`: first-class enum naming the construct that forced UNKNOWN (`LAYOUT_SECTION_FLOW`, `INCLUDE_DIRECTIVE`, `COMPONENT_TAG`, `FILE_UNREADABLE`, `UNKNOWN_LOCAL_DEPENDENCY`, `UNPARSABLE_PHP_BLOCK`, plus reasons reserved for later PRs).
+- `BladeTemplateAnalysis`: `(kind, unsafeKeys, uncertainties)` value object with a private constructor and three named factories (`safe()`, `unsafeKeys()`, `unknown()`) that enforce kind-to-payload invariants. `unsafeKeys([])` collapses to `safe()`; `unknown()` requires a non-empty list of reasons.
+- `PsalmBladeCompiler`: subclass of Laravel's `BladeCompiler`. Overrides `compileComponentTags` to detect (not resolve) `<x-foo>` and `@component` / `@slot` tags, so an unregistered user component cannot throw at analysis time. Overrides `restoreRawContent` and preprocesses the source to work around an upstream raw-block placeholder collision when `@endphp` is immediately followed by `{{`/`{!!`. Owns its own `Filesystem` and temp cache path; no Laravel container access required.
+- `BladeTemplateScanner::analyze($source): BladeTemplateAnalysis`: compiles via `PsalmBladeCompiler::compileBladeSource()` then walks the resulting PHP AST with `nikic/php-parser`. The visitor records raw-echoed top-level variables, scope-locals from assignments and foreach value/key vars (including nested destructuring), `$__env` method calls indicating layout/section/stack/include/component/fragment/translation flow, and emits `UNKNOWN_LOCAL_DEPENDENCY` as a conservative fallback when a raw echo's expression yields no top-level variables and is not a pure literal (catches `request()->input(...)`, variable variables, closure invocations, and other shapes the extractor does not model).
+- `BladeTemplateScanner::scan($source): list<BladeVariableUsage>`: lower-level per-usage records for diagnostics.
+- `BladeViewSafety`: `(viewName, path, analysis)` map entry.
+- `BladeSafetyMap`: `array<string, BladeViewSafety>` keyed by dotted view name. Built via `BladeSafetyMap::build(array $viewPaths, ?BladeTemplateScanner $scanner = null): self`. One scanner instance is amortised across the whole build. First-match-wins applies to ALL kinds, including SAFE — a later UNSAFE shadow cannot displace a first-root SAFE view that Laravel would actually render. `file_get_contents` failures convert to `UNKNOWN(FILE_UNREADABLE)` instead of silent skip.
 
-Covered by `tests/Unit/Blade/BladeTemplateScannerTest.php` and `tests/Unit/Blade/BladeSafetyMapTest.php` (36 tests total). The scanner correctly handles `{{-- ... --}}` comments, `@verbatim` (including unclosed), `@{{ ... }}` and `@{!! ... !!}` escaped braces, legacy `{{{ ... }}}`, line number tracking across multi-line blanked regions, multi-line echoes, raw-echo literals inside `@php` strings, `@foreach` and `@forelse` loop aliases (key-value and single), simple inline assignments in `@if` / `@elseif` / `@while` conditions, and property or array access on top level variables. `BladeSafetyMap` tolerates missing view roots, filters non-blade siblings (including `.bak` and `~` editor files), and applies first-match-wins across multiple view paths.
+Covered by `tests/Unit/Blade/Blade*Test.php`. The scanner handles `{{-- ... --}}` comments and `@verbatim` (both stripped at compile time), `@{{ ... }}` / `@{!! ... !!}` escaped braces, legacy `{{{ ... }}}`, multi-line echoes, raw-echo literals inside `@php` strings, `@foreach` / `@forelse` aliases including list-destructuring `@foreach ($pairs as [$k, $v])`, inline assignments in `@if` / `@elseif` / `@while` conditions (any position, not just leading), `@inject` scope locals, `@php($foo = expr)` inline shorthand, property / array / method access top-level extraction, casts and unary operators (`(string) $x`, `!$x`, `-$x`), array literals and `match` expressions inside raw echoes, and chained `Js::from($data)->toHtml()`. `e($x, false)` and other multi-argument safe-wrapper calls correctly fall through to RAW. Cross-template directives (`@extends`, `@extendsFirst`, `@section`, `@yield`, `@show`, `@parent`, `@stack`, `@push`, `@prepend`, `@hasSection`, `@hasStack`, the `@include*` family, `@each`, `<x-...>` / `<x:...>` component tags, `@component`, `@slot`, `@fragment`, `@lang { ... }`) mark the template UNKNOWN with the appropriate `BladeUncertaintyReason`. `BladeSafetyMap` tolerates missing view roots, filters non-blade siblings (including `.bak` and `~` editor files), and applies first-match-wins across multiple view paths regardless of kind.
 
-Known scanner limitations (each pinned by a `test_known_limitation_*` test so intentional future improvements land with a visible test change):
+Known v1 limitations:
 
-- PHP string interpolation inside a raw echo (`{!! "hi {$x}" !!}`) extracts `x` as unsafe. Harmless at the sink layer (the outer expression is already unescaped), but worth knowing.
-- The inline `@php($foo = expr)` shorthand is not recognised as a scope-introducing directive.
-- `@if (call($x) && $y = expr)` style conditions with a preceding function call do not register `$y` as scope-local; the handler layer will need an explicit safe-list if that pattern matters.
+- The visitor's `scopeLocals` set is flat across the whole template. Assignments inside inner closures, arrow functions, function declarations, or unreachable `@if` branches still register the LHS as a scope-local for the outer raw-echo classification. Practical impact: a Blade `@php` block whose closure body shadows a view-data key with a literal silently filters that key out of the unsafe-key list. Push/pop scope frames is the fix; deferred.
+- Line numbers in `BladeVariableUsage` reflect the compiled PHP, not the Blade source. BladeCompiler does not preserve a source map, so per-occurrence line numbers are a hint, not a contract.
+- The catch-all `extractTopLevelVariables` branch for unknown calls (`FuncCall`, `StaticCall`, `New_`) recurses into arguments but does not surface the callable itself. `{!! random_fn($x) !!}` surfaces `x` (correct, since `$x` is the data flowing through), but `{!! $fn($x) !!}` does not surface `fn`. Acceptable: `$fn` is the callable identity, not the rendered data.
 
 ### What the prototype deliberately does not include
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -14,8 +14,6 @@
             <directory name="vendor"/>
             <directory name="tests-app"/>
             <directory name="tests/Unit/Handlers/Eloquent/Schema/migrations"/>
-            <!-- Issue #581 spike: tighten purity/pure-callable annotations before wiring into Plugin -->
-            <directory name="src/Blade"/>
         </ignoreFiles>
     </projectFiles>
 

--- a/src/Blade/BladeEchoKind.php
+++ b/src/Blade/BladeEchoKind.php
@@ -18,9 +18,9 @@ namespace Psalm\LaravelPlugin\Blade;
  */
 enum BladeEchoKind
 {
-    case ESCAPED;
-    case RAW;
-    case PHP_BLOCK;
+    case Escaped;
+    case Raw;
+    case PhpBlock;
 
     /**
      * True for any kind that does NOT pass through Blade's htmlspecialchars
@@ -30,6 +30,6 @@ enum BladeEchoKind
      */
     public function isUnescaped(): bool
     {
-        return $this !== self::ESCAPED;
+        return $this !== self::Escaped;
     }
 }

--- a/src/Blade/BladeSafetyMap.php
+++ b/src/Blade/BladeSafetyMap.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Blade;
 
-use function str_ends_with;
-
 /**
- * Per-template record of which data keys reach a raw echo context.
+ * Per-template safety record for every Blade view discovered under the
+ * configured view roots.
  *
  * The map is built once during plugin boot (similar to how MissingViewHandler
  * loads view paths) and queried for every `view()` / `Factory::make()` call.
@@ -15,6 +14,19 @@ use function str_ends_with;
  * Entries are keyed by Blade's dotted view name (`emails.welcome`), matching
  * how the view() helper is called in user code. Dotted names are resolved
  * relative to the template roots supplied at construction.
+ *
+ * Every resolved Blade view is recorded — SAFE, UNSAFE_KEYS, or UNKNOWN.
+ * Earlier versions only recorded views with unsafe keys; that conflated "we
+ * scanned this view and it is safe" with "we never saw this view", which
+ * silently downgrades UNKNOWN to SAFE at the handler layer. Recording all
+ * three states is required for sound taint refinement.
+ *
+ * First-match-wins matches Laravel's {@see \Illuminate\View\FileViewFinder}:
+ * the finder iterates view paths in order and returns the first existing
+ * `.blade.php`. The map mirrors that, *including* when the first view is SAFE
+ * and a later view in the override path is unsafe — earlier versions skipped
+ * safe templates, which meant a later UNSAFE view would shadow the SAFE one
+ * the finder would actually load.
  *
  * Not marked `@psalm-immutable`: {@see build()} performs filesystem IO, which
  * is inherently impure. Instances returned by `build()` are, however, safe to
@@ -25,29 +37,44 @@ use function str_ends_with;
 final readonly class BladeSafetyMap
 {
     /**
-     * @param array<string, list<string>> $unsafeKeysByView
-     *   view name => list of top-level variable names referenced in {!! !!} or @php
+     * @param array<non-empty-string, BladeViewSafety> $safetyByView
+     *
+     * @psalm-mutation-free
      */
     public function __construct(
-        private array $unsafeKeysByView,
+        private array $safetyByView,
     ) {}
 
     /**
      * Build a map by scanning every `*.blade.php` file under the given roots.
      *
-     * @param list<string> $viewPaths absolute paths of view directories, in the order
-     *                                returned by FileViewFinder::getPaths()
+     * A single {@see BladeTemplateScanner} is constructed once per build and
+     * reused for every template, so the underlying {@see PsalmBladeCompiler}
+     * and {@see \PhpParser\Parser} instances are amortised across the scan.
+     * Tests that need to substitute a scanner can pass it in.
+     *
+     * @param list<string>             $viewPaths absolute paths of view directories, in the order
+     *                                            returned by FileViewFinder::getPaths()
+     * @param BladeTemplateScanner|null $scanner  optional scanner instance; default builds one
+     *                                            with {@see BladeTemplateScanner::withDefaults()}.
      *
      * @psalm-api
      */
-    public static function build(array $viewPaths): self
+    public static function build(array $viewPaths, ?BladeTemplateScanner $scanner = null): self
     {
+        $scanner ??= BladeTemplateScanner::withDefaults();
         $map = [];
 
         foreach ($viewPaths as $root) {
             $root = \rtrim($root, \DIRECTORY_SEPARATOR);
 
-            if (!\is_dir($root)) {
+            /*
+             * Empty-string check must precede is_dir(): is_dir('') emits a
+             * "Filename cannot be empty" warning under PHP 8+, which the
+             * plugin's error handler turns into a thrown RuntimeException
+             * during boot.
+             */
+            if ($root === '' || !\is_dir($root)) {
                 continue;
             }
 
@@ -57,24 +84,42 @@ final readonly class BladeSafetyMap
                 // `/var` -> `/private/var`) and would break prefix-stripping.
                 $path = $file->getPathname();
 
-                $source = \file_get_contents($path);
-
-                if ($source === false) {
+                if ($path === '') {
                     continue;
                 }
 
                 $viewName = self::viewNameFor($root, $path);
-                $unsafe = BladeTemplateScanner::unsafeVariables($source);
 
-                if ($unsafe === []) {
+                if ($viewName === '') {
                     continue;
                 }
 
-                // First path wins — matches FileViewFinder::findInPaths(),
+                // First match wins — matches FileViewFinder::findInPaths(),
                 // which iterates paths in order and returns the first match.
-                if (!isset($map[$viewName])) {
-                    $map[$viewName] = $unsafe;
+                // CRITICAL: this branch must run regardless of the analysis
+                // kind; skipping safe views here would let a later-root unsafe
+                // shadow take precedence over a first-root safe view that
+                // Laravel would actually render.
+                if (isset($map[$viewName])) {
+                    continue;
                 }
+
+                // `@` suppresses the "Permission denied" warning when the
+                // file becomes unreadable between the iterator's isFile()
+                // check and this call. The `=== false` branch converts the
+                // failure to UNKNOWN (FILE_UNREADABLE) so the data is
+                // recorded; PR-4+ (handler integration) will surface that
+                // state as an explicit Psalm issue or fallback policy
+                // decision. Until then there is no user-visible signal
+                // for an unreadable view — acceptable because the scanner
+                // is not yet wired into analysis output.
+                $source = @\file_get_contents($path);
+
+                $analysis = $source === false
+                    ? BladeTemplateAnalysis::unknown([BladeUncertaintyReason::FileUnreadable])
+                    : $scanner->analyze($source);
+
+                $map[$viewName] = new BladeViewSafety($viewName, $path, $analysis);
             }
         }
 
@@ -82,30 +127,64 @@ final readonly class BladeSafetyMap
     }
 
     /**
-     * @return list<string> keys whose values must be treated as html sinks
-     *                      when rendered through this view, empty for safe views
+     * The full safety record for a view, or null when the view is unknown to
+     * the map (e.g. dynamic include, package view we did not scan, or a typo).
+     * Callers needing to distinguish "scanned and safe" from "never seen"
+     * must use this, not {@see unsafeKeysFor()}.
      *
      * @psalm-api
+     * @psalm-mutation-free
      */
-    public function unsafeKeysFor(string $viewName): array
+    public function safetyFor(string $viewName): ?BladeViewSafety
     {
-        return $this->unsafeKeysByView[$viewName] ?? [];
-    }
-
-    /** @psalm-api */
-    public function hasUnsafeKeys(string $viewName): bool
-    {
-        return isset($this->unsafeKeysByView[$viewName]);
+        return $this->safetyByView[$viewName] ?? null;
     }
 
     /**
-     * @return list<string>
+     * Convenience for handlers that only need the unsafe-key list. Returns
+     * the empty list both for SAFE views and for views the map never saw, so
+     * it must NOT be used to decide whether to apply the UNKNOWN fallback —
+     * use {@see isUnknown()} or {@see safetyFor()} for that decision.
+     *
+     * @return list<non-empty-string>
      *
      * @psalm-api
+     * @psalm-mutation-free
+     */
+    public function unsafeKeysFor(string $viewName): array
+    {
+        return ($this->safetyByView[$viewName] ?? null)?->unsafeKeys() ?? [];
+    }
+
+    /**
+     * @psalm-api
+     * @psalm-mutation-free
+     */
+    public function isKnownSafe(string $viewName): bool
+    {
+        return ($this->safetyByView[$viewName] ?? null)?->kind() === BladeViewSafetyKind::Safe;
+    }
+
+    /**
+     * @psalm-api
+     * @psalm-mutation-free
+     */
+    public function isUnknown(string $viewName): bool
+    {
+        return ($this->safetyByView[$viewName] ?? null)?->kind() === BladeViewSafetyKind::Unknown;
+    }
+
+    /**
+     * Every view name the map recorded, in insertion order (first-root first).
+     *
+     * @return list<non-empty-string>
+     *
+     * @psalm-api
+     * @psalm-mutation-free
      */
     public function knownViews(): array
     {
-        return \array_keys($this->unsafeKeysByView);
+        return \array_keys($this->safetyByView);
     }
 
     /**

--- a/src/Blade/BladeTemplateAnalysis.php
+++ b/src/Blade/BladeTemplateAnalysis.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Blade;
+
+/**
+ * Result of analysing a single Blade template.
+ *
+ * The shape mirrors {@see BladeViewSafety} but is decoupled from the
+ * filesystem layer: {@see BladeTemplateScanner::analyze()} returns this object
+ * given just a source string, while {@see BladeSafetyMap} adds the view name
+ * and resolved file path on top.
+ *
+ * Three kinds are possible:
+ *  - SAFE         -> unsafeKeys === [] && uncertainties === []
+ *  - UNSAFE_KEYS  -> unsafeKeys !== [] (uncertainties may be empty)
+ *  - UNKNOWN      -> uncertainties !== [] (unsafeKeys may also be non-empty;
+ *                     downstream handlers should treat UNKNOWN as the
+ *                     dominant signal)
+ *
+ * UNKNOWN dominates because a finite unsafe-key list is only sound when the
+ * scanner saw the whole template. Once any unhandled construct (e.g. an
+ * `@extends` directive) appears, additional keys could flow to raw output
+ * through paths the v1 scanner does not model, so the conservative answer is
+ * "we cannot enumerate keys precisely".
+ *
+ * The constructor is `private` so the kind-to-payload invariants in the bullet
+ * list above are only reachable through {@see safe()}, {@see unsafeKeys()}, and
+ * {@see unknown()}. A public constructor would let a caller produce e.g.
+ * `(SAFE, ['foo'], [])` and re-introduce the SAFE/UNKNOWN conflation this PR
+ * exists to prevent.
+ *
+ * @psalm-api
+ * @psalm-immutable
+ */
+final readonly class BladeTemplateAnalysis
+{
+    /**
+     * @param list<non-empty-string>       $unsafeKeys    top-level data keys reaching raw output
+     * @param list<BladeUncertaintyReason> $uncertainties reasons the scanner could not model the template
+     */
+    private function __construct(
+        public BladeViewSafetyKind $kind,
+        public array $unsafeKeys,
+        public array $uncertainties,
+    ) {}
+
+    /** @psalm-pure */
+    public static function safe(): self
+    {
+        return new self(BladeViewSafetyKind::Safe, [], []);
+    }
+
+    /**
+     * @param list<non-empty-string> $unsafeKeys
+     *
+     * @psalm-pure
+     */
+    public static function unsafeKeys(array $unsafeKeys): self
+    {
+        if ($unsafeKeys === []) {
+            return self::safe();
+        }
+
+        return new self(BladeViewSafetyKind::UnsafeKeys, $unsafeKeys, []);
+    }
+
+    /**
+     * Param type is `list<...>` rather than `non-empty-list<...>` so the
+     * runtime emptiness check below remains reachable from Psalm's view
+     * (a `non-empty-list` parameter would make `=== []` a TypeDoesNotContainType
+     * error). The factory still enforces non-empty at runtime; callers
+     * passing `[]` get an `InvalidArgumentException`.
+     *
+     * @param list<BladeUncertaintyReason> $uncertainties non-empty at runtime; see throw
+     * @param list<non-empty-string>       $unsafeKeys    keys observed before the uncertainty was hit
+     *
+     * @psalm-pure
+     */
+    public static function unknown(array $uncertainties, array $unsafeKeys = []): self
+    {
+        // Enforce the documented non-empty contract at runtime: an UNKNOWN
+        // with no uncertainty reasons would be indistinguishable from a
+        // safe template at the handler layer and re-introduce the
+        // SAFE/UNKNOWN conflation this class exists to prevent.
+        if ($uncertainties === []) {
+            throw new \InvalidArgumentException(
+                'BladeTemplateAnalysis::unknown() requires at least one BladeUncertaintyReason.',
+            );
+        }
+
+        return new self(BladeViewSafetyKind::Unknown, $unsafeKeys, $uncertainties);
+    }
+}

--- a/src/Blade/BladeTemplateScanner.php
+++ b/src/Blade/BladeTemplateScanner.php
@@ -4,315 +4,827 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Blade;
 
-use function max;
-use function substr_count;
+use PhpParser\Error as PhpParserError;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\Parser;
+use PhpParser\ParserFactory;
 
 /**
- * Regex-based scanner that extracts variable references from a Blade template
- * and classifies each by echo context (escaped vs. raw vs. @php block).
+ * Compiles a Blade template via {@see PsalmBladeCompiler} and walks the resulting
+ * PHP AST to classify the template as SAFE, UNSAFE_KEYS, or UNKNOWN.
  *
- * This is deliberately NOT a full Blade compiler. The scanner trades precision
- * for simplicity: it recognises the three echo syntaxes defined in
- * {@see BladeEchoKind} and extracts top-level variable names from each echo's
- * PHP expression. It does not:
+ * The scanner avoids regex-based Blade parsing entirely. Laravel's
+ * {@see \Illuminate\View\Compilers\BladeCompiler} already maps every Blade
+ * directive ({@code @foreach}, {@code @if}, {@code @php}, {@code @extends},
+ * {@code @include}, etc.) to a small, deterministic set of PHP statements:
  *
- *  - follow `@include` / `@extends` / `@yield` / `@section` data flows
- *  - resolve Blade components (`<x-foo :bar="$data" />`)
- *  - evaluate PHP expressions (e.g. `{!! $user->bio !!}` records `user`, not `bio`)
- *  - handle dynamic keys
+ *  - `{{ $x }}`               -> `echo e($x)`
+ *  - `{!! $x !!}`             -> `echo $x`
+ *  - `{{{ $x }}}`             -> `echo e($x)` (legacy triple-brace)
+ *  - `@foreach (...)`         -> `foreach (...): ... endforeach;`
+ *  - `@php ... @endphp`       -> `<?php ... ?>`
+ *  - `@extends(...)`          -> `$__env->make(...)->render()`
+ *  - `@yield(...)`            -> `echo $__env->yieldContent(...)`
+ *  - `@stack(...)`            -> `echo $__env->yieldPushContent(...)`
+ *  - `@include(...)`          -> `echo $__env->make(...)->render()`
+ *  - `@inject(...)`           -> `$name = app(...)`
  *
- * These are acceptable limitations for the initial taint-refinement use case:
- * we only need to know which *top-level* template variables reach a raw echo,
- * because the `view()` data array keys are always top-level variables after
- * `extract()`.
+ * Walking the resulting AST gives perfect handling of constructs that broke the
+ * regex backend: string literals containing `@yield(...)` inside `@php` blocks
+ * (compiled away), word-boundary issues between `@push` / `@pushOnce` (separate
+ * AST nodes), `@verbatim` regions ({{ }} stays literal in HTML output, never
+ * reaches an `echo` node), comments (compiled away), and inline assignments
+ * `@if ($x = expr)` ({@see Node\Expr\Assign} inside {@see Node\Stmt\If_::$cond}
+ * is plainly visible to the visitor).
  *
- * Scope-introduced variables (Blade directive aliases such as `@foreach(... as
- * $item)`) are tracked separately so they can be excluded from the
- * "unsafe view-data keys" result. `$item` in `@foreach ($items as $item) {!!
- * $item !!} @endforeach` is NOT a view data key, so it must not surface.
+ * Compiler / parser instances are injected so tests can substitute fakes and so
+ * a long-lived {@see BladeSafetyMap::build()} pass can reuse one parser across
+ * many templates. Both constructor arguments default to fresh instances built
+ * with no Laravel container access, so the scanner has no boot-time dependency
+ * on the plugin's Testbench-backed application.
  *
- * Edge-case handling:
- *  - `{{-- ... --}}` blade comments are stripped before scanning so tokens
- *    inside them are ignored.
- *  - `@verbatim ... @endverbatim` blocks are stripped (their contents are
- *    treated as literal text by Blade).
- *  - `@php ... @endphp` blocks are processed separately so their contents do
- *    not leak into the echo passes (strings like `"{!! x !!}"` inside @php
- *    would otherwise be matched as raw echoes).
- *  - `@{{ ... }}` / `@{!! ... !!}` (escaped braces) are treated as literal text.
- *  - `{{{ ... }}}` (legacy triple-brace escape) is treated as ESCAPED.
+ * Purity: the scanner is *not* marked `@psalm-pure` or `@psalm-mutation-free`.
+ * {@see PsalmBladeCompiler::compileBladeSource()} mutates the underlying
+ * BladeCompiler instance (footers, raw blocks, sawComponentTag flag), and the
+ * visitor maintains intermediate state. Each call to {@see analyze()} resets
+ * compiler state and constructs a fresh visitor, so externally the scanner
+ * behaves like a deterministic function from `$source` to `BladeTemplateAnalysis`.
+ *
+ * Known precision limitation: {@see BladeAstAnalysisVisitor} maintains a flat
+ * `scopeLocals` set. NodeTraverser visits inner closures, arrow functions,
+ * function declarations, and dead branches, so an assignment inside any of
+ * those still registers the LHS name as a scope-local for the whole template.
+ * The practical impact is a false-negative when a closure body shadows the
+ * name of a view-data key that is also raw-echoed at the top level. Adding
+ * push/pop scope frames is scoped to a follow-up PR.
  *
  * @psalm-api
  */
 final class BladeTemplateScanner
 {
+    /** Function names whose echo result is auto-escaped HTML. */
+    private const SAFE_HTML_WRAPPER_FUNCTIONS = ['e', 'htmlspecialchars', 'htmlentities'];
+
     /**
-     * Scan a blade template source and return every variable reference found
-     * inside an echo or @php block, paired with its echo kind and line number.
-     *
-     * @return list<BladeVariableUsage>
-     *
-     * @psalm-pure
+     * Static-method names treated as safe when called on a class named `Js`
+     * (Laravel's {@see \Illuminate\Support\Js} helper). Imported as either
+     * `use Illuminate\Support\Js;` (bare `Js::from`) or with the full
+     * namespace, so the scanner matches both shapes by short-name.
      */
-    public static function scan(string $source): array
+    private const SAFE_JS_HELPER_METHOD = 'from';
+
+    /**
+     * Auto-generated locals produced by the BladeCompiler in compiled output.
+     * These are never view-data keys, so a raw echo of e.g. `$loop->index`
+     * must not surface `loop` as an unsafe key.
+     */
+    private const FRAMEWORK_LOCALS = [
+        '__env' => true,
+        '__data' => true,
+        '__path' => true,
+        '__currentLoopData' => true,
+        'loop' => true,
+        '__empty_1' => true,
+    ];
+
+    /**
+     * `$__env` method names that signal layout / section / fragment /
+     * translation / stack flow. Mapped to
+     * {@see BladeUncertaintyReason::LayoutSectionFlow}.
+     *
+     *  - `@yield`, `@parent` -> yieldContent
+     *  - `@section`, `@show`, `@overwrite`, `@stop`, `@endsection`
+     *    -> startSection / stopSection / yieldSection / appendSection
+     *  - `@hasStack` -> isStackEmpty
+     *  - `@fragment`, `@endfragment` -> startFragment / stopFragment / renderFragment
+     *  - `@lang { ... } @endlang` -> startTranslation / renderTranslation
+     */
+    private const ENV_LAYOUT_METHODS = [
+        'yieldContent', 'yieldSection', 'startSection', 'stopSection',
+        'appendSection', 'isStackEmpty',
+        'startFragment', 'stopFragment', 'renderFragment',
+        'startTranslation', 'renderTranslation',
+    ];
+
+    /**
+     * `$__env` method names emitted by `@component` / `@slot` directives.
+     * Mapped to {@see BladeUncertaintyReason::ComponentTag} so downstream
+     * handlers can apply component-specific fallback policy (e.g. trace
+     * attribute / slot data flow) distinct from section-flow policy.
+     */
+    private const ENV_COMPONENT_METHODS = [
+        'startComponent', 'renderComponent', 'slot',
+    ];
+
+    /**
+     * `$__env` method names that signal an include / partial render.
+     * `@include`, `@includeIf`, `@includeFirst`, `@each` all map to one of
+     * these. `first` is the method called by `@extendsFirst` and
+     * `@includeFirst` (compiled to `$__env->first([...])->render()`).
+     */
+    private const ENV_INCLUDE_METHODS = [
+        'make', 'first', 'renderEach', 'renderWhen', 'renderUnless', 'renderFirst',
+    ];
+
+    /**
+     * `$__env` method names for the stack / push / prepend family. These
+     * compile to `$__env->yieldPushContent` / `$__env->startPush` etc., and
+     * any presence implies a cross-template stack flow. Mapped to the same
+     * {@see BladeUncertaintyReason::LayoutSectionFlow} reason because the
+     * fallback policy for both is identical.
+     */
+    private const ENV_STACK_METHODS = [
+        'yieldPushContent', 'yieldPushContentFirst',
+        'startPush', 'stopPush', 'startPrepend', 'stopPrepend',
+        'startPushOnce', 'stopPushOnce',
+        'startPrependOnce', 'stopPrependOnce',
+    ];
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function __construct(
+        private readonly PsalmBladeCompiler $compiler = new PsalmBladeCompiler(),
+        private readonly Parser $parser = new \PhpParser\Parser\Php8(new \PhpParser\Lexer()),
+    ) {}
+
+    /**
+     * Default-construction helper for callers that want the standard parser
+     * (newest supported PHP version) without importing {@see ParserFactory}.
+     *
+     * The named-default in the constructor is intentionally a {@see Parser\Php8}
+     * direct construction (cheap) rather than `ParserFactory::createForNewestSupportedVersion()`,
+     * which allocates a Lexer and walks a version-detection path. Tests that
+     * need the newest-PHP parser can call this helper.
+     *
+     * @psalm-api
+     */
+    public static function withDefaults(): self
     {
-        $cleaned = self::stripCommentsAndVerbatim($source);
-        $cleaned = self::protectEscapedBraces($cleaned);
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
 
-        // Run the @php pass against the cleaned source, then blank those
-        // regions before the echo passes. Without blanking, `{!! ... !!}`
-        // inside a PHP string literal would match the raw-echo regex and
-        // inject phantom "variables" from inside the literal.
-        $phpUsages = self::collect(
-            $cleaned,
-            '/@php\b(?P<expr>.*?)@endphp\b/s',
-            BladeEchoKind::PHP_BLOCK,
-        );
-
-        $withoutPhp = \preg_replace_callback(
-            '/@php\b.*?@endphp\b/s',
-            /** @param array{0: string} $m */
-            static fn(array $m): string => self::blank($m[0]),
-            $cleaned,
-        ) ?? $cleaned;
-
-        // {!! ... !!} — raw echo. Extracted first so the shorter {{ ... }} pass
-        // below runs on a template with raw-echo regions blanked out, avoiding
-        // double-matches with {{{ ... }}} and mis-matches with stray `{{`.
-        $rawUsages = self::collect(
-            $withoutPhp,
-            '/\{!!\s*(?P<expr>.*?)\s*!!\}/s',
-            BladeEchoKind::RAW,
-        );
-
-        $legacyUsages = self::collect(
-            $withoutPhp,
-            '/\{\{\{\s*(?P<expr>.*?)\s*\}\}\}/s',
-            BladeEchoKind::ESCAPED,
-        );
-
-        // Blank raw / legacy regions so the plain {{ ... }} pass cannot
-        // re-match their contents.
-        $remaining = \preg_replace_callback(
-            '/\{!!.*?!!\}|\{\{\{.*?\}\}\}/s',
-            /** @param array{0: string} $m */
-            static fn(array $m): string => self::blank($m[0]),
-            $withoutPhp,
-        ) ?? $withoutPhp;
-
-        $escapedUsages = self::collect(
-            $remaining,
-            '/\{\{\s*(?P<expr>.*?)\s*\}\}/s',
-            BladeEchoKind::ESCAPED,
-        );
-
-        return \array_merge($rawUsages, $legacyUsages, $escapedUsages, $phpUsages);
+        return new self(new PsalmBladeCompiler(), $parser);
     }
 
     /**
-     * Extract the set of variable names that appear in at least one unescaped
-     * echo context ({!! !!} or @php) AND are not introduced by a scope-local
-     * directive (@foreach, @forelse). These are the keys a caller must treat
-     * as html sinks when passing view data.
+     * Analyze a Blade template source and return the tri-state safety result.
+     *
+     * Pipeline:
+     *   1. {@see PsalmBladeCompiler::compileBladeSource()} produces compiled PHP.
+     *      Any compile-time exception (malformed Blade, unbalanced directives)
+     *      maps to UNKNOWN(UNPARSABLE_PHP_BLOCK).
+     *   2. {@see Parser::parse()} produces an AST. Parser errors (extremely
+     *      unlikely on BladeCompiler output, but possible if an `@php` block
+     *      contains malformed PHP) map to the same UNKNOWN reason.
+     *   3. {@see BladeAstAnalysisVisitor} walks the AST, collecting:
+     *      - top-level variables raw-echoed (unsafe keys, after filtering
+     *        scope-locals and framework locals);
+     *      - `$__env` method calls indicating layout/section/stack/include flow;
+     *      - the {@see PsalmBladeCompiler::sawComponentTag()} flag for `<x-...>`
+     *        and `@component` / `@slot` directives.
+     *   4. Uncertainties dominate: any uncertainty produces UNKNOWN; otherwise
+     *      a non-empty unsafe-key list produces UNSAFE_KEYS; otherwise SAFE.
+     */
+    public function analyze(string $source): BladeTemplateAnalysis
+    {
+        if ($this->hasUnclosedPhpBlock($source)) {
+            /*
+             * BladeCompiler does NOT throw on an unclosed `@php` block: the
+             * raw-block storage regex requires a matching `@endphp` and
+             * silently leaves an unclosed `@php` as literal text in the
+             * compiled output, where it becomes inline HTML in the AST.
+             * That would let any taint inside the unclosed region slip
+             * through as SAFE. Detect the imbalance ourselves and emit
+             * UNKNOWN(UNPARSABLE_PHP_BLOCK).
+             */
+            return BladeTemplateAnalysis::unknown([BladeUncertaintyReason::UnparsablePhpBlock]);
+        }
+
+        try {
+            $compiled = $this->compiler->compileBladeSource($source);
+        } catch (\Throwable) {
+            return BladeTemplateAnalysis::unknown([BladeUncertaintyReason::UnparsablePhpBlock]);
+        }
+
+        try {
+            /*
+             * BladeCompiler emits PHP open/close tags interleaved with
+             * literal HTML. The parser accepts that as a normal mixed-mode
+             * PHP file; no manual prefix needed.
+             */
+            $ast = $this->parser->parse($compiled);
+        } catch (PhpParserError) {
+            return BladeTemplateAnalysis::unknown([BladeUncertaintyReason::UnparsablePhpBlock]);
+        }
+
+        if ($ast === null) {
+            return BladeTemplateAnalysis::unknown([BladeUncertaintyReason::UnparsablePhpBlock]);
+        }
+
+        $visitor = new BladeAstAnalysisVisitor();
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        $uncertainties = $visitor->uncertainties;
+
+        if ($this->compiler->sawComponentTag()
+            && !\in_array(BladeUncertaintyReason::ComponentTag, $uncertainties, true)) {
+            $uncertainties[] = BladeUncertaintyReason::ComponentTag;
+        }
+
+        $unsafeKeys = $visitor->computeUnsafeKeys(self::FRAMEWORK_LOCALS);
+
+        if ($uncertainties !== []) {
+            return BladeTemplateAnalysis::unknown($uncertainties, $unsafeKeys);
+        }
+
+        return BladeTemplateAnalysis::unsafeKeys($unsafeKeys);
+    }
+
+    /**
+     * True when the source contains a multi-line `@php` directive that has
+     * no matching `@endphp`. The check matches BladeCompiler's own
+     * `storePhpBlocks` regex (which only stores blocks that are properly
+     * closed), so a leftover unclosed `@php` would otherwise be passed
+     * through as literal text.
+     *
+     * The inline `@php(...)` directive is excluded from the count because it
+     * is a single-expression form with no `@endphp` partner.
+     *
+     * @psalm-pure
+     */
+    private function hasUnclosedPhpBlock(string $source): bool
+    {
+        $openCount = \preg_match_all('/(?<!@)@php\b(?!\s*\()/', $source);
+        $closeCount = \preg_match_all('/(?<!@)@endphp\b/', $source);
+
+        return $openCount !== false && $closeCount !== false && $openCount > $closeCount;
+    }
+
+    /**
+     * Lower-level helper: return every variable reference observed inside an
+     * `echo` / `print` / `@php` block, with line numbers.
+     *
+     * Line numbers reflect the *compiled* PHP, not the original Blade source.
+     * BladeCompiler does not preserve a complete source map, so per-occurrence
+     * line tracking is approximate. Callers using {@see scan()} for
+     * diagnostics should treat the line number as a hint, not a contract.
+     *
+     * @return list<BladeVariableUsage>
+     */
+    public function scan(string $source): array
+    {
+        try {
+            $compiled = $this->compiler->compileBladeSource($source);
+        } catch (\Throwable) {
+            return [];
+        }
+
+        try {
+            $ast = $this->parser->parse($compiled);
+        } catch (PhpParserError) {
+            return [];
+        }
+
+        if ($ast === null) {
+            return [];
+        }
+
+        $visitor = new BladeAstAnalysisVisitor();
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        return $visitor->usages;
+    }
+
+    /**
+     * Used by {@see BladeAstAnalysisVisitor} to decide whether a call wraps
+     * its argument in HTML-escape semantics. Kept on the scanner so the list
+     * of safe wrappers is defined exactly once.
      *
      * @return list<string>
      *
-     * @psalm-pure
-     */
-    public static function unsafeVariables(string $source): array
-    {
-        $scopeLocals = self::scopeLocalVariables($source);
-
-        $unsafe = [];
-
-        foreach (self::scan($source) as $usage) {
-            if (!$usage->kind->isUnescaped()) {
-                continue;
-            }
-
-            if (isset($scopeLocals[$usage->name])) {
-                // e.g. `$item` in `@foreach ($items as $item)` — not a view
-                // data key, so we must not surface it as unsafe.
-                continue;
-            }
-
-            $unsafe[$usage->name] = true;
-        }
-
-        return \array_keys($unsafe);
-    }
-
-    /**
-     * Variables introduced by Blade control-flow directives that bind names in
-     * local scope. These names cannot be view data keys (they are bound after
-     * `extract()` runs), so they must be excluded from the unsafe-keys result.
-     *
-     * Covers:
-     *  - `@foreach ($items as $x)` and `@foreach ($items as $k => $v)`
-     *  - `@forelse (...)` (same alias syntax)
-     *  - Simple inline assignments `@if ($x = expr)` / `@elseif (...)` / `@while (...)`,
-     *    bounded to a single line.
-     *
-     * Known limitations:
-     *  - Conditions that mix a function call with an assignment on the same line
-     *    (for example `@if (count($rows) > 0 && $x = expr)`) fall through. The
-     *    name is not recorded as scope-local, so if `$x` is later raw-echoed it
-     *    will surface as an unsafe view-data key. This is a false positive at
-     *    the sink layer; an explicit safe-list on the handler side can cover it.
-     *  - The inline `@php($foo = expr)` directive (shorthand for `@php ... @endphp`)
-     *    is not recognised. Same failure mode.
-     *  - Nested `@foreach` inside a string literal (unlikely) is not stripped.
-     *
-     * @return array<string, true> name -> true, for O(1) membership
+     * @internal
      *
      * @psalm-pure
      */
-    private static function scopeLocalVariables(string $source): array
+    public static function safeHtmlWrapperFunctions(): array
     {
-        $locals = [];
-
-        // @foreach / @forelse — `as $val` or `as $key => $val`.
-        if (\preg_match_all('/@for(?:each|else)\s*\(.*?\bas\s+\$([a-zA-Z_][a-zA-Z0-9_]*)(?:\s*=>\s*\$([a-zA-Z_][a-zA-Z0-9_]*))?/s', $source, $matches) !== false) {
-            foreach ($matches[1] as $name) {
-                $locals[$name] = true;
-            }
-
-            foreach ($matches[2] as $name) {
-                if ($name !== '') {
-                    $locals[$name] = true;
-                }
-            }
-        }
-
-        // Inline assignments in @if / @elseif / @while conditions. The
-        // character class `[^()\n]*?` is intentionally line-scoped: proper
-        // paren balancing requires a non-regex parser, so we accept the
-        // single-line, no-nested-call shape and let the handler apply an
-        // explicit safe-list for more complex cases.
-        if (\preg_match_all('/@(?:if|elseif|while)\s*\(\s*\$([a-zA-Z_]\w*)\s*=[^=]/', $source, $matches) !== false) {
-            foreach ($matches[1] as $name) {
-                $locals[$name] = true;
-            }
-        }
-
-        return $locals;
+        return self::SAFE_HTML_WRAPPER_FUNCTIONS;
     }
 
     /**
-     * @return list<BladeVariableUsage>
+     * @internal
      *
      * @psalm-pure
      */
-    private static function collect(string $source, string $pattern, BladeEchoKind $kind): array
+    public static function safeJsHelperMethod(): string
     {
-        if (\preg_match_all($pattern, $source, $matches, \PREG_SET_ORDER | \PREG_OFFSET_CAPTURE) === false) {
-            return [];
+        return self::SAFE_JS_HELPER_METHOD;
+    }
+
+    /**
+     * @return list<string>
+     *
+     * @internal
+     *
+     * @psalm-pure
+     */
+    public static function envLayoutMethods(): array
+    {
+        return self::ENV_LAYOUT_METHODS;
+    }
+
+    /**
+     * @return list<string>
+     *
+     * @internal
+     *
+     * @psalm-pure
+     */
+    public static function envIncludeMethods(): array
+    {
+        return self::ENV_INCLUDE_METHODS;
+    }
+
+    /**
+     * @return list<string>
+     *
+     * @internal
+     *
+     * @psalm-pure
+     */
+    public static function envStackMethods(): array
+    {
+        return self::ENV_STACK_METHODS;
+    }
+
+    /**
+     * @return list<string>
+     *
+     * @internal
+     *
+     * @psalm-pure
+     */
+    public static function envComponentMethods(): array
+    {
+        return self::ENV_COMPONENT_METHODS;
+    }
+}
+
+/**
+ * Visits the compiled-Blade AST and accumulates the data needed to build a
+ * {@see BladeTemplateAnalysis}.
+ *
+ * The visitor owns state across one walk only; the parent scanner constructs a
+ * fresh visitor per `analyze()` / `scan()` call. State fields are public so
+ * the scanner can read them directly after traversal; no setter ceremony.
+ *
+ * @internal
+ */
+final class BladeAstAnalysisVisitor extends NodeVisitorAbstract
+{
+    /** @var list<BladeUncertaintyReason> */
+    public array $uncertainties = [];
+
+    /** @var list<BladeVariableUsage> */
+    public array $usages = [];
+
+    /** @var array<string, true> Variables introduced by assignments / foreach value-vars / etc. */
+    private array $scopeLocals = [];
+
+    /** @var array<string, true> Top-level variable names raw-echoed in the template. */
+    private array $rawTopVars = [];
+
+    /** @var array<string, true> reason-name => true, dedup uncertainty set */
+    private array $seenUncertainty = [];
+
+    #[\Override]
+    public function enterNode(Node $node): ?int
+    {
+        // Track scope-locals from assignment LHS. Covers `@inject` (Assign),
+        // inline `@if ($x = expr)` (Assign inside cond), `$__currentLoopData`
+        // setup, and the user's own `@php $foo = expr; @endphp`.
+        if ($node instanceof Node\Expr\Assign) {
+            $this->captureScopeLocalFromAssign($node);
         }
 
-        $usages = [];
+        if ($node instanceof Node\Stmt\Foreach_) {
+            $this->captureForeachLocals($node);
+        }
 
-        /** @var list<array{0: array{0: string, 1: int}, expr: array{0: string, 1: int}}> $matches */
-        foreach ($matches as $match) {
-            $offset = $match[0][1];
-            // `max(1, ...)` pins the return type to `int<1, max>` for the
-            // BladeVariableUsage constructor without a runtime assert.
-            $line = \max(1, 1 + \substr_count(\substr($source, 0, $offset), "\n"));
-
-            foreach (self::extractVariables($match['expr'][0]) as $name) {
-                $usages[] = new BladeVariableUsage($name, $line, $kind);
+        if ($node instanceof Node\Stmt\Echo_) {
+            foreach ($node->exprs as $expr) {
+                $this->classifyEcho($expr, $node->getStartLine());
             }
         }
 
-        return $usages;
+        if ($node instanceof Node\Expr\Print_) {
+            $this->classifyEcho($node->expr, $node->getStartLine());
+        }
+
+        if ($node instanceof Node\Expr\MethodCall) {
+            $this->classifyEnvMethodCall($node);
+        }
+
+        return null;
     }
 
     /**
-     * Replace a substring with whitespace while preserving `\n`. Keeping
-     * newlines intact is critical: later passes compute line numbers from
-     * `substr_count($prefix, "\n")` over the same buffer, so a blanked
-     * multi-line `@php` / `@verbatim` / raw-echo region must not collapse
-     * its interior newlines.
+     * Materialise the unsafe-keys list, filtering scope-locals and framework
+     * locals. Called once by the scanner after traversal.
      *
-     * Byte length is preserved because every non-newline character maps to a
-     * single space.
-     *
-     * @psalm-pure
-     */
-    private static function blank(string $match): string
-    {
-        return \preg_replace('/[^\n]/', ' ', $match) ?? $match;
-    }
-
-    /** @psalm-pure */
-    private static function stripCommentsAndVerbatim(string $source): string
-    {
-        // Blade comments never reach the compiler; variables inside them are
-        // never rendered, so we drop them.
-        $source = \preg_replace_callback(
-            '/\{\{--.*?--\}\}/s',
-            /** @param array{0: string} $m */
-            static fn(array $m): string => self::blank($m[0]),
-            $source,
-        ) ?? $source;
-
-        // @verbatim blocks preserve their inner text literally — Blade does
-        // not evaluate `{{ }}` inside them. Match either @endverbatim or EOF
-        // so an unclosed @verbatim still strips to end-of-file.
-        return \preg_replace_callback(
-            '/@verbatim\b.*?(?:@endverbatim\b|\z)/s',
-            /** @param array{0: string} $m */
-            static fn(array $m): string => self::blank($m[0]),
-            $source,
-        ) ?? $source;
-    }
-
-    /**
-     * Replace `@{{` / `@{!!` (escaped opening braces) with a same-length
-     * whitespace sequence so our echo regexes don't match them. Blade renders
-     * these literally — they're commonly used for Vue/Alpine templates that
-     * share the `{{ }}` syntax.
-     *
-     * @psalm-pure
-     */
-    private static function protectEscapedBraces(string $source): string
-    {
-        return \str_replace(['@{{', '@{!!'], ['   ', '    '], $source);
-    }
-
-    /**
-     * Extract top-level variable names from a PHP-like expression snippet.
-     *
-     * We purposefully only capture the identifier after the leading `$` and
-     * before any property/method/index access. For `$user->bio`, we record
-     * `user`; for `$data['html']`, we record `data`. This matches the
-     * granularity of view data keys, which are top-level after `extract()`.
-     *
-     * Ignores: variable variables (`$$foo`), string interpolation inside
-     * regex-like literals, and `static::`-prefixed identifiers (not `$`).
+     * @param array<string, true> $frameworkLocals
      *
      * @return list<non-empty-string>
      *
-     * @psalm-pure
+     * @psalm-mutation-free
      */
-    private static function extractVariables(string $expr): array
+    public function computeUnsafeKeys(array $frameworkLocals): array
     {
-        if (\preg_match_all('/\$([a-zA-Z_]\w*)/', $expr, $matches) === false) {
-            return [];
-        }
+        /** @var list<non-empty-string> $keys */
+        $keys = [];
 
-        /** @var list<non-empty-string> $names */
-        $names = [];
-        $seen = [];
-
-        foreach ($matches[1] as $name) {
-            if (isset($seen[$name])) {
+        foreach (\array_keys($this->rawTopVars) as $name) {
+            if ($name === '') {
                 continue;
             }
 
-            $seen[$name] = true;
-            $names[] = $name;
+            if (isset($this->scopeLocals[$name])) {
+                continue;
+            }
+
+            if (isset($frameworkLocals[$name])) {
+                continue;
+            }
+
+            $keys[] = $name;
         }
 
-        return $names;
+        return $keys;
+    }
+
+    private function classifyEcho(Node\Expr $expr, int $line): void
+    {
+        $kind = $this->isSafeHtmlWrappedCall($expr) ? BladeEchoKind::Escaped : BladeEchoKind::Raw;
+        $names = $this->extractTopLevelVariables($expr);
+
+        foreach ($names as $name) {
+            if ($name === '') {
+                continue;
+            }
+
+            $this->usages[] = new BladeVariableUsage(
+                $name,
+                \max(1, $line),
+                $kind,
+            );
+
+            if ($kind === BladeEchoKind::Raw) {
+                $this->rawTopVars[$name] = true;
+            }
+        }
+
+        /*
+         * Conservative fallback: if a RAW echo's expression yielded no
+         * top-level variables and is not a plain literal, the walker is
+         * looking at an expression shape it does not model. Examples that
+         * hit this branch:
+         *   {!! request()->input('html') !!}     // global helper
+         *   {!! Auth::user()->bio !!}            // static-call chain
+         *   {!! $$dynamicName !!}                // variable-variable
+         *   {!! (fn () => $x)() !!}              // closure result
+         * Silently classifying these as SAFE would be a security regression
+         * (the closed-set extractor would otherwise let canonical XSS
+         * sources bypass the analysis), so we mark the template UNKNOWN
+         * with a precise reason.
+         */
+        if ($kind === BladeEchoKind::Raw && $names === [] && !$this->isPureLiteralExpression($expr)) {
+            $this->addUncertainty(BladeUncertaintyReason::UnknownLocalDependency);
+        }
+    }
+
+    /**
+     * True for expressions whose value is statically known to be a literal:
+     * scalar literals, `null` / `true` / `false`, and class constants. Used
+     * by {@see classifyEcho()} to distinguish "raw echo of a constant"
+     * (genuinely safe) from "raw echo we don't understand" (must be UNKNOWN).
+     *
+     * @psalm-pure
+     */
+    private function isPureLiteralExpression(Node\Expr $expr): bool
+    {
+        if ($expr instanceof Node\Scalar\String_) {
+            return true;
+        }
+
+        if ($expr instanceof Node\Scalar\Int_ || $expr instanceof Node\Scalar\Float_) {
+            return true;
+        }
+
+        return $expr instanceof Node\Expr\ConstFetch || $expr instanceof Node\Expr\ClassConstFetch;
+    }
+
+    /*
+     * Not annotated `@psalm-pure` or `@psalm-mutation-free`: the helper
+     * reads {@see Node\Name::toLowerString()} and {@see Node\Name::getLast()},
+     * which php-parser does not mark pure. Callers can still be marked
+     * external-mutation-free because Psalm treats this method as impure
+     * only inside fully-pure contexts.
+     */
+    private function isSafeHtmlWrappedCall(Node\Expr $expr): bool
+    {
+        if ($expr instanceof Node\Expr\FuncCall && $expr->name instanceof Node\Name) {
+            $name = $expr->name->toLowerString();
+
+            if (!\in_array($name, BladeTemplateScanner::safeHtmlWrapperFunctions(), true)) {
+                return false;
+            }
+
+            /*
+             * Only the single-argument form is safe. `e($x, false)` disables
+             * double-encoding (allowing pre-escaped `&` to slip through);
+             * `htmlspecialchars($x, ENT_NOQUOTES)` does not escape quotes,
+             * leaving HTML-attribute contexts vulnerable. Conservatively
+             * fall through to RAW when extra arguments are present so the
+             * inner variable surfaces as unsafe.
+             */
+            return \count($expr->args) === 1;
+        }
+
+        if ($this->isJsFromStaticCall($expr)) {
+            return true;
+        }
+
+        /*
+         * Chained method calls on a Js::from result (e.g.
+         * `Js::from($data)->toHtml()`) remain HTML-safe because every
+         * method on the Js helper escapes its output. Surfacing the
+         * receiver chain again here would re-leak `$data`.
+         */
+        return $expr instanceof Node\Expr\MethodCall
+            && $this->isJsFromStaticCall($expr->var);
+    }
+
+    private function isJsFromStaticCall(Node\Expr $expr): bool
+    {
+        if (!($expr instanceof Node\Expr\StaticCall)) {
+            return false;
+        }
+
+        if (!($expr->class instanceof Node\Name)) {
+            return false;
+        }
+
+        if (!($expr->name instanceof Node\Identifier)) {
+            return false;
+        }
+
+        $shortName = $expr->class->getLast();
+        $method = $expr->name->toString();
+
+        // `Js::from` or `\Illuminate\Support\Js::from`. Short-name match is
+        // intentional: an aliased `use Illuminate\Support\Js as J;` would
+        // not satisfy a strict FQCN check.
+        return $shortName === 'Js' && $method === BladeTemplateScanner::safeJsHelperMethod();
+    }
+
+    /**
+     * Recursively extract top-level variable names from an expression tree.
+     *
+     * "Top-level" means the variable that appears as the root of a chain of
+     * property/array/method accesses. `$user->bio` yields `user`;
+     * `$data['html']` yields `data`; `$x . $y` yields both `x` and `y`;
+     * `"hello {$attacker}"` yields `attacker`.
+     *
+     * @return list<string>
+     *
+     * @psalm-mutation-free
+     */
+    private function extractTopLevelVariables(Node\Expr $expr): array
+    {
+        if ($expr instanceof Node\Expr\Variable && \is_string($expr->name)) {
+            return [$expr->name];
+        }
+
+        if ($expr instanceof Node\Expr\PropertyFetch
+            || $expr instanceof Node\Expr\NullsafePropertyFetch
+            || $expr instanceof Node\Expr\ArrayDimFetch
+        ) {
+            return $this->extractTopLevelVariables($expr->var);
+        }
+
+        if ($expr instanceof Node\Expr\StaticPropertyFetch) {
+            // `Class::$prop` — the class name is a Node\Name, not a variable.
+            // No top-level data flows through this construct, so return empty.
+            return [];
+        }
+
+        if ($expr instanceof Node\Expr\MethodCall || $expr instanceof Node\Expr\NullsafeMethodCall) {
+            /*
+             * For `$svc->render($body)`, the receiver `$svc` is one top-level
+             * input and each argument expression contributes additional
+             * top-level inputs. When the receiver is a scope-local (e.g. an
+             * injected service), the call's result is opaque, so any
+             * view-data argument should still surface as unsafe.
+             */
+            $names = $this->extractTopLevelVariables($expr->var);
+
+            foreach ($expr->args as $arg) {
+                if ($arg instanceof Node\Arg) {
+                    $names = [...$names, ...$this->extractTopLevelVariables($arg->value)];
+                }
+            }
+
+            return $names;
+        }
+
+        if ($expr instanceof Node\Expr\BinaryOp) {
+            return [
+                ...$this->extractTopLevelVariables($expr->left),
+                ...$this->extractTopLevelVariables($expr->right),
+            ];
+        }
+
+        if ($expr instanceof Node\Expr\Ternary) {
+            $names = $this->extractTopLevelVariables($expr->cond);
+            if ($expr->if instanceof Node\Expr) {
+                $names = [...$names, ...$this->extractTopLevelVariables($expr->if)];
+            }
+
+            $names = [...$names, ...$this->extractTopLevelVariables($expr->else)];
+
+            return $names;
+        }
+
+        if ($expr instanceof Node\Scalar\InterpolatedString) {
+            $names = [];
+            foreach ($expr->parts as $part) {
+                if ($part instanceof Node\Expr) {
+                    $names = [...$names, ...$this->extractTopLevelVariables($part)];
+                }
+            }
+
+            return $names;
+        }
+
+        if ($expr instanceof Node\Expr\Cast
+            || $expr instanceof Node\Expr\BooleanNot
+            || $expr instanceof Node\Expr\BitwiseNot
+            || $expr instanceof Node\Expr\UnaryMinus
+            || $expr instanceof Node\Expr\UnaryPlus
+        ) {
+            /*
+             * Single-operand operators ((string)$x, !$x, ~$x, -$x). Type
+             * casts do not sanitize HTML, so `(string) $tainted` flowing
+             * into a raw echo must surface `tainted` as unsafe.
+             */
+            return $this->extractTopLevelVariables($expr->expr);
+        }
+
+        if ($expr instanceof Node\Expr\Array_) {
+            $names = [];
+            foreach ($expr->items as $item) {
+                if (!($item instanceof Node\ArrayItem)) {
+                    // Skipped slots in destructuring shapes such as `[, $b]`
+                    // surface as `null` in the items list.
+                    continue;
+                }
+
+                $names = [...$names, ...$this->extractTopLevelVariables($item->value)];
+                if ($item->key instanceof Node\Expr) {
+                    $names = [...$names, ...$this->extractTopLevelVariables($item->key)];
+                }
+            }
+
+            return $names;
+        }
+
+        if ($expr instanceof Node\Expr\Match_) {
+            $names = $this->extractTopLevelVariables($expr->cond);
+            foreach ($expr->arms as $arm) {
+                $names = [...$names, ...$this->extractTopLevelVariables($arm->body)];
+
+                if ($arm->conds !== null) {
+                    foreach ($arm->conds as $cond) {
+                        $names = [...$names, ...$this->extractTopLevelVariables($cond)];
+                    }
+                }
+            }
+
+            return $names;
+        }
+
+        if ($expr instanceof Node\Expr\FuncCall || $expr instanceof Node\Expr\StaticCall || $expr instanceof Node\Expr\New_) {
+            // Unknown call inside an echo — conservatively treat its arguments
+            // as raw-echoed inputs. This is the "treat unknown calls as
+            // unsafe" rule from the design doc; callers can later add
+            // taint-escape annotations to specific helpers (out of scope for
+            // this PR).
+            $names = [];
+            foreach ($expr->args as $arg) {
+                if ($arg instanceof Node\Arg) {
+                    $names = [...$names, ...$this->extractTopLevelVariables($arg->value)];
+                }
+            }
+
+            return $names;
+        }
+
+        return [];
+    }
+
+    /** @psalm-external-mutation-free */
+    private function captureScopeLocalFromAssign(Node\Expr\Assign $assign): void
+    {
+        $this->captureLhsTargets($assign->var);
+    }
+
+    /** @psalm-external-mutation-free */
+    private function captureForeachLocals(Node\Stmt\Foreach_ $foreach): void
+    {
+        $this->captureLhsTargets($foreach->valueVar);
+
+        if ($foreach->keyVar instanceof Node\Expr) {
+            $this->captureLhsTargets($foreach->keyVar);
+        }
+    }
+
+    /**
+     * Walks an LHS expression (assignment target or foreach value/key var)
+     * and records every {@see Node\Expr\Variable} it finds as a scope-local.
+     *
+     * Handles nested destructuring: `[$a, [$b, $c]] = $data` records `a`, `b`,
+     * `c`; `@foreach ($pairs as [$k, $v])` records `k`, `v`. Without this
+     * walk, downstream raw echoes of the destructured names would surface as
+     * false-positive view-data keys.
+     *
+     * @psalm-external-mutation-free
+     */
+    private function captureLhsTargets(Node\Expr $target): void
+    {
+        if ($target instanceof Node\Expr\Variable && \is_string($target->name)) {
+            $this->scopeLocals[$target->name] = true;
+            return;
+        }
+
+        if ($target instanceof Node\Expr\List_ || $target instanceof Node\Expr\Array_) {
+            foreach ($target->items as $item) {
+                if (!($item instanceof Node\ArrayItem)) {
+                    continue;
+                }
+
+                $this->captureLhsTargets($item->value);
+            }
+        }
+    }
+
+    /** @psalm-external-mutation-free */
+    private function classifyEnvMethodCall(Node\Expr\MethodCall $call): void
+    {
+        if (!($call->var instanceof Node\Expr\Variable)) {
+            return;
+        }
+
+        if ($call->var->name !== '__env') {
+            return;
+        }
+
+        if (!($call->name instanceof Node\Identifier)) {
+            return;
+        }
+
+        $method = $call->name->toString();
+
+        if (\in_array($method, BladeTemplateScanner::envComponentMethods(), true)) {
+            $this->addUncertainty(BladeUncertaintyReason::ComponentTag);
+            return;
+        }
+
+        if (\in_array($method, BladeTemplateScanner::envLayoutMethods(), true)
+            || \in_array($method, BladeTemplateScanner::envStackMethods(), true)
+        ) {
+            $this->addUncertainty(BladeUncertaintyReason::LayoutSectionFlow);
+            return;
+        }
+
+        if (\in_array($method, BladeTemplateScanner::envIncludeMethods(), true)) {
+            $this->addUncertainty(BladeUncertaintyReason::IncludeDirective);
+        }
+    }
+
+    /** @psalm-external-mutation-free */
+    private function addUncertainty(BladeUncertaintyReason $reason): void
+    {
+        if (isset($this->seenUncertainty[$reason->name])) {
+            return;
+        }
+
+        $this->seenUncertainty[$reason->name] = true;
+        $this->uncertainties[] = $reason;
     }
 }

--- a/src/Blade/BladeUncertaintyReason.php
+++ b/src/Blade/BladeUncertaintyReason.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Blade;
+
+/**
+ * Why the scanner gave up on a template (or part of one) and marked it
+ * {@see BladeViewSafetyKind::Unknown}.
+ *
+ * Each reason corresponds to a Blade construct the current scanner cannot model
+ * soundly. Reasons are first-class (not free-form strings) so:
+ *
+ *  - tests can pin the exact reason a fixture produces, instead of asserting on
+ *    a comment-style message that drifts;
+ *  - downstream handlers can apply different fallback policies per reason
+ *    (e.g. treat dynamic includes more conservatively than unparsable PHP);
+ *  - metrics counters can answer "which uncertainty dominates" so the next
+ *    incremental PR knows where to invest effort.
+ *
+ * PR 1 emits {@see LAYOUT_SECTION_FLOW}, {@see INCLUDE_DIRECTIVE},
+ * {@see COMPONENT_TAG}, {@see FILE_UNREADABLE}, {@see UNPARSABLE_PHP_BLOCK}
+ * (compile/parser failure plus unclosed `@php` detection), and
+ * {@see UNKNOWN_LOCAL_DEPENDENCY} (raw echo with no extractable top-level
+ * variables and a non-literal expression).
+ *
+ * The remaining cases are reserved for later PRs:
+ * {@see UNPARSABLE_PHP_EXPRESSION} for finer-grained malformed-expression
+ * reporting, {@see DYNAMIC_VARIABLE_VARIABLE} for the `${$expr}` form that
+ * currently rolls up into {@see UNKNOWN_LOCAL_DEPENDENCY}, and
+ * {@see DYNAMIC_VIEW_NAME} for view-resolution support at the handler layer.
+ *
+ * @psalm-api
+ */
+enum BladeUncertaintyReason
+{
+    /**
+     * Template uses `@extends`, `@section`, `@sectionMissing`, `@yield`,
+     * `@show`, `@parent`, `@stack`, `@push`, `@prepend`, `@pushOnce`,
+     * `@prependOnce`, `@pushIf`, or `@hasSection`. `compileYield()` and
+     * `compileStack()` both emit raw `<?php echo $__env->...; ?>` (no `e()`
+     * wrapper), so section/layout data flow is security-relevant and the v1
+     * scanner cannot trace it across templates.
+     */
+    case LayoutSectionFlow;
+
+    /**
+     * Template uses `@include`, `@includeIf`, `@includeWhen`, `@includeUnless`,
+     * `@includeFirst`, `@includeIsolated`, or `@each`. Every form compiles to
+     * `<?php echo $__env->make($view, ...)->render(); ?>` — raw output of a
+     * child template the v1 scanner does not visit. PR 2+ may resolve literal
+     * include targets by walking the included template.
+     */
+    case IncludeDirective;
+
+    /**
+     * Template contains `<x-foo>` / `<x:foo>` component tags, `@component`, or
+     * `@slot`. v1 does not resolve component attribute/slot data flow; v2 will
+     * add it.
+     */
+    case ComponentTag;
+
+    /**
+     * `view($expr)` or `View::make($expr)` with a non-literal view name at the
+     * call site. Surfaced by the handler, not the scanner, but declared here
+     * so handlers and scanner share one reason vocabulary.
+     */
+    case DynamicViewName;
+
+    /**
+     * `{!! ... !!}` whose contents could not be parsed as a PHP expression.
+     * Detection lands in PR 2 when the regex scanner is replaced with
+     * php-parser for echo expressions.
+     */
+    case UnparsablePhpExpression;
+
+    /**
+     * `@php ... @endphp` block with a PHP syntax error. Detection lands in
+     * PR 2; PR 1's regex-based PHP pass cannot tell well-formed from
+     * malformed PHP.
+     */
+    case UnparsablePhpBlock;
+
+    /**
+     * `{!! $$name !!}` or `{!! ${$expr} !!}` — variable variables defeat
+     * static name tracking. Detection lands in PR 2.
+     */
+    case DynamicVariableVariable;
+
+    /**
+     * Raw output of a local whose origin the scanner cannot trace
+     * (complex assignment, unsupported directive). Detection lands in PR 2
+     * with the local-variable dependency graph.
+     */
+    case UnknownLocalDependency;
+
+    /**
+     * Blade file resolved on disk but `file_get_contents()` returned false
+     * (permission, race, etc.). UNKNOWN is the only sound state — silent
+     * SAFE would hide the file from the handler.
+     */
+    case FileUnreadable;
+}

--- a/src/Blade/BladeViewSafety.php
+++ b/src/Blade/BladeViewSafety.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Blade;
+
+/**
+ * A {@see BladeTemplateAnalysis} carrying the view name and resolved file path
+ * that identify which Blade template the result came from.
+ *
+ * Separating "analysis of this source string" ({@see BladeTemplateAnalysis})
+ * from "this is the analysis for view X resolved at path Y" (this class) keeps
+ * {@see BladeTemplateScanner} pure: the scanner never touches the filesystem,
+ * the map never re-parses source.
+ *
+ * @psalm-api
+ * @psalm-immutable
+ */
+final readonly class BladeViewSafety
+{
+    public function __construct(
+        /** @var non-empty-string */
+        public string $viewName,
+        /** @var non-empty-string */
+        public string $path,
+        public BladeTemplateAnalysis $analysis,
+    ) {}
+
+    public function kind(): BladeViewSafetyKind
+    {
+        return $this->analysis->kind;
+    }
+
+    /** @return list<non-empty-string> */
+    public function unsafeKeys(): array
+    {
+        return $this->analysis->unsafeKeys;
+    }
+
+    /** @return list<BladeUncertaintyReason> */
+    public function uncertainties(): array
+    {
+        return $this->analysis->uncertainties;
+    }
+}

--- a/src/Blade/BladeViewSafetyKind.php
+++ b/src/Blade/BladeViewSafetyKind.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Blade;
+
+/**
+ * Tri-state safety classification for a single Blade template.
+ *
+ * A flat list of unsafe keys cannot represent the difference between
+ * "we scanned this template and it has no raw output" (SAFE) and
+ * "we saw something we cannot model soundly" (UNKNOWN). Conflating them is a
+ * security smell: an UNKNOWN template silently treated as SAFE would suppress
+ * the very `TaintedHtml` reports the integration is supposed to surface.
+ *
+ * Downstream handlers branch on this:
+ *  - SAFE         -> do nothing
+ *  - UNSAFE_KEYS  -> add per-key sinks for {@see BladeViewSafety::$unsafeKeys}
+ *  - UNKNOWN      -> apply the configured fallback policy (sink the whole
+ *                    data argument, skip, or report — depending on plugin
+ *                    config and the {@see BladeUncertaintyReason} list)
+ *
+ * @psalm-api
+ */
+enum BladeViewSafetyKind
+{
+    /** Scanned end-to-end; no unescaped top-level data flow found. */
+    case Safe;
+
+    /** Scanned end-to-end; a finite set of top-level keys reaches raw output. */
+    case UnsafeKeys;
+
+    /** Scanner saw a construct it cannot model soundly. See uncertainties for reasons. */
+    case Unknown;
+}

--- a/src/Blade/PsalmBladeCompiler.php
+++ b/src/Blade/PsalmBladeCompiler.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Blade;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\View\Compilers\BladeCompiler;
+
+/**
+ * Subclass of {@see BladeCompiler} that swaps two behaviours so the compiler is
+ * usable as a pure source-to-PHP transformer for static analysis.
+ *
+ * Two upstream behaviours are unsuitable for our analysis-time use:
+ *
+ * 1. {@see BladeCompiler::compileComponentTags()} instantiates a
+ *    {@see \Illuminate\View\Compilers\ComponentTagCompiler}, which calls
+ *    {@see \Illuminate\Container\Container::make()} on the discovered
+ *    component class. At analysis time the user's components are not
+ *    bound in the container the plugin booted, so the call throws
+ *    {@see \Illuminate\Contracts\Container\BindingResolutionException}.
+ *    We do not want to resolve components — we want to detect them and
+ *    surface {@see BladeUncertaintyReason::ComponentTag}. This subclass
+ *    overrides the method to flip {@see $sawComponentTag} when a `<x-foo>`
+ *    or `<x:foo>` tag is present, and leaves the markup untouched.
+ *    The scanner reads the flag after `compileString()` returns.
+ *
+ * 2. {@see BladeCompiler::restoreRawContent()} fails to substitute the
+ *    placeholder that {@see BladeCompiler::storePhpBlocks()} inserted for
+ *    `@php ... @endphp` blocks when the template has `{{` (or `{!!` or
+ *    `{{{`) immediately following `@endphp`. The placeholder is
+ *    `@__raw_block_N__@` (note the trailing `@`); compileEchos' regex
+ *    `(@)?{{...}}` matches the placeholder's trailing `@` as an escape
+ *    marker, emits the inner `{{ ... }}` literally, and consumes the `@`.
+ *    `restoreRawContent`'s regex requires the `@` suffix, so it cannot
+ *    match and the placeholder leaks into the compiled output. We override
+ *    the regex with an `@?` (optional suffix) so restoration tolerates the
+ *    eaten `@`. The replacement content is still correct PHP; only the
+ *    placeholder framing is patched.
+ *
+ *    Upstream fix in flight at laravel/framework#60136. The override and
+ *    the source preprocessing in {@see compileBladeSource()} can be removed
+ *    once the fix ships in a supported Laravel release; until then this
+ *    subclass closes the gap locally.
+ *
+ * The class is constructed with a fresh {@see Filesystem} and a writable
+ * cache path; we never actually write cache files because we only ever call
+ * `compileString()`, but the {@see BladeCompiler} constructor requires both.
+ *
+ * @internal
+ */
+final class PsalmBladeCompiler extends BladeCompiler
+{
+    private bool $sawComponentTag = false;
+
+    public function __construct(?Filesystem $files = null, ?string $cachePath = null)
+    {
+        parent::__construct(
+            $files ?? new Filesystem(),
+            $cachePath ?? \sys_get_temp_dir(),
+        );
+
+        /*
+         * Parent base classes declare these as `protected $foo;` without
+         * defaults, which makes Psalm's `PropertyNotSetInConstructor` fire
+         * on the subclass. The parent compiler lazily writes them as it
+         * processes a template; we seed them with empty strings here to
+         * satisfy the analysis without changing runtime behaviour.
+         */
+        $this->path = '';
+        $this->lastSection = '';
+        $this->lastFragment = '';
+    }
+
+    /**
+     * Resets the per-compile state and runs the parent {@see compileString()}.
+     *
+     * `BladeCompiler` keeps `$rawBlocks` and `$footer` as instance state
+     * mutated by every `compileString` call. The parent constructor zeroes
+     * `$footer` at entry but never resets `$rawBlocks`, so a previous run's
+     * placeholders can collide on the next run. We reset both up front and
+     * additionally clear our own `sawComponentTag` flag so each scan starts
+     * with a clean slate.
+     *
+     * Adds a single defensive preprocessing pass to insert whitespace between
+     * `@endphp` / `@endverbatim` and an immediately following `{` (which
+     * starts a `{{`, `{!!`, or `{{{` echo) or `@` (which starts an adjacent
+     * raw block). Without the space, `storeUncompiledBlocks` produces
+     * `@__raw_block_N__@{{...`, and the inner compileEchos regex
+     * `(@)?{{...}}` consumes the placeholder's trailing `@` as an
+     * escape-brace marker, leaving the echo uncompiled and the placeholder
+     * unrestorable. The inserted whitespace breaks the adjacency without
+     * changing the rendered output (Blade collapses HTML whitespace at
+     * render time).
+     *
+     * @param string $value Blade template source
+     *
+     * @return string compiled PHP
+     */
+    public function compileBladeSource(string $value): string
+    {
+        $this->sawComponentTag = false;
+        $this->resetRawBlocks();
+
+        $value = \preg_replace(
+            '/(@end(?:php|verbatim))(?=[{@])/',
+            '$1 ',
+            $value,
+        ) ?? $value;
+
+        return $this->compileString($value);
+    }
+
+    public function sawComponentTag(): bool
+    {
+        return $this->sawComponentTag;
+    }
+
+    /**
+     * Detect component tags without trying to resolve their classes.
+     *
+     * Pattern matches both `<x-foo>` and `<x:foo>` plus the directive forms
+     * `@component` and `@slot`. Matches the Laravel parser's accepted
+     * surface (see {@see \Illuminate\View\Compilers\ComponentTagCompiler}).
+     *
+     * @psalm-external-mutation-free
+     */
+    #[\Override]
+    protected function compileComponentTags($value)
+    {
+        if (\preg_match('/<x[-:][a-zA-Z][\w.:-]*|@(?:component|slot)\b/', $value) === 1) {
+            $this->sawComponentTag = true;
+        }
+
+        return $value;
+    }
+
+    /**
+     * Tolerant restoration: accepts both `@__raw_block_N__@` (well-formed)
+     * and `@__raw_block_N__` (trailing `@` eaten by compileEchos when the
+     * template has `{{` immediately following `@endphp`).
+     *
+     * @psalm-external-mutation-free
+     */
+    #[\Override]
+    protected function restoreRawContent($result)
+    {
+        /** @var array<int, string> $rawBlocks */
+        $rawBlocks = $this->rawBlocks;
+
+        $restored = \preg_replace_callback(
+            '/@__raw_block_(\d+)__@?/',
+            /** @param array<array-key, string> $matches */
+            static function (array $matches) use ($rawBlocks): string {
+                $index = (int) ($matches[1] ?? '0');
+
+                return $rawBlocks[$index] ?? ($matches[0] ?? '');
+            },
+            $result,
+        );
+
+        $this->rawBlocks = [];
+
+        return $restored ?? $result;
+    }
+
+    /**
+     * `rawBlocks` is `protected` on the parent, so this writer lives on the
+     * subclass purely so callers don't reach into the parent's internals via
+     * reflection. Called from {@see compileBladeSource()} before every run.
+     *
+     * @psalm-external-mutation-free
+     */
+    private function resetRawBlocks(): void
+    {
+        $this->rawBlocks = [];
+    }
+}

--- a/tests/Unit/Blade/BladeSafetyMapTest.php
+++ b/tests/Unit/Blade/BladeSafetyMapTest.php
@@ -6,14 +6,23 @@ namespace Psalm\LaravelPlugin\Tests\Unit\Blade;
 
 use PHPUnit\Framework\TestCase;
 use Psalm\LaravelPlugin\Blade\BladeSafetyMap;
+use Psalm\LaravelPlugin\Blade\BladeUncertaintyReason;
+use Psalm\LaravelPlugin\Blade\BladeViewSafetyKind;
 
 final class BladeSafetyMapTest extends TestCase
 {
     /** @var list<string> */
     private array $rootsToCleanUp = [];
 
-    private string $root;
+    /**
+     * Initialised in {@see setUp()}, which PHPUnit invokes before each test
+     * method. Declared `string` rather than `?string` because every test
+     * method dereferences it; a null sentinel would only delay the obvious
+     * failure (and trip Psalm's PossiblyNullArgument on every read).
+     */
+    private string $root = '';
 
+    #[\Override]
     protected function setUp(): void
     {
         $this->root = $this->makeTempRoot();
@@ -22,6 +31,7 @@ final class BladeSafetyMapTest extends TestCase
         \mkdir($this->root . \DIRECTORY_SEPARATOR . 'posts', 0777, true);
     }
 
+    #[\Override]
     protected function tearDown(): void
     {
         foreach ($this->rootsToCleanUp as $root) {
@@ -38,7 +48,7 @@ final class BladeSafetyMapTest extends TestCase
         $map = BladeSafetyMap::build([$this->root]);
 
         $this->assertSame(['banner'], $map->unsafeKeysFor('emails.welcome'));
-        $this->assertTrue($map->hasUnsafeKeys('emails.welcome'));
+        $this->assertSame(BladeViewSafetyKind::UnsafeKeys, $map->safetyFor('emails.welcome')?->kind());
     }
 
     public function test_nested_subdirectory_produces_multi_segment_view_name(): void
@@ -51,15 +61,40 @@ final class BladeSafetyMapTest extends TestCase
         $this->assertSame(['html'], $map->unsafeKeysFor('partials.forms.input'));
     }
 
-    public function test_safe_templates_are_not_recorded(): void
+    public function test_safe_templates_are_recorded_as_safe(): void
     {
+        // Earlier versions only stored unsafe templates, leaving SAFE views
+        // indistinguishable from "never scanned". The handler layer needs the
+        // distinction to decide between "no sink" and "apply UNKNOWN fallback".
         $this->writeBlade($this->root, 'posts/show.blade.php', '<h1>{{ $post->title }}</h1>');
 
         $map = BladeSafetyMap::build([$this->root]);
 
-        $this->assertFalse($map->hasUnsafeKeys('posts.show'));
+        $this->assertTrue($map->isKnownSafe('posts.show'));
+        $this->assertFalse($map->isUnknown('posts.show'));
         $this->assertSame([], $map->unsafeKeysFor('posts.show'));
-        $this->assertSame([], $map->knownViews());
+        $this->assertSame(['posts.show'], $map->knownViews());
+        $this->assertSame(BladeViewSafetyKind::Safe, $map->safetyFor('posts.show')?->kind());
+    }
+
+    public function test_layout_template_is_recorded_as_unknown(): void
+    {
+        \mkdir($this->root . \DIRECTORY_SEPARATOR . 'layouts', 0777, true);
+        $this->writeBlade(
+            $this->root,
+            'layouts/app.blade.php',
+            "<html><body>@yield('content')</body></html>",
+        );
+
+        $map = BladeSafetyMap::build([$this->root]);
+
+        $this->assertTrue($map->isUnknown('layouts.app'));
+
+        $safety = $map->safetyFor('layouts.app');
+
+        $this->assertInstanceOf(\Psalm\LaravelPlugin\Blade\BladeViewSafety::class, $safety);
+        $this->assertSame(BladeViewSafetyKind::Unknown, $safety->kind());
+        $this->assertContains(BladeUncertaintyReason::LayoutSectionFlow, $safety->uncertainties());
     }
 
     public function test_multiple_unsafe_keys_are_collected(): void
@@ -78,7 +113,7 @@ final class BladeSafetyMapTest extends TestCase
         $this->assertSame(['rawFooter', 'summaryHtml'], $unsafe);
     }
 
-    public function test_first_matching_path_wins(): void
+    public function test_first_matching_path_wins_for_unsafe_view(): void
     {
         // Laravel's FileViewFinder iterates paths in order and returns the
         // first match. BladeSafetyMap mirrors that: the first occurrence of a
@@ -92,6 +127,24 @@ final class BladeSafetyMapTest extends TestCase
         $map = BladeSafetyMap::build([$this->root, $altRoot]);
 
         $this->assertSame(['primary'], $map->unsafeKeysFor('emails.welcome'));
+    }
+
+    public function test_first_matching_path_wins_when_first_is_safe(): void
+    {
+        // Regression for the earlier PoC: when the first root had a SAFE view
+        // and a later root had an UNSAFE view, the map skipped the SAFE one
+        // and stored the UNSAFE shadow — which Laravel would never render.
+        // The map must record the first match regardless of safety kind.
+        $altRoot = $this->makeTempRoot();
+        \mkdir($altRoot . \DIRECTORY_SEPARATOR . 'emails', 0777, true);
+
+        $this->writeBlade($this->root, 'emails/welcome.blade.php', '<h1>{{ $title }}</h1>');
+        $this->writeBlade($altRoot, 'emails/welcome.blade.php', '{!! $injected !!}');
+
+        $map = BladeSafetyMap::build([$this->root, $altRoot]);
+
+        $this->assertTrue($map->isKnownSafe('emails.welcome'));
+        $this->assertSame([], $map->unsafeKeysFor('emails.welcome'));
     }
 
     public function test_view_in_second_path_is_picked_up_when_absent_from_first(): void
@@ -129,6 +182,45 @@ final class BladeSafetyMapTest extends TestCase
         $map = BladeSafetyMap::build(['/nonexistent/path/to/views']);
 
         $this->assertSame([], $map->knownViews());
+    }
+
+    public function test_unknown_view_name_returns_null_from_safety_for(): void
+    {
+        $map = BladeSafetyMap::build([$this->root]);
+
+        $this->assertNotInstanceOf(\Psalm\LaravelPlugin\Blade\BladeViewSafety::class, $map->safetyFor('never.scanned'));
+        $this->assertFalse($map->isKnownSafe('never.scanned'));
+        $this->assertFalse($map->isUnknown('never.scanned'));
+        $this->assertSame([], $map->unsafeKeysFor('never.scanned'));
+    }
+
+    public function test_unreadable_blade_file_is_recorded_as_unknown(): void
+    {
+        // Verifies the FILE_UNREADABLE branch in BladeSafetyMap::build().
+        // chmod 0000 is ineffective on Windows and as root, so we skip in
+        // those environments rather than fake the test.
+        if (\PHP_OS_FAMILY === 'Windows' || (\function_exists('posix_geteuid') && \posix_geteuid() === 0)) {
+            $this->markTestSkipped('chmod 0000 not effective on Windows or as root');
+        }
+
+        $path = $this->root . \DIRECTORY_SEPARATOR . 'emails' . \DIRECTORY_SEPARATOR . 'locked.blade.php';
+        \file_put_contents($path, '{!! $banner !!}');
+        \chmod($path, 0000);
+
+        try {
+            $map = BladeSafetyMap::build([$this->root]);
+
+            $this->assertTrue($map->isUnknown('emails.locked'));
+            $safety = $map->safetyFor('emails.locked');
+            $this->assertInstanceOf(\Psalm\LaravelPlugin\Blade\BladeViewSafety::class, $safety);
+            $this->assertContains(
+                BladeUncertaintyReason::FileUnreadable,
+                $safety->uncertainties(),
+            );
+        } finally {
+            // Restore so the recursive teardown can unlink the file.
+            \chmod($path, 0644);
+        }
     }
 
     private function writeBlade(string $root, string $relativePath, string $contents): void

--- a/tests/Unit/Blade/BladeTemplateAnalysisTest.php
+++ b/tests/Unit/Blade/BladeTemplateAnalysisTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Tests\Unit\Blade;
+
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Blade\BladeTemplateAnalysis;
+use Psalm\LaravelPlugin\Blade\BladeUncertaintyReason;
+use Psalm\LaravelPlugin\Blade\BladeViewSafetyKind;
+
+final class BladeTemplateAnalysisTest extends TestCase
+{
+    public function test_safe_factory_produces_safe_with_empty_payload(): void
+    {
+        $a = BladeTemplateAnalysis::safe();
+
+        $this->assertSame(BladeViewSafetyKind::Safe, $a->kind);
+        $this->assertSame([], $a->unsafeKeys);
+        $this->assertSame([], $a->uncertainties);
+    }
+
+    public function test_unsafe_keys_factory_collapses_to_safe_on_empty_input(): void
+    {
+        // Load-bearing invariant: `analyze()` returning UNSAFE_KEYS with an
+        // empty key list would be incoherent. Pinning the factory collapse so
+        // a future refactor splitting `unsafeKeys()` and `safe()` cannot break
+        // this without a test signalling.
+        $a = BladeTemplateAnalysis::unsafeKeys([]);
+
+        $this->assertSame(BladeViewSafetyKind::Safe, $a->kind);
+        $this->assertSame([], $a->unsafeKeys);
+    }
+
+    public function test_unsafe_keys_factory_with_keys_produces_unsafe_kind(): void
+    {
+        $a = BladeTemplateAnalysis::unsafeKeys(['bio', 'html']);
+
+        $this->assertSame(BladeViewSafetyKind::UnsafeKeys, $a->kind);
+        $this->assertSame(['bio', 'html'], $a->unsafeKeys);
+        $this->assertSame([], $a->uncertainties);
+    }
+
+    public function test_unknown_factory_preserves_observed_unsafe_keys(): void
+    {
+        // UNKNOWN dominates `kind`, but the scanner still emits the keys it
+        // observed before hitting the unhandled construct. Handlers may use
+        // them for diagnostics even when applying the whole-data fallback.
+        $a = BladeTemplateAnalysis::unknown(
+            [BladeUncertaintyReason::LayoutSectionFlow],
+            ['bio'],
+        );
+
+        $this->assertSame(BladeViewSafetyKind::Unknown, $a->kind);
+        $this->assertSame(['bio'], $a->unsafeKeys);
+        $this->assertSame([BladeUncertaintyReason::LayoutSectionFlow], $a->uncertainties);
+    }
+
+    public function test_unknown_factory_omitting_keys_defaults_to_empty_list(): void
+    {
+        $a = BladeTemplateAnalysis::unknown([BladeUncertaintyReason::FileUnreadable]);
+
+        $this->assertSame(BladeViewSafetyKind::Unknown, $a->kind);
+        $this->assertSame([], $a->unsafeKeys);
+        $this->assertSame([BladeUncertaintyReason::FileUnreadable], $a->uncertainties);
+    }
+
+    public function test_unknown_factory_rejects_empty_uncertainty_list(): void
+    {
+        // The non-empty-list contract is load-bearing: UNKNOWN with no
+        // reasons would be indistinguishable from a safe template at the
+        // handler layer and re-introduce the SAFE/UNKNOWN conflation this
+        // class exists to prevent.
+        $this->expectException(\InvalidArgumentException::class);
+
+        BladeTemplateAnalysis::unknown([]);
+    }
+}

--- a/tests/Unit/Blade/BladeTemplateScannerCompilerIntegrationTest.php
+++ b/tests/Unit/Blade/BladeTemplateScannerCompilerIntegrationTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Tests\Unit\Blade;
+
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Blade\BladeTemplateScanner;
+use Psalm\LaravelPlugin\Blade\BladeUncertaintyReason;
+use Psalm\LaravelPlugin\Blade\BladeViewSafetyKind;
+use Psalm\LaravelPlugin\Blade\PsalmBladeCompiler;
+
+/**
+ * Integration tests that exercise the real {@see PsalmBladeCompiler} against a
+ * full {@see BladeTemplateScanner} pipeline. Distinct from
+ * {@see BladeTemplateScannerTest}: this file is the place to add fixtures that
+ * cover compiled-Blade quirks the regex backend could not reach, and to verify
+ * the scanner does not crash on real-world template shapes.
+ *
+ * No Testbench / Laravel container needed: {@see PsalmBladeCompiler} builds a
+ * compiler with a default {@see \Illuminate\Filesystem\Filesystem} and a temp
+ * cache path, so the scanner has no boot dependency.
+ */
+final class BladeTemplateScannerCompilerIntegrationTest extends TestCase
+{
+    private BladeTemplateScanner $scanner;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->scanner = new BladeTemplateScanner(new PsalmBladeCompiler());
+    }
+
+    public function test_php_endphp_immediately_followed_by_echo_does_not_leak_placeholder(): void
+    {
+        /*
+         * Regression for an upstream Laravel quirk: the raw-block placeholder
+         * `@__raw_block_N__@` collides with `compileEchos`' `(@)?{{...}}`
+         * escape-brace capture when `@endphp` is followed by `{{`. The
+         * PsalmBladeCompiler preprocesses the source to insert whitespace
+         * between `@endphp` / `@endverbatim` and an adjacent `{` (or `@`)
+         * so the placeholder survives restoration AND the echo is compiled.
+         *
+         * The analysis check verifies the classification; the scan() check
+         * verifies the echo was actually compiled to a real Stmt\Echo_ node
+         * (an uncompiled `{{ $x }}` would leave `$x` invisible to scan()).
+         */
+        $source = "@php \$x = 1; @endphp{{ \$x }}";
+
+        $analysis = $this->scanner->analyze($source);
+        $usages = $this->scanner->scan($source);
+
+        $this->assertSame(BladeViewSafetyKind::Safe, $analysis->kind);
+        $this->assertSame([], $analysis->unsafeKeys);
+        $this->assertNotSame(
+            [],
+            \array_filter($usages, static fn(\Psalm\LaravelPlugin\Blade\BladeVariableUsage $u): bool => $u->name === 'x'),
+            'Echo of $x after @endphp must reach the AST walker; an empty result means the placeholder leaked and the echo was rendered literally.',
+        );
+    }
+
+    public function test_php_endphp_immediately_followed_by_raw_echo_does_not_leak_placeholder(): void
+    {
+        $source = "@php \$x = 1; @endphp{!! \$x !!}";
+
+        $analysis = $this->scanner->analyze($source);
+        $usages = $this->scanner->scan($source);
+
+        $this->assertSame(BladeViewSafetyKind::Safe, $analysis->kind);
+        $this->assertSame([], $analysis->unsafeKeys);
+        $this->assertNotSame(
+            [],
+            \array_filter($usages, static fn(\Psalm\LaravelPlugin\Blade\BladeVariableUsage $u): bool => $u->name === 'x'),
+            'Raw echo of $x after @endphp must compile to a real echo statement.',
+        );
+    }
+
+    public function test_two_adjacent_php_blocks_compile_cleanly(): void
+    {
+        $source = "@php \$x = 1; @endphp@php \$y = 2; @endphp";
+
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertSame(BladeViewSafetyKind::Safe, $analysis->kind);
+        $this->assertSame([], $analysis->unsafeKeys);
+    }
+
+    public function test_verbatim_immediately_followed_by_echo_is_isolated(): void
+    {
+        $source = "@verbatim{{vue}}@endverbatim{{ \$x }}";
+
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertSame(['x'], \array_unique(
+            \array_map(static fn(\Psalm\LaravelPlugin\Blade\BladeVariableUsage $u): string => $u->name, $this->scanner->scan($source)),
+        ));
+        $this->assertSame(BladeViewSafetyKind::Safe, $analysis->kind);
+    }
+
+    public function test_unresolved_component_tag_does_not_throw(): void
+    {
+        /*
+         * In production the user's component class may not be loaded in the
+         * compiler's container. The compiler's component-tag pass would
+         * normally throw an InvalidArgumentException / BindingResolutionException
+         * when it tries to resolve the class. {@see PsalmBladeCompiler}
+         * overrides {@see \Illuminate\View\Compilers\BladeCompiler::compileComponentTags()}
+         * to flip a flag and leave the markup unresolved, so the scanner can
+         * report UNKNOWN(COMPONENT_TAG) instead of crashing.
+         */
+        $source = '<x-some-unregistered-component :data="$data" />';
+
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
+        $this->assertContains(BladeUncertaintyReason::ComponentTag, $analysis->uncertainties);
+    }
+
+    public function test_realistic_email_template_classifies_safe(): void
+    {
+        $source = <<<'BLADE'
+            <!DOCTYPE html>
+            <html>
+            <body>
+                <h1>Hello, {{ $user->name }}!</h1>
+                <p>Your balance is {{ number_format($balance, 2) }}.</p>
+                @foreach ($transactions as $tx)
+                    <li>{{ $tx->description }}: {{ $tx->amount }}</li>
+                @endforeach
+                <footer>{{ config('app.name') }}</footer>
+            </body>
+            </html>
+            BLADE;
+
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertSame(BladeViewSafetyKind::Safe, $analysis->kind);
+        $this->assertSame([], $analysis->uncertainties);
+    }
+
+    public function test_realistic_admin_template_with_raw_html_surfaces_unsafe_key(): void
+    {
+        $source = <<<'BLADE'
+            <article>
+                <h1>{{ $post->title }}</h1>
+                <div class="body">{!! $post->renderedHtml !!}</div>
+                <p>By {{ $post->author }}</p>
+            </article>
+            BLADE;
+
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertSame(BladeViewSafetyKind::UnsafeKeys, $analysis->kind);
+        $this->assertSame(['post'], $analysis->unsafeKeys);
+    }
+
+    public function test_real_world_layout_template_classifies_unknown(): void
+    {
+        // Realistic shape from a notification email layout: section + push +
+        // include + component all in one template.
+        $source = <<<'BLADE'
+            @extends('mail::layouts.main')
+
+            @section('header')
+                @include('partials.logo')
+            @endsection
+
+            @push('styles')
+                <style>body { color: black; }</style>
+            @endpush
+
+            @section('body')
+                <p>{!! $bodyHtml !!}</p>
+            @endsection
+            BLADE;
+
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
+        $this->assertNotEmpty($analysis->uncertainties);
+        $this->assertContains('bodyHtml', $analysis->unsafeKeys);
+    }
+}

--- a/tests/Unit/Blade/BladeTemplateScannerTest.php
+++ b/tests/Unit/Blade/BladeTemplateScannerTest.php
@@ -4,75 +4,67 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Tests\Unit\Blade;
 
-use function count;
-
 use PHPUnit\Framework\TestCase;
 use Psalm\LaravelPlugin\Blade\BladeEchoKind;
 use Psalm\LaravelPlugin\Blade\BladeTemplateScanner;
+use Psalm\LaravelPlugin\Blade\BladeUncertaintyReason;
+use Psalm\LaravelPlugin\Blade\BladeViewSafetyKind;
 
+/**
+ * Tests cover the public contract of {@see BladeTemplateScanner}: the tri-state
+ * classification ({@see BladeViewSafetyKind}), the unsafe-key extraction, the
+ * uncertainty enumeration, and the per-occurrence {@see BladeVariableUsage}
+ * list returned by {@see BladeTemplateScanner::scan()}.
+ *
+ * Tests that pinned regex-era quirks (string-literal-inside-@php fooling the
+ * scope-local regex, word-boundary edge cases on directive names, escaped-brace
+ * stripping order) were deleted: the compiled-Blade backend processes those
+ * inputs structurally, so the asymmetries no longer exist.
+ */
 final class BladeTemplateScannerTest extends TestCase
 {
+    private BladeTemplateScanner $scanner;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->scanner = BladeTemplateScanner::withDefaults();
+    }
+
     public function test_escaped_echo_is_classified_as_escaped(): void
     {
-        $usages = BladeTemplateScanner::scan('<h1>{{ $title }}</h1>');
+        $usages = $this->scanner->scan('<h1>{{ $title }}</h1>');
 
         $this->assertCount(1, $usages);
         $this->assertSame('title', $usages[0]->name);
-        $this->assertSame(BladeEchoKind::ESCAPED, $usages[0]->kind);
+        $this->assertSame(BladeEchoKind::Escaped, $usages[0]->kind);
     }
 
     public function test_raw_echo_is_classified_as_raw(): void
     {
-        $usages = BladeTemplateScanner::scan('<div>{!! $html !!}</div>');
+        $usages = $this->scanner->scan('<div>{!! $html !!}</div>');
 
         $this->assertCount(1, $usages);
         $this->assertSame('html', $usages[0]->name);
-        $this->assertSame(BladeEchoKind::RAW, $usages[0]->kind);
+        $this->assertSame(BladeEchoKind::Raw, $usages[0]->kind);
     }
 
     public function test_legacy_triple_brace_is_classified_as_escaped(): void
     {
-        $usages = BladeTemplateScanner::scan('<p>{{{ $legacy }}}</p>');
+        // Laravel compiles `{{{ $x }}}` to `echo e($x)`, same as `{{ $x }}`.
+        $usages = $this->scanner->scan('<p>{{{ $legacy }}}</p>');
 
         $this->assertCount(1, $usages);
         $this->assertSame('legacy', $usages[0]->name);
-        $this->assertSame(BladeEchoKind::ESCAPED, $usages[0]->kind);
-    }
-
-    public function test_php_block_classifies_variables_as_php_block(): void
-    {
-        $source = <<<'BLADE'
-            @php
-                echo $dangerous;
-            @endphp
-            BLADE;
-
-        $usages = BladeTemplateScanner::scan($source);
-
-        $this->assertCount(1, $usages);
-        $this->assertSame('dangerous', $usages[0]->name);
-        $this->assertSame(BladeEchoKind::PHP_BLOCK, $usages[0]->kind);
-    }
-
-    public function test_raw_echo_literal_inside_php_string_is_not_mis_matched(): void
-    {
-        // Regression: before the @php-blank pass, the raw-echo regex would
-        // match the literal `{!! pwned !!}` inside the PHP string and emit
-        // `pwned` as an unsafe variable.
-        $source = <<<'BLADE'
-            @php $note = "Text with {!! pwned !!} brace-literal"; @endphp
-            BLADE;
-
-        $unsafe = BladeTemplateScanner::unsafeVariables($source);
-
-        $this->assertSame(['note'], $unsafe);
+        $this->assertSame(BladeEchoKind::Escaped, $usages[0]->kind);
     }
 
     public function test_blade_comments_are_ignored(): void
     {
-        $source = '{{-- {!! $hidden !!} --}} {{ $visible }}';
-
-        $usages = BladeTemplateScanner::scan($source);
+        // `{{-- comment --}}` is stripped at compile time; the variable inside
+        // never reaches an `echo`. Free correctness vs. the regex backend's
+        // explicit strip pass.
+        $usages = $this->scanner->scan('{{-- {!! $hidden !!} --}} {{ $visible }}');
 
         $this->assertCount(1, $usages);
         $this->assertSame('visible', $usages[0]->name);
@@ -87,27 +79,16 @@ final class BladeTemplateScannerTest extends TestCase
             {{ $real }}
             BLADE;
 
-        $usages = BladeTemplateScanner::scan($source);
+        $usages = $this->scanner->scan($source);
 
         $this->assertCount(1, $usages);
         $this->assertSame('real', $usages[0]->name);
     }
 
-    public function test_unclosed_verbatim_block_strips_to_end_of_file(): void
-    {
-        // Real Blade compiler would throw on an unclosed @verbatim; the
-        // scanner should fail safe by treating everything after the opening
-        // directive as literal text, not by leaking variables from it.
-        $source = "@verbatim\n{!! \$leaked !!}\nno closing tag";
-
-        $this->assertSame([], BladeTemplateScanner::unsafeVariables($source));
-    }
-
     public function test_escaped_braces_are_ignored(): void
     {
-        // `@{{ $x }}` is rendered literally as `{{ $x }}` by Blade — it's a
-        // common pattern for Vue/Alpine templates. No PHP variable is emitted.
-        $usages = BladeTemplateScanner::scan('@{{ $vuetemplate }} {{ $real }}');
+        // `@{{ $x }}` renders literally as `{{ $x }}` (Vue/Alpine pattern).
+        $usages = $this->scanner->scan('@{{ $vuetemplate }} {{ $real }}');
 
         $this->assertCount(1, $usages);
         $this->assertSame('real', $usages[0]->name);
@@ -115,7 +96,7 @@ final class BladeTemplateScannerTest extends TestCase
 
     public function test_escaped_raw_brace_is_ignored(): void
     {
-        $usages = BladeTemplateScanner::scan('@{!! $literal !!} {{ $real }}');
+        $usages = $this->scanner->scan('@{!! $literal !!} {{ $real }}');
 
         $this->assertCount(1, $usages);
         $this->assertSame('real', $usages[0]->name);
@@ -123,16 +104,17 @@ final class BladeTemplateScannerTest extends TestCase
 
     public function test_foreach_alias_is_not_treated_as_view_data_key(): void
     {
-        // `$item` comes from the @foreach alias, not from the view() call's
-        // data array. Reporting it as an unsafe view-data key would be a
-        // false positive at the taint-sink layer.
+        // `$item` is bound by @foreach, not by the view() data array.
         $source = <<<'BLADE'
             @foreach ($items as $item)
                 {!! $item !!}
             @endforeach
             BLADE;
 
-        $this->assertSame([], BladeTemplateScanner::unsafeVariables($source));
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertSame(BladeViewSafetyKind::Safe, $analysis->kind);
+        $this->assertSame([], $analysis->unsafeKeys);
     }
 
     public function test_foreach_key_value_aliases_are_excluded(): void
@@ -143,7 +125,9 @@ final class BladeTemplateScannerTest extends TestCase
             @endforeach
             BLADE;
 
-        $this->assertSame([], BladeTemplateScanner::unsafeVariables($source));
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertSame(BladeViewSafetyKind::Safe, $analysis->kind);
     }
 
     public function test_forelse_alias_is_excluded(): void
@@ -156,25 +140,57 @@ final class BladeTemplateScannerTest extends TestCase
             @endforelse
             BLADE;
 
-        $this->assertSame([], BladeTemplateScanner::unsafeVariables($source));
+        $this->assertSame(BladeViewSafetyKind::Safe, $this->scanner->analyze($source)->kind);
     }
 
     public function test_inline_assignment_in_if_condition_is_excluded(): void
     {
+        // The AST walker sees the {@see \PhpParser\Node\Expr\Assign} inside
+        // the {@see \PhpParser\Node\Stmt\If_::$cond} and registers `$rendered`
+        // as a scope-local. Subsequent raw echo of `$rendered` is not surfaced
+        // as an unsafe view-data key.
         $source = <<<'BLADE'
             @if ($rendered = markdown($post->body))
                 {!! $rendered !!}
             @endif
             BLADE;
 
-        $this->assertSame([], BladeTemplateScanner::unsafeVariables($source));
+        $this->assertSame(BladeViewSafetyKind::Safe, $this->scanner->analyze($source)->kind);
+    }
+
+    public function test_complex_inline_assignment_resolves_dependency(): void
+    {
+        // Regression for the regex-era known-limitation: assignments mid-condition
+        // (after a `count(...)` call) used to leak `$rendered` as an unsafe key.
+        // The AST walker now sees the {@see \PhpParser\Node\Expr\Assign}
+        // regardless of position.
+        $source = "@if (count(\$rows) > 0 && \$rendered = compute())\n{!! \$rendered !!}\n@endif";
+
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertSame(BladeViewSafetyKind::Safe, $analysis->kind);
+        $this->assertSame([], $analysis->unsafeKeys);
+    }
+
+    public function test_inline_php_directive_resolves_dependency(): void
+    {
+        /*
+         * Regression for the regex-era known-limitation: the inline `@php(...)`
+         * directive wasn't matched by the multi-line `@php ... @endphp` regex.
+         * BladeCompiler turns `@php($foo = 'x')` into a normal PHP statement,
+         * and the AST walker registers `$foo` as a scope-local.
+         */
+        $source = "@php(\$foo = 'x')\n{!! \$foo !!}";
+
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertSame(BladeViewSafetyKind::Safe, $analysis->kind);
+        $this->assertSame([], $analysis->unsafeKeys);
     }
 
     public function test_property_access_reports_top_level_variable_only(): void
     {
-        // `{!! $user->bio !!}` — the view data key is `user`, not `bio`.
-        // The scanner deliberately operates at top-level granularity.
-        $usages = BladeTemplateScanner::scan('{!! $user->bio !!}');
+        $usages = $this->scanner->scan('{!! $user->bio !!}');
 
         $this->assertCount(1, $usages);
         $this->assertSame('user', $usages[0]->name);
@@ -182,79 +198,24 @@ final class BladeTemplateScannerTest extends TestCase
 
     public function test_array_access_reports_top_level_variable_only(): void
     {
-        $usages = BladeTemplateScanner::scan('{!! $data["html"] !!}');
+        $usages = $this->scanner->scan('{!! $data["html"] !!}');
 
         $this->assertCount(1, $usages);
         $this->assertSame('data', $usages[0]->name);
-    }
-
-    public function test_line_numbers_are_reported_correctly(): void
-    {
-        $source = "line1\nline2 {!! \$bad !!}\nline3 {{ \$good }}\n";
-
-        $usages = BladeTemplateScanner::scan($source);
-
-        $byName = [];
-
-        foreach ($usages as $usage) {
-            $byName[$usage->name] = $usage;
-        }
-
-        $this->assertCount(2, $byName);
-        $this->assertSame(2, $byName['bad']->line);
-        $this->assertSame(3, $byName['good']->line);
-    }
-
-    public function test_line_numbers_survive_multi_line_blanked_region(): void
-    {
-        // Regression: `blank()` previously replaced newlines with spaces,
-        // collapsing downstream line numbers. `$later` must report line 6,
-        // not line 2, even though the preceding @php / @verbatim / comment
-        // block spans multiple lines.
-        $source = <<<'BLADE'
-            @php
-                $noise = 'stuff';
-            @endphp
-
-            {{ $later }}
-            BLADE;
-
-        $usages = BladeTemplateScanner::scan($source);
-
-        $byName = [];
-
-        foreach ($usages as $usage) {
-            $byName[$usage->name] = $usage;
-        }
-
-        $this->assertSame(5, $byName['later']->line);
-    }
-
-    public function test_line_numbers_survive_multi_line_raw_echo(): void
-    {
-        $source = "{!!\n\$x\n!!}\n\n{{ \$after }}";
-
-        $byName = [];
-
-        foreach (BladeTemplateScanner::scan($source) as $usage) {
-            $byName[$usage->name] = $usage;
-        }
-
-        $this->assertSame(5, $byName['after']->line);
     }
 
     public function test_multi_line_echo_is_handled(): void
     {
         $source = "{!!\n\$wrapped\n!!}";
 
-        $unsafe = BladeTemplateScanner::unsafeVariables($source);
+        $analysis = $this->scanner->analyze($source);
 
-        $this->assertSame(['wrapped'], $unsafe);
+        $this->assertSame(['wrapped'], $analysis->unsafeKeys);
     }
 
     public function test_multiple_echoes_on_one_line(): void
     {
-        $usages = BladeTemplateScanner::scan('{{ $a }} and {!! $b !!}');
+        $usages = $this->scanner->scan('{{ $a }} and {!! $b !!}');
 
         $byName = [];
 
@@ -262,41 +223,73 @@ final class BladeTemplateScannerTest extends TestCase
             $byName[$usage->name] = $usage;
         }
 
-        $this->assertSame(BladeEchoKind::ESCAPED, $byName['a']->kind);
-        $this->assertSame(BladeEchoKind::RAW, $byName['b']->kind);
+        $this->assertSame(BladeEchoKind::Escaped, $byName['a']->kind);
+        $this->assertSame(BladeEchoKind::Raw, $byName['b']->kind);
     }
 
-    public function test_unsafe_variables_aggregates_across_kinds(): void
+    public function test_analyze_collects_unsafe_keys_from_raw_echoes(): void
     {
         $source = <<<'BLADE'
             {{ $safe }}
             {!! $raw !!}
-            @php echo $phpBlock; @endphp
             BLADE;
 
-        $unsafe = BladeTemplateScanner::unsafeVariables($source);
+        $unsafe = $this->scanner->analyze($source)->unsafeKeys;
 
-        \sort($unsafe);
+        $this->assertSame(['raw'], $unsafe);
+    }
 
-        $this->assertSame(['phpBlock', 'raw'], $unsafe);
+    public function test_php_block_echo_classified_as_unsafe(): void
+    {
+        /*
+         * `@php echo $x; @endphp` compiles to the same AST shape as
+         * `{!! $x !!}`. The walker treats every Stmt\Echo_ node uniformly;
+         * the distinction between BladeEchoKind::PhpBlock and BladeEchoKind::Raw
+         * is no longer observable at compile time and collapses to RAW for
+         * {@see BladeTemplateScanner::scan()}.
+         */
+        $source = "@php echo \$dangerous; @endphp";
+
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertSame(['dangerous'], $analysis->unsafeKeys);
+    }
+
+    public function test_php_block_assignment_does_not_become_unsafe_key(): void
+    {
+        // `@php $note = ...; @endphp` is purely an assignment — no echo. The
+        // regex backend used to surface `note` as an unsafe key because it
+        // collected every `$var` reference inside a @php block. The AST
+        // walker only records actual echoes.
+        $source = "@php \$note = 'hello'; @endphp\n<p>literal</p>";
+
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertSame(BladeViewSafetyKind::Safe, $analysis->kind);
+        $this->assertSame([], $analysis->unsafeKeys);
     }
 
     public function test_same_variable_in_safe_and_raw_contexts_is_reported_unsafe(): void
     {
-        // When the same key is rendered both ways, the raw occurrence dominates
-        // — if ANY echo is unsafe, the key must be treated as an html sink.
-        $source = '{{ $title }} ... {!! $title !!}';
+        // If ANY echo of a variable is raw, the key must surface as unsafe.
+        $analysis = $this->scanner->analyze('{{ $title }} ... {!! $title !!}');
 
-        $this->assertSame(['title'], BladeTemplateScanner::unsafeVariables($source));
+        $this->assertSame(BladeViewSafetyKind::UnsafeKeys, $analysis->kind);
+        $this->assertSame(['title'], $analysis->unsafeKeys);
     }
 
-    public function test_no_variables_returns_empty(): void
+    public function test_no_variables_returns_safe(): void
     {
-        $this->assertSame([], BladeTemplateScanner::scan('<p>Hello, world!</p>'));
-        $this->assertSame([], BladeTemplateScanner::unsafeVariables('<p>Hello, world!</p>'));
+        $this->assertSame([], $this->scanner->scan('<p>Hello, world!</p>'));
+
+        $analysis = $this->scanner->analyze('<p>Hello, world!</p>');
+
+        $this->assertSame(BladeViewSafetyKind::Safe, $analysis->kind);
+        $this->assertSame([], $analysis->unsafeKeys);
+        $this->assertSame([], $analysis->uncertainties);
     }
 
-    public function test_all_safe_template_has_no_unsafe_variables(): void
+    public function test_all_safe_template_is_classified_safe(): void
     {
         $source = <<<'BLADE'
             <h1>{{ $title }}</h1>
@@ -306,12 +299,15 @@ final class BladeTemplateScannerTest extends TestCase
             @endforeach
             BLADE;
 
-        $this->assertSame([], BladeTemplateScanner::unsafeVariables($source));
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertSame(BladeViewSafetyKind::Safe, $analysis->kind);
+        $this->assertSame([], $analysis->unsafeKeys);
     }
 
     public function test_multiple_variables_in_single_echo(): void
     {
-        $usages = BladeTemplateScanner::scan('{!! $a . $b . $c !!}');
+        $usages = $this->scanner->scan('{!! $a . $b . $c !!}');
 
         $names = \array_map(static fn(\Psalm\LaravelPlugin\Blade\BladeVariableUsage $u): string => $u->name, $usages);
 
@@ -320,47 +316,476 @@ final class BladeTemplateScannerTest extends TestCase
         $this->assertSame(['a', 'b', 'c'], $names);
     }
 
-    public function test_section_with_content_argument_does_not_flag_variable(): void
+    public function test_known_safe_wrapper_e_is_recognized(): void
     {
-        // @section('title', $dynamic) passes data but does NOT echo it raw.
-        // Blade escapes it at the @yield site via `echo e($content)`. The
-        // current scanner ignores @section entirely — this test pins that.
+        // `{!! e($x) !!}` is RAW-echoed-but-safely-wrapped Blade. The walker
+        // detects {@see \PhpParser\Node\Expr\FuncCall} with name `e` inside
+        // the echo and classifies it as ESCAPED.
+        $analysis = $this->scanner->analyze('{!! e($safe) !!}');
+
+        $this->assertSame(BladeViewSafetyKind::Safe, $analysis->kind);
+    }
+
+    public function test_known_safe_wrapper_htmlspecialchars_is_recognized(): void
+    {
+        $analysis = $this->scanner->analyze('{!! htmlspecialchars($safe) !!}');
+
+        $this->assertSame(BladeViewSafetyKind::Safe, $analysis->kind);
+    }
+
+    public function test_known_safe_wrapper_htmlentities_is_recognized(): void
+    {
+        $analysis = $this->scanner->analyze('{!! htmlentities($safe) !!}');
+
+        $this->assertSame(BladeViewSafetyKind::Safe, $analysis->kind);
+    }
+
+    public function test_unknown_function_call_in_raw_echo_surfaces_argument_variable(): void
+    {
+        // `{!! random_fn($x) !!}` — the walker has no taint-escape annotation
+        // for `random_fn`, so it conservatively surfaces top-level vars from
+        // the call's arguments as unsafe keys.
+        $analysis = $this->scanner->analyze('{!! random_fn($x) !!}');
+
+        $this->assertSame(['x'], $analysis->unsafeKeys);
+    }
+
+    public function test_section_directive_marks_template_unknown(): void
+    {
+        /*
+         * `@section('title', $dynamic)` compiles to a `$__env->startSection(...)`
+         * call. The {@see \PhpParser\Node\Expr\MethodCall} on `$__env`
+         * signals LAYOUT_SECTION_FLOW.
+         */
         $source = "@section('title', \$dynamic)\n@stop";
 
-        $this->assertSame([], BladeTemplateScanner::unsafeVariables($source));
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
+        $this->assertContains(BladeUncertaintyReason::LayoutSectionFlow, $analysis->uncertainties);
     }
 
-    public function test_known_limitation_string_interpolation_inside_raw_echo_surfaces_names(): void
+    public function test_extends_directive_marks_template_unknown(): void
     {
-        // The regex scanner does not understand PHP string interpolation.
-        // `{!! "hello {$attacker}" !!}` extracts `attacker` as an unsafe key.
-        // This is accepted as a known limitation: the handler integration
-        // layer must treat this case conservatively (the outer expression is
-        // already an unescaped echo, so any key appearing inside should be
-        // sinked regardless). Pinning the current behaviour so intentional
-        // future changes are visible.
-        $this->assertSame(['attacker'], BladeTemplateScanner::unsafeVariables('{!! "hello {$attacker}" !!}'));
+        // `@extends('layouts.app')` adds a `$__env->make(...)->render()` call
+        // to the compiled output's footer. The make() call is mapped to
+        // INCLUDE_DIRECTIVE; either uncertainty triggers the same UNKNOWN
+        // fallback policy at the handler layer, so the spec-mapping of
+        // make → INCLUDE is acceptable.
+        $source = <<<'BLADE'
+            @extends('layouts.app')
+            @section('content')
+                <p>{{ $title }}</p>
+            @endsection
+            BLADE;
+
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
+        $this->assertNotEmpty($analysis->uncertainties);
     }
 
-    public function test_known_limitation_at_php_inline_directive_is_not_recognised(): void
+    public function test_yield_directive_marks_template_unknown(): void
     {
-        // `@php($foo = bar())` is the inline alternative to @php...@endphp.
-        // It is NOT matched by the `@php ... @endphp` regex, so the
-        // assignment does not register `$foo` as scope-local. If $foo is
-        // later raw-echoed, it will surface as unsafe. Pinned so a future
-        // improvement lands with an intentional test change.
-        $source = "@php(\$foo = 'x')\n{!! \$foo !!}";
+        $analysis = $this->scanner->analyze("<body>@yield('content')</body>");
 
-        $this->assertSame(['foo'], BladeTemplateScanner::unsafeVariables($source));
+        $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
+        $this->assertContains(BladeUncertaintyReason::LayoutSectionFlow, $analysis->uncertainties);
     }
 
-    public function test_known_limitation_assignment_with_preceding_call_in_condition(): void
+    public function test_stack_directive_marks_template_unknown(): void
     {
-        // `@if (count($rows) > 0 && $x = compute())` — the scope-local regex
-        // only recognises `@if ($x = ...)` at the top of the condition. Pin
-        // the known-limitation behaviour: `$x` is NOT excluded.
-        $source = "@if (count(\$rows) > 0 && \$rendered = compute())\n{!! \$rendered !!}\n@endif";
+        $analysis = $this->scanner->analyze("<head>@stack('scripts')</head>");
 
-        $this->assertSame(['rendered'], BladeTemplateScanner::unsafeVariables($source));
+        $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
+        $this->assertContains(BladeUncertaintyReason::LayoutSectionFlow, $analysis->uncertainties);
+    }
+
+    public function test_push_directive_marks_template_unknown(): void
+    {
+        $source = <<<'BLADE'
+            @push('scripts')
+                <script>console.log({!! $debug !!});</script>
+            @endpush
+            BLADE;
+
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
+        $this->assertContains(BladeUncertaintyReason::LayoutSectionFlow, $analysis->uncertainties);
+    }
+
+    public function test_prepend_directive_marks_template_unknown(): void
+    {
+        $analysis = $this->scanner->analyze("@prepend('foo')bar@endprepend");
+
+        $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
+        $this->assertContains(BladeUncertaintyReason::LayoutSectionFlow, $analysis->uncertainties);
+    }
+
+    public function test_include_directive_marks_template_unknown(): void
+    {
+        $analysis = $this->scanner->analyze("@include('partials.user', ['html' => \$html])");
+
+        $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
+        $this->assertContains(BladeUncertaintyReason::IncludeDirective, $analysis->uncertainties);
+    }
+
+    public function test_include_when_directive_marks_template_unknown(): void
+    {
+        $analysis = $this->scanner->analyze("@includeWhen(\$cond, 'partials.flash')");
+
+        $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
+        $this->assertContains(BladeUncertaintyReason::IncludeDirective, $analysis->uncertainties);
+    }
+
+    public function test_each_directive_marks_template_unknown(): void
+    {
+        $analysis = $this->scanner->analyze("@each('partials.user', \$users, 'user', 'empty')");
+
+        $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
+        $this->assertContains(BladeUncertaintyReason::IncludeDirective, $analysis->uncertainties);
+    }
+
+    public function test_dash_form_component_tag_marks_template_unknown(): void
+    {
+        $analysis = $this->scanner->analyze('<x-alert :message="$message" />');
+
+        $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
+        $this->assertContains(BladeUncertaintyReason::ComponentTag, $analysis->uncertainties);
+    }
+
+    public function test_colon_form_component_tag_marks_template_unknown(): void
+    {
+        // Laravel's ComponentTagCompiler accepts both `<x-foo>` and `<x:foo>`.
+        $analysis = $this->scanner->analyze('<x:alert :message="$message" />');
+
+        $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
+        $this->assertContains(BladeUncertaintyReason::ComponentTag, $analysis->uncertainties);
+    }
+
+    public function test_namespaced_component_tag_marks_template_unknown(): void
+    {
+        $analysis = $this->scanner->analyze('<x-mail::message>hi</x-mail::message>');
+
+        $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
+        $this->assertContains(BladeUncertaintyReason::ComponentTag, $analysis->uncertainties);
+    }
+
+    public function test_component_directive_marks_template_unknown(): void
+    {
+        $source = <<<'BLADE'
+            @component('alert')
+                @slot('title') {{ $title }} @endslot
+            @endcomponent
+            BLADE;
+
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
+        $this->assertContains(BladeUncertaintyReason::ComponentTag, $analysis->uncertainties);
+    }
+
+    public function test_inject_binds_a_scope_local(): void
+    {
+        /*
+         * `@inject('renderer', ...)` compiles to a `$renderer = app(...);`
+         * statement. The {@see \PhpParser\Node\Expr\Assign} captures
+         * `$renderer` as a scope-local, so a raw echo of
+         * `$renderer->render($body)` surfaces only the data-driven `body`,
+         * not `renderer`.
+         */
+        $source = "@inject('renderer', App\\Renderer::class)\n{!! \$renderer->render(\$body) !!}";
+
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertContains('body', $analysis->unsafeKeys);
+        $this->assertNotContains('renderer', $analysis->unsafeKeys);
+    }
+
+    public function test_inject_with_double_quoted_name_binds_local(): void
+    {
+        $source = "@inject(\"renderer\", App\\Renderer::class)\n{!! \$renderer !!}";
+
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertNotContains('renderer', $analysis->unsafeKeys);
+    }
+
+    public function test_directive_shaped_string_inside_php_block_does_not_trigger_uncertainty(): void
+    {
+        // BladeCompiler stores `@php` bodies as raw blocks before any other
+        // directive matching runs, so directive-shaped string literals inside
+        // are never seen as directives. The visitor only sees the assignment.
+        $source = "@php \$s = '@yield(1)'; @endphp\n<p>Hello</p>";
+
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertNotContains(BladeUncertaintyReason::LayoutSectionFlow, $analysis->uncertainties);
+    }
+
+    public function test_component_shaped_string_inside_php_block_does_not_trigger_uncertainty(): void
+    {
+        $source = "@php \$s = '<x-foo>'; @endphp\n<p>Hi</p>";
+
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertNotContains(BladeUncertaintyReason::ComponentTag, $analysis->uncertainties);
+    }
+
+    public function test_include_shaped_string_inside_php_block_does_not_trigger_uncertainty(): void
+    {
+        $source = "@php \$s = '@include(\"x\")'; @endphp\n<p>Hi</p>";
+
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertNotContains(BladeUncertaintyReason::IncludeDirective, $analysis->uncertainties);
+    }
+
+    public function test_foreach_shaped_string_inside_php_block_does_not_fake_scope_local(): void
+    {
+        // Critical security regression: a directive-shaped string literal
+        // inside `@php` must not register fake scope-locals. Compile-time
+        // raw-block storage isolates the string, and `$y` is correctly
+        // surfaced as unsafe by the later raw echo.
+        $source = "@php \$s = '@foreach (\$x as \$y)'; @endphp\n{!! \$y !!}";
+
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertContains('y', $analysis->unsafeKeys);
+    }
+
+    public function test_layout_unknown_preserves_observed_unsafe_keys(): void
+    {
+        // UNKNOWN dominates the kind, but observed unsafe keys still appear
+        // in the analysis so handlers can surface them in diagnostics.
+        $source = <<<'BLADE'
+            @extends('layouts.app')
+            @section('body')
+                {!! $bio !!}
+            @endsection
+            BLADE;
+
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
+        $this->assertSame(['bio'], $analysis->unsafeKeys);
+    }
+
+    public function test_string_interpolation_inside_raw_echo_surfaces_inner_names(): void
+    {
+        /*
+         * `{!! "hello {$attacker}" !!}` compiles to an Echo wrapping a
+         * Scalar\InterpolatedString node. The walker recurses into its parts
+         * and surfaces every embedded variable as unsafe.
+         */
+        $analysis = $this->scanner->analyze('{!! "hello {$attacker}" !!}');
+
+        $this->assertSame(['attacker'], $analysis->unsafeKeys);
+    }
+
+    public function test_extends_first_directive_marks_template_unknown(): void
+    {
+        // `@extendsFirst([...])` compiles to a `$__env->first(...)->render()`
+        // call appended as a footer. The walker sees the cross-template flow.
+        $analysis = $this->scanner->analyze("@extendsFirst(['mobile.layout', 'desktop.layout'])");
+
+        $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
+        $this->assertNotEmpty($analysis->uncertainties);
+    }
+
+    public function test_has_stack_directive_marks_template_unknown(): void
+    {
+        $analysis = $this->scanner->analyze("@hasStack('scripts')\n  <div></div>\n@endif");
+
+        $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
+        $this->assertContains(BladeUncertaintyReason::LayoutSectionFlow, $analysis->uncertainties);
+    }
+
+    public function test_malformed_blade_returns_unknown(): void
+    {
+        // BladeCompiler throws on unbalanced directives. The scanner catches
+        // and emits UNKNOWN(UNPARSABLE_PHP_BLOCK).
+        $source = "@php this is not valid php @endphp";
+
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
+        $this->assertContains(BladeUncertaintyReason::UnparsablePhpBlock, $analysis->uncertainties);
+    }
+
+    public function test_unclosed_php_block_returns_unknown(): void
+    {
+        // BladeCompiler's storePhpBlocks regex requires a matching `@endphp`,
+        // so an unclosed `@php` falls through as literal text in compiled
+        // output. The scanner pre-detects the imbalance and emits
+        // UNKNOWN(UNPARSABLE_PHP_BLOCK) instead of letting the unclosed
+        // region slip through as SAFE.
+        $source = "@php \$x = 1; // forgot endphp\n{{ \$y }}";
+
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
+        $this->assertContains(BladeUncertaintyReason::UnparsablePhpBlock, $analysis->uncertainties);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function includeFamilyDirectiveProvider(): iterable
+    {
+        yield 'include' => ["@include('p.x')"];
+        yield 'includeIf' => ["@includeIf('p.x')"];
+        yield 'includeWhen' => ['@includeWhen($cond, \'p.x\')'];
+        yield 'includeUnless' => ['@includeUnless($cond, \'p.x\')'];
+        yield 'includeFirst' => ["@includeFirst(['a', 'b'])"];
+        yield 'each' => ['@each(\'p.row\', $rows, \'row\')'];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('includeFamilyDirectiveProvider')]
+    public function test_include_family_directive_marks_template_unknown(string $source): void
+    {
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
+        $this->assertContains(BladeUncertaintyReason::IncludeDirective, $analysis->uncertainties);
+    }
+
+    public function test_raw_echo_of_string_cast_surfaces_inner_variable(): void
+    {
+        // `(string) $tainted` does not sanitize HTML. Raw echo must
+        // surface `tainted` as an unsafe key.
+        $analysis = $this->scanner->analyze('{!! (string) $tainted !!}');
+
+        $this->assertSame(BladeViewSafetyKind::UnsafeKeys, $analysis->kind);
+        $this->assertSame(['tainted'], $analysis->unsafeKeys);
+    }
+
+    public function test_raw_echo_of_negation_surfaces_inner_variable(): void
+    {
+        $analysis = $this->scanner->analyze('{!! !$tainted !!}');
+
+        $this->assertSame(BladeViewSafetyKind::UnsafeKeys, $analysis->kind);
+        $this->assertSame(['tainted'], $analysis->unsafeKeys);
+    }
+
+    public function test_raw_echo_of_array_literal_surfaces_inner_variables(): void
+    {
+        $analysis = $this->scanner->analyze('{!! [$attacker][0] !!}');
+
+        $this->assertSame(BladeViewSafetyKind::UnsafeKeys, $analysis->kind);
+        $this->assertSame(['attacker'], $analysis->unsafeKeys);
+    }
+
+    public function test_raw_echo_of_match_expression_surfaces_inner_variables(): void
+    {
+        $source = '{!! match($t) { "html" => $rawHtml, default => "" } !!}';
+
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertSame(BladeViewSafetyKind::UnsafeKeys, $analysis->kind);
+        $this->assertContains('rawHtml', $analysis->unsafeKeys);
+    }
+
+    public function test_raw_echo_of_global_helper_call_marks_template_unknown(): void
+    {
+        // `{!! request()->input(...) !!}` is a canonical XSS source. The
+        // scanner cannot enumerate top-level vars from a global helper chain,
+        // so it conservatively classifies the template UNKNOWN with
+        // UNKNOWN_LOCAL_DEPENDENCY.
+        $analysis = $this->scanner->analyze("{!! request()->input('html') !!}");
+
+        $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
+        $this->assertContains(BladeUncertaintyReason::UnknownLocalDependency, $analysis->uncertainties);
+    }
+
+    public function test_variable_variable_raw_echo_marks_template_unknown(): void
+    {
+        // `{!! $$name !!}` and `{!! ${$expr} !!}` cannot be tracked to a
+        // top-level data key. The conservative fallback in classifyEcho
+        // surfaces this as UNKNOWN_LOCAL_DEPENDENCY instead of letting it
+        // slip through as SAFE.
+        $analysis = $this->scanner->analyze('{!! $$name !!}');
+
+        $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
+        $this->assertContains(BladeUncertaintyReason::UnknownLocalDependency, $analysis->uncertainties);
+    }
+
+    public function test_raw_echo_of_closure_invocation_marks_template_unknown(): void
+    {
+        // A closure result is opaque to the scanner; conservatively UNKNOWN.
+        $analysis = $this->scanner->analyze("{!! (fn () => 'x')() !!}");
+
+        $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
+        $this->assertContains(BladeUncertaintyReason::UnknownLocalDependency, $analysis->uncertainties);
+    }
+
+    public function test_raw_echo_of_string_literal_remains_safe(): void
+    {
+        // A literal raw echo carries no taint; the conservative fallback
+        // must not over-fire on this case.
+        $analysis = $this->scanner->analyze('{!! "literal" !!}');
+
+        $this->assertSame(BladeViewSafetyKind::Safe, $analysis->kind);
+    }
+
+    public function test_foreach_destructuring_value_var_binds_inner_locals(): void
+    {
+        // `@foreach ($pairs as [$k, $v]) {!! $v !!} @endforeach` — `$v` is
+        // bound by the destructuring, not by the view data array.
+        $source = <<<'BLADE'
+            @foreach ($pairs as [$k, $v])
+                {!! $v !!} {{ $k }}
+            @endforeach
+            BLADE;
+
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertSame(BladeViewSafetyKind::Safe, $analysis->kind);
+        $this->assertSame([], $analysis->unsafeKeys);
+    }
+
+    public function test_nested_destructuring_in_php_block_binds_inner_locals(): void
+    {
+        $source = "@php [\$a, [\$b, \$c]] = \$data; @endphp\n{!! \$b !!}";
+
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertSame(BladeViewSafetyKind::Safe, $analysis->kind);
+        $this->assertNotContains('b', $analysis->unsafeKeys);
+    }
+
+    public function test_e_with_two_arguments_is_not_treated_as_safe(): void
+    {
+        // `e($x, false)` disables double-encoding and is no longer a sound
+        // HTML wrapper. The walker falls back to RAW classification.
+        $analysis = $this->scanner->analyze('{!! e($x, false) !!}');
+
+        $this->assertSame(BladeViewSafetyKind::UnsafeKeys, $analysis->kind);
+        $this->assertSame(['x'], $analysis->unsafeKeys);
+    }
+
+    public function test_js_from_chained_to_html_is_treated_as_safe(): void
+    {
+        // `Js::from($data)->toHtml()` continues to produce HTML-safe output.
+        $analysis = $this->scanner->analyze('{!! ' . \Illuminate\Support\Js::class . '::from($data)->toHtml() !!}');
+
+        $this->assertSame(BladeViewSafetyKind::Safe, $analysis->kind);
+    }
+
+    public function test_multiple_uncertainties_accumulate_independently(): void
+    {
+        // The visitor collects every uncertainty it sees, without short-circuiting.
+        $source = <<<'BLADE'
+            @yield('content')
+            @include('partials.alert')
+            <x-button :label="$label" />
+            BLADE;
+
+        $uncertainties = $this->scanner->analyze($source)->uncertainties;
+
+        $this->assertContains(BladeUncertaintyReason::LayoutSectionFlow, $uncertainties);
+        $this->assertContains(BladeUncertaintyReason::IncludeDirective, $uncertainties);
+        $this->assertContains(BladeUncertaintyReason::ComponentTag, $uncertainties);
     }
 }


### PR DESCRIPTION
## Summary

Adds a tri-state Blade safety scanner that classifies every template as `SAFE`, `UNSAFE_KEYS`, or `UNKNOWN`. The integration layer (PR-3) can then distinguish "scanned and safe" from "scanner uncertain" instead of silently downgrading `UNKNOWN` to `SAFE`.

The scanner uses Laravel's own `BladeCompiler::compileString()` + `nikic/php-parser` AST walking. Both dependencies are already vendored (Laravel pulls the compiler; Psalm 7 pulls the parser). An earlier draft of this PR shipped a regex backend; that has been replaced entirely.

## Approach

```
source  --PsalmBladeCompiler::compileBladeSource-->  compiled PHP
        --PhpParser::parse-->  AST
        --BladeAstAnalysisVisitor walk-->  BladeTemplateAnalysis
```

The visitor records:

- raw-echoed top-level variables (`{!! $user->bio !!}` -> `user`)
- scope-locals from assignments and foreach value/key vars, including nested destructuring `[$a, [$b, $c]] = $data` and `foreach ($pairs as [$k, $v])`
- `$__env` method calls indicating layout / section / stack / include / component / fragment / translation flow
- `UNKNOWN_LOCAL_DEPENDENCY` as a conservative fallback when a raw echo's expression yields no top-level variables and is not a pure literal (catches `request()->input(...)`, variable variables, closure invocations)

`PsalmBladeCompiler` is a small subclass of Laravel's `BladeCompiler` that overrides `compileComponentTags()` to detect (not resolve) component tags so unregistered user components do not throw at analysis time, and patches an upstream raw-block placeholder restoration quirk when `@endphp` is immediately followed by `{{` / `{!!` / `{{{`. It owns a `Filesystem` and temp cache path; no Laravel container access required.

## Coverage gains over a regex backend

- `{!! e($x) !!}`, `{!! htmlspecialchars($x) !!}`, `{!! htmlentities($x) !!}`, `Js::from($x)->toHtml()` correctly classified ESCAPED
- `e($x, false)` and other multi-argument safe-wrapper forms fall through to RAW (the second argument disables double-encoding)
- Inline `@php($foo = expr)` and mid-condition assignments (`@if (count($rows) > 0 && $x = compute())`) register scope-locals correctly
- Casts (`(string) $x`, `!$x`, `-$x`), array literals, `match` expressions, string interpolation, method-call chains all recurse correctly
- Directive-shaped string literals inside `@php` / `@verbatim` cannot leak into uncertainty detection or fake scope-locals (Blade stores them as raw-block placeholders before any directive matching runs)

## Known limitations

- The visitor maintains a flat `scopeLocals` set across the whole template, so an assignment inside an inner closure or unreachable `@if` branch can filter the outer raw-echo classification. Push/pop scope frames is the fix; deferred to a follow-up.
- Line numbers in `BladeVariableUsage` reflect the compiled PHP, not the Blade source. `BladeCompiler` does not preserve a source map.

## Out of scope

- Psalm taint-graph integration (`BladeAwareViewTaintHandler`) - separate PR.
- Caching the safety map - separate PR.
- Resolving literal `@include('child')` by recursing into the child template - future PR.

## Verification

All toolchains pass:

- `composer test:unit` (548 tests, including 100 Blade tests)
- `composer test:type` (393 tests)
- `composer psalm` (clean)
- `composer cs` (clean)
- `composer rector` (clean)

Manual check against 5 real Laravel notification / mail templates (`vendor/laravel/framework/src/Illuminate/.../*.blade.php`) produces sensible classifications: `email.blade.php` -> UNKNOWN (component tag); `layout.blade.php` -> UNSAFE_KEYS (`head, header, slot, subcopy, footer`); `footer.blade.php` -> SAFE.