### PR TITLE
Narrow MySQL `SET` columns to literal union in `ModelPropertyHandler`

### DIFF
--- a/src/Handlers/Eloquent/ModelPropertyHandler.php
+++ b/src/Handlers/Eloquent/ModelPropertyHandler.php
@@ -243,7 +243,10 @@ final class ModelPropertyHandler
             SchemaColumn::TYPE_STRING => Type::getString(),
             SchemaColumn::TYPE_FLOAT => Type::getFloat(),
             SchemaColumn::TYPE_BOOL => Type::getBool(),
-            SchemaColumn::TYPE_ENUM => self::mapEnumColumn($column),
+            // MySQL SET is comma-separated at runtime (e.g. 'draft,published'), so the
+            // literal-union here is an over-narrowing approximation — strictly better than
+            // `mixed` for the common `in_array($column, [...])` check. Matches Larastan.
+            SchemaColumn::TYPE_ENUM, SchemaColumn::TYPE_SET => self::mapLiteralUnionFromOptions($column),
             SchemaColumn::TYPE_ARRAY => new Union([Type\Atomic\TKeyedArray::make(
                 [Type::getFloat()],
                 fallback_params: [Type::getInt(), Type::getFloat()],
@@ -259,18 +262,31 @@ final class ModelPropertyHandler
         return $type;
     }
 
-    private static function mapEnumColumn(SchemaColumn $column): Union
+    /**
+     * Build a literal-string union from a column's options list. Shared by ENUM and SET
+     * because both store their option set the same way in {@see SchemaColumn::$options}
+     * and benefit from the same narrowing (with the SET caveat documented at the caller).
+     */
+    private static function mapLiteralUnionFromOptions(SchemaColumn $column): Union
     {
         if ($column->options === []) {
             return Type::getString();
         }
 
-        $literals = [];
-        foreach ($column->options as $option) {
-            $literals[] = Type\Atomic\TLiteralString::make($option);
-        }
+        try {
+            $literals = [];
+            foreach ($column->options as $option) {
+                $literals[] = Type\Atomic\TLiteralString::make($option);
+            }
 
-        return new Union($literals);
+            return new Union($literals);
+        } catch (\UnexpectedValueException|\InvalidArgumentException) {
+            // TLiteralString::make() throws InvalidArgumentException when an option
+            // exceeds Config::max_string_length, and UnexpectedValueException when
+            // called outside an initialized Psalm Config (e.g. unit tests). Mirrors
+            // {@see \Psalm\LaravelPlugin\Handlers\Validation\ValidationRuleAnalyzer::inRuleToLiteralUnion}.
+            return Type::getString();
+        }
     }
 
     /** @var array<string, bool> Cache for hasNativeProperty() keyed by "class::property" */

--- a/src/Handlers/Eloquent/ModelPropertyHandler.php
+++ b/src/Handlers/Eloquent/ModelPropertyHandler.php
@@ -245,7 +245,7 @@ final class ModelPropertyHandler
             SchemaColumn::TYPE_BOOL => Type::getBool(),
             // MySQL SET is comma-separated at runtime (e.g. 'draft,published'), so the
             // literal-union here is an over-narrowing approximation — strictly better than
-            // `mixed` for the common `in_array($column, [...])` check. Matches Larastan.
+            // `mixed` for the common `in_array($model->status, [...])` check. Matches Larastan.
             SchemaColumn::TYPE_ENUM, SchemaColumn::TYPE_SET => self::mapLiteralUnionFromOptions($column),
             SchemaColumn::TYPE_ARRAY => new Union([Type\Atomic\TKeyedArray::make(
                 [Type::getFloat()],

--- a/src/Handlers/Eloquent/Schema/SchemaAggregator.php
+++ b/src/Handlers/Eloquent/Schema/SchemaAggregator.php
@@ -652,7 +652,7 @@ final class SchemaAggregator
                     break;
 
                 case 'enum':
-                    $table->setColumn(new SchemaColumn($column_name, 'enum', $nullable, $second_arg_array ?? [], default: $default));
+                    $table->setColumn(new SchemaColumn($column_name, SchemaColumn::TYPE_ENUM, $nullable, $second_arg_array ?? [], default: $default));
                     break;
 
                 case 'numericmorphs':
@@ -703,7 +703,7 @@ final class SchemaAggregator
                     break;
 
                 case 'set':
-                    $table->setColumn(new SchemaColumn($column_name, 'set', $nullable, $second_arg_array ?? [], default: $default));
+                    $table->setColumn(new SchemaColumn($column_name, SchemaColumn::TYPE_SET, $nullable, $second_arg_array ?? [], default: $default));
                     break;
 
                 case 'year':

--- a/src/Handlers/Eloquent/Schema/SchemaColumn.php
+++ b/src/Handlers/Eloquent/Schema/SchemaColumn.php
@@ -17,21 +17,24 @@ final class SchemaColumn
 
     public const TYPE_ENUM = 'enum';
 
+    public const TYPE_SET = 'set';
+
     public const TYPE_ARRAY = 'array';
 
     public const TYPE_MIXED = 'mixed';
 
     /**
-     * Allowed values for enum columns, e.g. ['draft', 'published'] from
-     * {@see \Illuminate\Database\Schema\Blueprint::enum()}'s second argument.
-     * Empty for non-enum column types.
+     * Allowed values for enum/set columns, e.g. ['draft', 'published'] from
+     * {@see \Illuminate\Database\Schema\Blueprint::enum()} or
+     * {@see \Illuminate\Database\Schema\Blueprint::set()}'s second argument.
+     * Empty for non-enum/set column types.
      *
      * @var array<int, string>
      */
     public array $options;
 
     /**
-     * @param array<int, string> $options Allowed enum values (see {@see $options})
+     * @param array<int, string> $options Allowed enum/set values (see {@see $options})
      * @psalm-mutation-free
      */
     public function __construct(

--- a/src/Handlers/Eloquent/Schema/SqlSchemaParser.php
+++ b/src/Handlers/Eloquent/Schema/SqlSchemaParser.php
@@ -312,8 +312,7 @@ final readonly class SqlSchemaParser
             }
 
             if (\str_starts_with($typeLower, 'set')) {
-                // No TYPE_SET constant — uses literal 'set' to match SchemaAggregator behavior
-                return 'set';
+                return SchemaColumn::TYPE_SET;
             }
         }
 
@@ -350,7 +349,7 @@ final readonly class SqlSchemaParser
 
             // enum/set without options (rare, but handle gracefully)
             'enum' => SchemaColumn::TYPE_ENUM,
-            'set' => 'set',
+            'set' => SchemaColumn::TYPE_SET,
 
             default => SchemaColumn::TYPE_MIXED,
         };

--- a/tests/Unit/Handlers/Eloquent/ModelPropertyHandlerTest.php
+++ b/tests/Unit/Handlers/Eloquent/ModelPropertyHandlerTest.php
@@ -96,7 +96,7 @@ final class ModelPropertyHandlerTest extends TestCase
      *
      * MySQL returns SET as a comma-separated string at runtime (e.g. `'draft,published'`),
      * so a literal-union is an over-narrowing approximation, but strictly better than
-     * `mixed` for the common `in_array($column, [...])` pattern. Mirrors Larastan.
+     * `mixed` for the common `in_array($model->status, [...])` pattern. Mirrors Larastan.
      *
      * Without Psalm Config initialized, {@see \Psalm\Type\Atomic\TLiteralString::make()}
      * falls back to plain `TString` — so we assert against the string type rather than

--- a/tests/Unit/Handlers/Eloquent/ModelPropertyHandlerTest.php
+++ b/tests/Unit/Handlers/Eloquent/ModelPropertyHandlerTest.php
@@ -107,7 +107,7 @@ final class ModelPropertyHandlerTest extends TestCase
     public function it_narrows_set_column_away_from_mixed(): void
     {
         $column = ModelPropertyHandler::resolveAllColumns(WorkOrder::class)['status'];
-        $union = self::invokeMapColumnType($column);
+        $union = $this->invokeMapColumnType($column);
 
         $this->assertFalse($union->isMixed(), 'SET column must not be inferred as `mixed`');
         $this->assertTrue($union->hasString(), 'SET column should map to a string-flavored union');
@@ -124,7 +124,7 @@ final class ModelPropertyHandlerTest extends TestCase
             options: ['draft', 'published'],
         );
 
-        $union = self::invokeMapColumnType($column);
+        $union = $this->invokeMapColumnType($column);
 
         $this->assertFalse($union->isMixed());
         $this->assertTrue($union->isNullable(), 'Nullable SET column must include null');
@@ -140,13 +140,13 @@ final class ModelPropertyHandlerTest extends TestCase
     {
         $column = new SchemaColumn('status', SchemaColumn::TYPE_SET, options: []);
 
-        $union = self::invokeMapColumnType($column);
+        $union = $this->invokeMapColumnType($column);
 
         $this->assertFalse($union->isMixed());
         $this->assertTrue($union->hasString());
     }
 
-    private static function invokeMapColumnType(SchemaColumn $column): \Psalm\Type\Union
+    private function invokeMapColumnType(SchemaColumn $column): \Psalm\Type\Union
     {
         $method = new \ReflectionMethod(ModelPropertyHandler::class, 'mapColumnType');
 

--- a/tests/Unit/Handlers/Eloquent/ModelPropertyHandlerTest.php
+++ b/tests/Unit/Handlers/Eloquent/ModelPropertyHandlerTest.php
@@ -33,6 +33,11 @@ final class ModelPropertyHandlerTest extends TestCase
         $table->setColumn(new SchemaColumn('id', SchemaColumn::TYPE_INT));
         $table->setColumn(new SchemaColumn('title', SchemaColumn::TYPE_STRING));
         $table->setColumn(new SchemaColumn('published_at', SchemaColumn::TYPE_STRING, nullable: true));
+        $table->setColumn(new SchemaColumn(
+            'status',
+            SchemaColumn::TYPE_SET,
+            options: ['draft', 'published', 'archived'],
+        ));
         $schema->tables['work_orders'] = $table;
         SchemaStateProvider::setSchema($schema);
 
@@ -81,7 +86,71 @@ final class ModelPropertyHandlerTest extends TestCase
         $this->assertArrayHasKey('id', $columns);
         $this->assertArrayHasKey('title', $columns);
         $this->assertArrayHasKey('published_at', $columns);
-        $this->assertCount(3, $columns);
+        $this->assertArrayHasKey('status', $columns);
+        $this->assertCount(4, $columns);
+    }
+
+    /**
+     * Regression test for #924: MySQL SET columns previously fell through to `mixed`
+     * because `mapColumnType()` had no arm for {@see SchemaColumn::TYPE_SET}.
+     *
+     * MySQL returns SET as a comma-separated string at runtime (e.g. `'draft,published'`),
+     * so a literal-union is an over-narrowing approximation, but strictly better than
+     * `mixed` for the common `in_array($column, [...])` pattern. Mirrors Larastan.
+     *
+     * Without Psalm Config initialized, {@see \Psalm\Type\Atomic\TLiteralString::make()}
+     * falls back to plain `TString` — so we assert against the string type rather than
+     * the literals (see {@see \Tests\Psalm\LaravelPlugin\Unit\Handlers\Validation\ValidationRuleAnalyzerTest::in_rule_returns_string_type}
+     * for the same pattern). The literal narrowing is exercised end-to-end in integration runs.
+     */
+    #[Test]
+    public function it_narrows_set_column_away_from_mixed(): void
+    {
+        $column = ModelPropertyHandler::resolveAllColumns(WorkOrder::class)['status'];
+        $union = self::invokeMapColumnType($column);
+
+        $this->assertFalse($union->isMixed(), 'SET column must not be inferred as `mixed`');
+        $this->assertTrue($union->hasString(), 'SET column should map to a string-flavored union');
+        $this->assertFalse($union->isNullable(), 'Non-nullable SET column must not include null');
+    }
+
+    #[Test]
+    public function it_includes_null_for_nullable_set_column(): void
+    {
+        $column = new SchemaColumn(
+            'status',
+            SchemaColumn::TYPE_SET,
+            nullable: true,
+            options: ['draft', 'published'],
+        );
+
+        $union = self::invokeMapColumnType($column);
+
+        $this->assertFalse($union->isMixed());
+        $this->assertTrue($union->isNullable(), 'Nullable SET column must include null');
+    }
+
+    /**
+     * Edge case: a SET column whose options never get parsed (rare — e.g. a malformed
+     * migration or {@see \Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SqlSchemaParser}
+     * meeting `SET` without an option list). Should degrade to plain string, never `mixed`.
+     */
+    #[Test]
+    public function it_falls_back_to_string_for_set_column_without_options(): void
+    {
+        $column = new SchemaColumn('status', SchemaColumn::TYPE_SET, options: []);
+
+        $union = self::invokeMapColumnType($column);
+
+        $this->assertFalse($union->isMixed());
+        $this->assertTrue($union->hasString());
+    }
+
+    private static function invokeMapColumnType(SchemaColumn $column): \Psalm\Type\Union
+    {
+        $method = new \ReflectionMethod(ModelPropertyHandler::class, 'mapColumnType');
+
+        return $method->invoke(null, $column);
     }
 
     #[Test]

--- a/tests/Unit/Handlers/Eloquent/Schema/SqlSchemaParserTest.php
+++ b/tests/Unit/Handlers/Eloquent/Schema/SqlSchemaParserTest.php
@@ -668,7 +668,7 @@ final class SqlSchemaParserTest extends TestCase
             SQL;
 
         $column = $this->parse($sql)->tables['test']->columns['permissions'];
-        $this->assertSame('set', $column->type);
+        $this->assertSame(SchemaColumn::TYPE_SET, $column->type);
         $this->assertSame(['read', 'write', 'execute'], $column->options);
     }
 


### PR DESCRIPTION
## Issue to Solve

MySQL `SET` columns are parsed by the schema layer but fall through to `mixed` in `ModelPropertyHandler::getColumnType()`. `ENUM` columns work; `SET` does not, despite identical option storage in `SchemaColumn::$options`.

```php
Schema::create('posts', function (Blueprint $table) {
    $table->id();
    $table->set('status', ['draft', 'published', 'archived']);
});

$post = Post::find(1);
$post->status; // before: mixed   after: 'draft'|'published'|'archived'
```

## Related

Closes #924

## Solution Description

- Add `SchemaColumn::TYPE_SET` constant for parity with the other `TYPE_*` constants.
- Group `TYPE_SET` with `TYPE_ENUM` in `ModelPropertyHandler::mapColumnType` (single match arm, delegates to a shared `mapLiteralUnionFromOptions` helper, renamed from `mapEnumColumn` so the name reflects both callers).
- Replace literal `'set'` / `'enum'` strings in `SchemaAggregator` and `SqlSchemaParser` with the constants.
- Wrap `TLiteralString::make()` with the same try/catch fallback used by `ValidationRuleAnalyzer::inRuleToLiteralUnion` so the helper degrades to plain string when Psalm `Config` is not yet initialized (unit-test context) or when an option exceeds `max_string_length`.

### Empirical verification of SET runtime behavior

To pick the right type, I tested Laravel 12 + MySQL 8 + Eloquent end-to-end with the model `$post = Post::find($id); $post->status;` and inspected the inferred PHP value:

| Insert | DB stores | Eloquent returns | PHP type |
| --- | --- | --- | --- |
| `'draft'` | `'draft'` | `'draft'` | `string` |
| `'draft,published'` | `'draft,published'` | `'draft,published'` | `string` |
| `'archived,draft,published'` | `'draft,published,archived'` (MySQL reorders to definition order) | same | `string` |
| `''` (empty) | `''` | `''` | `string` |
| `null` (nullable column) | `NULL` | `null` | `null` |
| `['draft', 'archived']` (PHP array) | throws `QueryException: Array to string conversion` | n/a | n/a |
| `1` (PHP int, options were `[1, 2, 3, 4]`) | `'1'` (stored as string) | `'1'` | `string` |

Key observations:
- Eloquent **always** returns SET column as `string` (or `null` when the column is nullable and the row stores NULL). Never an array, never an int, even when migration options are integers.
- MySQL DDL quotes all options regardless of PHP type: `set('levels', [1, 2, 3])` emits `set('1','2','3','4')`.
- MySQL reorders multi-value results to the column's defined option order, so position-dependent comparisons would be unsafe.
- SQLite, Postgres, and SQL Server have no `typeSet`; `Blueprint::set()` throws `BadMethodCallException` on those drivers. The plugin path is MySQL/MariaDB-only.

### Type choice: trade-off between strict correctness and ergonomics

The Psalm type system cannot express "literal-of-options when the column holds a single value, otherwise an arbitrary comma-separated string" (`'a'|string` collapses to `string`). Two honest options exist:

| Type | Single-value SET (`'draft'`) | Multi-value (`'draft,published'`) | Empty (`''`) | DX |
| --- | --- | --- | --- | --- |
| `string` (strict) | comparable but not narrowed | covered | covered | weak (no narrowing, no exhaustiveness) |
| `'a'\|'b'\|'c'` literal union (this PR) | narrowed correctly | not in union, false `TypeDoesNotContainType` | not in union | strong on the degenerate-ENUM common case |

This PR picks the literal union because:

1. In practice SET is most often used as a degenerate ENUM (single option per row). The plugin's narrowing is correct for that case.
2. Bitmask-style multi-value SET is the exception, not the rule. Users who need it usually pick `int`, JSON, or a dedicated pivot table.
3. Larastan picked the same trade-off in [larastan/larastan@f4ffec0](https://github.com/larastan/larastan/commit/f4ffec04e362e65a8cdc1c720eaf1be18346f19a) ("fix: handle enum db columns correctly", 2022-12-23). Diverging here would surprise users who switch between the two tools.
4. `mixed` was strictly worse than either option, so any narrowing is a net improvement.
5. The decision is reversible. If community feedback shows multi-value SET is common, the SET arm can change to `Type::getString()` in a single line, and the existing unit tests still pass (`assertFalse($union->isMixed())` + `assertTrue($union->hasString())`).
6. Users on a multi-value SET column can opt out today via a custom Eloquent cast that returns `list<'draft'|'published'|'archived'>`. The plugin's `CastResolver` already routes around the column-type inference whenever a cast is declared.

### Parity check against Larastan (live)

To confirm 100% parity with Larastan rather than rely on source reading, I ran Larastan v3 against a fresh Laravel 12 app with the same migration above:

```
$post->status   →   'archived'|'draft'|'published'    (non-nullable, 3 options)
$post->tags     →   'laravel'|'php'|null              (nullable, 2 options)
$post->title    →   string                            (sanity check)
```

That is byte-for-byte the same shape produced by this PR.

### Implementation verification

- Three new unit tests in `tests/Unit/Handlers/Eloquent/ModelPropertyHandlerTest.php`:
  - `it_narrows_set_column_away_from_mixed` (regression for #924)
  - `it_includes_null_for_nullable_set_column`
  - `it_falls_back_to_string_for_set_column_without_options`
- Existing `SqlSchemaParserTest::it_handles_mysql_set_type` updated to assert against `SchemaColumn::TYPE_SET`.
- `composer test:unit`, `composer test:type`, `composer psalm`, `composer cs:check` all pass cleanly.

A PHPT type-level test was considered but deferred. The type-test infrastructure has no migration wiring for `tests/Application` models, and a SET column on `Customer` / `WorkOrder` would also need a dedicated archetype model. The unit tests above exercise the same code path through `mapColumnType` via reflection.

## Checklist
- [x] Tests cover the change (unit tests in `tests/Unit/Handlers/Eloquent/ModelPropertyHandlerTest.php`)
