### PR TITLE
feat(blade): refine view() data taint via BladeSafetyMap #581

### DIFF
--- a/docs/issues/581-blade-taint-exploration.md
+++ b/docs/issues/581-blade-taint-exploration.md
@@ -8,6 +8,35 @@ nav_exclude: true
 
 Exploration document for [issue #581](https://github.com/psalm/psalm-plugin-laravel/issues/581).
 
+## Delivery and merge strategy
+
+The work lands in incremental sub-PRs that all target the umbrella branch
+[`worktree-581-blade-taint-exploration`](https://github.com/psalm/psalm-plugin-laravel/pull/872),
+not `master`. Merging the scanner epic piecewise into `master` would expose
+half-implementations (e.g. a scanner that classifies templates but no handler
+that consumes the classification), so each sub-PR stacks on the umbrella
+branch and is reviewed against it. Once every sub-PR (PR-1 through PR-5)
+is merged into the umbrella branch, the umbrella PR ships into `master` as
+a single reviewable unit.
+
+Status of the epic at the time of writing:
+
+| PR | Scope | Status |
+|----|-------|--------|
+| PR-1 [#920](https://github.com/psalm/psalm-plugin-laravel/pull/920) | Tri-state scanner via `BladeCompiler` + php-parser. `BladeViewSafetyKind`, `BladeUncertaintyReason`, `BladeSafetyMap`. | merged into umbrella |
+| PR-2 (TBD) | First-pass scanner precision: `@include` literal resolution, scope frame push/pop, source-mapped line numbers. | not started |
+| PR-3 (this PR) | `BladeAwareViewTaintHandler`. Wires `BladeSafetyMap` into Psalm's taint flow for `view()` / `Factory::make()` / facade `View::make()`. Per-key sinks for `UNSAFE_KEYS`, whole-data fallback for `UNKNOWN` and dynamic view names. | shipping |
+| PR-4 (TBD) | `Factory::first()` (union of safety records), `Factory::renderEach()` (per-iterator key shape), `ResponseFactory::view()`. Cross-template `@include` data-flow propagation when the include target is literal. | not started |
+| PR-5 (TBD) | Component data flow (`<x-foo :bar="$data" />`), section graph, scanner result caching across analysis runs. | not started |
+
+PR-3 deliberately does NOT include integration tests under `tests/Application/`.
+The Application test harness (`tests/Application/laravel-test.sh`) runs Psalm
+without `--taint-analysis`, so a taint-validating fixture would require either
+a new harness flow or a refactor of the existing one. The handler is covered
+end-to-end by `tests/Type/tests/Blade/` (PHPT) and unit tests; the Application
+test layer still exercises Plugin.php's boot path through `initBladeAwareViewTaintHandler`,
+so a boot crash would still surface there.
+
 ## Current state (baseline)
 
 After the regression in [#684](https://github.com/psalm/psalm-plugin-laravel/issues/684), all `html` taint sinks on view data parameters were removed:
@@ -169,9 +198,9 @@ Known v1 limitations:
 
 ### What the prototype deliberately does not include
 
-- **Plugin integration.** Wiring the map into a handler requires adding a taint sink via `Codebase::$taint_flow_graph`. The API surface exists (see "Psalm API notes" below) but the integration belongs in the actual PR, not the spike.
-- **Cross file data flow.** `@include('child', ['x' => $y])` is not propagated. A safe default is to treat a template with any unresolved `@include` call as "all keys unsafe", reverting to the conservative whole array sink for that template only.
-- **Components.** `<x-foo :bar="$data" />` is out of scope for v1.
+- **Plugin integration.** ~~Wiring the map into a handler requires adding a taint sink via `Codebase::$taint_flow_graph`. The API surface exists (see "Psalm API notes" below) but the integration belongs in the actual PR, not the spike.~~ Delivered in PR-3 (this PR) as `BladeAwareViewTaintHandler`. Reads the map at every `view()` / `Factory::make()` / facade `View::make()` call, dispatches per safety kind: SAFE no-op, UNSAFE_KEYS per-key html sink, UNKNOWN whole-data sink, dynamic view name whole-data sink. Boots once per analysis run in `Plugin::initBladeAwareViewTaintHandler()`; gated on `taint_flow_graph !== null` so non-taint runs pay no scan cost.
+- **Cross file data flow.** `@include('child', ['x' => $y])` is not propagated. A safe default is to treat a template with any unresolved `@include` call as "all keys unsafe", reverting to the conservative whole array sink for that template only. PR-3 implements this fallback by classifying the parent as UNKNOWN(IncludeDirective); PR-4 will resolve literal include targets and propagate the child's unsafe-keys into the parent.
+- **Components.** `<x-foo :bar="$data" />` is out of scope for v1. PR-5 territory.
 
 ## Psalm API notes (for the integration PR)
 

--- a/src/Handlers/Views/BladeAwareViewTaintHandler.php
+++ b/src/Handlers/Views/BladeAwareViewTaintHandler.php
@@ -1,0 +1,780 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Views;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\ArrayItem;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Scalar\Int_;
+use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Scalar\String_;
+use Psalm\Codebase;
+use Psalm\CodeLocation;
+use Psalm\Internal\Codebase\TaintFlowGraph;
+use Psalm\Internal\DataFlow\DataFlowNode;
+use Psalm\LaravelPlugin\Blade\BladeSafetyMap;
+use Psalm\LaravelPlugin\Blade\BladeViewSafety;
+use Psalm\LaravelPlugin\Blade\BladeViewSafetyKind;
+use Psalm\Plugin\EventHandler\AfterFunctionCallAnalysisInterface;
+use Psalm\Plugin\EventHandler\AfterMethodCallAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterFunctionCallAnalysisEvent;
+use Psalm\Plugin\EventHandler\Event\AfterMethodCallAnalysisEvent;
+use Psalm\StatementsSource;
+use Psalm\Type\TaintKind;
+use Psalm\Type\Union;
+
+/**
+ * Bridge {@see BladeSafetyMap} into Psalm's taint flow graph for `view()` /
+ * `View::make()` / `Factory::make()` / `Factory::renderWhen()` /
+ * `Factory::renderUnless()` call sites.
+ *
+ * Per-call refinement rules (see PR #872 and PR-3 brief in issue #581):
+ *
+ *  - SAFE         — do nothing. The template auto-escapes every echo of its
+ *                   top-level data keys, so passing tainted html through is
+ *                   not exploitable. No sink is installed.
+ *  - UNSAFE_KEYS  — install an `html` taint sink on the data-array entry for
+ *                   each key the scanner observed reaching a raw echo
+ *                   ({!! ... !!} or @php).
+ *  - UNKNOWN      — install an `html` taint sink on every entry of the data
+ *                   array. The scanner could not prove which keys are safe
+ *                   (cross-template flow, unparsable @php, file unreadable),
+ *                   so all keys must be treated as potentially raw output.
+ *  - dynamic name — same fallback as UNKNOWN. A non-literal view name means
+ *                   the call site cannot resolve the template at analysis
+ *                   time, so every key is conservatively tainted. Matches
+ *                   {@see \Psalm\LaravelPlugin\Blade\BladeUncertaintyReason::DynamicViewName}.
+ *
+ * A view absent from the map (typo, package view not under the configured
+ * roots) gets no sink. {@see MissingViewHandler} already reports the typo
+ * separately; double-reporting through taint would be noise. Both handlers
+ * coexist by design — the missing-view diagnostic and the taint refinement
+ * answer different questions about the same call site.
+ *
+ * `$mergeData` (the third argument on `view()` / `Factory::make()`) feeds the
+ * same `extract()` call as `$data`, so it is subjected to identical rules:
+ * the keys observed by the scanner apply to either source.
+ *
+ * Out of scope (handled in PR-4 onwards, tracked under issue #581):
+ *  - `@include('child', [...])` propagation into the parent template's safety
+ *    record. The scanner flags any include as UNKNOWN, so the conservative
+ *    fallback already covers it; PR-4 will narrow this.
+ *  - Component data flow (`<x-foo :bar="$data" />`).
+ *  - `Factory::first(array $views, ...)` and `Factory::renderEach()`. `first()`
+ *    needs a union over multiple template safety records; `renderEach()` has a
+ *    different argument shape (`$data` is a collection, `$iterator` names the
+ *    per-item variable, the template echoes `$iterator` not data-array keys).
+ *    Both fold into the same dispatch helper but require extra wiring beyond
+ *    the scope of this PR.
+ *  - `ResponseFactory::view()`. Same shape as `Factory::make()` but on a
+ *    different service class; will follow once PR-3 stabilises the per-call
+ *    sink construction.
+ *
+ * Stability: the taint sink construction uses Psalm's internal classes
+ * {@see TaintFlowGraph} and {@see DataFlowNode}, both `@internal` in
+ * `vimeo/psalm`. The plugin already depends on these for the validation taint
+ * removal path; if Psalm 7.x changes the API, the validation handler will
+ * also break, and the fix lands in both places at once.
+ *
+ * @internal
+ */
+final class BladeAwareViewTaintHandler implements
+    AfterFunctionCallAnalysisInterface,
+    AfterMethodCallAnalysisInterface
+{
+    /**
+     * The `view()` helper as registered in Laravel's global function table.
+     * Compared against the lowercased form of
+     * {@see AfterFunctionCallAnalysisEvent::getFunctionId()}.
+     *
+     * Psalm preserves the call-site casing in `function_id` (only the leading
+     * backslash is stripped), so we lower-case explicitly before comparing to
+     * cover `\View(...)` / `\VIEW(...)` and any other legal-but-unusual casing.
+     * Most Laravel codebases write `view(...)`, but the normalisation is cheap
+     * insurance against a missed taint sink when a stray uppercase slips in.
+     */
+    private const FUNCTION_VIEW = 'view';
+
+    /**
+     * Synthetic stable id used as the `method_id` for our generated sink nodes.
+     * The id is intentionally NOT a real Laravel method — that would collide
+     * with sinks installed elsewhere (e.g. by future taint annotations on
+     * `Factory::make`). The constant prefix plus the per-call CodeLocation
+     * specialisation produces unique node ids per call site.
+     */
+    private const SINK_METHOD_ID = 'laravel-blade-view-data';
+
+    private const SINK_CASED_METHOD_ID = 'Laravel\\Blade\\ViewData';
+
+    /**
+     * The data-key sink uses argument offset 0 because the synthetic
+     * "function" has only one logical parameter: the value being rendered.
+     * The DataFlowNode label encodes the per-key identity via the cased id
+     * suffix; offset is just plumbing for {@see DataFlowNode::getForMethodArgument()}.
+     */
+    private const SINK_ARG_OFFSET = 0;
+
+    private static ?BladeSafetyMap $map = null;
+
+    /**
+     * Method-id → argument shape descriptor. Built once at init from
+     * {@see \Illuminate\View\Factory::class} plus its facade classes (so calls
+     * like `\View::make()` route through the same dispatch). Keyed by the
+     * lower-cased method id Psalm emits in {@see AfterMethodCallAnalysisEvent::getMethodId()}.
+     *
+     * @var array<lowercase-string, MakeLikeMethodSpec>
+     */
+    private static array $methodSpecs = [];
+
+    private static bool $enabled = false;
+
+    /**
+     * Initialise the handler with the safety map and the set of facade classes
+     * that proxy to {@see \Illuminate\View\Factory}. Idempotent: callers may
+     * invoke this multiple times during a single analysis run.
+     *
+     * @param list<class-string> $factoryFacadeClasses additional class names whose
+     *                                                 `::make()` should be treated
+     *                                                 as a Blade view call site
+     *
+     * @psalm-external-mutation-free
+     */
+    public static function init(BladeSafetyMap $map, array $factoryFacadeClasses = []): void
+    {
+        self::$map = $map;
+        self::$enabled = true;
+        self::$methodSpecs = self::buildMethodSpecs($factoryFacadeClasses);
+    }
+
+    /**
+     * Exposed for tests; production code re-initialises by calling
+     * {@see self::init()} again. Marked `@psalm-api` so the self-analysis
+     * pass does not flag it as unused: the only call site lives under
+     * `tests/`, which is excluded from `composer psalm`.
+     *
+     * @internal
+     *
+     * @psalm-api
+     * @psalm-external-mutation-free
+     */
+    public static function reset(): void
+    {
+        self::$map = null;
+        self::$methodSpecs = [];
+        self::$enabled = false;
+    }
+
+    /** @inheritDoc */
+    #[\Override]
+    public static function afterFunctionCallAnalysis(AfterFunctionCallAnalysisEvent $event): void
+    {
+        if (!self::$enabled || !self::$map instanceof \Psalm\LaravelPlugin\Blade\BladeSafetyMap) {
+            return;
+        }
+
+        if (\strtolower($event->getFunctionId()) !== self::FUNCTION_VIEW) {
+            return;
+        }
+
+        $taintGraph = $event->getCodebase()->taint_flow_graph;
+
+        if (!$taintGraph instanceof \Psalm\Internal\Codebase\TaintFlowGraph) {
+            return;
+        }
+
+        $args = $event->getExpr()->getArgs();
+
+        if ($args === []) {
+            return;
+        }
+
+        self::dispatchSinks(
+            map: self::$map,
+            viewArg: $args[0],
+            dataArg: $args[1] ?? null,
+            mergeDataArg: $args[2] ?? null,
+            source: $event->getStatementsSource(),
+            codebase: $event->getCodebase(),
+            taintGraph: $taintGraph,
+        );
+    }
+
+    /** @inheritDoc */
+    #[\Override]
+    public static function afterMethodCallAnalysis(AfterMethodCallAnalysisEvent $event): void
+    {
+        if (!self::$enabled || !self::$map instanceof \Psalm\LaravelPlugin\Blade\BladeSafetyMap) {
+            return;
+        }
+
+        // Cheap suffix gate first to avoid allocating a lowercased copy of every
+        // method id Psalm hands us. `MethodIdentifier` guarantees the method-name
+        // suffix is already lowercase (vendor/vimeo/psalm/.../MethodIdentifier.php
+        // declares `lowercase-string $method_name`), so a literal substring match
+        // is sound and allocation-free. This handler hooks every method call in
+        // the analyzed codebase; skipping `strtolower` on the >99% reject path
+        // is a measurable analysis-time win on large projects.
+        $methodId = $event->getMethodId();
+
+        if (!self::isViewLikeMethodId($methodId)) {
+            // Facade aliases may inherit make() rather than re-declare it, so
+            // also probe the appearing id. Same suffix gate.
+            $methodId = $event->getAppearingMethodId();
+
+            if (!self::isViewLikeMethodId($methodId)) {
+                return;
+            }
+        }
+
+        // We deliberately check both the resolved and the appearing method ids
+        // so facade aliases (which inherit `make()` rather than re-declaring
+        // it) are also caught when the resolved id is a non-Factory class.
+        $spec = self::$methodSpecs[\strtolower($methodId)]
+            ?? self::$methodSpecs[\strtolower($event->getAppearingMethodId())]
+            ?? null;
+
+        if ($spec === null) {
+            return;
+        }
+
+        $taintGraph = $event->getCodebase()->taint_flow_graph;
+
+        if (!$taintGraph instanceof \Psalm\Internal\Codebase\TaintFlowGraph) {
+            return;
+        }
+
+        $args = $event->getExpr()->getArgs();
+
+        if (!isset($args[$spec->viewArgIndex])) {
+            return;
+        }
+
+        self::dispatchSinks(
+            map: self::$map,
+            viewArg: $args[$spec->viewArgIndex],
+            dataArg: $args[$spec->dataArgIndex] ?? null,
+            mergeDataArg: $spec->mergeDataArgIndex !== null
+                ? ($args[$spec->mergeDataArgIndex] ?? null)
+                : null,
+            source: $event->getStatementsSource(),
+            codebase: $event->getCodebase(),
+            taintGraph: $taintGraph,
+        );
+    }
+
+    /**
+     * Walk both data arguments and install the right sinks for the resolved
+     * safety record. Extracted so the function and method entry points share
+     * the same logic.
+     */
+    private static function dispatchSinks(
+        BladeSafetyMap $map,
+        Arg $viewArg,
+        ?Arg $dataArg,
+        ?Arg $mergeDataArg,
+        StatementsSource $source,
+        Codebase $codebase,
+        TaintFlowGraph $taintGraph,
+    ): void {
+        // No data array means nothing to sink. `view('home')` with zero
+        // arguments is the most common shape and short-circuits cleanly here.
+        if (!$dataArg instanceof \PhpParser\Node\Arg && !$mergeDataArg instanceof \PhpParser\Node\Arg) {
+            return;
+        }
+
+        $viewName = self::literalString($viewArg);
+
+        if ($viewName === null) {
+            // Dynamic view name: handler cannot resolve which template will
+            // render, so apply the conservative whole-data fallback. This is
+            // the documented `BladeUncertaintyReason::DynamicViewName` policy.
+            self::installWholeDataSink('<dynamic>', $dataArg, $source, $codebase, $taintGraph);
+            self::installWholeDataSink('<dynamic>', $mergeDataArg, $source, $codebase, $taintGraph);
+
+            return;
+        }
+
+        $safety = $map->safetyFor($viewName);
+
+        if (!$safety instanceof \Psalm\LaravelPlugin\Blade\BladeViewSafety) {
+            // View not in the map. Could be a typo (MissingViewHandler already
+            // reports that), a namespaced view from a package the scanner did
+            // not see, or a view added after the map was built. We deliberately
+            // do NOT fall back to the whole-data sink here: it would either
+            // duplicate the missing-view diagnostic with a less-actionable
+            // signal, or introduce false positives on package views the user
+            // cannot influence.
+            return;
+        }
+
+        match ($safety->kind()) {
+            BladeViewSafetyKind::Safe => null,
+            BladeViewSafetyKind::UnsafeKeys => self::installUnsafeKeySinks(
+                $viewName,
+                $safety,
+                $dataArg,
+                $mergeDataArg,
+                $source,
+                $codebase,
+                $taintGraph,
+            ),
+            BladeViewSafetyKind::Unknown => self::installUnknownFallback(
+                $viewName,
+                $dataArg,
+                $mergeDataArg,
+                $source,
+                $codebase,
+                $taintGraph,
+            ),
+        };
+    }
+
+    private static function installUnsafeKeySinks(
+        string $viewName,
+        BladeViewSafety $safety,
+        ?Arg $dataArg,
+        ?Arg $mergeDataArg,
+        StatementsSource $source,
+        Codebase $codebase,
+        TaintFlowGraph $taintGraph,
+    ): void {
+        $unsafeKeys = $safety->unsafeKeys();
+
+        if ($unsafeKeys === []) {
+            // Defensive: UnsafeKeys analysis MUST have at least one key.
+            // BladeTemplateAnalysis::unsafeKeys() coerces empty lists to Safe,
+            // so this branch is unreachable through the factory. Falling back
+            // to whole-data on an empty unsafe-key list would be the wrong
+            // signal — bail instead.
+            return;
+        }
+
+        foreach ([$dataArg, $mergeDataArg] as $arg) {
+            if (!$arg instanceof \PhpParser\Node\Arg) {
+                continue;
+            }
+
+            self::installSinksForArg($viewName, $arg, $unsafeKeys, $source, $codebase, $taintGraph);
+        }
+    }
+
+    /**
+     * @param list<non-empty-string> $unsafeKeys
+     */
+    private static function installSinksForArg(
+        string $viewName,
+        Arg $arg,
+        array $unsafeKeys,
+        StatementsSource $source,
+        Codebase $codebase,
+        TaintFlowGraph $taintGraph,
+    ): void {
+        $arrayLiteral = self::asArrayLiteral($arg);
+
+        if (!$arrayLiteral instanceof \PhpParser\Node\Expr\Array_) {
+            // Cannot map keys without an inline array literal. Apply the
+            // conservative whole-data sink so untracked keys still surface.
+            self::installWholeDataSink($viewName, $arg, $source, $codebase, $taintGraph);
+
+            return;
+        }
+
+        $unsafeKeyLookup = \array_fill_keys($unsafeKeys, true);
+
+        foreach ($arrayLiteral->items as $item) {
+            if ($item === null) {
+                continue;
+            }
+
+            $key = self::literalArrayKey($item);
+
+            if ($key === null || !isset($unsafeKeyLookup[$key])) {
+                continue;
+            }
+
+            self::installSinkForExpression(
+                viewName: $viewName,
+                key: $key,
+                expr: $item->value,
+                source: $source,
+                codebase: $codebase,
+                taintGraph: $taintGraph,
+            );
+        }
+    }
+
+    private static function installUnknownFallback(
+        string $viewName,
+        ?Arg $dataArg,
+        ?Arg $mergeDataArg,
+        StatementsSource $source,
+        Codebase $codebase,
+        TaintFlowGraph $taintGraph,
+    ): void {
+        self::installWholeDataSink($viewName, $dataArg, $source, $codebase, $taintGraph);
+        self::installWholeDataSink($viewName, $mergeDataArg, $source, $codebase, $taintGraph);
+    }
+
+    /**
+     * Install an `html` sink on every value of the data argument, regardless
+     * of key. Used for UNKNOWN templates, dynamic view names, and the
+     * non-array-literal fallback in UNSAFE_KEYS handling.
+     *
+     * If the data argument is an inline array literal we iterate items and
+     * sink each value individually, so per-item parent nodes are picked up.
+     * Otherwise we attach a single sink to the whole argument's value
+     * expression — Psalm's array-value flow propagates element taints through
+     * that node.
+     */
+    private static function installWholeDataSink(
+        string $viewName,
+        ?Arg $arg,
+        StatementsSource $source,
+        Codebase $codebase,
+        TaintFlowGraph $taintGraph,
+    ): void {
+        if (!$arg instanceof \PhpParser\Node\Arg) {
+            return;
+        }
+
+        $arrayLiteral = self::asArrayLiteral($arg);
+
+        if ($arrayLiteral instanceof \PhpParser\Node\Expr\Array_) {
+            foreach ($arrayLiteral->items as $item) {
+                if ($item === null) {
+                    continue;
+                }
+
+                $key = self::literalArrayKey($item) ?? '<entry>';
+
+                self::installSinkForExpression(
+                    viewName: $viewName,
+                    key: $key,
+                    expr: $item->value,
+                    source: $source,
+                    codebase: $codebase,
+                    taintGraph: $taintGraph,
+                );
+            }
+
+            return;
+        }
+
+        // Non-literal data argument (e.g. `view('x', $data)`). Sink the value
+        // expression itself; Psalm's array-arg flow plumbs element taints
+        // through the argument's parent nodes.
+        self::installSinkForExpression(
+            viewName: $viewName,
+            key: '<argument>',
+            expr: $arg->value,
+            source: $source,
+            codebase: $codebase,
+            taintGraph: $taintGraph,
+        );
+    }
+
+    /**
+     * Attach an `html` sink to the given expression's data-flow parent nodes.
+     *
+     * Sink identity has two components:
+     *  - the `method_id` carries the view name and key so two keys in the same
+     *    call site produce distinct node ids. Without this, both
+     *    `view('post', ['bio' => $a, 'title' => $b])` keys would hash to the
+     *    same `laravel-blade-view-data#1` id and the second sink would
+     *    silently overwrite the first inside {@see TaintFlowGraph::$sinks}.
+     *  - the {@see CodeLocation} drives the per-call specialisation, keeping
+     *    sinks from two different call sites distinct even when they target
+     *    the same `(view, key)` pair.
+     *
+     * The cased label restates the same identity in a user-readable form;
+     * Psalm surfaces it as the sink description on every TaintedHtml report.
+     */
+    private static function installSinkForExpression(
+        string $viewName,
+        string $key,
+        Expr $expr,
+        StatementsSource $source,
+        Codebase $codebase,
+        TaintFlowGraph $taintGraph,
+    ): void {
+        $type = $source->getNodeTypeProvider()->getType($expr);
+
+        if (!$type instanceof \Psalm\Type\Union || $type->parent_nodes === []) {
+            // No data-flow nodes means no taint can reach the sink. Skip the
+            // allocation rather than create a dead sink — the latter would
+            // bloat the graph during whole-program analysis.
+            return;
+        }
+
+        $codeLocation = new CodeLocation($source, $expr);
+
+        // Encode (view, key) into the method id so two keys in the same call
+        // produce distinct node ids. The cased id mirrors the structure for
+        // human-readable diagnostics. Non-alphanumeric characters in the view
+        // name (dotted form, package `::` prefix) are passed through verbatim:
+        // they cannot collide with PHP identifiers, so the resulting node id
+        // stays unique.
+        $methodId = self::SINK_METHOD_ID . '::' . $viewName . '::' . $key;
+        $casedMethodId = self::SINK_CASED_METHOD_ID . "({$viewName}, '{$key}')";
+
+        $sink = DataFlowNode::getForMethodArgument(
+            $methodId,
+            $casedMethodId,
+            self::SINK_ARG_OFFSET,
+            $codeLocation,
+            $codeLocation,
+            TaintKind::INPUT_HTML,
+        );
+
+        $taintGraph->addSink($sink);
+
+        foreach ($type->parent_nodes as $parentNode) {
+            // Pass 0 for $added_taints, NOT INPUT_HTML. The 4th argument to
+            // addPath is the edge's added-taints delta, not the sink's
+            // matching kind. The sink's own taint kind (set via the 6th arg
+            // of getForMethodArgument above) gates which kinds trigger the
+            // TaintedHtml report. Adding INPUT_HTML on the edge would lift
+            // unrelated taints (e.g. INPUT_SQL from a narrow custom source)
+            // up to INPUT_HTML mid-flow and produce false-positive
+            // TaintedHtml reports. See vendor/vimeo/psalm/src/Psalm/Internal/
+            // Codebase/TaintFlowGraph.php and ArgumentAnalyzer.php for the
+            // canonical pattern: added_taints is the call-site's dispatched
+            // delta (usually 0), removed_taints likewise.
+            $taintGraph->addPath($parentNode, $sink, 'arg');
+        }
+    }
+
+    /**
+     * Suffix-based fast reject for the method-call hot path. Matches the
+     * method-name portion of a Psalm method id (`Class::method`) against the
+     * known view-creating method names. Allocation-free; designed to run on
+     * every method call analysed.
+     *
+     * Stays in sync with {@see buildMethodSpecs()}: every method name added
+     * there must appear here. The keys table holds the actual class-bound
+     * lookups; this gate just skips the lowercased-id cost for the >99% of
+     * calls that miss.
+     *
+     * Suffixes are written in lowercase only. Psalm's
+     * {@see \Psalm\Internal\MethodIdentifier} declares `lowercase-string
+     * $method_name`, so the method-name part of every emitted method id is
+     * already lowercased — a camelCase suffix would never match in production.
+     *
+     * @psalm-pure
+     */
+    private static function isViewLikeMethodId(string $methodId): bool
+    {
+        return \str_ends_with($methodId, '::make')
+            || \str_ends_with($methodId, '::renderwhen')
+            || \str_ends_with($methodId, '::renderunless');
+    }
+
+    /**
+     * Extract a literal string view name from an argument, or null if the
+     * value is dynamic. Matches {@see MissingViewHandler}'s policy: only
+     * source-visible literal names are mapped.
+     *
+     * @psalm-mutation-free
+     */
+    private static function literalString(Arg $arg): ?string
+    {
+        if ($arg->value instanceof String_) {
+            return $arg->value->value;
+        }
+
+        return null;
+    }
+
+    /**
+     * Inline array-literal helper. Returns null for variable args, function
+     * calls, or any other non-literal expression.
+     *
+     * Rejection cases:
+     *  - argument-level spread (`view(...$args)`) — the argument itself is a
+     *    spread, so the whole-arg sink fallback applies.
+     *  - inline array-item spread (`view('x', ['safe' => $a, ...$rest])`) —
+     *    an inner spread item contributes opaque keys we cannot enumerate.
+     *    Map-driven per-key dispatch would silently miss unsafe keys hiding
+     *    in `$rest`, so we conservatively fall through to the whole-arg sink.
+     *
+     * @psalm-mutation-free
+     */
+    private static function asArrayLiteral(Arg $arg): ?Array_
+    {
+        if ($arg->unpack) {
+            return null;
+        }
+
+        if (!$arg->value instanceof Array_) {
+            return null;
+        }
+
+        // Reject the array if any item carries a key shape we cannot enumerate
+        // at analysis time:
+        //  - spread items (`...$rest`) — runtime keys are opaque.
+        //  - dynamic keys (`[$maybeKey => $value]`) — extract() binds whatever
+        //    `$maybeKey` evaluates to, which could collide with an unsafe key
+        //    in UNSAFE_KEYS mode and silently miss the sink.
+        // Integer literal keys (`[0 => $x]`) and list-style entries (`[$x]`)
+        // are NOT rejected here — they reach `literalArrayKey()` and return
+        // null because extract() drops them, so they cannot bind a variable
+        // name in the Blade template.
+        foreach ($arg->value->items as $item) {
+            if ($item === null) {
+                continue;
+            }
+
+            if ($item->unpack) {
+                return null;
+            }
+
+            $key = $item->key;
+
+            if ($key === null) {
+                // List-style entry; extract() drops it.
+                continue;
+            }
+
+            if ($key instanceof String_) {
+                // Literal string key; literalArrayKey decides identifier-ness.
+                continue;
+            }
+
+            if ($key instanceof LNumber || $key instanceof Int_) {
+                // Integer literal key; extract() drops it. Two class names
+                // because php-parser renamed LNumber→Int_ in 5.x; we accept
+                // both for forward compatibility.
+                continue;
+            }
+
+            // Any other expression (Variable, FuncCall, MethodCall, etc.)
+            // could resolve at runtime to a string that matches an unsafe
+            // key. Bail out so the caller falls through to the conservative
+            // whole-arg sink.
+            return null;
+        }
+
+        return $arg->value;
+    }
+
+    /**
+     * Pull the literal string key off an array item. Returns null for integer
+     * keys, dynamic keys, or list-style entries (`[$foo]`) — none of those
+     * correspond to a Blade data-bag key after `extract()`.
+     *
+     * @psalm-mutation-free
+     */
+    private static function literalArrayKey(ArrayItem $item): ?string
+    {
+        $key = $item->key;
+
+        if (!$key instanceof \PhpParser\Node\Expr) {
+            // List-style entry (`['foo', 'bar']`). Blade's `extract()` will not
+            // bind these to names, so they cannot reach a raw echo by name.
+            return null;
+        }
+
+        if (!$key instanceof String_) {
+            // Integer keys (`[0 => $x]`) and dynamic keys are out of scope:
+            // `extract()` skips non-string and non-identifier keys.
+            return null;
+        }
+
+        $value = $key->value;
+
+        if ($value === '' || \preg_match('/^[A-Za-z_]\w*$/', $value) !== 1) {
+            // PHP identifiers only — `extract()` silently drops invalid names.
+            return null;
+        }
+
+        return $value;
+    }
+
+    /**
+     * Build the method-id table for `Factory::make()` and every facade class
+     * that proxies to {@see \Illuminate\View\Factory}. The boot path passes
+     * the facade list explicitly so the handler stays decoupled from
+     * `FacadeMapProvider` (which is plugin-internal and harder to fake in
+     * unit tests).
+     *
+     * @param list<class-string> $factoryFacadeClasses
+     *
+     * @return array<lowercase-string, MakeLikeMethodSpec>
+     *
+     * @psalm-pure
+     */
+    private static function buildMethodSpecs(array $factoryFacadeClasses): array
+    {
+        // `make($view, $data = [], $mergeData = [])` is the canonical shape on
+        // `\Illuminate\View\Factory`. Facade classes inherit it (or stub it via
+        // the plugin's generated alias stubs); the argument layout is identical.
+        $makeSpec = new MakeLikeMethodSpec(
+            viewArgIndex: 0,
+            dataArgIndex: 1,
+            mergeDataArgIndex: 2,
+        );
+
+        // `renderWhen($condition, $view, $data = [], $mergeData = [])` and
+        // `renderUnless` share the layout — they delegate to make() after the
+        // condition check (see Illuminate\View\Factory::renderWhen()). The
+        // condition arg shifts every index by one, but the (view, data,
+        // mergeData) triple still applies to taint sink dispatch.
+        $renderWhenSpec = new MakeLikeMethodSpec(
+            viewArgIndex: 1,
+            dataArgIndex: 2,
+            mergeDataArgIndex: 3,
+        );
+
+        $specs = [];
+
+        // `Illuminate\Contracts\View\Factory` (the interface) declares only
+        // `make()` from this set; `renderWhen` and `renderUnless` live on the
+        // concrete class. Apps using PSR-typed constructor injection
+        // (`__construct(\Illuminate\Contracts\View\Factory $views)`) emit a
+        // method id resolved to the contract for `make()`, NOT the concrete
+        // class — without the contract entry, that path would slip past the
+        // dispatcher.
+        $specs[\strtolower(\Illuminate\Contracts\View\Factory::class) . '::make'] = $makeSpec;
+
+        // The concrete class plus every facade alias that proxies to it.
+        // Facades inherit `make()` / `renderWhen()` / `renderUnless()` from
+        // the underlying class via __callStatic; the plugin's generated
+        // alias stubs surface them as real static methods at analysis time.
+        $concreteClasses = [
+            \Illuminate\View\Factory::class,
+            ...$factoryFacadeClasses,
+        ];
+
+        foreach ($concreteClasses as $class) {
+            $classLc = \strtolower($class);
+            $specs[$classLc . '::make'] = $makeSpec;
+            $specs[$classLc . '::renderwhen'] = $renderWhenSpec;
+            $specs[$classLc . '::renderunless'] = $renderWhenSpec;
+        }
+
+        // Known coverage gaps left for PR-4+:
+        //  - `Illuminate\View\Factory::first(array $views, $data = [], $mergeData = [])`
+        //    needs a union over multiple template safety records.
+        //  - `Illuminate\View\Factory::renderEach($view, $data, $iterator, $empty)`
+        //    binds each item under `$iterator`, not under the data array's keys.
+        //  - `Illuminate\Routing\ResponseFactory::view($view, $data, $status, $headers)`
+        //    same shape as Factory::make() but on a separate class.
+        //  - `Illuminate\View\View::with($key, $value)` and `::nest($key, $view, $data)`
+        //    chained data binding (e.g. `view('home')->with('user', $user)`); the
+        //    factory `view()` call has no `$data` arg, so the binding is invisible
+        //    here.
+        //  - `Illuminate\Mail\Mailable::view()/markdown()/text()` and
+        //    `Illuminate\Notifications\Messages\MailMessage::view()/markdown()/text()`
+        //    and `Illuminate\Mail\Mailables\Content::__construct()` — view name +
+        //    data are stored on the Mailable instance and replayed through
+        //    `Mailer::renderView()` inside the framework. The user's literal call
+        //    site is therefore not a direct `view()` / `Factory::make()` call,
+        //    and the eventual `make()` invocation reads the name from an
+        //    instance property (dynamic, not literal).
+
+        return $specs;
+    }
+}

--- a/src/Handlers/Views/MakeLikeMethodSpec.php
+++ b/src/Handlers/Views/MakeLikeMethodSpec.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Views;
+
+/**
+ * Argument shape descriptor for `Factory::make()`-style methods consumed by
+ * {@see BladeAwareViewTaintHandler}.
+ *
+ * `Factory::make($view, $data = [], $mergeData = [])` is the only shape PR-3
+ * dispatches on, but the descriptor is a small object rather than a tuple so
+ * PR-4+ can add `first()` (where the view argument is `array<string>`) or
+ * `renderEach()` (where `$data` is a collection and an extra `$iterator` arg
+ * names the per-item variable) without changing the call sites in the handler.
+ *
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final readonly class MakeLikeMethodSpec
+{
+    public function __construct(
+        public int $viewArgIndex,
+        public int $dataArgIndex,
+        public ?int $mergeDataArgIndex,
+    ) {}
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -6,6 +6,7 @@ namespace Psalm\LaravelPlugin;
 
 use Illuminate\Foundation\Application;
 use Psalm\Internal\Analyzer\ProjectAnalyzer;
+use Psalm\LaravelPlugin\Blade\BladeSafetyMap;
 use Psalm\LaravelPlugin\Providers\AliasStubProvider;
 use Psalm\LaravelPlugin\Providers\ApplicationProvider;
 use Psalm\LaravelPlugin\Providers\CarbonStubProvider;
@@ -48,6 +49,8 @@ final class Plugin implements PluginEntryPointInterface
             if ($pluginConfig->findMissingViews) {
                 $this->initMissingViewHandler($output);
             }
+
+            $this->initBladeAwareViewTaintHandler($output);
 
             $this->initNoEnvOutsideConfigHandler($pluginConfig, $output);
 
@@ -249,6 +252,16 @@ final class Plugin implements PluginEntryPointInterface
             require_once __DIR__ . '/Handlers/Views/MissingViewHandler.php';
             $registration->registerHooksFromClass(Handlers\Views\MissingViewHandler::class);
         }
+
+        // BladeAwareViewTaintHandler installs per-key html sinks on view()/Factory::make()
+        // call sites, refined by the per-template BladeSafetyMap built in
+        // initBladeAwareViewTaintHandler(). It is a no-op when the map is empty
+        // (taint analysis disabled or view roots unavailable), but the registration
+        // is unconditional so users get the refinement automatically once they
+        // enable --taint-analysis.
+        require_once __DIR__ . '/Handlers/Views/MakeLikeMethodSpec.php';
+        require_once __DIR__ . '/Handlers/Views/BladeAwareViewTaintHandler.php';
+        $registration->registerHooksFromClass(Handlers\Views\BladeAwareViewTaintHandler::class);
     }
 
     /**
@@ -369,6 +382,103 @@ final class Plugin implements PluginEntryPointInterface
         $extensions = $finder->getExtensions();
 
         Handlers\Views\MissingViewHandler::init($paths, $extensions);
+    }
+
+    /**
+     * Scan the booted app's view roots, build a {@see BladeSafetyMap}, and hand
+     * it to {@see Handlers\Views\BladeAwareViewTaintHandler}. The scan is the
+     * one piece of filesystem IO this handler needs at boot; once built, the
+     * map is queried in-memory for every `view()` / `Factory::make()` call
+     * Psalm analyses.
+     *
+     * Build is skipped when:
+     *  - taint analysis is off (no `taint_flow_graph` on the Codebase). Reading
+     *    every blade file under `resources/views/` would be pure waste when the
+     *    handler has nothing to plumb the result into.
+     *  - the view finder service is absent or non-standard. The plugin already
+     *    falls back gracefully in {@see initMissingViewHandler()}; the same
+     *    fall-back applies here.
+     *
+     * The handler stays registered either way — once registered it short-circuits
+     * on `!self::$enabled`, so a no-op init just means it never installs sinks.
+     */
+    private function initBladeAwareViewTaintHandler(\Psalm\Progress\Progress $output): void
+    {
+        $taintEnabled = false;
+
+        try {
+            $codebase = ProjectAnalyzer::getInstance()->getCodebase();
+            $taintEnabled = $codebase->taint_flow_graph instanceof \Psalm\Internal\Codebase\TaintFlowGraph;
+        } catch (\Error) {
+            // ProjectAnalyzer::$instance is a typed non-nullable property that
+            // throws \Error when accessed unset — the only realistic failure
+            // mode here. This happens in unit-test harnesses that boot the
+            // plugin without a full Psalm run.
+            //
+            // We catch \Error specifically, NOT \Throwable: a future Psalm
+            // API change (e.g. taint_flow_graph renamed) should bubble out to
+            // the outer __invoke() try/catch and route through
+            // InternalErrorReporter for visibility, rather than be silently
+            // swallowed here. Silent disable is appropriate only for the
+            // documented "ProjectAnalyzer not yet initialised" case.
+        }
+
+        if (!$taintEnabled) {
+            return;
+        }
+
+        $app = ApplicationProvider::getApp();
+
+        // Mirror initMissingViewHandler's resolution chain (view.finder first,
+        // fall back to the Factory's finder). Both code paths can disappear
+        // in a stripped Testbench setup, in which case there are no paths to
+        // scan and the handler stays disabled.
+        if ($app->bound('view.finder')) {
+            $finder = $app->make('view.finder');
+        } elseif ($app->bound('view')) {
+            $factory = $app->make('view');
+
+            if (!$factory instanceof \Illuminate\View\Factory) {
+                return;
+            }
+
+            $finder = $factory->getFinder();
+        } else {
+            return;
+        }
+
+        if (!$finder instanceof \Illuminate\View\FileViewFinder) {
+            return;
+        }
+
+        /** @var list<string> $paths */
+        $paths = $finder->getPaths();
+
+        // Empty paths is allowed: an empty BladeSafetyMap still drives the
+        // dynamic-view-name fallback. Skipping init in this case would let
+        // taint flow unfiltered through `view($name, $data)` where `$name`
+        // is non-literal, which is the most common XSS shape in real apps.
+
+        try {
+            $map = BladeSafetyMap::build($paths);
+        } catch (\Throwable $throwable) {
+            // The scanner is defensive (catches per-file IO failures internally),
+            // so reaching this branch means something unexpected — e.g. a
+            // RecursiveDirectoryIterator construction failure on a removed root.
+            // Log via the progress channel and leave the handler disabled rather
+            // than fatal-erroring the whole plugin.
+            $output->warning(
+                "Laravel plugin: failed to build BladeSafetyMap, view-data taint refinement disabled: {$throwable->getMessage()}",
+            );
+
+            return;
+        }
+
+        $factoryFacadeClasses = FacadeMapProvider::getFacadeClasses(\Illuminate\View\Factory::class);
+
+        require_once __DIR__ . '/Handlers/Views/MakeLikeMethodSpec.php';
+        require_once __DIR__ . '/Handlers/Views/BladeAwareViewTaintHandler.php';
+        Handlers\Views\BladeAwareViewTaintHandler::init($map, $factoryFacadeClasses);
     }
 
     private function buildSchema(PluginConfig $pluginConfig): void

--- a/tests/Type/tests/Blade/TaintedHtmlDynamicViewName.phpt
+++ b/tests/Type/tests/Blade/TaintedHtmlDynamicViewName.phpt
@@ -1,0 +1,23 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Locks in the dynamic-view-name fallback: when the view name is not a literal,
+ * the BladeAwareViewTaintHandler cannot resolve which template will render, so
+ * it installs an html sink on every entry of the data array. The tainted
+ * `$_GET['x']` reaching the 'bio' key must then surface as TaintedHtml.
+ *
+ * Sibling cases (Safe / UnsafeKeys / Unknown) need fixture blade templates on
+ * the booted Testbench view path; they live in tests/Application/ rather than
+ * here. See docs/issues/581-blade-taint-exploration.md for the PR-3 split.
+ */
+function renderDynamic(string $viewName): void {
+    /** @var string $tainted */
+    $tainted = $_GET['x'];
+    view($viewName, ['bio' => $tainted]);
+}
+?>
+--EXPECTF--
+%ATaintedHtml%a

--- a/tests/Unit/Handlers/Views/BladeAwareViewTaintHandlerTest.php
+++ b/tests/Unit/Handlers/Views/BladeAwareViewTaintHandlerTest.php
@@ -1,0 +1,974 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Views;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\ArrayItem;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\Codebase;
+use Psalm\Context;
+use Psalm\Internal\Codebase\TaintFlowGraph;
+use Psalm\Internal\DataFlow\DataFlowNode;
+use Psalm\LaravelPlugin\Blade\BladeSafetyMap;
+use Psalm\LaravelPlugin\Blade\BladeTemplateAnalysis;
+use Psalm\LaravelPlugin\Blade\BladeUncertaintyReason;
+use Psalm\LaravelPlugin\Blade\BladeViewSafety;
+use Psalm\LaravelPlugin\Handlers\Views\BladeAwareViewTaintHandler;
+use Psalm\NodeTypeProvider;
+use Psalm\Plugin\EventHandler\Event\AfterFunctionCallAnalysisEvent;
+use Psalm\Plugin\EventHandler\Event\AfterMethodCallAnalysisEvent;
+use Psalm\StatementsSource;
+use Psalm\Type;
+use Psalm\Type\TaintKind;
+use Psalm\Type\Union;
+
+/**
+ * Unit coverage for the handler's dispatch logic.
+ *
+ * Each test builds a real {@see TaintFlowGraph}, hands it to the handler via a
+ * stubbed {@see Codebase}, and asserts on the graph's contents through reflection.
+ * No Psalm process is spawned: this layer pins behaviour at a granularity that
+ * the PHPT/Application layers (which run the real plugin against a real
+ * codebase) cannot.
+ */
+#[CoversClass(BladeAwareViewTaintHandler::class)]
+final class BladeAwareViewTaintHandlerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        BladeAwareViewTaintHandler::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        BladeAwareViewTaintHandler::reset();
+    }
+
+    #[Test]
+    public function does_nothing_when_disabled(): void
+    {
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeFunctionEvent('view', [
+            new Arg(new String_('post')),
+            new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterFunctionCallAnalysis($event);
+
+        $this->assertSame([], $this->graphSinks($graph));
+    }
+
+    #[Test]
+    public function does_nothing_when_taint_graph_absent(): void
+    {
+        $this->initWithMap([
+            'post' => new BladeViewSafety('post', '/views/post.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+        ]);
+
+        $codebase = $this->createCodebase(null);
+
+        $event = $this->makeFunctionEvent('view', [
+            new Arg(new String_('post')),
+            new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterFunctionCallAnalysis($event);
+
+        // No graph was passed in, so nothing observable to assert beyond not
+        // throwing. The real signal is that the handler exited early —
+        // dereferencing $codebase->taint_flow_graph would have crashed.
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function ignores_unrelated_function_id(): void
+    {
+        $this->initWithMap([
+            'post' => new BladeViewSafety('post', '/views/post.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeFunctionEvent('unrelated', [
+            new Arg(new String_('post')),
+            new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterFunctionCallAnalysis($event);
+
+        $this->assertSame([], $this->graphSinks($graph));
+    }
+
+    #[Test]
+    public function installs_per_key_sinks_for_unsafe_keys_view(): void
+    {
+        $this->initWithMap([
+            'post' => new BladeViewSafety('post', '/views/post.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeFunctionEvent('view', [
+            new Arg(new String_('post')),
+            new Arg($this->arrayLiteral([
+                'bio' => $this->taintedVariable('bio'),
+                // 'title' is not on the unsafe-keys list; it must not receive a sink.
+                'title' => $this->taintedVariable('title'),
+            ])),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterFunctionCallAnalysis($event);
+
+        $sinks = $this->graphSinks($graph);
+
+        $this->assertCount(1, $sinks, 'Exactly one sink should be installed: the unsafe key.');
+        $this->assertStringContainsString("(post, 'bio')", $sinks[0]['label']);
+        $this->assertSame(TaintKind::INPUT_HTML, $sinks[0]['taints']);
+    }
+
+    #[Test]
+    public function safe_view_installs_no_sink(): void
+    {
+        $this->initWithMap([
+            'home' => new BladeViewSafety('home', '/views/home.blade.php', BladeTemplateAnalysis::safe()),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeFunctionEvent('view', [
+            new Arg(new String_('home')),
+            new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterFunctionCallAnalysis($event);
+
+        $this->assertSame([], $this->graphSinks($graph));
+    }
+
+    #[Test]
+    public function unknown_view_installs_sink_on_every_data_key(): void
+    {
+        $this->initWithMap([
+            'broken' => new BladeViewSafety(
+                'broken',
+                '/views/broken.blade.php',
+                BladeTemplateAnalysis::unknown([BladeUncertaintyReason::LayoutSectionFlow]),
+            ),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeFunctionEvent('view', [
+            new Arg(new String_('broken')),
+            new Arg($this->arrayLiteral([
+                'bio' => $this->taintedVariable('bio'),
+                'title' => $this->taintedVariable('title'),
+            ])),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterFunctionCallAnalysis($event);
+
+        $sinks = $this->graphSinks($graph);
+
+        $this->assertCount(2, $sinks, 'UNKNOWN must sink every entry of the data array.');
+        $this->assertSinkLabelExists($sinks, "(broken, 'bio')");
+        $this->assertSinkLabelExists($sinks, "(broken, 'title')");
+    }
+
+    #[Test]
+    public function dynamic_view_name_installs_whole_data_sink(): void
+    {
+        $this->initWithMap([]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeFunctionEvent('view', [
+            new Arg(new Variable('dynamicViewName')),
+            new Arg($this->arrayLiteral([
+                'bio' => $this->taintedVariable('bio'),
+                'title' => $this->taintedVariable('title'),
+            ])),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterFunctionCallAnalysis($event);
+
+        $sinks = $this->graphSinks($graph);
+
+        $this->assertCount(2, $sinks);
+        $this->assertSinkLabelExists($sinks, "(<dynamic>, 'bio')");
+        $this->assertSinkLabelExists($sinks, "(<dynamic>, 'title')");
+    }
+
+    #[Test]
+    public function missing_view_installs_no_sink(): void
+    {
+        // Empty map: every literal view name yields safetyFor() === null. The
+        // missing-view diagnostic is MissingViewHandler's job; this handler must
+        // not double-report.
+        $this->initWithMap([]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeFunctionEvent('view', [
+            new Arg(new String_('does-not-exist')),
+            new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterFunctionCallAnalysis($event);
+
+        $this->assertSame([], $this->graphSinks($graph));
+    }
+
+    #[Test]
+    public function method_call_on_factory_make_installs_sink(): void
+    {
+        $this->initWithMap([
+            'post' => new BladeViewSafety('post', '/views/post.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeMethodEvent(
+            \Illuminate\View\Factory::class . '::make',
+            [
+                new Arg(new String_('post')),
+                new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+            ],
+            $codebase,
+        );
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $sinks = $this->graphSinks($graph);
+
+        $this->assertCount(1, $sinks);
+        $this->assertStringContainsString("(post, 'bio')", $sinks[0]['label']);
+    }
+
+    #[Test]
+    public function method_call_on_unregistered_method_is_ignored(): void
+    {
+        $this->initWithMap([
+            'post' => new BladeViewSafety('post', '/views/post.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeMethodEvent(
+            \Illuminate\View\Factory::class . '::renderEach',
+            [
+                new Arg(new String_('post')),
+                new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+            ],
+            $codebase,
+        );
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertSame([], $this->graphSinks($graph));
+    }
+
+    #[Test]
+    public function merge_data_is_sunk_alongside_data(): void
+    {
+        $this->initWithMap([
+            'post' => new BladeViewSafety(
+                'post',
+                '/views/post.blade.php',
+                BladeTemplateAnalysis::unsafeKeys(['bio', 'note']),
+            ),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeFunctionEvent('view', [
+            new Arg(new String_('post')),
+            new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+            new Arg($this->arrayLiteral(['note' => $this->taintedVariable('note')])),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterFunctionCallAnalysis($event);
+
+        $sinks = $this->graphSinks($graph);
+
+        $this->assertSinkLabelExists($sinks, "(post, 'bio')");
+        $this->assertSinkLabelExists($sinks, "(post, 'note')");
+    }
+
+    #[Test]
+    public function non_array_literal_data_falls_back_to_whole_argument_sink(): void
+    {
+        $this->initWithMap([
+            'post' => new BladeViewSafety('post', '/views/post.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeFunctionEvent('view', [
+            new Arg(new String_('post')),
+            new Arg($this->taintedVariable('data')),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterFunctionCallAnalysis($event);
+
+        $this->assertSinkLabelExists($this->graphSinks($graph), "(post, '<argument>')");
+    }
+
+    #[Test]
+    public function path_added_taints_stay_zero_to_avoid_cross_kind_false_positives(): void
+    {
+        // Regression guard for the addPath argument fix. The edge that joins a
+        // value's parent_node to our html sink must NOT lift unrelated taint
+        // kinds (INPUT_SQL, INPUT_SHELL, etc.) into INPUT_HTML mid-flow. The
+        // sink's `$taints` field is the kind gate; the path's
+        // `$added_taints` is the call-site delta and must remain 0.
+        $this->initWithMap([
+            'post' => new BladeViewSafety('post', '/views/post.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeFunctionEvent('view', [
+            new Arg(new String_('post')),
+            new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterFunctionCallAnalysis($event);
+
+        $this->assertCount(1, $this->graphSinks($graph));
+
+        $forwardEdges = (new \ReflectionProperty(TaintFlowGraph::class, 'forward_edges'))->getValue($graph);
+        \assert(\is_array($forwardEdges));
+
+        $observedAddedTaints = [];
+
+        foreach ($forwardEdges as $perFrom) {
+            \assert(\is_array($perFrom));
+
+            foreach ($perFrom as $path) {
+                $this->assertInstanceOf(\Psalm\Internal\DataFlow\Path::class, $path);
+                $observedAddedTaints[] = $path->added_taints;
+            }
+        }
+
+        $this->assertNotEmpty($observedAddedTaints, 'Expected at least one path on the taint graph.');
+        $this->assertSame([0], \array_values(\array_unique($observedAddedTaints)));
+    }
+
+    #[Test]
+    public function method_call_on_contracts_factory_make_installs_sink(): void
+    {
+        // Apps that DI \Illuminate\Contracts\View\Factory (the interface) instead
+        // of the concrete class produce method ids resolved to the contract.
+        // The dispatcher must cover this surface, otherwise PSR-typed code
+        // bypasses the handler silently.
+        $this->initWithMap([
+            'post' => new BladeViewSafety('post', '/views/post.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeMethodEvent(
+            \Illuminate\Contracts\View\Factory::class . '::make',
+            [
+                new Arg(new String_('post')),
+                new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+            ],
+            $codebase,
+        );
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertCount(1, $this->graphSinks($graph));
+    }
+
+    #[Test]
+    public function method_call_on_factory_render_when_installs_sink(): void
+    {
+        $this->initWithMap([
+            'post' => new BladeViewSafety('post', '/views/post.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        // renderWhen($condition, $view, $data = [], $mergeData = [])
+        // viewArgIndex = 1, dataArgIndex = 2
+        $event = $this->makeMethodEvent(
+            // Lowercase suffix mirrors what Psalm's MethodIdentifier produces
+            // (method-name part is `lowercase-string`).
+            \Illuminate\View\Factory::class . '::renderwhen',
+            [
+                new Arg(new Variable('condition')),
+                new Arg(new String_('post')),
+                new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+            ],
+            $codebase,
+        );
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertSinkLabelExists($this->graphSinks($graph), "(post, 'bio')");
+    }
+
+    #[Test]
+    public function method_call_on_factory_render_unless_installs_sink(): void
+    {
+        $this->initWithMap([
+            'post' => new BladeViewSafety('post', '/views/post.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeMethodEvent(
+            \Illuminate\View\Factory::class . '::renderunless',
+            [
+                new Arg(new Variable('condition')),
+                new Arg(new String_('post')),
+                new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+            ],
+            $codebase,
+        );
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertSinkLabelExists($this->graphSinks($graph), "(post, 'bio')");
+    }
+
+    #[Test]
+    public function inner_array_spread_falls_back_to_whole_argument_sink(): void
+    {
+        // `view('post', ['safe' => $a, ...$rest])` cannot enumerate $rest's
+        // keys at analysis time. The handler must treat this as the whole-arg
+        // sink so any unsafe-key entries hiding in $rest still surface.
+        $this->initWithMap([
+            'post' => new BladeViewSafety('post', '/views/post.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $spreadItem = new ArrayItem($this->taintedVariable('rest'));
+        $spreadItem->unpack = true;
+
+        $arrayWithSpread = new Array_([
+            new ArrayItem($this->taintedVariable('safe'), new String_('safe')),
+            $spreadItem,
+        ]);
+
+        $event = $this->makeFunctionEvent('view', [
+            new Arg(new String_('post')),
+            new Arg($arrayWithSpread),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterFunctionCallAnalysis($event);
+
+        $this->assertSinkLabelExists($this->graphSinks($graph), "(post, '<argument>')");
+    }
+
+    #[Test]
+    public function dynamic_array_key_falls_back_to_whole_argument_sink(): void
+    {
+        // `view('post', [$maybeKey => $val])`: a runtime-resolved key could
+        // collide with an unsafe key in UNSAFE_KEYS mode. Symmetric to the
+        // inner-spread case — drop into the whole-arg fallback rather than
+        // silently skip the entry.
+        $this->initWithMap([
+            'post' => new BladeViewSafety('post', '/views/post.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $dynamicKeyed = new Array_([
+            new ArrayItem(
+                $this->taintedVariable('value'),
+                $this->taintedVariable('maybeKey'),
+            ),
+        ]);
+
+        $event = $this->makeFunctionEvent('view', [
+            new Arg(new String_('post')),
+            new Arg($dynamicKeyed),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterFunctionCallAnalysis($event);
+
+        $this->assertSinkLabelExists($this->graphSinks($graph), "(post, '<argument>')");
+    }
+
+    #[Test]
+    public function non_identifier_keys_get_no_sink(): void
+    {
+        // Reject branches in literalArrayKey(): integer keys, list-style
+        // entries, and non-identifier strings (`extract()` skips all three).
+        // Only the valid identifier 'bio' should receive a sink even though
+        // 'bio' is also (under different shapes) in the array literal.
+        $this->initWithMap([
+            'post' => new BladeViewSafety('post', '/views/post.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $items = [
+            new ArrayItem($this->taintedVariable('bio'), new String_('bio')),
+            // Integer key — handler must skip.
+            new ArrayItem($this->taintedVariable('intKeyed')),
+            // Hyphenated string — not a PHP identifier, extract() skips.
+            new ArrayItem($this->taintedVariable('hyphen'), new String_('invalid-key')),
+            // Empty string — extract() skips.
+            new ArrayItem($this->taintedVariable('empty'), new String_('')),
+        ];
+
+        $event = $this->makeFunctionEvent('view', [
+            new Arg(new String_('post')),
+            new Arg(new Array_($items)),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterFunctionCallAnalysis($event);
+
+        $sinks = $this->graphSinks($graph);
+        $this->assertCount(1, $sinks);
+        $this->assertSinkLabelExists($sinks, "(post, 'bio')");
+    }
+
+    #[Test]
+    public function multiple_unsafe_keys_each_get_their_own_sink(): void
+    {
+        // Lock in the per-key loop: a single call with two unsafe keys + one
+        // safe key must yield exactly two sinks with the right labels.
+        $this->initWithMap([
+            'post' => new BladeViewSafety(
+                'post',
+                '/views/post.blade.php',
+                BladeTemplateAnalysis::unsafeKeys(['bio', 'note']),
+            ),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeFunctionEvent('view', [
+            new Arg(new String_('post')),
+            new Arg($this->arrayLiteral([
+                'bio' => $this->taintedVariable('bio'),
+                'note' => $this->taintedVariable('note'),
+                'title' => $this->taintedVariable('title'),
+            ])),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterFunctionCallAnalysis($event);
+
+        $sinks = $this->graphSinks($graph);
+        $this->assertCount(2, $sinks);
+        $this->assertSinkLabelExists($sinks, "(post, 'bio')");
+        $this->assertSinkLabelExists($sinks, "(post, 'note')");
+    }
+
+    #[Test]
+    public function empty_parent_nodes_short_circuit_skips_sink(): void
+    {
+        // installSinkForExpression() bails when the value Union has no
+        // parent_nodes — there is no data flow to plumb, so allocating a
+        // sink would just bloat the graph during whole-program analysis.
+        // The test supplies a Variable that the type provider returns null
+        // for (no Union → no parent_nodes).
+        $this->initWithMap([
+            'post' => new BladeViewSafety('post', '/views/post.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $untypedValue = new Variable('untyped');
+
+        // Bypass our makeSource helper's typing pass: build the source manually
+        // so $untypedValue does NOT get parent_nodes registered.
+        $source = $this->createStub(StatementsSource::class);
+        $source->method('getFilePath')->willReturn('/app/Untyped.php');
+        $source->method('getFileName')->willReturn('Untyped.php');
+        $source->method('getNodeTypeProvider')->willReturn(
+            new class implements NodeTypeProvider {
+                #[\Override]
+                public function getType(\PhpParser\NodeAbstract $node): ?Union
+                {
+                    return null;
+                }
+
+                #[\Override]
+                public function setType(\PhpParser\NodeAbstract $node, Union $type): void {}
+            },
+        );
+
+        $funcCall = new FuncCall(new Name('view'), [
+            new Arg(new String_('post')),
+            new Arg($this->arrayLiteral(['bio' => $untypedValue])),
+        ]);
+        $funcCall->setAttribute('startFilePos', 0);
+        $funcCall->setAttribute('endFilePos', 100);
+
+        $event = new AfterFunctionCallAnalysisEvent(
+            $funcCall,
+            'view',
+            new Context(),
+            $source,
+            $codebase,
+            Type::getMixed(),
+            [],
+        );
+
+        BladeAwareViewTaintHandler::afterFunctionCallAnalysis($event);
+
+        $this->assertSame([], $this->graphSinks($graph));
+    }
+
+    #[Test]
+    public function merge_data_unknown_view_installs_whole_data_sinks_on_both(): void
+    {
+        $this->initWithMap([
+            'broken' => new BladeViewSafety(
+                'broken',
+                '/views/broken.blade.php',
+                BladeTemplateAnalysis::unknown([BladeUncertaintyReason::LayoutSectionFlow]),
+            ),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeFunctionEvent('view', [
+            new Arg(new String_('broken')),
+            new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+            new Arg($this->arrayLiteral(['note' => $this->taintedVariable('note')])),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterFunctionCallAnalysis($event);
+
+        $sinks = $this->graphSinks($graph);
+        $this->assertSinkLabelExists($sinks, "(broken, 'bio')");
+        $this->assertSinkLabelExists($sinks, "(broken, 'note')");
+    }
+
+    #[Test]
+    public function merge_data_dynamic_view_installs_whole_data_sinks_on_both(): void
+    {
+        $this->initWithMap([]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeFunctionEvent('view', [
+            new Arg(new Variable('dynamic')),
+            new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+            new Arg($this->arrayLiteral(['note' => $this->taintedVariable('note')])),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterFunctionCallAnalysis($event);
+
+        $sinks = $this->graphSinks($graph);
+        $this->assertSinkLabelExists($sinks, "(<dynamic>, 'bio')");
+        $this->assertSinkLabelExists($sinks, "(<dynamic>, 'note')");
+    }
+
+    #[Test]
+    public function function_id_case_insensitive_match(): void
+    {
+        // Psalm preserves call-site casing in `function_id` (only the leading
+        // backslash is stripped). The handler must compare case-insensitively
+        // so `\View(...)` / unusual capitalisations are not silently bypassed.
+        $this->initWithMap([
+            'post' => new BladeViewSafety('post', '/views/post.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeFunctionEvent('View', [
+            new Arg(new String_('post')),
+            new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterFunctionCallAnalysis($event);
+
+        $this->assertSinkLabelExists($this->graphSinks($graph), "(post, 'bio')");
+    }
+
+    /**
+     * Build the handler with a synthetic safety map. The map is opaque to the
+     * scanner here: tests fabricate {@see BladeViewSafety} records directly,
+     * bypassing the on-disk scan.
+     *
+     * @param array<string, BladeViewSafety> $safetyByView
+     */
+    private function initWithMap(array $safetyByView): void
+    {
+        BladeAwareViewTaintHandler::init(new BladeSafetyMap($safetyByView));
+    }
+
+    /**
+     * Build an {@see AfterFunctionCallAnalysisEvent} wired to a fake source
+     * whose {@see NodeTypeProvider} returns a typed-with-parent-nodes Union for
+     * every variable expression. The parent-node id matches the variable name
+     * so assertions can identify which value ended up on the sink path.
+     *
+     * @param list<Arg> $args
+     */
+    private function makeFunctionEvent(string $functionId, array $args, Codebase $codebase): AfterFunctionCallAnalysisEvent
+    {
+        $funcCall = new FuncCall(new Name($functionId), $args);
+        $funcCall->setAttribute('startFilePos', 0);
+        $funcCall->setAttribute('endFilePos', 100);
+
+        $source = $this->makeSource($args);
+
+        return new AfterFunctionCallAnalysisEvent(
+            $funcCall,
+            $functionId === '' ? 'view' : $functionId,
+            new Context(),
+            $source,
+            $codebase,
+            Type::getMixed(),
+            [],
+        );
+    }
+
+    /**
+     * @param list<Arg> $args
+     */
+    private function makeMethodEvent(string $methodId, array $args, Codebase $codebase): AfterMethodCallAnalysisEvent
+    {
+        $staticCall = new StaticCall(
+            new Name(\explode('::', $methodId)[0]),
+            \explode('::', $methodId)[1],
+            $args,
+        );
+        $staticCall->setAttribute('startFilePos', 0);
+        $staticCall->setAttribute('endFilePos', 100);
+
+        $source = $this->makeSource($args);
+
+        return new AfterMethodCallAnalysisEvent(
+            $staticCall,
+            $methodId,
+            $methodId,
+            $methodId,
+            new Context(),
+            $source,
+            $codebase,
+        );
+    }
+
+    /**
+     * Build a {@see StatementsSource} whose {@see NodeTypeProvider::getType}
+     * returns a Union with a single parent_node for every {@see Variable}
+     * expression in $args. ArrayItems' values are recursively typed too so
+     * the per-key path picks them up.
+     *
+     * Only Variable nodes get typed; literal strings stay null-typed because
+     * the handler does not query their types (it reads .value directly).
+     *
+     * @param list<Arg> $args
+     */
+    private function makeSource(array $args): StatementsSource
+    {
+        /** @var \SplObjectStorage<\PhpParser\NodeAbstract, Union> $typeMap */
+        $typeMap = new \SplObjectStorage();
+
+        foreach ($args as $arg) {
+            $this->collectTypedExpressions($arg->value, $typeMap);
+        }
+
+        $source = $this->createStub(StatementsSource::class);
+        $source->method('getFilePath')->willReturn('/app/HomeController.php');
+        $source->method('getFileName')->willReturn('HomeController.php');
+
+        $typeProvider = new class ($typeMap) implements NodeTypeProvider {
+            /** @param \SplObjectStorage<\PhpParser\NodeAbstract, Union> $typeMap */
+            public function __construct(private readonly \SplObjectStorage $typeMap) {}
+
+            #[\Override]
+            public function getType(\PhpParser\NodeAbstract $node): ?Union
+            {
+                /** @var Union|null $type */
+                $type = $this->typeMap[$node] ?? null;
+
+                return $type;
+            }
+
+            #[\Override]
+            public function setType(\PhpParser\NodeAbstract $node, Union $type): void
+            {
+                $this->typeMap[$node] = $type;
+            }
+        };
+
+        $source->method('getNodeTypeProvider')->willReturn($typeProvider);
+
+        return $source;
+    }
+
+    /**
+     * Walk an expression and record a typed Union (with a parent_node tagged by
+     * the variable name) for every Variable encountered. Only Variable
+     * expressions need typing — they are the only nodes the handler walks
+     * past array literals to query.
+     *
+     * @param \SplObjectStorage<\PhpParser\NodeAbstract, Union> $typeMap
+     */
+    private function collectTypedExpressions(\PhpParser\Node $node, \SplObjectStorage $typeMap): void
+    {
+        if ($node instanceof Variable && \is_string($node->name)) {
+            $parentNode = DataFlowNode::make(
+                'var:' . $node->name,
+                $node->name,
+                null,
+                null,
+                TaintKind::INPUT_HTML,
+            );
+
+            $type = Type::getString();
+            $typeMap[$node] = $type->setParentNodes([$parentNode->id => $parentNode]);
+
+            return;
+        }
+
+        if ($node instanceof Array_) {
+            // Type the Array_ itself with a parent_node too — the whole-arg
+            // sink path in installWholeDataSink fetches getType($arg->value)
+            // when the array literal cannot be walked per-item (e.g. inner
+            // spread). Real Psalm assigns parent_nodes to array literals via
+            // getForAssignment(); we mirror that with a synthetic node.
+            $arrayParent = DataFlowNode::make(
+                'array:' . \spl_object_id($node),
+                'inline-array',
+                null,
+                null,
+                TaintKind::INPUT_HTML,
+            );
+
+            $arrayType = Type::getArray();
+            $typeMap[$node] = $arrayType->setParentNodes([$arrayParent->id => $arrayParent]);
+
+            foreach ($node->items as $item) {
+                if ($item instanceof ArrayItem) {
+                    $this->collectTypedExpressions($item->value, $typeMap);
+                }
+            }
+
+            return;
+        }
+    }
+
+    private function arrayLiteral(array $entries): Array_
+    {
+        $items = [];
+
+        foreach ($entries as $key => $value) {
+            $items[] = new ArrayItem($value, new String_((string) $key));
+        }
+
+        return new Array_($items);
+    }
+
+    private function taintedVariable(string $name): Variable
+    {
+        return new Variable($name);
+    }
+
+    /**
+     * Build a Codebase whose only relevant field — `$taint_flow_graph` — is
+     * the test-supplied graph. The real Codebase wires up dozens of providers
+     * that are irrelevant here; reflection lets us short-circuit construction.
+     */
+    private function createCodebase(?TaintFlowGraph $graph): Codebase
+    {
+        $codebase = (new \ReflectionClass(Codebase::class))->newInstanceWithoutConstructor();
+
+        $property = new \ReflectionProperty(Codebase::class, 'taint_flow_graph');
+        $property->setValue($codebase, $graph);
+
+        return $codebase;
+    }
+
+    /**
+     * Custom assertion: at least one sink label contains the given fragment.
+     *
+     * Labels carry an argument-offset suffix (`#1`) appended by
+     * {@see DataFlowNode::getForMethodArgument}, so the test cannot match the
+     * full string verbatim; substring matching keeps the assertion robust
+     * against that suffix changing position in future Psalm versions.
+     *
+     * @param list<array{id: string, label: string, taints: int}> $sinks
+     */
+    private function assertSinkLabelExists(array $sinks, string $fragment): void
+    {
+        $labels = \array_column($sinks, 'label');
+
+        foreach ($labels as $label) {
+            if (\str_contains($label, $fragment)) {
+                $this->addToAssertionCount(1);
+
+                return;
+            }
+        }
+
+        $this->fail(\sprintf(
+            "No sink label contained '%s'. Observed labels: [%s]",
+            $fragment,
+            \implode(', ', $labels),
+        ));
+    }
+
+    /**
+     * Snapshot a {@see TaintFlowGraph}'s sinks via reflection. The class keeps
+     * its node tables private, but they are stable across Psalm 7.x patch
+     * versions (the property names ship in `composer.lock`).
+     *
+     * @return list<array{id: string, label: string, taints: int}>
+     */
+    private function graphSinks(TaintFlowGraph $graph): array
+    {
+        $sinks = (new \ReflectionProperty(TaintFlowGraph::class, 'sinks'))->getValue($graph);
+
+        \assert(\is_array($sinks));
+
+        $out = [];
+
+        foreach ($sinks as $sink) {
+            $this->assertInstanceOf(DataFlowNode::class, $sink);
+            $out[] = [
+                'id' => $sink->id,
+                'label' => $sink->label,
+                'taints' => $sink->taints,
+            ];
+        }
+
+        return $out;
+    }
+}


### PR DESCRIPTION
## Issue to Solve

PR-3 of the Blade taint-analysis stack. PR-1 (#920) merged the tri-state scanner + safety map + uncertainty enum into the umbrella branch (#872); this PR is the integration half: wire `BladeSafetyMap` into Psalm's taint flow graph so `view()` / `View::make()` / `Factory::make()` call sites install per-key html sinks scoped by each template's `BladeViewSafetyKind`.

## Related

Sub-PR of #872 (umbrella for #581). Stacked on, and opened against, `worktree-581-blade-taint-exploration`. The full plan and the multi-PR merge strategy live in `docs/issues/581-blade-taint-exploration.md` (Delivery and merge strategy section). PR-4+ remains tracked in #581.

## Solution Description

New handler `Psalm\LaravelPlugin\Handlers\Views\BladeAwareViewTaintHandler` implements `AfterFunctionCallAnalysisInterface` and `AfterMethodCallAnalysisInterface`. For each `view(...)`, `Factory::make(...)`, facade `View::make(...)`, `Factory::renderWhen(...)`, and `Factory::renderUnless(...)` call site, the handler resolves the literal view name (when present) and dispatches per the four documented rules:

| Safety kind        | Sink installed                                                                 |
| ------------------ | ------------------------------------------------------------------------------ |
| SAFE               | none — Blade auto-escapes every echo, so the call site cannot leak html        |
| UNSAFE_KEYS        | per-key `html` sink on each entry of `$data` / `$mergeData` whose key matches  |
| UNKNOWN            | `html` sink on every literal-key entry — scanner could not enumerate safe keys |
| dynamic view name  | `html` sink on every entry — call site cannot resolve the template             |

Views absent from the map (typos, package views not under the configured roots) receive no sink; `MissingViewHandler` already reports the typo separately and double-reporting through taint would be noise. Data arguments whose shape cannot be enumerated at analysis time (argument-level spread, inner array spread, dynamic keys) conservatively fall through to a whole-arg sink so an unsafe key cannot slip through.

Boot wiring (`Plugin::initBladeAwareViewTaintHandler`) reads view roots from the booted Laravel app's `FileViewFinder::getPaths()` and constructs the `BladeSafetyMap` once. Gated on `$codebase->taint_flow_graph !== null` so type-only runs pay no scan cost.

Sink identity encodes `(view, key)` into the synthetic `method_id`; per-call `CodeLocation` provides the `specialization_key`, so two keys in the same call and two call sites with the same `(view, key)` stay distinct in the flow graph.

The `addPath` edge passes `$added_taints = 0` (the sink's own taint kind from `getForMethodArgument(..., INPUT_HTML)` gates the report). Earlier drafts passed `INPUT_HTML` here, which would have lifted unrelated taint kinds (`INPUT_SQL`, `INPUT_SHELL`) into `INPUT_HTML` mid-flow and emitted false-positive `TaintedHtml` reports. A regression test pins the path's `added_taints` field to 0.

### Out of scope (tracked for PR-4+)

- `Factory::first(array $views, ...)` — needs a union over multiple safety records.
- `Factory::renderEach($view, $data, $iterator, ...)` — different per-iterator binding shape.
- `Illuminate\Routing\ResponseFactory::view(...)` — identical shape on a separate service class.
- `Illuminate\View\View::with()` / `::nest()` — chained data binding after `view('home')`.
- `Illuminate\Mail\Mailable::view()` / `::markdown()` / `::text()` and `MailMessage` / `Mailables\Content` equivalents — view-name + data are stored on the instance and replayed inside the framework, so the user call site is not a direct `Factory::make` invocation.
- Cross-template `@include('child', [...])` propagation — scanner classifies includes as `UNKNOWN(IncludeDirective)`, so the conservative fallback already covers it; PR-4 will resolve literal include targets.
- Component data flow (`<x-foo :bar="$data" />`) — PR-5 territory.

The deferred list is mirrored verbatim in `BladeAwareViewTaintHandler::buildMethodSpecs()` so the next contributor finds it at the relevant code site.

### Tests

- `tests/Unit/Handlers/Views/BladeAwareViewTaintHandlerTest.php` — 24 unit tests covering the four fallback rules, mergeData on every kind, facade dispatch, `Illuminate\Contracts\View\Factory` dispatch (PSR-typed DI), `renderWhen` / `renderUnless`, inner array spread → whole-arg fallback, dynamic key → whole-arg fallback, non-identifier keys, multi-unsafe-key, empty `parent_nodes` short-circuit, case-insensitive function id, and the addPath-no-cross-kind regression. Assertions go through reflection on `TaintFlowGraph::$sinks` / `$forward_edges` so no Psalm process is spawned at this layer.
- `tests/Type/tests/Blade/TaintedHtmlDynamicViewName.phpt` — pins the dynamic-view-name path end-to-end against the real plugin boot.

A dedicated `tests/Application/` taint test is deferred: the existing `tests/Application/laravel-test.sh` harness runs Psalm without `--taint-analysis`, so adding taint coverage there needs a separate harness wired into a follow-up PR. The Application layer still exercises `Plugin::initBladeAwareViewTaintHandler` boot-path, so a registration crash would surface there.

Reviewed under `/psalm-review` across two clean rounds after fixing the addPath taint-kind argument, the missing contract/`renderWhen`/`renderUnless` entries, the inner-spread soundness gap, the dynamic-key soundness gap, and the method-call hot-path `strtolower` overhead.

## Checklist

- [x] Tests cover the change (`tests/Type/tests/Blade/` PHPT and `tests/Unit/Handlers/Views/` unit tests)
- [x] Documentation is updated (`docs/issues/581-blade-taint-exploration.md` marks PR-3 shipped and documents the umbrella merge strategy)
