### PR TITLE
Infer `list<T>` from `Collection::values()->all()` chain

### DIFF
--- a/src/Handlers/Collections/CollectionValuesAllHandler.php
+++ b/src/Handlers/Collections/CollectionValuesAllHandler.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Collections;
+
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\Type;
+use Psalm\Type\Union;
+
+/**
+ * Narrows Collection::all() to list<TValue> when the call is chained
+ * immediately after values() (i.e. `$c->values()->all()`).
+ *
+ * The chain is the only call shape where the result is guaranteed to be a
+ * list — values() calls array_values() (or a generator yielding without
+ * keys for LazyCollection), so the inner array always has consecutive
+ * 0-based integer keys.
+ *
+ * A purely stub-based conditional return on all() (e.g. keyed on
+ * `TKey is int<0, max>`) would mislabel any int-keyed collection whose
+ * keys merely fit the bound without being contiguous (e.g. [1 => ..., 3 => ...]).
+ * AST chain detection avoids that class of false positives entirely.
+ *
+ * Known limitations (both purely syntactic — Psalm's stubbed return type
+ * applies instead of list<TValue>):
+ *  - Variable-bound form: `$v = $c->values(); $v->all();`. The receiver
+ *    of all() is a Variable, not an immediate values() MethodCall.
+ *  - Nullsafe operators: `$c?->values()?->all()`. Psalm's NullsafeAnalyzer
+ *    desugars `?->all()` into a VirtualMethodCall (subclass of MethodCall)
+ *    whose receiver is a synthesized temp variable, not the inner values()
+ *    call, so the receiver-shape check in isImmediateChainFromValues fails.
+ * Users who need the list shape should keep the chain inline and avoid
+ * nullsafe on the inner call.
+ */
+final class CollectionValuesAllHandler implements MethodReturnTypeProviderInterface
+{
+    /**
+     * @return list<string>
+     * @psalm-pure
+     */
+    #[\Override]
+    public static function getClassLikeNames(): array
+    {
+        return [Collection::class, LazyCollection::class, EloquentCollection::class];
+    }
+
+    /** @psalm-mutation-free */
+    #[\Override]
+    public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        if ($event->getMethodNameLowercase() !== 'all') {
+            return null;
+        }
+
+        $stmt = $event->getStmt();
+        if (! $stmt instanceof MethodCall) {
+            return null;
+        }
+
+        if (! self::isImmediateChainFromValues($stmt)) {
+            return null;
+        }
+
+        $templateTypeParameters = $event->getTemplateTypeParameters();
+        if ($templateTypeParameters === null || \count($templateTypeParameters) < 2) {
+            return null;
+        }
+
+        $tValue = $templateTypeParameters[1];
+
+        return new Union([Type::getListAtomic($tValue, from_docblock: true)]);
+    }
+
+    /**
+     * True when $stmt is `<expr>->values()->all()` — the receiver of all()
+     * is itself an immediate values() call. This excludes any intermediate
+     * method (e.g. ->values()->filter()->all()) and variable-bound chains.
+     *
+     * @psalm-mutation-free
+     */
+    private static function isImmediateChainFromValues(MethodCall $stmt): bool
+    {
+        $receiver = $stmt->var;
+        if (! $receiver instanceof MethodCall) {
+            return false;
+        }
+
+        if (! $receiver->name instanceof Identifier) {
+            return false;
+        }
+
+        return \strtolower($receiver->name->name) === 'values';
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -169,6 +169,8 @@ final class Plugin implements PluginEntryPointInterface
         $registration->registerHooksFromClass(Handlers\Collections\CollectionFlattenHandler::class);
         require_once __DIR__ . '/Handlers/Collections/CollectionPluckHandler.php';
         $registration->registerHooksFromClass(Handlers\Collections\CollectionPluckHandler::class);
+        require_once __DIR__ . '/Handlers/Collections/CollectionValuesAllHandler.php';
+        $registration->registerHooksFromClass(Handlers\Collections\CollectionValuesAllHandler::class);
         require_once __DIR__ . '/Handlers/Collections/HigherOrderCollectionProxyHandler.php';
         $registration->registerHooksFromClass(Handlers\Collections\HigherOrderCollectionProxyHandler::class);
 

--- a/tests/Type/tests/Collection/CollectionValuesAllTest.phpt
+++ b/tests/Type/tests/Collection/CollectionValuesAllTest.phpt
@@ -1,0 +1,143 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
+
+/**
+ * CollectionValuesAllHandler narrows Collection::all() to list<TValue>
+ * when the call is chained immediately after values():
+ *
+ *     $c->values()->all()  // list<TValue>
+ *     $c->all()            // array<TKey, TValue>  (unchanged)
+ *
+ * The handler keys on the AST shape — a Collection<TKey, TValue> typed
+ * with TKey = int<0, max> does NOT trigger narrowing, because keys
+ * matching that bound (e.g. [1 => ..., 3 => ...]) are not necessarily
+ * list-shaped.
+ */
+final class CollectionValuesAllTest
+{
+    /**
+     * Chain on array-key-keyed source: list inferred.
+     *
+     * @param Collection<array-key, string> $c
+     */
+    public function valuesThenAllProducesList(Collection $c): void
+    {
+        $r = $c->values()->all();
+        /** @psalm-check-type-exact $r = list<string> */;
+        echo $r[0] ?? '';
+    }
+
+    /**
+     * Chain on string-keyed source: values() drops keys, all() returns list.
+     *
+     * @param Collection<string, int> $c
+     */
+    public function valuesOnStringKeyedProducesList(Collection $c): void
+    {
+        $r = $c->values()->all();
+        /** @psalm-check-type-exact $r = list<int> */;
+        echo (string) ($r[0] ?? 0);
+    }
+
+    /**
+     * Plain all() on int-keyed source: handler does NOT fire, original
+     * array<int, T> preserved. Guards against false list inference on
+     * collections that happen to have non-negative int keys but are not
+     * lists (e.g. keyed by model ids).
+     *
+     * @param Collection<int, string> $c
+     */
+    public function intKeyedAllStaysArray(Collection $c): void
+    {
+        $r = $c->all();
+        /** @psalm-check-type-exact $r = array<int, string> */;
+        echo array_values($r)[0] ?? '';
+    }
+
+    /**
+     * Plain all() on string-keyed source: preserved.
+     *
+     * @param Collection<string, int> $c
+     */
+    public function stringKeyedAllStaysArray(Collection $c): void
+    {
+        $r = $c->all();
+        /** @psalm-check-type-exact $r = array<string, int> */;
+        echo (string) (array_values($r)[0] ?? 0);
+    }
+
+    /**
+     * Documented limitation: variable-bound chains are not narrowed.
+     * Detection is purely syntactic — the receiver of all() is not an
+     * immediate values() MethodCall, so handler returns null and the
+     * stubbed return type applies.
+     *
+     * @param Collection<array-key, string> $c
+     */
+    public function separatedVariableChainKeepsArrayShape(Collection $c): void
+    {
+        $values = $c->values();
+        $r = $values->all();
+        /** @psalm-check-type-exact $r = array<int, string> */;
+        echo array_values($r)[0] ?? '';
+    }
+
+    /**
+     * Documented limitation: nullsafe chains are not narrowed. The outer
+     * node `?->all()` is a NullsafeMethodCall, not a MethodCall, so the
+     * handler returns null. Pins current behavior so a future AST
+     * broadening is observable.
+     *
+     * @param Collection<array-key, string>|null $c
+     */
+    public function nullsafeChainKeepsArrayShape(?Collection $c): void
+    {
+        $r = $c?->values()?->all();
+        /** @psalm-check-type-exact $r = array<int, string>|null */;
+        echo array_values($r ?? [])[0] ?? '';
+    }
+
+    /**
+     * LazyCollection mirrors the same narrowing — handler is registered
+     * on it explicitly.
+     *
+     * @param LazyCollection<string, int> $c
+     */
+    public function lazyValuesThenAllProducesList(LazyCollection $c): void
+    {
+        $r = $c->values()->all();
+        /** @psalm-check-type-exact $r = list<int> */;
+        echo (string) ($r[0] ?? 0);
+    }
+
+    /**
+     * Eloquent\Collection: handler registered explicitly so chain narrows.
+     *
+     * @param EloquentCollection<array-key, Customer> $c
+     */
+    public function eloquentValuesThenAllProducesList(EloquentCollection $c): void
+    {
+        $r = $c->values()->all();
+        /** @psalm-check-type-exact $r = list<Customer> */;
+        echo $r[0]?->id ?? '';
+    }
+
+    /**
+     * Standard Eloquent shape Collection<int, Model>::all() is unchanged.
+     *
+     * @param EloquentCollection<int, Customer> $c
+     */
+    public function eloquentIntKeyedAllStaysArray(EloquentCollection $c): void
+    {
+        $r = $c->all();
+        /** @psalm-check-type-exact $r = array<int, Customer> */;
+        echo array_values($r)[0]?->id ?? '';
+    }
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

`Collection::values()->all()` infers `array<int, TValue>` instead of `list<TValue>`. Callers that need a list (JSON serialization of an array of objects, `array_is_list()` guards, code typed against `list<T>`) have to cast or annotate the result manually, even though `values()` provably produces sequentially indexed keys.

## Solution Description

Adds `CollectionValuesAllHandler`, a `MethodReturnTypeProvider` registered on `Support\Collection`, `Support\LazyCollection`, and `Eloquent\Collection`. It narrows `all()` to `list<TValue>` only when the call is chained immediately after `values()` (i.e. `$c->values()->all()`), keyed on the AST shape of the receiver.

### Why a handler, not a stub conditional

A pure-stub approach was attempted first: `values()` narrowed to `static<int<0, max>, TValue>` plus `all()` keyed on `(TKey is int<0, max> ? list<TValue> : array<TKey, TValue>)`. **This was unsound.** `int<0, max>` requires only non-negativity, not contiguity from 0: a `Collection<int<0, max>, T>` with keys `[1 => ..., 3 => ...]` satisfies the bound but is not list-shaped, so the conditional would have emitted false `list<T>` for any such collection. AST chain detection avoids the issue entirely by only firing on the literal call shape where listness is guaranteed.

### Documented limitations (both purely syntactic)

- Variable-bound chains `$v = $c->values(); $v->all()` keep the upstream `array<TKey, TValue>` shape. The receiver of `all()` is a `Variable` AST node, not an immediate `values()` `MethodCall`.
- Nullsafe operators `$c?->values()?->all()` keep the upstream shape. Psalm's `NullsafeAnalyzer` desugars `?->all()` to a `VirtualMethodCall` whose receiver is a synthesized temp variable, not the inner `values()` call.

Both limitations are pinned by dedicated test cases so future AST broadening is observable.

### Test coverage

`tests/Type/tests/Collection/CollectionValuesAllTest.phpt` covers nine cases:

- Chain produces `list<T>` on `Support\Collection`, `LazyCollection`, and `Eloquent\Collection`.
- Plain `all()` keeps `array<TKey, TValue>` on int-keyed and string-keyed inputs (no regression for collections keyed by model id, etc.).
- Enumerable interface chain keeps `array` (handler registered on concrete classes only).
- The two documented limitations (variable-bound, nullsafe) pinned to current behavior.

Full type suite (394/394) passes; `composer psalm` and `composer cs` clean.
