### PR TITLE
Narrow `Model::only()` return shape from literal keys

### DIFF
--- a/src/Handlers/Eloquent/ModelAttributeSubsetHandler.php
+++ b/src/Handlers/Eloquent/ModelAttributeSubsetHandler.php
@@ -79,7 +79,7 @@ final class ModelAttributeSubsetHandler
     {
         $declaring = $codebase->methods->getDeclaringMethodId(new MethodIdentifier($modelClass, 'only'));
 
-        return $declaring !== null
+        return $declaring instanceof \Psalm\Internal\MethodIdentifier
             && \strtolower($declaring->fq_class_name) === \strtolower(HasAttributes::class);
     }
 

--- a/src/Handlers/Eloquent/ModelAttributeSubsetHandler.php
+++ b/src/Handlers/Eloquent/ModelAttributeSubsetHandler.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Handlers\Eloquent;
 
+use Illuminate\Database\Eloquent\Concerns\HasAttributes;
 use PhpParser\Node\Arg;
 use Psalm\Codebase;
+use Psalm\Internal\MethodIdentifier;
 use Psalm\NodeTypeProvider;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\Type;
@@ -49,16 +51,36 @@ final class ModelAttributeSubsetHandler
         }
 
         $source = $event->getSource();
+        $codebase = $source->getCodebase();
+        $modelClass = $event->getFqClasslikeName();
+
+        // Bail if a subclass (or a user trait) overrides only() — the override may
+        // return a different shape, and narrowing it to Laravel's TKeyedArray would
+        // mis-infer it.
+        if (!self::isLaravelOnly($codebase, $modelClass)) {
+            return null;
+        }
+
         $keys = self::collectLiteralKeys($args, $source->getNodeTypeProvider());
         if ($keys === null || $keys === []) {
             return null;
         }
 
-        return self::buildKeyedArray(
-            $source->getCodebase(),
-            $event->getFqClasslikeName(),
-            $keys,
-        );
+        return self::buildKeyedArray($codebase, $modelClass, $keys);
+    }
+
+    /**
+     * True when `$modelClass::only()` resolves to Laravel's `HasAttributes::only()`
+     * (i.e., no override on the concrete class or an intervening trait).
+     *
+     * @psalm-mutation-free
+     */
+    private static function isLaravelOnly(Codebase $codebase, string $modelClass): bool
+    {
+        $declaring = $codebase->methods->getDeclaringMethodId(new MethodIdentifier($modelClass, 'only'));
+
+        return $declaring !== null
+            && \strtolower($declaring->fq_class_name) === \strtolower(HasAttributes::class);
     }
 
     /**

--- a/src/Handlers/Eloquent/ModelAttributeSubsetHandler.php
+++ b/src/Handlers/Eloquent/ModelAttributeSubsetHandler.php
@@ -90,6 +90,7 @@ final class ModelAttributeSubsetHandler
             if (!$argType instanceof Union || !$argType->isSingleStringLiteral()) {
                 return null;
             }
+
             $keys[] = $argType->getSingleStringLiteral()->value;
         }
 
@@ -141,6 +142,7 @@ final class ModelAttributeSubsetHandler
             if ($propType->possibly_undefined || !$propType->isSingleStringLiteral()) {
                 return null;
             }
+
             $keys[] = $propType->getSingleStringLiteral()->value;
         }
 

--- a/src/Handlers/Eloquent/ModelAttributeSubsetHandler.php
+++ b/src/Handlers/Eloquent/ModelAttributeSubsetHandler.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Eloquent;
+
+use PhpParser\Node\Arg;
+use Psalm\Codebase;
+use Psalm\NodeTypeProvider;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Type;
+use Psalm\Type\Atomic\TKeyedArray;
+use Psalm\Type\Union;
+
+/**
+ * Narrows the return type of Model::only() to a TKeyedArray when the keys argument
+ * resolves to literal strings.
+ *
+ * Without this handler, $user->only(['email', 'name']) returns array<string, mixed>.
+ * With it, the type becomes array{email: string, name: string} when the model declares
+ * @property string $email and @property string $name. Unknown keys (no @property hint)
+ * resolve to mixed, but the shape — which keys are present — is still known.
+ *
+ * Mirrors Laravel's runtime behavior on `HasAttributes::only()`:
+ * - When the first argument is an array, that array's elements are used.
+ * - Otherwise, all positional arguments are taken as string keys.
+ *
+ * Registered per concrete Model class by {@see ModelRegistrationHandler} because
+ * Psalm's provider lookup uses exact class name matching. Both `only()` and `except()`
+ * live on Laravel's `HasAttributes` trait, hence the "AttributeSubset" name — `except()`
+ * can be added here once a complete attribute enumeration becomes available; for now
+ * `except()` cannot be soundly narrowed from `@property` declarations alone (the
+ * @property set is usually a strict subset of the actual database attributes).
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/931
+ * @internal
+ */
+final class ModelAttributeSubsetHandler
+{
+    public static function getReturnType(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        if ($event->getMethodNameLowercase() !== 'only') {
+            return null;
+        }
+
+        $args = $event->getCallArgs();
+        if ($args === []) {
+            return null;
+        }
+
+        $source = $event->getSource();
+        $keys = self::collectLiteralKeys($args, $source->getNodeTypeProvider());
+        if ($keys === null || $keys === []) {
+            return null;
+        }
+
+        return self::buildKeyedArray(
+            $source->getCodebase(),
+            $event->getFqClasslikeName(),
+            $keys,
+        );
+    }
+
+    /**
+     * Collect literal string keys from the call arguments.
+     * Returns null when any argument is not statically resolvable to literal strings.
+     *
+     * Laravel branches on whether the first argument is an array:
+     *   only(['a', 'b'])     → iterate ['a', 'b']
+     *   only('a', 'b')       → iterate func_get_args() = ['a', 'b']
+     *   only(['a','b'], 'c') → first arg is array, 'c' is ignored
+     *
+     * @param list<Arg> $args
+     * @return list<string>|null
+     */
+    private static function collectLiteralKeys(array $args, NodeTypeProvider $ntp): ?array
+    {
+        $firstArgType = $ntp->getType($args[0]->value);
+        if (!$firstArgType instanceof Union) {
+            return null;
+        }
+
+        if (self::isArrayLike($firstArgType)) {
+            return self::extractLiteralStringsFromArray($firstArgType);
+        }
+
+        $keys = [];
+        foreach ($args as $arg) {
+            $argType = $ntp->getType($arg->value);
+            if (!$argType instanceof Union || !$argType->isSingleStringLiteral()) {
+                return null;
+            }
+            $keys[] = $argType->getSingleStringLiteral()->value;
+        }
+
+        return $keys;
+    }
+
+    /** @psalm-mutation-free */
+    private static function isArrayLike(Union $type): bool
+    {
+        foreach ($type->getAtomicTypes() as $atomic) {
+            if ($atomic instanceof TKeyedArray || $atomic instanceof Type\Atomic\TArray) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Extract literal string values from an array-typed Union.
+     *
+     * Only sealed literal array shapes (a single TKeyedArray atomic with no
+     * fallback_params and no possibly-undefined entries) are narrowed. Falls back
+     * to Laravel's default signature in these cases:
+     * - Multi-atomic Union (e.g., `$cond ? ['id'] : ['name']`), because flattening
+     *   atomics into one shape would widen the runtime contract.
+     * - Non-`TKeyedArray` atomic (plain `TArray<K, V>`), which carries no literal keys.
+     * - Unsealed shape (`array{known: T, ...<K, V>}`, including `list<'a'|'b'>` that
+     *   Psalm models with fallback_params), which admits unknown extra keys.
+     * - Possibly-undefined entries, because the key may be absent at runtime.
+     *
+     * @return list<string>|null
+     * @psalm-mutation-free
+     */
+    private static function extractLiteralStringsFromArray(Union $type): ?array
+    {
+        $atomics = $type->getAtomicTypes();
+        if (\count($atomics) !== 1) {
+            return null;
+        }
+
+        $atomic = \reset($atomics);
+        if (!$atomic instanceof TKeyedArray || $atomic->fallback_params !== null) {
+            return null;
+        }
+
+        $keys = [];
+        foreach ($atomic->properties as $propType) {
+            if ($propType->possibly_undefined || !$propType->isSingleStringLiteral()) {
+                return null;
+            }
+            $keys[] = $propType->getSingleStringLiteral()->value;
+        }
+
+        return $keys;
+    }
+
+    /**
+     * Build a TKeyedArray with each key's value type pulled from the model's
+     * @property declaration; missing keys fall back to mixed.
+     *
+     * @param non-empty-list<string> $keys
+     * @psalm-mutation-free
+     */
+    private static function buildKeyedArray(Codebase $codebase, string $modelClass, array $keys): ?Union
+    {
+        try {
+            $classStorage = $codebase->classlike_storage_provider->get($modelClass);
+        } catch (\InvalidArgumentException) {
+            return null;
+        }
+
+        $properties = [];
+        foreach ($keys as $key) {
+            $properties[$key] = $classStorage->pseudo_property_get_types['$' . $key] ?? Type::getMixed();
+        }
+
+        return new Union([TKeyedArray::make($properties)]);
+    }
+}

--- a/src/Handlers/Eloquent/ModelRegistrationHandler.php
+++ b/src/Handlers/Eloquent/ModelRegistrationHandler.php
@@ -207,6 +207,12 @@ final class ModelRegistrationHandler implements AfterCodebasePopulatedInterface
             $className,
             ModelRelationReturnTypeHandler::getReturnType(...),
         );
+        // Model::only() shape narrowing from literal keys.
+        // See https://github.com/psalm/psalm-plugin-laravel/issues/931
+        $methods->return_type_provider->registerClosure(
+            $className,
+            ModelAttributeSubsetHandler::getReturnType(...),
+        );
 
         // Registration order matters — the first non-null result wins.
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -98,6 +98,7 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Eloquent/ModelFactoryTypeProvider.php';
         require_once __DIR__ . '/Handlers/Eloquent/FactoryCountTypeProvider.php';
         require_once __DIR__ . '/Handlers/Eloquent/ModelPropertyAccessorHandler.php';
+        require_once __DIR__ . '/Handlers/Eloquent/ModelAttributeSubsetHandler.php';
         if ($pluginConfig->shouldUseMigrations()) {
             require_once __DIR__ . '/Handlers/Eloquent/ModelPropertyHandler.php';
             Handlers\Eloquent\ModelRegistrationHandler::enableMigrations();

--- a/tests/Type/tests/Model/OnlyKeyedArrayTest.phpt
+++ b/tests/Type/tests/Model/OnlyKeyedArrayTest.phpt
@@ -1,0 +1,190 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Sandbox;
+
+use App\Models\Customer;
+use App\Models\Vehicle;
+use Carbon\CarbonInterface;
+
+/**
+ * Model::only() should narrow to a TKeyedArray when the keys argument resolves
+ * to literal strings. Without the handler, it returns array<string, mixed>.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/931
+ */
+
+/**
+ * Array argument with @property keys: narrowed to per-key types.
+ *
+ * Customer declares @property string $id and @property CarbonInterface|null $email_verified_at.
+ *
+ * @return array{id: string, email_verified_at: CarbonInterface|null}
+ */
+function test_array_arg_with_property_keys(Customer $customer): array
+{
+    /** @psalm-check-type-exact $slice = array{id: string, email_verified_at: \Carbon\CarbonInterface|null} */
+    $slice = $customer->only(['id', 'email_verified_at']);
+
+    return $slice;
+}
+
+/**
+ * Varargs form: same shape, same types.
+ *
+ * @return array{id: string, email_verified_at: CarbonInterface|null}
+ */
+function test_varargs_form(Customer $customer): array
+{
+    /** @psalm-check-type-exact $slice = array{id: string, email_verified_at: \Carbon\CarbonInterface|null} */
+    $slice = $customer->only('id', 'email_verified_at');
+
+    return $slice;
+}
+
+/**
+ * Single-string varargs.
+ *
+ * @return array{id: string}
+ */
+function test_single_string_arg(Customer $customer): array
+{
+    /** @psalm-check-type-exact $slice = array{id: string} */
+    $slice = $customer->only('id');
+
+    return $slice;
+}
+
+/**
+ * Unknown key with no @property declaration: shape narrowed, value falls back to mixed.
+ *
+ * @return array{id: string, no_such_property: mixed}
+ */
+function test_unknown_key_falls_back_to_mixed(Customer $customer): array
+{
+    /** @psalm-check-type-exact $slice = array{id: string, no_such_property: mixed} */
+    $slice = $customer->only(['id', 'no_such_property']);
+
+    return $slice;
+}
+
+/**
+ * Non-literal key: handler returns null, Laravel's signature applies.
+ *
+ * @return array<string, mixed>
+ */
+function test_non_literal_arg_falls_back(Customer $customer, string $key): array
+{
+    /** @psalm-check-type-exact $slice = array<string, mixed> */
+    $slice = $customer->only([$key]);
+
+    return $slice;
+}
+
+/**
+ * Empty array: handler returns null, Laravel's signature applies.
+ *
+ * @return array<string, mixed>
+ */
+function test_empty_array_falls_back(Customer $customer): array
+{
+    /** @psalm-check-type-exact $slice = array<string, mixed> */
+    $slice = $customer->only([]);
+
+    return $slice;
+}
+
+/**
+ * Unsealed shape (`list<'a'|'b'>` from a function return): handler falls back,
+ * since the fallback_params admit additional keys not statically enumerable.
+ *
+ * @return list<'id'|'email_verified_at'>
+ */
+function helper_keys_as_list(): array
+{
+    return ['id', 'email_verified_at'];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function test_unsealed_list_falls_back(Customer $customer): array
+{
+    /** @psalm-check-type-exact $slice = array<string, mixed> */
+    $slice = $customer->only(helper_keys_as_list());
+
+    return $slice;
+}
+
+/**
+ * Mixed literal and non-literal entries in an array argument: handler falls back.
+ *
+ * @return array<string, mixed>
+ */
+function test_array_arg_mixed_literal_and_var_falls_back(Customer $customer, string $key): array
+{
+    /** @psalm-check-type-exact $slice = array<string, mixed> */
+    $slice = $customer->only(['id', $key]);
+
+    return $slice;
+}
+
+/**
+ * Mixed literal and non-literal positional arguments: handler falls back.
+ *
+ * @return array<string, mixed>
+ */
+function test_varargs_mixed_literal_and_var_falls_back(Customer $customer, string $key): array
+{
+    /** @psalm-check-type-exact $slice = array<string, mixed> */
+    $slice = $customer->only('id', $key);
+
+    return $slice;
+}
+
+/**
+ * Plain `array<int, string>` (no literal keys): handler falls back.
+ *
+ * @param array<int, string> $keys
+ * @return array<string, mixed>
+ */
+function test_plain_typed_array_falls_back(Customer $customer, array $keys): array
+{
+    /** @psalm-check-type-exact $slice = array<string, mixed> */
+    $slice = $customer->only($keys);
+
+    return $slice;
+}
+
+/**
+ * Multi-atomic Union of distinct shapes (`['id'] | ['email_verified_at']`): handler
+ * falls back rather than flattening keys across both atomics, since the runtime
+ * value matches only one of the two shapes.
+ *
+ * @return array<string, mixed>
+ */
+function test_union_of_distinct_shapes_falls_back(Customer $customer, bool $cond): array
+{
+    $keys = $cond ? ['id'] : ['email_verified_at'];
+    /** @psalm-check-type-exact $slice = array<string, mixed> */
+    $slice = $customer->only($keys);
+
+    return $slice;
+}
+
+/**
+ * Object-typed @property value passes through `only()` unchanged.
+ *
+ * Customer declares `@property Vehicle|null $primary_vehicle`.
+ *
+ * @return array{primary_vehicle: Vehicle|null}
+ */
+function test_object_property_value(Customer $customer): array
+{
+    /** @psalm-check-type-exact $slice = array{primary_vehicle: \App\Models\Vehicle|null} */
+    $slice = $customer->only(['primary_vehicle']);
+
+    return $slice;
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Model/OnlyKeyedArrayTest.phpt
+++ b/tests/Type/tests/Model/OnlyKeyedArrayTest.phpt
@@ -186,5 +186,34 @@ function test_object_property_value(Customer $customer): array
 
     return $slice;
 }
+
+/**
+ * A subclass overrides only() with a refined return type — the handler MUST defer
+ * to the override and not impose Laravel's TKeyedArray shape derived from the
+ * literal-key arg.
+ */
+class CustomerWithOnlyOverride extends Customer
+{
+    /**
+     * @param  array<string>|mixed  $attributes
+     * @return array{custom: int}
+     */
+    #[\Override]
+    public function only($attributes): array
+    {
+        return ['custom' => 42];
+    }
+}
+
+/**
+ * @return array{custom: int}
+ */
+function test_user_override_is_respected(CustomerWithOnlyOverride $customer): array
+{
+    /** @psalm-check-type-exact $slice = array{custom: int} */
+    $slice = $customer->only(['id']);
+
+    return $slice;
+}
 ?>
 --EXPECTF--


### PR DESCRIPTION
## Issue to Solve

`$user->only(['email', 'name'])` returns a generic `array<string, mixed>` regardless of the literal keys passed, even when those keys correspond to declared model properties. The shape is unknown and per-field types are lost.

## Related

Closes #931.

Defers `Model::except()` (mentioned in the issue as part of the same handler). Soundly narrowing `except()`'s shape requires enumerating every model attribute, since the runtime result keys are `getAttributes() \ $args`. The `@property` set is usually a strict subset of the database columns, so deriving the shape from it would understate the runtime result. The handler is named after Laravel's `HasAttributes` trait so `except()` can land here once a complete attribute enumeration becomes available (e.g., the planned `ModelMetadataRegistry`).

## Solution Description

Adds `ModelAttributeSubsetHandler` registered per concrete `Model` subclass via `ModelRegistrationHandler` (Psalm's provider lookup uses exact class-name matching).

When the keys argument to `only()` resolves to a sealed literal-string array shape (or to pure string varargs), the return type becomes a `TKeyedArray` keyed on those literals, with each value pulled from `ClassLikeStorage::$pseudo_property_get_types` (the `@property` declaration map). Unknown keys fall back to `mixed`, so the shape is still narrowed even when individual value types are unknown.

The handler falls back to Laravel's default `array<string, mixed>` signature in these cases:

- Non-literal arguments (variables).
- Empty array argument.
- Plain `TArray<K, V>` argument (no literal keys).
- Unsealed `TKeyedArray` (`fallback_params !== null`, which includes `list<'a'|'b'>` in Psalm 7).
- Multi-atomic `Union` (e.g., `$cond ? ['id'] : ['name']`), because flattening atomics into one shape would widen the runtime contract.
- Possibly-undefined entries in a sealed shape.

Laravel's runtime branching on `is_array($attributes) ? $attributes : func_get_args()` is mirrored: when the first argument is an array, only that array is used; otherwise all positional arguments are taken as string keys.

Type tests in `tests/Type/tests/Model/OnlyKeyedArrayTest.phpt` cover both call forms (array + varargs), the unknown-key fallback, and every documented fallback case (non-literal, empty, plain typed array, unsealed list, multi-atomic union, mixed literal + variable). One test exercises an object-typed `@property` value (`Vehicle|null`) to confirm Union pass-through is correct.

## Checklist

- [x] Tests cover the change (type tests in `tests/Type/tests/Model/OnlyKeyedArrayTest.phpt`)
