### PR TITLE
feat(blade): cover first/renderEach/ResponseFactory + View::with #581

### DIFF
--- a/docs/issues/581-blade-taint-exploration.md
+++ b/docs/issues/581-blade-taint-exploration.md
@@ -24,12 +24,12 @@ Status of the epic at the time of writing:
 | PR | Scope | Status |
 |----|-------|--------|
 | PR-1 [#920](https://github.com/psalm/psalm-plugin-laravel/pull/920) | Tri-state scanner via `BladeCompiler` + php-parser. `BladeViewSafetyKind`, `BladeUncertaintyReason`, `BladeSafetyMap`. | merged into umbrella |
-| PR-2 (TBD) | First-pass scanner precision: `@include` literal resolution, scope frame push/pop, source-mapped line numbers. | not started |
-| PR-3 (this PR) | `BladeAwareViewTaintHandler`. Wires `BladeSafetyMap` into Psalm's taint flow for `view()` / `Factory::make()` / facade `View::make()`. Per-key sinks for `UNSAFE_KEYS`, whole-data fallback for `UNKNOWN` and dynamic view names. | shipping |
-| PR-4 (TBD) | `Factory::first()` (union of safety records), `Factory::renderEach()` (per-iterator key shape), `ResponseFactory::view()`. Cross-template `@include` data-flow propagation when the include target is literal. | not started |
-| PR-5 (TBD) | Component data flow (`<x-foo :bar="$data" />`), section graph, scanner result caching across analysis runs. | not started |
+| PR-2 (TBD) | First-pass scanner precision: scope frame push/pop, source-mapped line numbers. (Literal `@include` resolution shipped in PR-4.) | not started |
+| PR-3 [#926](https://github.com/psalm/psalm-plugin-laravel/pull/926) | `BladeAwareViewTaintHandler`. Wires `BladeSafetyMap` into Psalm's taint flow for `view()` / `Factory::make()` / facade `View::make()`. Per-key sinks for `UNSAFE_KEYS`, whole-data fallback for `UNKNOWN` and dynamic view names. | merged into umbrella |
+| PR-4 (this PR) | Extended dispatch to `Factory::first()` (multi-template union), `Factory::renderEach()` (per-iterator key shape), `Routing\ResponseFactory::view()` (concrete + contract), `View::with()` / `View::nest()` (receiver-resolved view name), and the Mailable / MailMessage / Content view-binding methods. Scanner records literal `@include('child', [...])` edges; `BladeSafetyMap::build()` folds child unsafe keys into the parent via a fixed-point pass that accounts for Laravel's `compileInclude()` mergeData pass-through. Cycles in the include graph bail to `UNKNOWN(IncludeCycle)`. | shipping |
+| PR-5 (TBD) | Component data flow (`<x-foo :bar="$data" />`), section graph, scanner result caching across analysis runs, variable-bound view-builder chains (`$v = view('home'); $v->with(...)`). | not started |
 
-PR-3 deliberately does NOT include integration tests under `tests/Application/`.
+Neither PR-3 nor PR-4 includes integration tests under `tests/Application/`.
 The Application test harness (`tests/Application/laravel-test.sh`) runs Psalm
 without `--taint-analysis`, so a taint-validating fixture would require either
 a new harness flow or a refactor of the existing one. The handler is covered

--- a/src/Blade/BladeIncludeEdge.php
+++ b/src/Blade/BladeIncludeEdge.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Blade;
+
+/**
+ * One literal `@include` directive observed in a Blade template.
+ *
+ * Models the data flow between a parent template and a child template at a
+ * single `@include('child', ['k' => $expr])` call site. {@see BladeSafetyMap}
+ * uses these edges to run a fixed-point pass that propagates the child's
+ * unsafe-key set onto the parent's safety record, mapping each child key
+ * through the parent's explicit data array (and through Laravel's implicit
+ * mergeData pass-through; see below).
+ *
+ * Laravel's `compileInclude()` always appends `array_diff_key(get_defined_vars(),
+ * ['__data' => 1, '__path' => 1])` as the trailing argument to the underlying
+ * `$__env->make()` call. That argument lands in `Factory::make()`'s
+ * `$mergeData` slot, and `Factory::make()` resolves the child's data bag as
+ * `array_merge($mergeData, $data)` — explicit `$data` keys win, but any key
+ * the parent template has in scope and that the explicit `$data` array does
+ * NOT bind is still pushed to the child verbatim.
+ *
+ * That means propagation has two flows that must both be sound:
+ *
+ *  - **Explicit binding.** When the parent calls `@include('child', ['x' =>
+ *    $y])` and the child has unsafe key `x`, the parent's unsafe-keys gain
+ *    every top-level variable found in the expression `$y`. The map field
+ *    {@see $explicitKeyMap} holds, for each explicit data-array entry, the
+ *    list of top-level variables present in the bound expression.
+ *
+ *  - **Implicit mergeData pass-through.** When the child has unsafe key
+ *    `bio` and the parent's explicit data array does NOT bind `bio`, the
+ *    parent's `$bio` (if any) reaches the child via `mergeData`. Soundness
+ *    requires we treat `bio` as a parent unsafe-key by its own name. We do
+ *    not know whether the parent template actually has `$bio` in scope, but
+ *    if no caller of the parent passes a `bio` key the propagation is a
+ *    harmless no-op; if a caller does pass `bio`, the propagation surfaces
+ *    a real flow that would otherwise be missed.
+ *
+ * A 2-argument `@include('child')` (no explicit data) is the limit case of
+ * "all keys flow through mergeData": {@see $explicitKeyMap} is `null` to
+ * distinguish it from "explicit data was an empty array" (which also exists
+ * but should be encoded as `[]`, not `null`). In both cases the propagation
+ * algorithm reads the same: every child unsafe key K propagates to the
+ * parent as K verbatim, except where {@see $explicitKeyMap} binds K.
+ *
+ * An edge is only created when the include's view-name argument is a literal
+ * string AND, in the 3-argument form, the data-array argument is a literal
+ * `Array_` node. If either condition fails the scanner emits
+ * {@see BladeUncertaintyReason::IncludeDirective} instead, with no edge —
+ * propagation cannot proceed without a known target or a known mapping.
+ *
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final readonly class BladeIncludeEdge
+{
+    /**
+     * @param non-empty-string                                $childViewName  literal dotted view name from the
+     *                                                                        include directive (`@include('emails.partials.row')`
+     *                                                                        becomes `emails.partials.row`)
+     * @param array<non-empty-string, list<non-empty-string>>|null $explicitKeyMap key-to-parent-vars binding extracted from
+     *                                                                        the literal data array, or null for the
+     *                                                                        2-argument `@include('child')` form. An
+     *                                                                        empty array means the user wrote
+     *                                                                        `@include('child', [])` — explicit binding
+     *                                                                        of zero keys, distinct from "no explicit
+     *                                                                        binding at all".
+     */
+    public function __construct(
+        public string $childViewName,
+        public ?array $explicitKeyMap,
+    ) {}
+}

--- a/src/Blade/BladeSafetyMap.php
+++ b/src/Blade/BladeSafetyMap.php
@@ -123,7 +123,395 @@ final readonly class BladeSafetyMap
             }
         }
 
-        return new self($map);
+        return new self(self::propagateIncludeEdges($map));
+    }
+
+    /**
+     * Fixed-point pass that consumes every template's `@include` edges and
+     * folds child unsafe keys into the parent template's safety record.
+     *
+     * Two passes:
+     *
+     *  1. DFS to detect cycle members. A template is a cycle member iff a path
+     *     of `@include`-emitted edges starting at it returns to it. Cycle
+     *     members are tracked as a set and finalised as
+     *     UNKNOWN(IncludeCycle) regardless of any other propagation result.
+     *
+     *  2. Memoised topological resolution per template:
+     *     - Templates whose scanner uncertainty contains only
+     *       {@see BladeUncertaintyReason::IncludeResolved} are eligible. For
+     *       each include edge, we look up the child's *final* (post-propagation)
+     *       state and apply two propagation rules:
+     *       * if the parent's explicit data array binds the child's unsafe key
+     *         K (i.e. `@include('child', ['K' => $expr])`), every top-level
+     *         variable observed in `$expr` is added to the parent's unsafe
+     *         keys;
+     *       * otherwise, K is added to the parent's unsafe keys verbatim,
+     *         because Laravel's `compileInclude()` always forwards the parent
+     *         template's scope as the trailing mergeData argument to
+     *         `$__env->make()`.
+     *     - If any child resolves to UNKNOWN (other than via {@see
+     *       BladeUncertaintyReason::IncludeCycle}, which we treat identically),
+     *       or if a child's view name is not in the map at all, the parent's
+     *       contribution from that include is opaque and the parent stays
+     *       UNKNOWN(IncludeDirective). This matches the conservative pre-PR-4
+     *       behaviour for the unresolvable case.
+     *     - Templates with any uncertainty other than IncludeResolved
+     *       (LayoutSectionFlow, IncludeDirective, ComponentTag, UnparsablePhpBlock,
+     *       etc., possibly alongside IncludeResolved) are NOT eligible and
+     *       pass through unchanged: any other uncertainty already dominates
+     *       and propagation would be a no-op anyway.
+     *
+     * The pass is in-process, runs once per `build()` call, and is bounded by
+     * the include-graph size (each template visited at most twice: once in
+     * the cycle DFS, once during memoised finalisation).
+     *
+     * @param array<non-empty-string, BladeViewSafety> $map
+     *
+     * @return array<non-empty-string, BladeViewSafety>
+     */
+    private static function propagateIncludeEdges(array $map): array
+    {
+        $cycleMembers = self::detectIncludeCycles($map);
+
+        /** @var array<string, BladeViewSafety> $finalised */
+        $finalised = [];
+
+        foreach (\array_keys($map) as $viewName) {
+            $finalised = self::finaliseSafetyForView($viewName, $map, $cycleMembers, $finalised);
+        }
+
+        /** @var array<non-empty-string, BladeViewSafety> $result */
+        $result = [];
+
+        foreach ($finalised as $viewName => $safety) {
+            if ($viewName === '') {
+                // Guaranteed unreachable by construction: every writer feeds
+                // $finalised from `$map[K] = ...` where K originates from
+                // `array_keys($map)` and $map is keyed by `non-empty-string`.
+                // The check exists to refine Psalm's array-key type back to
+                // `non-empty-string` for the public {@see $safetyByView}
+                // contract; without it, the broader `string` key type would
+                // bubble up to every caller of the map.
+                continue;
+            }
+
+            $result[$viewName] = $safety;
+        }
+
+        return $result;
+    }
+
+    /**
+     * DFS over the literal-include graph to record every template that
+     * participates in a cycle (template A includes B, B includes A;
+     * transitively; or a self-loop).
+     *
+     * The visit colouring (white → gray → black) is the classic three-colour
+     * cycle detection: a back-edge to a gray node identifies a cycle, and the
+     * set of stacked nodes from the back-edge target to the top of the stack
+     * are exactly the cycle members.
+     *
+     * @param array<non-empty-string, BladeViewSafety> $map
+     *
+     * @return array<string, true>
+     */
+    private static function detectIncludeCycles(array $map): array
+    {
+        /** @var array<string, 'gray'|'black'> $visit */
+        $visit = [];
+
+        /** @var list<string> $stack */
+        $stack = [];
+
+        /** @var array<string, true> $cycleMembers */
+        $cycleMembers = [];
+
+        foreach (\array_keys($map) as $viewName) {
+            if (isset($visit[$viewName])) {
+                continue;
+            }
+
+            self::dfsForCycles($viewName, $map, $visit, $stack, $cycleMembers);
+        }
+
+        return $cycleMembers;
+    }
+
+    /**
+     * @param array<non-empty-string, BladeViewSafety>      $map
+     * @param array<string, 'gray'|'black'>                 $visit
+     * @param list<string>                                  $stack
+     * @param array<string, true>                           $cycleMembers
+     */
+    private static function dfsForCycles(
+        string $current,
+        array $map,
+        array &$visit,
+        array &$stack,
+        array &$cycleMembers,
+    ): void {
+        $visit[$current] = 'gray';
+        $stack[] = $current;
+
+        $safety = $map[$current] ?? null;
+
+        if ($safety instanceof BladeViewSafety && self::isEligibleForPropagation($safety)) {
+            foreach ($safety->analysis->includeEdges as $edge) {
+                $childName = $edge->childViewName;
+                $childState = $visit[$childName] ?? null;
+
+                if ($childState === null) {
+                    self::dfsForCycles($childName, $map, $visit, $stack, $cycleMembers);
+                } elseif ($childState === 'gray') {
+                    // Back-edge: every node from the gray child up to the
+                    // current top of the stack participates in the cycle.
+                    $cycleStart = \array_search($childName, $stack, true);
+
+                    if ($cycleStart !== false) {
+                        $stackSize = \count($stack);
+
+                        for ($i = $cycleStart; $i < $stackSize; ++$i) {
+                            $cycleMembers[$stack[$i]] = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        \array_pop($stack);
+        $visit[$current] = 'black';
+    }
+
+    /**
+     * Compute (memoised) the post-propagation safety record for `$viewName`
+     * and return an updated `$finalised` map. Non-eligible templates pass
+     * through unchanged; cycle members become UNKNOWN(IncludeCycle); eligible
+     * templates fold each child include's contribution per the rules
+     * documented on {@see propagateIncludeEdges()}.
+     *
+     * Returns the new accumulator rather than mutating by reference: Psalm's
+     * by-reference param type tracking widens the array key type to plain
+     * `string` once any non-`array_keys` source contributes, which would
+     * break the narrow `non-empty-string` invariant of {@see $safetyByView}.
+     * Functional accumulator passes the inferred type back to the caller.
+     *
+     * @param array<non-empty-string, BladeViewSafety> $map
+     * @param array<string, true>                      $cycleMembers
+     * @param array<string, BladeViewSafety>           $finalised
+     *
+     * @return array<string, BladeViewSafety>
+     *
+     * @psalm-pure
+     */
+    private static function finaliseSafetyForView(
+        string $viewName,
+        array $map,
+        array $cycleMembers,
+        array $finalised,
+    ): array {
+        if (isset($finalised[$viewName])) {
+            return $finalised;
+        }
+
+        $safety = $map[$viewName] ?? null;
+
+        if (!$safety instanceof BladeViewSafety) {
+            return $finalised;
+        }
+
+        if (isset($cycleMembers[$viewName])) {
+            $newAnalysis = BladeTemplateAnalysis::unknown(
+                [BladeUncertaintyReason::IncludeCycle],
+                $safety->analysis->unsafeKeys,
+            );
+
+            $finalised[$viewName] = new BladeViewSafety($safety->viewName, $safety->path, $newAnalysis);
+
+            return $finalised;
+        }
+
+        if (!self::isEligibleForPropagation($safety)) {
+            // Template has uncertainties other than IncludeResolved (e.g.
+            // ComponentTag + IncludeResolved). The non-IncludeResolved
+            // uncertainty dominates; propagation would be a no-op anyway.
+            // Strip IncludeResolved before exposing the safety record: the
+            // enum's documented contract is that consumers of a built
+            // BladeSafetyMap never see IncludeResolved. Without the strip,
+            // mixed-uncertainty templates would leak the intermediate marker.
+            $finalised[$viewName] = self::stripIncludeResolved($safety);
+
+            return $finalised;
+        }
+
+        $combined = \array_fill_keys($safety->analysis->unsafeKeys, true);
+
+        $hasUnknownContribution = false;
+
+        foreach ($safety->analysis->includeEdges as $edge) {
+            $childName = $edge->childViewName;
+
+            if (!isset($map[$childName])) {
+                // Include target not in the scanned roots: typo, package view,
+                // or out-of-scope path. Conservative fallback — the include's
+                // contribution is opaque.
+                $hasUnknownContribution = true;
+                continue;
+            }
+
+            $finalised = self::finaliseSafetyForView($childName, $map, $cycleMembers, $finalised);
+
+            $childSafety = $finalised[$childName] ?? null;
+
+            if (!$childSafety instanceof BladeViewSafety) {
+                $hasUnknownContribution = true;
+                continue;
+            }
+
+            if ($childSafety->analysis->kind === BladeViewSafetyKind::Unknown) {
+                $hasUnknownContribution = true;
+                continue;
+            }
+
+            foreach ($childSafety->analysis->unsafeKeys as $childKey) {
+                $combined = self::propagateChildKey($childKey, $edge->explicitKeyMap, $combined);
+            }
+        }
+
+        if ($hasUnknownContribution) {
+            $newAnalysis = BladeTemplateAnalysis::unknown(
+                [BladeUncertaintyReason::IncludeDirective],
+                $safety->analysis->unsafeKeys,
+            );
+        } else {
+            $keys = \array_keys($combined);
+
+            $newAnalysis = $keys === []
+                ? BladeTemplateAnalysis::safe()
+                : BladeTemplateAnalysis::unsafeKeys($keys);
+        }
+
+        $finalised[$viewName] = new BladeViewSafety($safety->viewName, $safety->path, $newAnalysis);
+
+        return $finalised;
+    }
+
+    /**
+     * Apply the per-key propagation rule for one `(child unsafe key, parent
+     * explicit data array)` pair. Returns the new accumulator with the parent
+     * variables contributed by this child key folded in.
+     *
+     * Functional shape (return-the-accumulator rather than mutate-by-ref) so
+     * Psalm can preserve the `non-empty-string` key invariant across calls.
+     *
+     * @param array<non-empty-string, list<non-empty-string>>|null $explicitKeyMap
+     * @param array<non-empty-string, true>                        $combined
+     *
+     * @return array<non-empty-string, true>
+     *
+     * @psalm-pure
+     */
+    private static function propagateChildKey(
+        string $childKey,
+        ?array $explicitKeyMap,
+        array $combined,
+    ): array {
+        if ($explicitKeyMap !== null && isset($explicitKeyMap[$childKey])) {
+            // Explicit binding wins. Parent's explicit array maps the child's
+            // key to some expression; the parent variables present in that
+            // expression are the parent's contribution.
+            foreach ($explicitKeyMap[$childKey] as $parentVar) {
+                $combined[$parentVar] = true;
+            }
+
+            return $combined;
+        }
+
+        // mergeData verbatim pass-through. `compileInclude()` always forwards
+        // the parent template's whole scope, so a child unsafe key K that the
+        // parent does not bind explicitly reaches the child as the parent's
+        // `$K`. Parent unsafe keys gain K verbatim.
+        if ($childKey !== '') {
+            $combined[$childKey] = true;
+        }
+
+        return $combined;
+    }
+
+    /**
+     * Project a non-eligible safety record onto its post-propagation form by
+     * removing the intermediate {@see BladeUncertaintyReason::IncludeResolved}
+     * marker. The remaining uncertainty list (LayoutSectionFlow, ComponentTag,
+     * IncludeDirective, etc.) already dominates the result, and the enum
+     * documents that IncludeResolved is never exposed to map consumers.
+     *
+     * Returns the original safety unchanged when no IncludeResolved marker is
+     * present — the common case for templates whose only uncertainty is
+     * something other than an include directive.
+     *
+     * @psalm-pure
+     */
+    private static function stripIncludeResolved(BladeViewSafety $safety): BladeViewSafety
+    {
+        $uncertainties = $safety->analysis->uncertainties;
+        $filtered = [];
+        $sawIncludeResolved = false;
+
+        foreach ($uncertainties as $reason) {
+            if ($reason === BladeUncertaintyReason::IncludeResolved) {
+                $sawIncludeResolved = true;
+                continue;
+            }
+
+            $filtered[] = $reason;
+        }
+
+        if (!$sawIncludeResolved) {
+            return $safety;
+        }
+
+        if ($filtered === []) {
+            // Defensive: a template flagged non-eligible MUST have at least
+            // one non-IncludeResolved uncertainty (that is what makes it
+            // non-eligible). Reaching here with $filtered === [] means the
+            // eligibility check and this filter disagreed; restoring the
+            // original record is the safest fallback (still wrong, but does
+            // not crash via the unknown() non-empty contract).
+            return $safety;
+        }
+
+        $newAnalysis = BladeTemplateAnalysis::unknown($filtered, $safety->analysis->unsafeKeys);
+
+        return new BladeViewSafety($safety->viewName, $safety->path, $newAnalysis);
+    }
+
+    /**
+     * True if a template is a candidate for include-edge propagation: its
+     * only uncertainty is {@see BladeUncertaintyReason::IncludeResolved}, and
+     * therefore the propagation pass can soundly fold child contributions
+     * back into a SAFE / UNSAFE_KEYS result.
+     *
+     * Templates with any other uncertainty (LayoutSectionFlow, IncludeDirective,
+     * ComponentTag, etc.) stay UNKNOWN regardless, so propagation would be a
+     * no-op anyway.
+     *
+     * @psalm-pure
+     */
+    private static function isEligibleForPropagation(BladeViewSafety $safety): bool
+    {
+        $uncertainties = $safety->analysis->uncertainties;
+
+        if ($uncertainties === []) {
+            return false;
+        }
+
+        foreach ($uncertainties as $uncertainty) {
+            if ($uncertainty !== BladeUncertaintyReason::IncludeResolved) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/Blade/BladeTemplateAnalysis.php
+++ b/src/Blade/BladeTemplateAnalysis.php
@@ -25,6 +25,15 @@ namespace Psalm\LaravelPlugin\Blade;
  * through paths the v1 scanner does not model, so the conservative answer is
  * "we cannot enumerate keys precisely".
  *
+ * `includeEdges` carries the literal `@include('child', [...])` directives
+ * the scanner resolved (see {@see BladeIncludeEdge}). The scanner emits one
+ * edge per resolvable include AND records {@see BladeUncertaintyReason::IncludeResolved}
+ * so the analysis stays UNKNOWN at the source-only layer (an include's
+ * contribution to the parent's unsafe keys cannot be computed without
+ * inspecting the child template). {@see BladeSafetyMap::build()} runs a
+ * fixed-point propagation pass that consumes these edges and flips eligible
+ * parents to SAFE or UNSAFE_KEYS.
+ *
  * The constructor is `private` so the kind-to-payload invariants in the bullet
  * list above are only reachable through {@see safe()}, {@see unsafeKeys()}, and
  * {@see unknown()}. A public constructor would let a caller produce e.g.
@@ -39,11 +48,13 @@ final readonly class BladeTemplateAnalysis
     /**
      * @param list<non-empty-string>       $unsafeKeys    top-level data keys reaching raw output
      * @param list<BladeUncertaintyReason> $uncertainties reasons the scanner could not model the template
+     * @param list<BladeIncludeEdge>       $includeEdges  resolvable `@include` edges observed in the template
      */
     private function __construct(
         public BladeViewSafetyKind $kind,
         public array $unsafeKeys,
         public array $uncertainties,
+        public array $includeEdges = [],
     ) {}
 
     /** @psalm-pure */
@@ -75,10 +86,11 @@ final readonly class BladeTemplateAnalysis
      *
      * @param list<BladeUncertaintyReason> $uncertainties non-empty at runtime; see throw
      * @param list<non-empty-string>       $unsafeKeys    keys observed before the uncertainty was hit
+     * @param list<BladeIncludeEdge>       $includeEdges  resolvable include edges captured during the scan
      *
      * @psalm-pure
      */
-    public static function unknown(array $uncertainties, array $unsafeKeys = []): self
+    public static function unknown(array $uncertainties, array $unsafeKeys = [], array $includeEdges = []): self
     {
         // Enforce the documented non-empty contract at runtime: an UNKNOWN
         // with no uncertainty reasons would be indistinguishable from a
@@ -90,6 +102,7 @@ final readonly class BladeTemplateAnalysis
             );
         }
 
-        return new self(BladeViewSafetyKind::Unknown, $unsafeKeys, $uncertainties);
+        return new self(BladeViewSafetyKind::Unknown, $unsafeKeys, $uncertainties, $includeEdges);
     }
+
 }

--- a/src/Blade/BladeTemplateScanner.php
+++ b/src/Blade/BladeTemplateScanner.php
@@ -236,9 +236,10 @@ final class BladeTemplateScanner
         }
 
         $unsafeKeys = $visitor->computeUnsafeKeys(self::FRAMEWORK_LOCALS);
+        $includeEdges = $visitor->computeIncludeEdges(self::FRAMEWORK_LOCALS);
 
         if ($uncertainties !== []) {
-            return BladeTemplateAnalysis::unknown($uncertainties, $unsafeKeys);
+            return BladeTemplateAnalysis::unknown($uncertainties, $unsafeKeys, $includeEdges);
         }
 
         return BladeTemplateAnalysis::unsafeKeys($unsafeKeys);
@@ -402,6 +403,18 @@ final class BladeAstAnalysisVisitor extends NodeVisitorAbstract
 
     /** @var array<string, true> reason-name => true, dedup uncertainty set */
     private array $seenUncertainty = [];
+
+    /**
+     * Raw `@include` edges collected during traversal. Each entry records the
+     * literal child view name and, for the 3-argument compileInclude form, the
+     * unfiltered top-level variables present in each explicit-data-array entry.
+     * Filtering (scope-locals / framework-locals) is deferred to
+     * {@see computeIncludeEdges()} because scope-local discovery completes
+     * only after the whole AST has been walked.
+     *
+     * @var list<array{view: non-empty-string, explicit: array<non-empty-string, list<string>>|null}>
+     */
+    private array $rawIncludeEdges = [];
 
     #[\Override]
     public function enterNode(Node $node): ?int
@@ -813,8 +826,215 @@ final class BladeAstAnalysisVisitor extends NodeVisitorAbstract
         }
 
         if (\in_array($method, BladeTemplateScanner::envIncludeMethods(), true)) {
+            // Only `$__env->make(...)` (compiled from `@include` /
+            // `@includeIf` / `@includeIsolated`) is statically resolvable
+            // here. `first` / `renderEach` / `renderWhen` / `renderUnless`
+            // come from include-family directives the scanner does not yet
+            // model precisely (different call-arg shapes; resolution is
+            // tracked in PR-5+), so they fall through to the conservative
+            // IncludeDirective uncertainty unchanged.
+            if ($method === 'make' && $this->tryRecordIncludeEdge($call)) {
+                $this->addUncertainty(BladeUncertaintyReason::IncludeResolved);
+                return;
+            }
+
             $this->addUncertainty(BladeUncertaintyReason::IncludeDirective);
         }
+    }
+
+    /**
+     * Inspect a compiled `$__env->make(...)` call. When the view-name argument
+     * is a literal string AND (in the 3-arg form) the explicit-data argument
+     * is a literal `Array_`, record a {@see BladeIncludeEdge} and return true.
+     * Otherwise return false so the caller falls through to the unresolvable
+     * `IncludeDirective` path.
+     *
+     * `compileInclude()` emits at most three arguments:
+     *  - 2 args: `make($view, $mergeData = array_diff_key(get_defined_vars(),
+     *    ['__data' => 1, '__path' => 1]))`. There is no explicit data array;
+     *    every parent-scope variable flows through `mergeData`.
+     *  - 3 args: `make($view, $explicitData, $mergeData = array_diff_key(...))`.
+     *    The user wrote `@include('child', [...])` and the second argument is
+     *    the literal data array (Laravel does not transform it).
+     *
+     * Any other call shape (zero args, four+ args, `$__env->make(...)` outside
+     * the include compilation path) is treated as unresolvable.
+     *
+     * @psalm-external-mutation-free
+     */
+    private function tryRecordIncludeEdge(Node\Expr\MethodCall $call): bool
+    {
+        $args = $call->args;
+
+        if (\count($args) < 2 || \count($args) > 3) {
+            return false;
+        }
+
+        $viewArg = $args[0];
+
+        if (!$viewArg instanceof Node\Arg || $viewArg->unpack) {
+            return false;
+        }
+
+        if (!$viewArg->value instanceof Node\Scalar\String_) {
+            return false;
+        }
+
+        $view = $viewArg->value->value;
+
+        if ($view === '') {
+            return false;
+        }
+
+        if (\count($args) === 2) {
+            // 2-arg form: arg1 is the implicit mergeData (array_diff_key call).
+            // No explicit user-provided data array; encode as `null` so the
+            // propagation pass falls back entirely to the verbatim-key rule.
+            $this->rawIncludeEdges[] = ['view' => $view, 'explicit' => null];
+
+            return true;
+        }
+
+        $dataArg = $args[1];
+
+        if (!$dataArg instanceof Node\Arg || $dataArg->unpack) {
+            return false;
+        }
+
+        if (!$dataArg->value instanceof Node\Expr\Array_) {
+            return false;
+        }
+
+        $mapping = $this->parseLiteralKeyMap($dataArg->value);
+
+        if ($mapping === null) {
+            return false;
+        }
+
+        $this->rawIncludeEdges[] = ['view' => $view, 'explicit' => $mapping];
+
+        return true;
+    }
+
+    /**
+     * Build a key-to-bound-vars map from a literal data-array node. Returns
+     * null if any item carries an unenumerable key shape (argument spread,
+     * dynamic key); the caller falls through to the unresolvable path.
+     *
+     * Integer keys, list-style entries, and invalid-identifier string keys are
+     * silently skipped because `extract()` would not bind them to a usable
+     * variable name in the child template — including them would create
+     * keys that no child raw echo can match.
+     *
+     * @return array<non-empty-string, list<string>>|null
+     *
+     * @psalm-mutation-free
+     */
+    private function parseLiteralKeyMap(Node\Expr\Array_ $array): ?array
+    {
+        $map = [];
+
+        foreach ($array->items as $item) {
+            if (!$item instanceof Node\ArrayItem) {
+                continue;
+            }
+
+            if ($item->unpack) {
+                // Inline spread `[...$rest]` carries opaque keys.
+                return null;
+            }
+
+            $keyNode = $item->key;
+
+            if (!$keyNode instanceof \PhpParser\Node\Expr) {
+                // List-style entry `['foo']`; extract() drops it.
+                continue;
+            }
+
+            if ($keyNode instanceof Node\Scalar\Int_ || $keyNode instanceof Node\Scalar\LNumber) {
+                // Integer literal key `[0 => $x]`; extract() drops it.
+                // Two class names because php-parser renamed LNumber → Int_
+                // in 5.x; matching both keeps the scanner forward-compatible.
+                continue;
+            }
+
+            if (!$keyNode instanceof Node\Scalar\String_) {
+                // Dynamic key shape: defeats enumeration.
+                return null;
+            }
+
+            $keyName = $keyNode->value;
+
+            if ($keyName === '' || \preg_match('/^[A-Za-z_]\w*$/', $keyName) !== 1) {
+                // Non-identifier string key (`['1foo' => ...]`, empty string,
+                // dotted etc.); extract() drops it for the same reason
+                // BladeAwareViewTaintHandler::literalArrayKey() does.
+                continue;
+            }
+
+            $map[$keyName] = $this->extractTopLevelVariables($item->value);
+        }
+
+        return $map;
+    }
+
+    /**
+     * Project the raw edge list collected during traversal onto a list of
+     * {@see BladeIncludeEdge} value objects, filtering each explicit-key
+     * binding's variable list against scope-locals and framework-locals.
+     *
+     * Filtering happens here, not at edge-recording time, because the visitor
+     * traverses top-down: an assignment inside an `@php ... @endphp` block
+     * that follows an `@include` directive only registers as a scope-local
+     * after the include itself has been visited.
+     *
+     * @param array<string, true> $frameworkLocals
+     *
+     * @return list<BladeIncludeEdge>
+     *
+     * @psalm-mutation-free
+     */
+    public function computeIncludeEdges(array $frameworkLocals): array
+    {
+        $edges = [];
+
+        foreach ($this->rawIncludeEdges as $raw) {
+            $rawExplicit = $raw['explicit'];
+
+            if ($rawExplicit === null) {
+                $edges[] = new BladeIncludeEdge($raw['view'], null);
+                continue;
+            }
+
+            /** @var array<non-empty-string, list<non-empty-string>> $cleaned */
+            $cleaned = [];
+
+            foreach ($rawExplicit as $keyName => $names) {
+                $filtered = [];
+
+                foreach ($names as $name) {
+                    if ($name === '') {
+                        continue;
+                    }
+
+                    if (isset($this->scopeLocals[$name])) {
+                        continue;
+                    }
+
+                    if (isset($frameworkLocals[$name])) {
+                        continue;
+                    }
+
+                    $filtered[] = $name;
+                }
+
+                $cleaned[$keyName] = $filtered;
+            }
+
+            $edges[] = new BladeIncludeEdge($raw['view'], $cleaned);
+        }
+
+        return $edges;
     }
 
     /** @psalm-external-mutation-free */

--- a/src/Blade/BladeUncertaintyReason.php
+++ b/src/Blade/BladeUncertaintyReason.php
@@ -45,13 +45,50 @@ enum BladeUncertaintyReason
     case LayoutSectionFlow;
 
     /**
-     * Template uses `@include`, `@includeIf`, `@includeWhen`, `@includeUnless`,
-     * `@includeFirst`, `@includeIsolated`, or `@each`. Every form compiles to
-     * `<?php echo $__env->make($view, ...)->render(); ?>` — raw output of a
-     * child template the v1 scanner does not visit. PR 2+ may resolve literal
-     * include targets by walking the included template.
+     * Template uses an include-family directive whose target view name or data
+     * shape the scanner could not resolve at parse time: non-literal `@include`
+     * target, `@includeFirst([...])`, `@includeWhen` / `@includeUnless` (which
+     * compile to `$__env->renderWhen` / `renderUnless` rather than `make`), or
+     * `@each`. The compiled output reaches `$__env->make($view, ...)` /
+     * `renderEach(...)` / `first(...)` with arguments the scanner cannot
+     * statically inspect. Forces UNKNOWN regardless of any other propagation
+     * pass {@see BladeSafetyMap} performs.
      */
     case IncludeDirective;
+
+    /**
+     * Template's `@include('child', ['k' => ...])` directives all resolve
+     * to literal view names with literal-or-absent data arrays. Emitted by
+     * {@see BladeTemplateScanner} alongside a list of {@see BladeIncludeEdge}
+     * records so {@see BladeSafetyMap::build()} can run a fixed-point pass
+     * that propagates child unsafe keys (mapped through the include's data
+     * array and through Laravel's `compileInclude` mergeData pass-through)
+     * into the parent template's safety record.
+     *
+     * Once propagation runs the parent is flipped to SAFE or UNSAFE_KEYS;
+     * this case only appears on intermediate {@see BladeTemplateAnalysis}
+     * values returned directly by the scanner. Callers that consume a fully
+     * built {@see BladeSafetyMap} will never see this case — they see the
+     * post-propagation kind/keys instead.
+     */
+    case IncludeResolved;
+
+    /**
+     * Template is a member of an `@include` cycle (template A includes
+     * template B includes template A, possibly transitively). The cycle
+     * defeats the fixed-point propagation pass: any of the participating
+     * templates' unsafe-keys list could in principle depend on its own
+     * (yet-to-be-computed) result, so the conservative answer for every
+     * cycle member is UNKNOWN. Emitted by {@see BladeSafetyMap::build()}
+     * after DFS detects a back-edge.
+     *
+     * Note: templates that *include into* a cycle member (but are not
+     * themselves on the cycle) inherit UNKNOWN through the normal
+     * "child is UNKNOWN → parent is UNKNOWN(IncludeDirective)" rule, not
+     * through this case. That keeps the {@see IncludeCycle} signal precise:
+     * it tags the actual cycle members, not their downstream consumers.
+     */
+    case IncludeCycle;
 
     /**
      * Template contains `<x-foo>` / `<x:foo>` component tags, `@component`, or

--- a/src/Handlers/Views/BladeAwareViewTaintHandler.php
+++ b/src/Handlers/Views/BladeAwareViewTaintHandler.php
@@ -16,6 +16,7 @@ use Psalm\CodeLocation;
 use Psalm\Internal\Codebase\TaintFlowGraph;
 use Psalm\Internal\DataFlow\DataFlowNode;
 use Psalm\LaravelPlugin\Blade\BladeSafetyMap;
+use Psalm\LaravelPlugin\Blade\BladeTemplateAnalysis;
 use Psalm\LaravelPlugin\Blade\BladeViewSafety;
 use Psalm\LaravelPlugin\Blade\BladeViewSafetyKind;
 use Psalm\Plugin\EventHandler\AfterFunctionCallAnalysisInterface;
@@ -58,20 +59,26 @@ use Psalm\Type\Union;
  * same `extract()` call as `$data`, so it is subjected to identical rules:
  * the keys observed by the scanner apply to either source.
  *
- * Out of scope (handled in PR-4 onwards, tracked under issue #581):
- *  - `@include('child', [...])` propagation into the parent template's safety
- *    record. The scanner flags any include as UNKNOWN, so the conservative
- *    fallback already covers it; PR-4 will narrow this.
+ * Out of scope (tracked under issue #581 for PR-5+):
  *  - Component data flow (`<x-foo :bar="$data" />`).
- *  - `Factory::first(array $views, ...)` and `Factory::renderEach()`. `first()`
- *    needs a union over multiple template safety records; `renderEach()` has a
- *    different argument shape (`$data` is a collection, `$iterator` names the
- *    per-item variable, the template echoes `$iterator` not data-array keys).
- *    Both fold into the same dispatch helper but require extra wiring beyond
- *    the scope of this PR.
- *  - `ResponseFactory::view()`. Same shape as `Factory::make()` but on a
- *    different service class; will follow once PR-3 stabilises the per-call
- *    sink construction.
+ *  - Variable-bound view-builder chains (`$v = view('home'); $v->with(...)`)
+ *    where the receiver-walk in {@see self::resolveReceiverViewName()} cannot
+ *    recover the literal view name through the intermediate variable binding.
+ *    PR-5 may attach view-name metadata to the {@see Union} returned by
+ *    `view()` / `Factory::make()` so the chain resolves through the variable.
+ *  - `Mailable::with($key, $value)` chained onto `Mailable::view(...)` /
+ *    `Mailable::markdown(...)` / `Mailable::text(...)`. `Mailable::view`,
+ *    `markdown`, `text` ARE registered as direct sink sites, but the
+ *    receiver-walk does not recognise their return-`$this` chain shape, and
+ *    `Mailable::with` is NOT registered as a sink site (registration without
+ *    receiver-walk support would be a no-op). Users who write
+ *    `(new InvoiceMail)->view('mail.invoice')->with('bio', $tainted)` will
+ *    have the `view()` call analysed (no data array there) but `with()`
+ *    silently miss. Same scope as variable-bound chains; same PR-5 fix.
+ *  - `View::share()` global view data — runtime-injected across every
+ *    subsequent `view()` call, with no per-call site for the dispatcher to
+ *    hook.
+ *  - Scanner result caching across analysis runs.
  *
  * Stability: the taint sink construction uses Psalm's internal classes
  * {@see TaintFlowGraph} and {@see DataFlowNode}, both `@internal` in
@@ -123,11 +130,44 @@ final class BladeAwareViewTaintHandler implements
      * Method-id → argument shape descriptor. Built once at init from
      * {@see \Illuminate\View\Factory::class} plus its facade classes (so calls
      * like `\View::make()` route through the same dispatch). Keyed by the
-     * lower-cased method id Psalm emits in {@see AfterMethodCallAnalysisEvent::getMethodId()}.
+     * lower-cased method id Psalm emits in
+     * {@see AfterMethodCallAnalysisEvent::getMethodId()}.
      *
-     * @var array<lowercase-string, MakeLikeMethodSpec>
+     * Value is a {@see ViewBindingSinkSpec} sealed-union: the dispatcher
+     * branches on the concrete spec type via `match (true)` to handle the
+     * different call shapes (make/renderWhen, first, renderEach, with).
+     *
+     * @var array<lowercase-string, ViewBindingSinkSpec>
      */
     private static array $methodSpecs = [];
+
+    /**
+     * Lower-cased method-name suffixes that gate the hot path. Every entry
+     * here must correspond to at least one method id installed by
+     * {@see buildMethodSpecs()}; adding a suffix without a matching id
+     * is a pure cost (lookup misses every time). Removing a suffix without
+     * removing its corresponding ids silently drops the dispatch.
+     *
+     * Most suffixes are uncommon outside Laravel (`renderwhen`, `rendereach`,
+     * `renderunless`, `markdown`, `nest`). A handful (`view`, `with`,
+     * `first`, `text`, `make`, `__construct`) appear in many non-Laravel
+     * call sites; the gate still rejects them cheaply via the isset check,
+     * deferring the more expensive full-id lookup until after the suffix
+     * matches.
+     */
+    private const METHOD_NAME_SUFFIXES = [
+        'make' => true,
+        'renderwhen' => true,
+        'renderunless' => true,
+        'first' => true,
+        'rendereach' => true,
+        'view' => true,
+        'with' => true,
+        'nest' => true,
+        'markdown' => true,
+        'text' => true,
+        '__construct' => true,
+    ];
 
     private static bool $enabled = false;
 
@@ -136,17 +176,25 @@ final class BladeAwareViewTaintHandler implements
      * that proxy to {@see \Illuminate\View\Factory}. Idempotent: callers may
      * invoke this multiple times during a single analysis run.
      *
-     * @param list<class-string> $factoryFacadeClasses additional class names whose
-     *                                                 `::make()` should be treated
-     *                                                 as a Blade view call site
+     * @param list<class-string> $factoryFacadeClasses          additional class names whose
+     *                                                          `::make()` (and friends) should be
+     *                                                          treated as a `\Illuminate\View\Factory`
+     *                                                          call site
+     * @param list<class-string> $responseFactoryFacadeClasses  additional class names whose
+     *                                                          `::view()` should be treated as a
+     *                                                          `\Illuminate\Routing\ResponseFactory`
+     *                                                          call site (e.g. `\Illuminate\Support\Facades\Response`)
      *
      * @psalm-external-mutation-free
      */
-    public static function init(BladeSafetyMap $map, array $factoryFacadeClasses = []): void
-    {
+    public static function init(
+        BladeSafetyMap $map,
+        array $factoryFacadeClasses = [],
+        array $responseFactoryFacadeClasses = [],
+    ): void {
         self::$map = $map;
         self::$enabled = true;
-        self::$methodSpecs = self::buildMethodSpecs($factoryFacadeClasses);
+        self::$methodSpecs = self::buildMethodSpecs($factoryFacadeClasses, $responseFactoryFacadeClasses);
     }
 
     /**
@@ -247,22 +295,683 @@ final class BladeAwareViewTaintHandler implements
         }
 
         $args = $event->getExpr()->getArgs();
+        $source = $event->getStatementsSource();
+        $codebase = $event->getCodebase();
+        $map = self::$map;
 
-        if (!isset($args[$spec->viewArgIndex])) {
+        // Dispatch by concrete spec type. `match (true)` makes the dispatch
+        // exhaustive — the spec union is sealed via {@see ViewBindingSinkSpec},
+        // so adding a new shape requires touching this site.
+        match (true) {
+            $spec instanceof MakeLikeMethodSpec => self::dispatchMakeLike(
+                $spec,
+                $args,
+                $map,
+                $source,
+                $codebase,
+                $taintGraph,
+            ),
+            $spec instanceof FirstLikeMethodSpec => self::dispatchFirstLike(
+                $spec,
+                $args,
+                $map,
+                $source,
+                $codebase,
+                $taintGraph,
+            ),
+            $spec instanceof RenderEachLikeMethodSpec => self::dispatchRenderEachLike(
+                $spec,
+                $args,
+                $map,
+                $source,
+                $codebase,
+                $taintGraph,
+            ),
+            $spec instanceof WithLikeMethodSpec => self::dispatchWithLike(
+                $spec,
+                $args,
+                $event->getExpr(),
+                $map,
+                $source,
+                $codebase,
+                $taintGraph,
+            ),
+        };
+    }
+
+    /**
+     * Run the per-key / per-view sink installer for a {@see MakeLikeMethodSpec}
+     * call. The spec can carry multiple view-name slots (Content::__construct
+     * has three: view, text, markdown); each slot dispatches independently
+     * against the same shared data argument.
+     *
+     * @param array<array-key, Arg> $args
+     */
+    private static function dispatchMakeLike(
+        MakeLikeMethodSpec $spec,
+        array $args,
+        BladeSafetyMap $map,
+        StatementsSource $source,
+        Codebase $codebase,
+        TaintFlowGraph $taintGraph,
+    ): void {
+        $dataArg = $args[$spec->dataArgIndex] ?? null;
+        $mergeDataArg = $spec->mergeDataArgIndex !== null
+            ? ($args[$spec->mergeDataArgIndex] ?? null)
+            : null;
+
+        foreach ($spec->viewArgIndices as $viewArgIndex) {
+            $viewArg = $args[$viewArgIndex] ?? null;
+
+            if (!$viewArg instanceof Arg) {
+                // Missing view slot — positional argument was omitted (e.g.
+                // `new Content('emails.welcome')` passing only $view).
+                continue;
+            }
+
+            if (self::isLiteralNull($viewArg)) {
+                // Explicit-null slot (e.g. `new Content(view: 'foo',
+                // text: null, markdown: null, with: $data)`). Without this
+                // check, the slot would fall through `dispatchSinks` →
+                // `literalString()` (which returns null for any non-String_
+                // value, including ConstFetch('null')) → the dynamic-name
+                // fallback, emitting a `<dynamic>` whole-data sink for every
+                // opted-out slot. The literal `null` documents intent: this
+                // slot does NOT render a template; install nothing.
+                continue;
+            }
+
+            self::dispatchSinks(
+                map: $map,
+                viewArg: $viewArg,
+                dataArg: $dataArg,
+                mergeDataArg: $mergeDataArg,
+                source: $source,
+                codebase: $codebase,
+                taintGraph: $taintGraph,
+            );
+        }
+    }
+
+    /**
+     * Dispatch sinks for `Factory::first(array $views, $data, $mergeData)`.
+     * Per task spec: if every listed view is a literal string AND every
+     * resolved template is SAFE or UNSAFE_KEYS, the unsafe-key sets are
+     * unioned; if ANY listed template is UNKNOWN or unknown to the map, the
+     * whole-data sink fires. Non-literal items in the views array, or a
+     * non-array views argument, collapse to the dynamic-name fallback.
+     *
+     * @param array<array-key, Arg> $args
+     */
+    private static function dispatchFirstLike(
+        FirstLikeMethodSpec $spec,
+        array $args,
+        BladeSafetyMap $map,
+        StatementsSource $source,
+        Codebase $codebase,
+        TaintFlowGraph $taintGraph,
+    ): void {
+        $viewsArg = $args[$spec->viewsArrayArgIndex] ?? null;
+        $dataArg = $args[$spec->dataArgIndex] ?? null;
+        $mergeDataArg = $spec->mergeDataArgIndex !== null
+            ? ($args[$spec->mergeDataArgIndex] ?? null)
+            : null;
+
+        if (!$viewsArg instanceof Arg) {
             return;
         }
 
-        self::dispatchSinks(
-            map: self::$map,
-            viewArg: $args[$spec->viewArgIndex],
-            dataArg: $args[$spec->dataArgIndex] ?? null,
-            mergeDataArg: $spec->mergeDataArgIndex !== null
-                ? ($args[$spec->mergeDataArgIndex] ?? null)
-                : null,
-            source: $event->getStatementsSource(),
-            codebase: $event->getCodebase(),
+        if (!$dataArg instanceof Arg && !$mergeDataArg instanceof Arg) {
+            // No data to sink; nothing to do regardless of view safety.
+            return;
+        }
+
+        $viewsArray = self::asArrayLiteral($viewsArg);
+
+        if (!$viewsArray instanceof Array_) {
+            // Non-array-literal views arg (`$views`, function call, etc.):
+            // we cannot enumerate candidate templates. Fall back to the
+            // dynamic-name policy.
+            self::installWholeDataSink('<dynamic>', $dataArg, $source, $codebase, $taintGraph);
+            self::installWholeDataSink('<dynamic>', $mergeDataArg, $source, $codebase, $taintGraph);
+
+            return;
+        }
+
+        // Iterate the literal views, accumulating the unsafe-key union or
+        // tripping the UNKNOWN flag the moment we see a non-literal item or
+        // an unresolvable template.
+        /** @var array<non-empty-string, true> $unionKeys */
+        $unionKeys = [];
+
+        $sawUnknown = false;
+
+        $resolvedViewLabel = '';
+
+        foreach ($viewsArray->items as $item) {
+            if (!$item instanceof ArrayItem) {
+                continue;
+            }
+
+            if ($item->unpack || $item->key instanceof \PhpParser\Node\Expr) {
+                // Inner spread or explicit keys: we cannot enumerate the
+                // list. Conservative fallback.
+                $sawUnknown = true;
+                break;
+            }
+
+            $value = $item->value;
+
+            if (!$value instanceof String_) {
+                // Non-literal candidate view name.
+                $sawUnknown = true;
+                break;
+            }
+
+            $candidateName = $value->value;
+
+            if ($candidateName === '') {
+                continue;
+            }
+
+            $safety = $map->safetyFor($candidateName);
+
+            if (!$safety instanceof BladeViewSafety) {
+                // Candidate not in the map: typo, package view, or
+                // out-of-scope path. Mirrors {@see dispatchSinks()}'s
+                // "view not in map → no sink" policy: do NOT promote to
+                // UNKNOWN. Skipping the unresolvable candidate is sound
+                // because Laravel's `first()` picks the first existing
+                // view at runtime; if the in-map candidates cover the
+                // existing case, their union is precise. If they don't
+                // (every candidate is missing), MissingViewHandler emits
+                // the typo diagnostic instead. Promoting to UNKNOWN here
+                // would re-introduce the package-view false-positive
+                // regression PR #684 fixed.
+                continue;
+            }
+
+            $kind = $safety->kind();
+
+            if ($kind === BladeViewSafetyKind::Unknown) {
+                $sawUnknown = true;
+                $resolvedViewLabel = $resolvedViewLabel === '' ? $candidateName : $resolvedViewLabel;
+                break;
+            }
+
+            // SAFE templates contribute zero keys (no-op). UNSAFE_KEYS
+            // contribute their keys to the union.
+            foreach ($safety->unsafeKeys() as $key) {
+                $unionKeys[$key] = true;
+            }
+
+            $resolvedViewLabel = $resolvedViewLabel === '' ? $candidateName : $resolvedViewLabel . '|' . $candidateName;
+        }
+
+        if ($sawUnknown) {
+            // Any UNKNOWN / non-literal contributor → whole-data fallback.
+            // The view label uses the first candidate that triggered the
+            // fallback so the sink identity remains stable across calls.
+            $label = $resolvedViewLabel === '' ? '<first-dynamic>' : $resolvedViewLabel;
+            self::installWholeDataSink($label, $dataArg, $source, $codebase, $taintGraph);
+            self::installWholeDataSink($label, $mergeDataArg, $source, $codebase, $taintGraph);
+
+            return;
+        }
+
+        if ($unionKeys === []) {
+            // Every literal candidate resolved SAFE. No sink needed; matches
+            // the SAFE policy from PR-3 dispatch.
+            return;
+        }
+
+        /** @var list<non-empty-string> $unionKeyList */
+        $unionKeyList = \array_keys($unionKeys);
+
+        $label = $resolvedViewLabel === '' ? '<first>' : $resolvedViewLabel;
+
+        // Synthesize a safety record using the union. We pass it to the same
+        // installer used for normal UNSAFE_KEYS dispatch so the sink identity
+        // and per-key dispatch logic match PR-3 exactly.
+        $unionSafety = new BladeViewSafety(
+            $label,
+            $label,
+            BladeTemplateAnalysis::unsafeKeys($unionKeyList),
+        );
+
+        self::installUnsafeKeySinks(
+            $label,
+            $unionSafety,
+            $dataArg,
+            $mergeDataArg,
+            $source,
+            $codebase,
+            $taintGraph,
+        );
+    }
+
+    /**
+     * Dispatch sinks for `Factory::renderEach($view, $data, $iterator,
+     * $empty)`. The shape differs from `make()`: `$data` is iterable, each
+     * element binds to a variable named by the literal `$iterator` in the
+     * child template.
+     *
+     * Sink rules:
+     *  - SAFE template → no sink.
+     *  - UNSAFE_KEYS template + literal `$iterator` matching unsafe keys →
+     *    install a sink on `$data` keyed by the iterator name.
+     *  - UNSAFE_KEYS template + literal `$iterator` NOT matching → no sink.
+     *  - Non-literal `$iterator` OR UNKNOWN template → whole-data sink on
+     *    `$data`.
+     *  - Dynamic `$view` → dynamic-name fallback (whole-data on `$data`).
+     *  - View not in map → no sink (MissingViewHandler covers the typo).
+     *
+     * @param array<array-key, Arg> $args
+     */
+    private static function dispatchRenderEachLike(
+        RenderEachLikeMethodSpec $spec,
+        array $args,
+        BladeSafetyMap $map,
+        StatementsSource $source,
+        Codebase $codebase,
+        TaintFlowGraph $taintGraph,
+    ): void {
+        $viewArg = $args[$spec->viewArgIndex] ?? null;
+        $dataArg = $args[$spec->dataArgIndex] ?? null;
+        $iteratorArg = $args[$spec->iteratorArgIndex] ?? null;
+
+        if (!$viewArg instanceof Arg || !$dataArg instanceof Arg) {
+            return;
+        }
+
+        $viewName = self::literalString($viewArg);
+
+        if ($viewName === null) {
+            self::installWholeDataSink('<dynamic>', $dataArg, $source, $codebase, $taintGraph);
+
+            return;
+        }
+
+        $safety = $map->safetyFor($viewName);
+
+        if (!$safety instanceof BladeViewSafety) {
+            return;
+        }
+
+        $kind = $safety->kind();
+
+        if ($kind === BladeViewSafetyKind::Safe) {
+            return;
+        }
+
+        $iteratorName = $iteratorArg instanceof Arg ? self::literalString($iteratorArg) : null;
+
+        if ($kind === BladeViewSafetyKind::Unknown || $iteratorName === null) {
+            // UNKNOWN template OR non-literal $iterator: the per-element
+            // flow's destination variable is opaque. Sink the whole data
+            // iterable.
+            self::installWholeDataSink($viewName, $dataArg, $source, $codebase, $taintGraph);
+
+            return;
+        }
+
+        $unsafeKeys = $safety->unsafeKeys();
+        $unsafeKeyLookup = \array_fill_keys($unsafeKeys, true);
+
+        if (!isset($unsafeKeyLookup[$iteratorName])) {
+            // $iterator names a variable the child template never raw-echoes.
+            // No flow possible.
+            return;
+        }
+
+        // Per-element flow into an unsafe key. The data argument is an
+        // iterable of element values; sinking the whole arg is the correct
+        // grain because Psalm's element-level taint flow reaches the sink
+        // through the iterable's parent nodes.
+        self::installSinkForExpression(
+            viewName: $viewName,
+            key: $iteratorName,
+            expr: $dataArg->value,
+            source: $source,
+            codebase: $codebase,
             taintGraph: $taintGraph,
         );
+    }
+
+    /**
+     * Dispatch sinks for `\Illuminate\View\View::with($key, $value)`. The
+     * receiver carries the view name; this method walks the receiver
+     * expression to recover it.
+     *
+     * @param array<array-key, Arg> $args
+     */
+    private static function dispatchWithLike(
+        WithLikeMethodSpec $spec,
+        array $args,
+        \PhpParser\Node\Expr\MethodCall|\PhpParser\Node\Expr\StaticCall $callExpr,
+        BladeSafetyMap $map,
+        StatementsSource $source,
+        Codebase $codebase,
+        TaintFlowGraph $taintGraph,
+    ): void {
+        $keyArg = $args[$spec->keyArgIndex] ?? null;
+        $valueArg = $args[$spec->valueArgIndex] ?? null;
+
+        if (!$keyArg instanceof Arg) {
+            // No key argument: not a real `with` call. Nothing to sink.
+            return;
+        }
+
+        // Receiver is only available on instance method calls. Static calls
+        // (Facade::with(...)) do not chain off a view-builder receiver and
+        // therefore cannot carry a resolvable view name; skip them.
+        // `NullsafeMethodCall` cannot reach this dispatcher: Psalm rewrites
+        // `?->method(...)` calls into a `VirtualMethodCall` inside a
+        // VirtualTernary before `AfterMethodCallAnalysisEvent` fires (see
+        // vendor/vimeo/psalm/.../NullsafeAnalyzer.php).
+        if (!$callExpr instanceof \PhpParser\Node\Expr\MethodCall) {
+            return;
+        }
+
+        $viewName = self::resolveReceiverViewName($callExpr->var);
+
+        if ($viewName === null) {
+            // Receiver does not name a literal view. Consistent with PR-3's
+            // "view not in map → no sink" policy — silently passing the
+            // whole-data fallback here would create false positives for
+            // common variable-bound view-builder patterns
+            // (`$v = view('home'); $v->with(...)`).
+            return;
+        }
+
+        $safety = $map->safetyFor($viewName);
+
+        if (!$safety instanceof BladeViewSafety) {
+            return;
+        }
+
+        $kind = $safety->kind();
+
+        if ($kind === BladeViewSafetyKind::Safe) {
+            return;
+        }
+
+        // Laravel's `View::with($key, $value = null)` accepts `$key` as
+        // string OR array. When `$key` is an array, Laravel merges every
+        // entry into the view data and IGNORES `$value` entirely
+        // (vendor/laravel/framework/src/Illuminate/View/View.php: `with`
+        // dispatches via `is_array($key) ? $this->data = array_merge(...) :
+        // $this->data[$key] = $value`). The dispatcher mirrors this:
+        //
+        //  - $valueArg missing (1-arg call `with([...])`): unambiguous array
+        //    form per Laravel's signature default.
+        //  - $keyArg->value is an inline `Array_`: always array form
+        //    regardless of $value, because Laravel ignores $value when $key
+        //    is an array. Covers `with([...], null)` AND `with([...], $x)`.
+        //  - else (`with('key', $value)`, `with($var, $value)`,
+        //    `with('key', null)`, `with($var, null)`): string-key form.
+        //    No silent over-sink on the key expression.
+        $keyIsLiteralArray = $keyArg->value instanceof Array_;
+        $treatAsArrayForm = $valueArg === null || $keyIsLiteralArray;
+
+        if ($treatAsArrayForm) {
+            if ($kind === BladeViewSafetyKind::Unknown) {
+                self::installWholeDataSink($viewName, $keyArg, $source, $codebase, $taintGraph);
+
+                return;
+            }
+
+            // UNSAFE_KEYS template + array-form $key: dispatch the inline
+            // array's entries through the same per-key path used for
+            // `Factory::make($view, $data)`. When $key is a variable
+            // (`with($arrayVar)`), `installSinksForArg` falls back to the
+            // whole-arg sink via `asArrayLiteral` returning null — same as
+            // the non-literal data argument path on `make()`.
+            self::installSinksForArg($viewName, $keyArg, $safety->unsafeKeys(), $source, $codebase, $taintGraph);
+
+            return;
+        }
+
+        // String-key form: `with($key, $value)` with non-array $key. The
+        // array-form branch above already returned for $valueArg === null
+        // (1-arg call) or for any inline-array $key (Laravel ignores $value
+        // when $key is an array). Anything reaching this line therefore has
+        // a non-null $valueArg with a non-array $key — assert to narrow
+        // Psalm's null tracking.
+        if (!$valueArg instanceof Arg) {
+            return;
+        }
+
+        $keyName = self::literalString($keyArg);
+
+        if ($kind === BladeViewSafetyKind::Unknown || $keyName === null) {
+            // Unknown template OR non-literal key: cannot prove the value
+            // does NOT flow to a raw echo. Sink the value expression itself.
+            self::installSinkForExpression(
+                viewName: $viewName,
+                key: $keyName ?? '<argument>',
+                expr: $valueArg->value,
+                source: $source,
+                codebase: $codebase,
+                taintGraph: $taintGraph,
+            );
+
+            return;
+        }
+
+        $unsafeKeys = $safety->unsafeKeys();
+        $unsafeKeyLookup = \array_fill_keys($unsafeKeys, true);
+
+        if (!isset($unsafeKeyLookup[$keyName])) {
+            // Literal key not in the unsafe set — no flow.
+            return;
+        }
+
+        self::installSinkForExpression(
+            viewName: $viewName,
+            key: $keyName,
+            expr: $valueArg->value,
+            source: $source,
+            codebase: $codebase,
+            taintGraph: $taintGraph,
+        );
+    }
+
+    /**
+     * True when an argument is an explicit literal `null` constant (e.g.
+     * `with('key', null)` or `new Content(view: null, ...)`). Distinguished
+     * from "argument absent altogether" so callers can treat both as "no
+     * value supplied" — both shapes hit the same fallback paths in the
+     * View::with array form and the Content __construct dispatch.
+     */
+    private static function isLiteralNull(Arg $arg): bool
+    {
+        $value = $arg->value;
+
+        if (!$value instanceof \PhpParser\Node\Expr\ConstFetch) {
+            return false;
+        }
+
+        return $value->name->toLowerString() === 'null';
+    }
+
+    /**
+     * Walk a `View::with()` receiver expression to recover the bound view
+     * name. Returns null when the receiver shape cannot be resolved (variable
+     * receiver, dynamic view name, chained call with no statically known
+     * source).
+     *
+     * Resolvable shapes:
+     *  - `view('home')->with(...)`
+     *    – `FuncCall(name='view', args=[String('home'), ...])`
+     *  - `View::make('home')->with(...)` or `app('view')->make('home')->with(...)`
+     *    – `MethodCall(name='make', args=[String('home'), ...])` /
+     *      `StaticCall(name='make', args=[String('home'), ...])`
+     *  - `view('home')->with('a', 1)->with(...)` — recurse into receiver's
+     *    receiver for any chain of `with()` calls.
+     *  - `View::first(['a', 'b'])->with(...)` — first literal in the array.
+     *
+     * PR-4 does not propagate view names through variable bindings; a future
+     * PR may attach metadata to {@see \Psalm\Type\Union} via NodeTypeProvider
+     * to cover the `$v = view('home'); $v->with(...)` pattern.
+     */
+    private static function resolveReceiverViewName(\PhpParser\Node\Expr $receiver): ?string
+    {
+        // Treat nullsafe and regular method calls uniformly. We re-dispatch
+        // by drilling into the same shape rather than constructing a fresh
+        // MethodCall node (which would trigger Psalm's purity guards on the
+        // node constructor).
+        if ($receiver instanceof \PhpParser\Node\Expr\NullsafeMethodCall) {
+            return self::resolveMethodCallReceiver($receiver->var, $receiver->name, $receiver->args);
+        }
+
+        if ($receiver instanceof \PhpParser\Node\Expr\FuncCall) {
+            return self::viewNameFromFuncCall($receiver);
+        }
+
+        if ($receiver instanceof \PhpParser\Node\Expr\MethodCall) {
+            return self::resolveMethodCallReceiver($receiver->var, $receiver->name, $receiver->args);
+        }
+
+        if ($receiver instanceof \PhpParser\Node\Expr\StaticCall) {
+            if (!$receiver->name instanceof \PhpParser\Node\Identifier) {
+                return null;
+            }
+
+            $methodName = $receiver->name->toLowerString();
+
+            if ($methodName === 'make') {
+                return self::viewNameFromArg($receiver->args[0] ?? null);
+            }
+
+            if ($methodName === 'first') {
+                return self::firstLiteralFromArrayArg($receiver->args[0] ?? null);
+            }
+
+            return null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Shared resolution for `MethodCall` / `NullsafeMethodCall` receivers.
+     * Both shapes carry the same `(receiver, method-name, args)` triple; the
+     * caller pre-extracts them so this helper can run on either node type
+     * without constructing intermediate AST nodes (which would breach Psalm
+     * purity guards on the php-parser constructors).
+     *
+     * @param array<array-key, \PhpParser\Node\VariadicPlaceholder|\PhpParser\Node\Arg> $args
+     */
+    private static function resolveMethodCallReceiver(
+        \PhpParser\Node\Expr $methodReceiver,
+        \PhpParser\Node\Identifier|\PhpParser\Node\Expr $methodName,
+        array $args,
+    ): ?string {
+        if (!$methodName instanceof \PhpParser\Node\Identifier) {
+            return null;
+        }
+
+        $methodNameLc = $methodName->toLowerString();
+
+        // Chained `with()` / `withErrors()` (and similar) preserve the
+        // view-builder identity. Recurse into the receiver's receiver to
+        // recover the underlying view name.
+        if ($methodNameLc === 'with' || $methodNameLc === 'witherrors') {
+            return self::resolveReceiverViewName($methodReceiver);
+        }
+
+        if ($methodNameLc === 'make') {
+            return self::viewNameFromArg($args[0] ?? null);
+        }
+
+        if ($methodNameLc === 'first') {
+            return self::firstLiteralFromArrayArg($args[0] ?? null);
+        }
+
+        return null;
+    }
+
+    private static function viewNameFromFuncCall(\PhpParser\Node\Expr\FuncCall $call): ?string
+    {
+        if (!$call->name instanceof \PhpParser\Node\Name) {
+            return null;
+        }
+
+        if ($call->name->toLowerString() !== self::FUNCTION_VIEW) {
+            return null;
+        }
+
+        return self::viewNameFromArg($call->args[0] ?? null);
+    }
+
+    /** @psalm-mutation-free */
+    private static function viewNameFromArg(\PhpParser\Node\VariadicPlaceholder|\PhpParser\Node\Arg|null $arg): ?string
+    {
+        if (!$arg instanceof Arg) {
+            return null;
+        }
+
+        return self::literalString($arg);
+    }
+
+    /**
+     * Return the sole literal-string element of an array literal argument, or
+     * null if the argument is not an array literal, contains no literal
+     * strings, or contains MORE THAN ONE literal string.
+     *
+     * Used for `View::first(['a', 'b'])->with(...)` chains. Laravel's runtime
+     * semantics for `first()` are "render the first existing view"; at
+     * analysis time we cannot know which candidate exists, so picking ANY one
+     * literal would be unsound for the receiver-walk's single-view lookup.
+     * Consider:
+     *
+     *     view::first(['safe_layout', 'unsafe_show'])->with('html_body', $tainted);
+     *
+     * If `safe_layout` ships and `unsafe_show` doesn't, no XSS. If
+     * `safe_layout` is later renamed and Laravel falls back to `unsafe_show`,
+     * `$tainted` reaches a raw echo. Picking `safe_layout` for the with-
+     * dispatcher's safety lookup would silently miss this regression.
+     *
+     * The conservative fix is to refuse resolution entirely for multi-
+     * candidate arrays. `dispatchFirstLike` already takes the union across
+     * all literals at the direct `Factory::first(...)` call site; the
+     * receiver-walk path (chained `with()` off a `first()` receiver) does
+     * not have an equivalent union mechanism wired here yet. Treating the
+     * receiver as unresolvable is consistent with PR-3's "view not in map
+     * → no sink" policy.
+     *
+     * @psalm-mutation-free
+     */
+    private static function firstLiteralFromArrayArg(\PhpParser\Node\VariadicPlaceholder|\PhpParser\Node\Arg|null $arg): ?string
+    {
+        if (!$arg instanceof Arg || $arg->unpack || !$arg->value instanceof Array_) {
+            return null;
+        }
+
+        $resolved = null;
+
+        foreach ($arg->value->items as $item) {
+            if (!$item instanceof ArrayItem) {
+                continue;
+            }
+
+            if (!$item->value instanceof String_) {
+                // Non-literal candidate: the runtime view name is opaque, so
+                // any earlier match we picked would be unsound. Bail.
+                return null;
+            }
+
+            if ($resolved !== null) {
+                // Second literal observed: cannot tell which Laravel will
+                // pick. Conservatively refuse resolution.
+                return null;
+            }
+
+            $resolved = $item->value->value;
+        }
+
+        return $resolved;
     }
 
     /**
@@ -548,28 +1257,32 @@ final class BladeAwareViewTaintHandler implements
     }
 
     /**
-     * Suffix-based fast reject for the method-call hot path. Matches the
-     * method-name portion of a Psalm method id (`Class::method`) against the
-     * known view-creating method names. Allocation-free; designed to run on
-     * every method call analysed.
+     * Suffix-based fast reject for the method-call hot path. Extracts the
+     * method-name portion of a Psalm method id (`Class::method`) and probes
+     * it against {@see self::METHOD_NAME_SUFFIXES}. Designed to run on every
+     * method call analysed; one `strrpos` + one `substr` + one isset.
      *
      * Stays in sync with {@see buildMethodSpecs()}: every method name added
-     * there must appear here. The keys table holds the actual class-bound
-     * lookups; this gate just skips the lowercased-id cost for the >99% of
-     * calls that miss.
+     * there must appear in the suffix table. The keys table holds the actual
+     * class-bound lookups; this gate just rejects the >99% of calls that miss
+     * before the dispatcher allocates a lower-cased copy of the full id.
      *
-     * Suffixes are written in lowercase only. Psalm's
-     * {@see \Psalm\Internal\MethodIdentifier} declares `lowercase-string
-     * $method_name`, so the method-name part of every emitted method id is
-     * already lowercased — a camelCase suffix would never match in production.
+     * Psalm's {@see \Psalm\Internal\MethodIdentifier} declares the method-name
+     * suffix as `lowercase-string`, so the substring extracted here is
+     * already lower-case — a camelCase entry in the suffix table would never
+     * match in production.
      *
      * @psalm-pure
      */
     private static function isViewLikeMethodId(string $methodId): bool
     {
-        return \str_ends_with($methodId, '::make')
-            || \str_ends_with($methodId, '::renderwhen')
-            || \str_ends_with($methodId, '::renderunless');
+        $pos = \strrpos($methodId, '::');
+
+        if ($pos === false) {
+            return false;
+        }
+
+        return isset(self::METHOD_NAME_SUFFIXES[\substr($methodId, $pos + 2)]);
     }
 
     /**
@@ -694,25 +1407,27 @@ final class BladeAwareViewTaintHandler implements
     }
 
     /**
-     * Build the method-id table for `Factory::make()` and every facade class
-     * that proxies to {@see \Illuminate\View\Factory}. The boot path passes
-     * the facade list explicitly so the handler stays decoupled from
-     * `FacadeMapProvider` (which is plugin-internal and harder to fake in
-     * unit tests).
+     * Build the method-id table for every Laravel API the handler dispatches
+     * on. The boot path passes the facade list explicitly so the handler
+     * stays decoupled from `FacadeMapProvider` (which is plugin-internal and
+     * harder to fake in unit tests).
      *
      * @param list<class-string> $factoryFacadeClasses
+     * @param list<class-string> $responseFactoryFacadeClasses
      *
-     * @return array<lowercase-string, MakeLikeMethodSpec>
+     * @return array<lowercase-string, ViewBindingSinkSpec>
      *
      * @psalm-pure
      */
-    private static function buildMethodSpecs(array $factoryFacadeClasses): array
-    {
+    private static function buildMethodSpecs(
+        array $factoryFacadeClasses,
+        array $responseFactoryFacadeClasses = [],
+    ): array {
         // `make($view, $data = [], $mergeData = [])` is the canonical shape on
         // `\Illuminate\View\Factory`. Facade classes inherit it (or stub it via
         // the plugin's generated alias stubs); the argument layout is identical.
         $makeSpec = new MakeLikeMethodSpec(
-            viewArgIndex: 0,
+            viewArgIndices: [0],
             dataArgIndex: 1,
             mergeDataArgIndex: 2,
         );
@@ -723,57 +1438,159 @@ final class BladeAwareViewTaintHandler implements
         // condition arg shifts every index by one, but the (view, data,
         // mergeData) triple still applies to taint sink dispatch.
         $renderWhenSpec = new MakeLikeMethodSpec(
-            viewArgIndex: 1,
+            viewArgIndices: [1],
             dataArgIndex: 2,
             mergeDataArgIndex: 3,
+        );
+
+        // `first(array $views, $data = [], $mergeData = [])`. Multi-template
+        // union; see {@see FirstLikeMethodSpec}.
+        $firstSpec = new FirstLikeMethodSpec(
+            viewsArrayArgIndex: 0,
+            dataArgIndex: 1,
+            mergeDataArgIndex: 2,
+        );
+
+        // `renderEach($view, $data, $iterator, $empty = 'raw|')`.
+        $renderEachSpec = new RenderEachLikeMethodSpec(
+            viewArgIndex: 0,
+            dataArgIndex: 1,
+            iteratorArgIndex: 2,
+        );
+
+        // `ResponseFactory::view($view, $data, $status, $headers)`. Same
+        // (view, data) layout as `make()` but with no mergeData; the third
+        // arg is the response status and is not a view-data carrier.
+        $responseViewSpec = new MakeLikeMethodSpec(
+            viewArgIndices: [0],
+            dataArgIndex: 1,
+            mergeDataArgIndex: null,
+        );
+
+        // `View::with($key, $value)`. Receiver-resolved single key/value
+        // sink; see {@see WithLikeMethodSpec}.
+        $withSpec = new WithLikeMethodSpec(
+            keyArgIndex: 0,
+            valueArgIndex: 1,
+        );
+
+        // `View::nest($key, $view, $data = [])`. Equivalent to a child
+        // Factory::make() call: view at index 1, data at index 2, no
+        // mergeData. The receiver's view name is irrelevant (the nested
+        // view's safety record governs the sink).
+        $nestSpec = new MakeLikeMethodSpec(
+            viewArgIndices: [1],
+            dataArgIndex: 2,
+            mergeDataArgIndex: null,
+        );
+
+        // `Mailable::view($view, array $data = [])` and the markdown / text
+        // siblings; `MailMessage` has the same shape on its three methods.
+        // None of these have a separate mergeData slot — the second argument
+        // is the single data array.
+        $mailMethodSpec = new MakeLikeMethodSpec(
+            viewArgIndices: [0],
+            dataArgIndex: 1,
+            mergeDataArgIndex: null,
+        );
+
+        // `Content::__construct(?$view, ?$html, ?$text, $markdown, $with,
+        // ?$htmlString)`. Three view-name slots (view at 0, text at 2,
+        // markdown at 3) share the single `$with` data array at index 4.
+        // `$html` (index 1) and `$htmlString` (index 5) are pre-rendered
+        // HTML strings, not Blade view names; they are not registered. The
+        // dispatcher emits one sink per view slot that resolves to a
+        // literal string at the call site.
+        $contentConstructorSpec = new MakeLikeMethodSpec(
+            viewArgIndices: [0, 2, 3],
+            dataArgIndex: 4,
+            mergeDataArgIndex: null,
         );
 
         $specs = [];
 
         // `Illuminate\Contracts\View\Factory` (the interface) declares only
-        // `make()` from this set; `renderWhen` and `renderUnless` live on the
-        // concrete class. Apps using PSR-typed constructor injection
-        // (`__construct(\Illuminate\Contracts\View\Factory $views)`) emit a
-        // method id resolved to the contract for `make()`, NOT the concrete
-        // class — without the contract entry, that path would slip past the
-        // dispatcher.
+        // `make()` from this set; `renderWhen`, `renderUnless`, `first`,
+        // `renderEach` live on the concrete class. Apps using PSR-typed
+        // constructor injection emit method ids resolved to the contract
+        // for `make()`; without the contract entry, that path would slip
+        // past the dispatcher.
         $specs[\strtolower(\Illuminate\Contracts\View\Factory::class) . '::make'] = $makeSpec;
 
-        // The concrete class plus every facade alias that proxies to it.
-        // Facades inherit `make()` / `renderWhen()` / `renderUnless()` from
-        // the underlying class via __callStatic; the plugin's generated
+        // `Illuminate\Contracts\View\View` declares `with()` (but not
+        // `nest()`). Mirror the same routing as the concrete class.
+        $viewContractLc = \strtolower(\Illuminate\Contracts\View\View::class);
+        $specs[$viewContractLc . '::with'] = $withSpec;
+
+        // The concrete View\Factory plus every facade alias that proxies to
+        // it. Facades inherit make/renderWhen/renderUnless/first/renderEach
+        // from the underlying class via __callStatic; the plugin's generated
         // alias stubs surface them as real static methods at analysis time.
-        $concreteClasses = [
+        $factoryConcrete = [
             \Illuminate\View\Factory::class,
             ...$factoryFacadeClasses,
         ];
 
-        foreach ($concreteClasses as $class) {
+        foreach ($factoryConcrete as $class) {
             $classLc = \strtolower($class);
             $specs[$classLc . '::make'] = $makeSpec;
             $specs[$classLc . '::renderwhen'] = $renderWhenSpec;
             $specs[$classLc . '::renderunless'] = $renderWhenSpec;
+            $specs[$classLc . '::first'] = $firstSpec;
+            $specs[$classLc . '::rendereach'] = $renderEachSpec;
         }
 
-        // Known coverage gaps left for PR-4+:
-        //  - `Illuminate\View\Factory::first(array $views, $data = [], $mergeData = [])`
-        //    needs a union over multiple template safety records.
-        //  - `Illuminate\View\Factory::renderEach($view, $data, $iterator, $empty)`
-        //    binds each item under `$iterator`, not under the data array's keys.
-        //  - `Illuminate\Routing\ResponseFactory::view($view, $data, $status, $headers)`
-        //    same shape as Factory::make() but on a separate class.
-        //  - `Illuminate\View\View::with($key, $value)` and `::nest($key, $view, $data)`
-        //    chained data binding (e.g. `view('home')->with('user', $user)`); the
-        //    factory `view()` call has no `$data` arg, so the binding is invisible
-        //    here.
-        //  - `Illuminate\Mail\Mailable::view()/markdown()/text()` and
-        //    `Illuminate\Notifications\Messages\MailMessage::view()/markdown()/text()`
-        //    and `Illuminate\Mail\Mailables\Content::__construct()` — view name +
-        //    data are stored on the Mailable instance and replayed through
-        //    `Mailer::renderView()` inside the framework. The user's literal call
-        //    site is therefore not a direct `view()` / `Factory::make()` call,
-        //    and the eventual `make()` invocation reads the name from an
-        //    instance property (dynamic, not literal).
+        // `Illuminate\View\View` carries the chained `with()` and `nest()`.
+        $viewClassLc = \strtolower(\Illuminate\View\View::class);
+        $specs[$viewClassLc . '::with'] = $withSpec;
+        $specs[$viewClassLc . '::nest'] = $nestSpec;
+
+        // `Illuminate\Routing\ResponseFactory::view()` and its contract,
+        // plus every facade class that proxies to either binding (e.g.
+        // `\Illuminate\Support\Facades\Response`). Without the facade list,
+        // calls written as `\Response::view(...)` would slip past the
+        // dispatcher entirely — Psalm resolves the method id to the facade
+        // class, not to the contract.
+        $responseFactoryClasses = [
+            \Illuminate\Routing\ResponseFactory::class,
+            \Illuminate\Contracts\Routing\ResponseFactory::class,
+            ...$responseFactoryFacadeClasses,
+        ];
+
+        foreach ($responseFactoryClasses as $class) {
+            $specs[\strtolower($class) . '::view'] = $responseViewSpec;
+        }
+
+        // Mail / Notification view-binding methods: `view`, `markdown`, `text`
+        // on Mailable and MailMessage. Identical layout; one spec instance
+        // serves both.
+        $mailClasses = [
+            \Illuminate\Mail\Mailable::class,
+            \Illuminate\Notifications\Messages\MailMessage::class,
+        ];
+
+        foreach ($mailClasses as $class) {
+            $classLc = \strtolower($class);
+            $specs[$classLc . '::view'] = $mailMethodSpec;
+            $specs[$classLc . '::markdown'] = $mailMethodSpec;
+            $specs[$classLc . '::text'] = $mailMethodSpec;
+        }
+
+        // `Mail\Mailables\Content::__construct` — three view slots, one data
+        // slot, dispatched as a single multi-view spec.
+        $specs[\strtolower(\Illuminate\Mail\Mailables\Content::class) . '::__construct'] = $contentConstructorSpec;
+
+        // Known coverage gaps left for PR-5+:
+        //  - Component data flow `<x-foo :bar="$data" />` (PR-5 scope).
+        //  - `View::share()` global view data — the binding is replayed at
+        //    render-time across every subsequent `view()` call from any
+        //    caller, so the scanner's per-call dispatch model does not fit.
+        //  - Variable-bound view-builder chains
+        //    (`$v = view('home'); $v->with(...)`) — PR-5 may attach view
+        //    names to {@see \Psalm\Type\Union} via NodeTypeProvider metadata
+        //    to recover the view name through indirections.
+        //  - Caching the safety map across analysis runs — handled in a
+        //    follow-up after PR-5 stabilises the map shape.
 
         return $specs;
     }

--- a/src/Handlers/Views/FirstLikeMethodSpec.php
+++ b/src/Handlers/Views/FirstLikeMethodSpec.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Views;
+
+/**
+ * Argument-shape descriptor for `Factory::first(array $views, $data = [],
+ * $mergeData = [])`. Unlike {@see MakeLikeMethodSpec}, the view argument is
+ * itself an `array<string>` of candidate view names (Laravel renders the
+ * first that exists).
+ *
+ * Sink dispatch rules (see {@see BladeAwareViewTaintHandler}):
+ *
+ *  - If the views array is a literal array of literal strings, the handler
+ *    looks up each view's safety record and takes the union of unsafe keys
+ *    across the templates. The union is sound because `Factory::first` calls
+ *    `Factory::make` on whichever existing view it finds, and analysis-time
+ *    cannot tell which will exist at runtime.
+ *  - If ANY listed template is UNKNOWN (or unknown to the map), the call
+ *    falls back to the whole-data sink. The unsafe-key union is only sound
+ *    when every contributing template has an enumerable key set.
+ *  - If the views argument is not a literal array (e.g. `$views`), the
+ *    handler applies the dynamic-name fallback identical to `Factory::make`
+ *    with a dynamic first argument: whole-data sink on `$data` and
+ *    `$mergeData`.
+ *
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final readonly class FirstLikeMethodSpec implements ViewBindingSinkSpec
+{
+    public function __construct(
+        public int $viewsArrayArgIndex,
+        public int $dataArgIndex,
+        public ?int $mergeDataArgIndex,
+    ) {}
+}

--- a/src/Handlers/Views/MakeLikeMethodSpec.php
+++ b/src/Handlers/Views/MakeLikeMethodSpec.php
@@ -5,23 +5,51 @@ declare(strict_types=1);
 namespace Psalm\LaravelPlugin\Handlers\Views;
 
 /**
- * Argument shape descriptor for `Factory::make()`-style methods consumed by
+ * Argument-shape descriptor for `Factory::make()`-style methods consumed by
  * {@see BladeAwareViewTaintHandler}.
  *
- * `Factory::make($view, $data = [], $mergeData = [])` is the only shape PR-3
- * dispatches on, but the descriptor is a small object rather than a tuple so
- * PR-4+ can add `first()` (where the view argument is `array<string>`) or
- * `renderEach()` (where `$data` is a collection and an extra `$iterator` arg
- * names the per-item variable) without changing the call sites in the handler.
+ * Covers every call shape with one or more string-name view arguments, a
+ * single associative-array data argument, and optionally a second mergeData
+ * argument. Laravel methods using this shape include:
+ *
+ *  - `\Illuminate\View\Factory::make($view, $data = [], $mergeData = [])`
+ *    and the contract method `\Illuminate\Contracts\View\Factory::make`
+ *  - `\Illuminate\View\Factory::renderWhen($cond, $view, $data, $mergeData)`
+ *    and the symmetric `renderUnless` (single view arg at index 1)
+ *  - `\Illuminate\Routing\ResponseFactory::view($view, $data, $status, $headers)`
+ *    plus its contract (single view arg, single data arg, no mergeData)
+ *  - `\Illuminate\View\View::nest($key, $view, $data = [])` (view at index 1)
+ *  - `\Illuminate\Mail\Mailable::view($view, array $data = [])` and the
+ *    `markdown` / `text` siblings; `MailMessage::view` / `markdown` / `text`
+ *    on `\Illuminate\Notifications\Messages\MailMessage`
+ *  - `\Illuminate\Mail\Mailables\Content::__construct(?$view, ?$html, ?$text,
+ *    $markdown, $with, ?$htmlString)` — three view-name slots (view at 0,
+ *    text at 2, markdown at 3) sharing one $with data slot
+ *
+ * The handler dispatches one sink-installation pass per `viewArgIndices`
+ * entry. Each pass treats the named view independently, so a single Content
+ * constructor produces one TaintedHtml report per literal view slot whose
+ * scanner safety record says the bound key is unsafe.
  *
  * @internal
  *
  * @psalm-immutable
  */
-final readonly class MakeLikeMethodSpec
+final readonly class MakeLikeMethodSpec implements ViewBindingSinkSpec
 {
+    /**
+     * @param non-empty-list<int> $viewArgIndices argument positions carrying a literal-string view name.
+     *                                            Single-view methods pass a one-element list (e.g. `[0]`);
+     *                                            Content's three-slot constructor passes `[0, 2, 3]`.
+     * @param int                 $dataArgIndex   position of the shared data array. Every view slot in
+     *                                            {@see $viewArgIndices} dispatches against this single
+     *                                            data argument.
+     * @param ?int                $mergeDataArgIndex optional secondary data argument; only
+     *                                              `Factory::make` / `renderWhen` / `renderUnless` use it.
+     *                                              Other shapes pass null.
+     */
     public function __construct(
-        public int $viewArgIndex,
+        public array $viewArgIndices,
         public int $dataArgIndex,
         public ?int $mergeDataArgIndex,
     ) {}

--- a/src/Handlers/Views/RenderEachLikeMethodSpec.php
+++ b/src/Handlers/Views/RenderEachLikeMethodSpec.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Views;
+
+/**
+ * Argument-shape descriptor for `Factory::renderEach($view, $data, $iterator,
+ * $empty = 'raw|')`.
+ *
+ * `renderEach` is structurally different from {@see MakeLikeMethodSpec}: the
+ * `$data` argument is an iterable of elements, not an associative array
+ * extracted into the template, and the literal string `$iterator` names the
+ * variable each element is bound to in the rendered child template.
+ *
+ * Sink dispatch rules (see {@see BladeAwareViewTaintHandler}):
+ *
+ *  - Resolve the child template via the literal `$view` name.
+ *  - If the template is SAFE, install no sink (the iterator's value cannot
+ *    reach a raw echo).
+ *  - If the template is UNSAFE_KEYS and `$iterator` is a literal whose value
+ *    appears in the child's unsafe-keys set, install an `html` sink on
+ *    `$data`. Each element flows to the named variable, so sinking the data
+ *    argument catches every element-level taint.
+ *  - If `$iterator` is non-literal, the child binds an unknown variable
+ *    name and the handler cannot prove the iterator does NOT match an unsafe
+ *    key; fall back to the whole-data sink on `$data`.
+ *  - If the template is UNKNOWN (cycles, unparsable blocks, etc.), apply the
+ *    whole-data sink regardless of `$iterator`.
+ *  - Dynamic `$view` falls back identically to other dispatch shapes
+ *    (whole-data sink with the documented `DynamicViewName` policy).
+ *
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final readonly class RenderEachLikeMethodSpec implements ViewBindingSinkSpec
+{
+    public function __construct(
+        public int $viewArgIndex,
+        public int $dataArgIndex,
+        public int $iteratorArgIndex,
+    ) {}
+}

--- a/src/Handlers/Views/ViewBindingSinkSpec.php
+++ b/src/Handlers/Views/ViewBindingSinkSpec.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Views;
+
+/**
+ * Marker interface for the argument-shape descriptors consumed by
+ * {@see BladeAwareViewTaintHandler}.
+ *
+ * Each Laravel API the handler dispatches on (`Factory::make`,
+ * `Factory::first`, `Factory::renderEach`, `View::with`, `Mailable::view`,
+ * `Content::__construct`, etc.) accepts a different argument layout. Rather
+ * than bloat one descriptor with optional fields for every shape, the handler
+ * uses a discriminated union: distinct implementations of this interface
+ * encode each call shape, and the dispatcher branches on the concrete type
+ * via `match (true) { ... }`.
+ *
+ * Implementations are intentionally narrow value objects (one or two int
+ * fields each) and are constructed once at boot from
+ * {@see BladeAwareViewTaintHandler::buildMethodSpecs()}. There is no runtime
+ * polymorphism in the dispatch hot path; every concrete instance is `final`
+ * and the `match` shape is exhaustive.
+ *
+ * PHP lacks a `sealed` keyword, but the interface is `@internal` to the
+ * plugin and the dispatcher's match arms enumerate every implementation. New
+ * implementations require updating the dispatcher in lockstep.
+ *
+ * @internal
+ *
+ * @psalm-immutable
+ */
+interface ViewBindingSinkSpec {}

--- a/src/Handlers/Views/WithLikeMethodSpec.php
+++ b/src/Handlers/Views/WithLikeMethodSpec.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Views;
+
+/**
+ * Argument-shape descriptor for `\Illuminate\View\View::with($key, $value)`
+ * (and the matching contract method) — Laravel's chained data-binding
+ * primitive.
+ *
+ * `with()` differs from {@see MakeLikeMethodSpec} in two ways:
+ *
+ *  - The data shape is `($key, $value)` — a single key/value pair, not an
+ *    associative array. The handler dispatches one sink per call site.
+ *  - The view name is NOT in the argument list. It lives on the receiver:
+ *    `view('home')->with('user', $user)` carries the view name `'home'` on
+ *    the `MethodCall::$var` expression. The dispatcher walks that
+ *    sub-expression to recover the view name. Receivers that PR-4 can
+ *    statically resolve:
+ *      * `view(string)` global function call
+ *      * `_::make(string)` / `_::first([string])` direct call on the
+ *        `\Illuminate\View\Factory` (or facade) class — first literal view
+ *        wins for `first`
+ *
+ *    Receivers we cannot resolve (variable-bound chains
+ *    `$v = view('home'); $v->with(...)`, dynamic view names, etc.) skip the
+ *    sink entirely. PR-5 will add a NodeTypeProvider attachment that
+ *    propagates view names through return-type metadata for the
+ *    variable-bound case.
+ *
+ * Sink dispatch rules:
+ *
+ *  - If the receiver's view name resolves AND the key is a literal that
+ *    matches the resolved template's unsafe-keys set, install an `html` sink
+ *    on `$value` keyed by the literal `$key`.
+ *  - If the template is UNKNOWN or the key is non-literal, install a
+ *    whole-arg sink on `$value` (single key, single value — the "whole-data"
+ *    fallback collapses to one sink here).
+ *  - If the template is SAFE, install no sink.
+ *  - If the receiver does not resolve, install no sink (consistent with
+ *    PR-3's "view not in map → no sink" policy).
+ *
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final readonly class WithLikeMethodSpec implements ViewBindingSinkSpec
+{
+    public function __construct(
+        public int $keyArgIndex,
+        public int $valueArgIndex,
+    ) {}
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -259,7 +259,11 @@ final class Plugin implements PluginEntryPointInterface
         // (taint analysis disabled or view roots unavailable), but the registration
         // is unconditional so users get the refinement automatically once they
         // enable --taint-analysis.
+        require_once __DIR__ . '/Handlers/Views/ViewBindingSinkSpec.php';
         require_once __DIR__ . '/Handlers/Views/MakeLikeMethodSpec.php';
+        require_once __DIR__ . '/Handlers/Views/FirstLikeMethodSpec.php';
+        require_once __DIR__ . '/Handlers/Views/RenderEachLikeMethodSpec.php';
+        require_once __DIR__ . '/Handlers/Views/WithLikeMethodSpec.php';
         require_once __DIR__ . '/Handlers/Views/BladeAwareViewTaintHandler.php';
         $registration->registerHooksFromClass(Handlers\Views\BladeAwareViewTaintHandler::class);
     }
@@ -476,9 +480,24 @@ final class Plugin implements PluginEntryPointInterface
 
         $factoryFacadeClasses = FacadeMapProvider::getFacadeClasses(\Illuminate\View\Factory::class);
 
+        // Pull the facade classes for both the concrete `Routing\ResponseFactory`
+        // and its contract. Laravel ships `\Illuminate\Support\Facades\Response`
+        // as the facade for the contract; user-registered aliases may map to
+        // either binding. Without this routing, calls through `\Response::view(...)`
+        // bypass the dispatch table (the resolved method id lives on the facade
+        // class, not on the contract).
+        $responseFactoryFacadeClasses = [
+            ...FacadeMapProvider::getFacadeClasses(\Illuminate\Routing\ResponseFactory::class),
+            ...FacadeMapProvider::getFacadeClasses(\Illuminate\Contracts\Routing\ResponseFactory::class),
+        ];
+
+        require_once __DIR__ . '/Handlers/Views/ViewBindingSinkSpec.php';
         require_once __DIR__ . '/Handlers/Views/MakeLikeMethodSpec.php';
+        require_once __DIR__ . '/Handlers/Views/FirstLikeMethodSpec.php';
+        require_once __DIR__ . '/Handlers/Views/RenderEachLikeMethodSpec.php';
+        require_once __DIR__ . '/Handlers/Views/WithLikeMethodSpec.php';
         require_once __DIR__ . '/Handlers/Views/BladeAwareViewTaintHandler.php';
-        Handlers\Views\BladeAwareViewTaintHandler::init($map, $factoryFacadeClasses);
+        Handlers\Views\BladeAwareViewTaintHandler::init($map, $factoryFacadeClasses, $responseFactoryFacadeClasses);
     }
 
     private function buildSchema(PluginConfig $pluginConfig): void

--- a/tests/Type/tests/Blade/NoTaintedHtmlFirstAllLiteralUnknownViews.phpt
+++ b/tests/Type/tests/Blade/NoTaintedHtmlFirstAllLiteralUnknownViews.phpt
@@ -1,0 +1,23 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Negative regression: `Factory::first()` with an all-literal views array
+ * where NONE of the candidate views exist in the {@see BladeSafetyMap}
+ * (the default Testbench app has no fixture blade templates). The
+ * dispatcher follows PR-3's "view not in map → no sink" policy and
+ * installs no html sink for the call site, so no TaintedHtml is raised
+ * even though `$_GET['x']` flows to the data array.
+ *
+ * A regression that switched the policy to "unknown view → whole-data
+ * sink" would re-introduce the package-view false positives PR #684
+ * fixed. MissingViewHandler is the appropriate surface for these typos.
+ */
+function renderFirstAllLiterals(\Illuminate\View\Factory $factory, string $tainted): void {
+    $factory->first(['home', 'fallback'], ['bio' => $tainted]);
+}
+?>
+--EXPECTF--
+

--- a/tests/Type/tests/Blade/TaintedHtmlFirstDynamicViewsArray.phpt
+++ b/tests/Type/tests/Blade/TaintedHtmlFirstDynamicViewsArray.phpt
@@ -1,0 +1,26 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Locks in the `Factory::first()` dynamic-array fallback. When the views
+ * array contains a non-literal item, the handler cannot enumerate which
+ * candidate template will render, so it installs an html sink on every
+ * entry of the data array. The tainted `$_GET['x']` reaching the 'bio'
+ * key must then surface as TaintedHtml.
+ *
+ * Sibling cases that require literal view-name + on-disk template fixtures
+ * (e.g. "literal unsafe-keys template fires per-key sink") would need a
+ * custom Testbench view path with fixture blade files. PR-3 documented
+ * that the PHPT layer cannot provide that today; tracked as future work
+ * alongside the Application --taint-analysis run.
+ */
+function renderFirstWithDynamicItem(\Illuminate\View\Factory $factory, string $candidate): void {
+    /** @var string $tainted */
+    $tainted = $_GET['x'];
+    $factory->first(['home', $candidate], ['bio' => $tainted]);
+}
+?>
+--EXPECTF--
+%ATaintedHtml%a

--- a/tests/Type/tests/Blade/TaintedHtmlResponseFactoryDynamicView.phpt
+++ b/tests/Type/tests/Blade/TaintedHtmlResponseFactoryDynamicView.phpt
@@ -1,0 +1,22 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Locks in the dispatcher registration for
+ * `\Illuminate\Routing\ResponseFactory::view($view, $data, $status, $headers)`
+ * and its contract sibling. With a non-literal `$view` argument the handler
+ * applies the dynamic-name fallback (whole-data sink) just like
+ * `Factory::make()`, so the tainted `$_GET['x']` flowing to `bio` surfaces
+ * as TaintedHtml. A registration regression would leave this call site
+ * un-sunk and the assertion would fail.
+ */
+function renderResponse(\Illuminate\Contracts\Routing\ResponseFactory $responseFactory, string $viewName): void {
+    /** @var string $tainted */
+    $tainted = $_GET['x'];
+    $responseFactory->view($viewName, ['bio' => $tainted]);
+}
+?>
+--EXPECTF--
+%ATaintedHtml%a

--- a/tests/Unit/Blade/BladeSafetyMapTest.php
+++ b/tests/Unit/Blade/BladeSafetyMapTest.php
@@ -194,6 +194,251 @@ final class BladeSafetyMapTest extends TestCase
         $this->assertSame([], $map->unsafeKeysFor('never.scanned'));
     }
 
+    public function test_include_literal_target_propagates_child_unsafe_keys_through_explicit_data_array(): void
+    {
+        // Parent calls `@include('partials.row', ['html' => $bio])`. Child's
+        // unsafe key 'html' is mapped through the parent's explicit array to
+        // the parent variable $bio. The parent's unsafe-keys gain 'bio' AND
+        // every other child unsafe key not bound by the explicit array
+        // (mergeData verbatim pass-through).
+        \mkdir($this->root . \DIRECTORY_SEPARATOR . 'partials', 0777, true);
+
+        $this->writeBlade($this->root, 'partials/row.blade.php', '{!! $html !!} {!! $secret !!}');
+        $this->writeBlade(
+            $this->root,
+            'posts/show.blade.php',
+            "@include('partials.row', ['html' => \$bio])",
+        );
+
+        $map = BladeSafetyMap::build([$this->root]);
+
+        $parentSafety = $map->safetyFor('posts.show');
+
+        $this->assertInstanceOf(\Psalm\LaravelPlugin\Blade\BladeViewSafety::class, $parentSafety);
+        $this->assertSame(BladeViewSafetyKind::UnsafeKeys, $parentSafety->kind());
+
+        $unsafe = $parentSafety->unsafeKeys();
+        \sort($unsafe);
+
+        // - 'html' was bound to $bio → parent gains 'bio'.
+        // - 'secret' was NOT bound → parent gains 'secret' verbatim (mergeData).
+        $this->assertSame(['bio', 'secret'], $unsafe);
+    }
+
+    public function test_include_with_no_explicit_data_propagates_child_keys_verbatim(): void
+    {
+        // 2-arg `@include('partials.row')` — no explicit data array, so every
+        // child unsafe key reaches the parent as the parent's same-named
+        // variable via mergeData.
+        \mkdir($this->root . \DIRECTORY_SEPARATOR . 'partials', 0777, true);
+
+        $this->writeBlade($this->root, 'partials/row.blade.php', '{!! $html !!}');
+        $this->writeBlade($this->root, 'posts/show.blade.php', "@include('partials.row')");
+
+        $map = BladeSafetyMap::build([$this->root]);
+
+        $this->assertSame(['html'], $map->unsafeKeysFor('posts.show'));
+        $this->assertSame(BladeViewSafetyKind::UnsafeKeys, $map->safetyFor('posts.show')?->kind());
+    }
+
+    public function test_include_into_safe_child_leaves_parent_safe(): void
+    {
+        // A literal `@include` of a SAFE template propagates zero unsafe keys.
+        // The parent is flipped from UNKNOWN(IncludeResolved) to SAFE.
+        \mkdir($this->root . \DIRECTORY_SEPARATOR . 'partials', 0777, true);
+
+        $this->writeBlade($this->root, 'partials/row.blade.php', '<p>{{ $html }}</p>');
+        $this->writeBlade($this->root, 'posts/show.blade.php', "@include('partials.row')");
+
+        $map = BladeSafetyMap::build([$this->root]);
+
+        $this->assertTrue($map->isKnownSafe('posts.show'));
+        $this->assertSame([], $map->unsafeKeysFor('posts.show'));
+    }
+
+    public function test_include_with_non_literal_target_keeps_parent_unknown(): void
+    {
+        // Dynamic include target: scanner cannot resolve the child, so the
+        // propagation pass cannot run. Parent stays UNKNOWN(IncludeDirective).
+        $this->writeBlade($this->root, 'posts/show.blade.php', "@include(\$partial, ['x' => \$y])");
+
+        $map = BladeSafetyMap::build([$this->root]);
+
+        $safety = $map->safetyFor('posts.show');
+
+        $this->assertInstanceOf(\Psalm\LaravelPlugin\Blade\BladeViewSafety::class, $safety);
+        $this->assertSame(BladeViewSafetyKind::Unknown, $safety->kind());
+        $this->assertContains(BladeUncertaintyReason::IncludeDirective, $safety->uncertainties());
+    }
+
+    public function test_include_with_non_literal_data_array_keeps_parent_unknown(): void
+    {
+        // Literal target, dynamic data array (`$data`): the explicit key
+        // binding is unenumerable, so the scanner emits IncludeDirective
+        // rather than IncludeResolved. Parent stays UNKNOWN.
+        \mkdir($this->root . \DIRECTORY_SEPARATOR . 'partials', 0777, true);
+
+        $this->writeBlade($this->root, 'partials/row.blade.php', '{!! $html !!}');
+        $this->writeBlade($this->root, 'posts/show.blade.php', "@include('partials.row', \$data)");
+
+        $map = BladeSafetyMap::build([$this->root]);
+
+        $safety = $map->safetyFor('posts.show');
+
+        $this->assertInstanceOf(\Psalm\LaravelPlugin\Blade\BladeViewSafety::class, $safety);
+        $this->assertSame(BladeViewSafetyKind::Unknown, $safety->kind());
+        $this->assertContains(BladeUncertaintyReason::IncludeDirective, $safety->uncertainties());
+    }
+
+    public function test_include_into_unknown_child_keeps_parent_unknown(): void
+    {
+        // Child is UNKNOWN (its own LayoutSectionFlow uncertainty). Parent's
+        // contribution from the include is opaque → parent stays UNKNOWN
+        // even though the include itself was statically resolvable.
+        \mkdir($this->root . \DIRECTORY_SEPARATOR . 'partials', 0777, true);
+
+        $this->writeBlade(
+            $this->root,
+            'partials/row.blade.php',
+            "@yield('chunk')",
+        );
+        $this->writeBlade($this->root, 'posts/show.blade.php', "@include('partials.row')");
+
+        $map = BladeSafetyMap::build([$this->root]);
+
+        $safety = $map->safetyFor('posts.show');
+
+        $this->assertInstanceOf(\Psalm\LaravelPlugin\Blade\BladeViewSafety::class, $safety);
+        $this->assertSame(BladeViewSafetyKind::Unknown, $safety->kind());
+        $this->assertContains(BladeUncertaintyReason::IncludeDirective, $safety->uncertainties());
+    }
+
+    public function test_include_into_unknown_child_does_not_propagate_local_unsafe_keys(): void
+    {
+        // Even when a child is UNKNOWN, the propagation pass treats the
+        // include's contribution as opaque rather than reusing the child's
+        // local unsafe-keys list. The parent's localUnsafeKeys are
+        // preserved on the resulting safety record (for diagnostics) but
+        // they do not include the child's keys.
+        \mkdir($this->root . \DIRECTORY_SEPARATOR . 'partials', 0777, true);
+
+        $this->writeBlade(
+            $this->root,
+            'partials/row.blade.php',
+            "{!! \$inner !!} @yield('chunk')",
+        );
+        $this->writeBlade(
+            $this->root,
+            'posts/show.blade.php',
+            "{!! \$parentRaw !!} @include('partials.row')",
+        );
+
+        $map = BladeSafetyMap::build([$this->root]);
+
+        $safety = $map->safetyFor('posts.show');
+
+        $this->assertInstanceOf(\Psalm\LaravelPlugin\Blade\BladeViewSafety::class, $safety);
+        $this->assertSame(BladeViewSafetyKind::Unknown, $safety->kind());
+        // The parent's local raw echo of $parentRaw is preserved.
+        $this->assertContains('parentRaw', $safety->unsafeKeys());
+        // But the child's 'inner' key does NOT leak through opaque UNKNOWN.
+        $this->assertNotContains('inner', $safety->unsafeKeys());
+    }
+
+    public function test_include_cycle_marks_every_member_unknown_include_cycle(): void
+    {
+        // a → b → a. Both participate; both become UNKNOWN(IncludeCycle).
+        $this->writeBlade($this->root, 'posts/a.blade.php', "@include('posts.b')");
+        $this->writeBlade($this->root, 'posts/b.blade.php', "@include('posts.a')");
+
+        $map = BladeSafetyMap::build([$this->root]);
+
+        foreach (['posts.a', 'posts.b'] as $name) {
+            $safety = $map->safetyFor($name);
+
+            $this->assertInstanceOf(\Psalm\LaravelPlugin\Blade\BladeViewSafety::class, $safety);
+            $this->assertSame(BladeViewSafetyKind::Unknown, $safety->kind());
+            $this->assertContains(BladeUncertaintyReason::IncludeCycle, $safety->uncertainties());
+        }
+    }
+
+    public function test_include_self_loop_is_marked_include_cycle(): void
+    {
+        $this->writeBlade($this->root, 'posts/self.blade.php', "@include('posts.self')");
+
+        $map = BladeSafetyMap::build([$this->root]);
+
+        $safety = $map->safetyFor('posts.self');
+
+        $this->assertInstanceOf(\Psalm\LaravelPlugin\Blade\BladeViewSafety::class, $safety);
+        $this->assertSame(BladeViewSafetyKind::Unknown, $safety->kind());
+        $this->assertContains(BladeUncertaintyReason::IncludeCycle, $safety->uncertainties());
+    }
+
+    public function test_include_with_other_uncertainty_strips_include_resolved_marker(): void
+    {
+        // Parent has BOTH a literal `@include` (would normally produce
+        // IncludeResolved) AND another uncertainty (@yield → LayoutSectionFlow).
+        // The propagation pass is non-eligible (uncertainty list contains a
+        // non-IncludeResolved entry), so propagation is skipped. The
+        // post-build safety record must NOT expose IncludeResolved — that
+        // marker is documented as intermediate-only via
+        // {@see BladeUncertaintyReason::IncludeResolved}'s class docblock.
+        \mkdir($this->root . \DIRECTORY_SEPARATOR . 'partials', 0777, true);
+
+        $this->writeBlade($this->root, 'partials/row.blade.php', '{!! $html !!}');
+        $this->writeBlade(
+            $this->root,
+            'posts/show.blade.php',
+            "@yield('chunk')\n@include('partials.row')",
+        );
+
+        $map = BladeSafetyMap::build([$this->root]);
+
+        $safety = $map->safetyFor('posts.show');
+
+        $this->assertInstanceOf(\Psalm\LaravelPlugin\Blade\BladeViewSafety::class, $safety);
+        $this->assertSame(BladeViewSafetyKind::Unknown, $safety->kind());
+        $this->assertContains(BladeUncertaintyReason::LayoutSectionFlow, $safety->uncertainties());
+        $this->assertNotContains(
+            BladeUncertaintyReason::IncludeResolved,
+            $safety->uncertainties(),
+            'IncludeResolved is an intermediate marker and must not leak into the public map.',
+        );
+    }
+
+    public function test_include_chain_propagates_through_multiple_hops(): void
+    {
+        // a includes b, b includes c. c has unsafe key 'html'. The
+        // propagation pass folds c → b → a so a gains 'html'.
+        \mkdir($this->root . \DIRECTORY_SEPARATOR . 'partials', 0777, true);
+
+        $this->writeBlade($this->root, 'partials/c.blade.php', '{!! $html !!}');
+        $this->writeBlade($this->root, 'partials/b.blade.php', "@include('partials.c')");
+        $this->writeBlade($this->root, 'posts/a.blade.php', "@include('partials.b')");
+
+        $map = BladeSafetyMap::build([$this->root]);
+
+        $this->assertSame(['html'], $map->unsafeKeysFor('posts.a'));
+        $this->assertSame(['html'], $map->unsafeKeysFor('partials.b'));
+        $this->assertSame(['html'], $map->unsafeKeysFor('partials.c'));
+    }
+
+    public function test_include_with_missing_child_view_keeps_parent_unknown(): void
+    {
+        // Child view does not exist on disk (typo). Propagation cannot
+        // proceed; parent stays UNKNOWN(IncludeDirective).
+        $this->writeBlade($this->root, 'posts/show.blade.php', "@include('missing.partial')");
+
+        $map = BladeSafetyMap::build([$this->root]);
+
+        $safety = $map->safetyFor('posts.show');
+
+        $this->assertInstanceOf(\Psalm\LaravelPlugin\Blade\BladeViewSafety::class, $safety);
+        $this->assertSame(BladeViewSafetyKind::Unknown, $safety->kind());
+        $this->assertContains(BladeUncertaintyReason::IncludeDirective, $safety->uncertainties());
+    }
+
     public function test_unreadable_blade_file_is_recorded_as_unknown(): void
     {
         // Verifies the FILE_UNREADABLE branch in BladeSafetyMap::build().

--- a/tests/Unit/Blade/BladeTemplateScannerTest.php
+++ b/tests/Unit/Blade/BladeTemplateScannerTest.php
@@ -423,12 +423,43 @@ final class BladeTemplateScannerTest extends TestCase
         $this->assertContains(BladeUncertaintyReason::LayoutSectionFlow, $analysis->uncertainties);
     }
 
-    public function test_include_directive_marks_template_unknown(): void
+    public function test_literal_include_with_literal_data_array_emits_include_resolved(): void
     {
+        // Literal target + literal data array → scanner records an edge and
+        // emits IncludeResolved instead of IncludeDirective. BladeSafetyMap's
+        // propagation pass consumes the edge to compute parent unsafe-keys;
+        // see BladeSafetyMapTest for the post-propagation assertions.
         $analysis = $this->scanner->analyze("@include('partials.user', ['html' => \$html])");
 
         $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
+        $this->assertContains(BladeUncertaintyReason::IncludeResolved, $analysis->uncertainties);
+        $this->assertNotContains(BladeUncertaintyReason::IncludeDirective, $analysis->uncertainties);
+        $this->assertCount(1, $analysis->includeEdges);
+        $this->assertSame('partials.user', $analysis->includeEdges[0]->childViewName);
+        $this->assertSame(['html' => ['html']], $analysis->includeEdges[0]->explicitKeyMap);
+    }
+
+    public function test_include_with_dynamic_data_array_stays_include_directive(): void
+    {
+        // Literal view name but a variable data array: scanner cannot
+        // enumerate the keys, so it must fall through to the unresolvable
+        // IncludeDirective path.
+        $analysis = $this->scanner->analyze("@include('partials.user', \$data)");
+
+        $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
         $this->assertContains(BladeUncertaintyReason::IncludeDirective, $analysis->uncertainties);
+        $this->assertNotContains(BladeUncertaintyReason::IncludeResolved, $analysis->uncertainties);
+        $this->assertSame([], $analysis->includeEdges);
+    }
+
+    public function test_include_with_dynamic_view_name_stays_include_directive(): void
+    {
+        $analysis = $this->scanner->analyze("@include(\$view)");
+
+        $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
+        $this->assertContains(BladeUncertaintyReason::IncludeDirective, $analysis->uncertainties);
+        $this->assertNotContains(BladeUncertaintyReason::IncludeResolved, $analysis->uncertainties);
+        $this->assertSame([], $analysis->includeEdges);
     }
 
     public function test_include_when_directive_marks_template_unknown(): void
@@ -630,25 +661,58 @@ final class BladeTemplateScannerTest extends TestCase
     }
 
     /**
+     * Include-family directives that compile to call shapes the scanner does
+     * NOT statically resolve: `@includeWhen` / `@includeUnless` emit
+     * `$__env->renderWhen` / `renderUnless`, `@includeFirst` emits
+     * `$__env->first`, `@each` emits `$__env->renderEach`. Each falls through
+     * to the conservative IncludeDirective uncertainty.
+     *
      * @return iterable<string, array{string}>
      */
-    public static function includeFamilyDirectiveProvider(): iterable
+    public static function unresolvedIncludeFamilyDirectiveProvider(): iterable
     {
-        yield 'include' => ["@include('p.x')"];
-        yield 'includeIf' => ["@includeIf('p.x')"];
         yield 'includeWhen' => ['@includeWhen($cond, \'p.x\')'];
         yield 'includeUnless' => ['@includeUnless($cond, \'p.x\')'];
         yield 'includeFirst' => ["@includeFirst(['a', 'b'])"];
         yield 'each' => ['@each(\'p.row\', $rows, \'row\')'];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('includeFamilyDirectiveProvider')]
-    public function test_include_family_directive_marks_template_unknown(string $source): void
+    #[\PHPUnit\Framework\Attributes\DataProvider('unresolvedIncludeFamilyDirectiveProvider')]
+    public function test_unresolved_include_family_directive_marks_template_unknown(string $source): void
     {
         $analysis = $this->scanner->analyze($source);
 
         $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
         $this->assertContains(BladeUncertaintyReason::IncludeDirective, $analysis->uncertainties);
+        $this->assertNotContains(BladeUncertaintyReason::IncludeResolved, $analysis->uncertainties);
+    }
+
+    /**
+     * `@include` and `@includeIf` compile to `$__env->make(...)` whose
+     * arguments the scanner CAN statically resolve when the target is a
+     * literal string. These cases now emit IncludeResolved (with an attached
+     * edge) so {@see BladeSafetyMap} can fold the child's unsafe keys into
+     * the parent's safety record.
+     *
+     * @return iterable<string, array{string}>
+     */
+    public static function resolvedIncludeFamilyDirectiveProvider(): iterable
+    {
+        yield 'include' => ["@include('p.x')"];
+        yield 'includeIf' => ["@includeIf('p.x')"];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('resolvedIncludeFamilyDirectiveProvider')]
+    public function test_literal_include_directive_emits_include_resolved(string $source): void
+    {
+        $analysis = $this->scanner->analyze($source);
+
+        $this->assertSame(BladeViewSafetyKind::Unknown, $analysis->kind);
+        $this->assertContains(BladeUncertaintyReason::IncludeResolved, $analysis->uncertainties);
+        $this->assertNotContains(BladeUncertaintyReason::IncludeDirective, $analysis->uncertainties);
+        $this->assertNotEmpty($analysis->includeEdges);
+        $this->assertSame('p.x', $analysis->includeEdges[0]->childViewName);
+        $this->assertNull($analysis->includeEdges[0]->explicitKeyMap);
     }
 
     public function test_raw_echo_of_string_cast_surfaces_inner_variable(): void
@@ -776,9 +840,11 @@ final class BladeTemplateScannerTest extends TestCase
     public function test_multiple_uncertainties_accumulate_independently(): void
     {
         // The visitor collects every uncertainty it sees, without short-circuiting.
+        // `@include` here is dynamic-target so it stays IncludeDirective; a
+        // literal target would emit IncludeResolved (covered separately).
         $source = <<<'BLADE'
             @yield('content')
-            @include('partials.alert')
+            @include($name)
             <x-button :label="$label" />
             BLADE;
 

--- a/tests/Unit/Handlers/Views/BladeAwareViewTaintHandlerTest.php
+++ b/tests/Unit/Handlers/Views/BladeAwareViewTaintHandlerTest.php
@@ -274,8 +274,11 @@ final class BladeAwareViewTaintHandlerTest extends TestCase
         $graph = new TaintFlowGraph();
         $codebase = $this->createCodebase($graph);
 
+        // `share` is a real Factory method but is intentionally NOT in the
+        // dispatch table (see buildMethodSpecs' deferred-list comment). The
+        // hot-path suffix gate should reject it cleanly.
         $event = $this->makeMethodEvent(
-            \Illuminate\View\Factory::class . '::renderEach',
+            \Illuminate\View\Factory::class . '::share',
             [
                 new Arg(new String_('post')),
                 new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
@@ -719,6 +722,1045 @@ final class BladeAwareViewTaintHandlerTest extends TestCase
         $this->assertSinkLabelExists($this->graphSinks($graph), "(post, 'bio')");
     }
 
+    #[Test]
+    public function factory_first_unions_unsafe_keys_across_literal_templates(): void
+    {
+        // first(['a', 'b'], $data): scanner sees 'a' has 'bio', 'b' has 'title'.
+        // The handler sinks both keys when present in the data array.
+        $this->initWithMap([
+            'a' => new BladeViewSafety('a', '/views/a.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+            'b' => new BladeViewSafety('b', '/views/b.blade.php', BladeTemplateAnalysis::unsafeKeys(['title'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeMethodEvent(\Illuminate\View\Factory::class . '::first', [
+            new Arg($this->viewNameList(['a', 'b'])),
+            new Arg($this->arrayLiteral([
+                'bio' => $this->taintedVariable('bio'),
+                'title' => $this->taintedVariable('title'),
+                'safe' => $this->taintedVariable('safe'),
+            ])),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $sinks = $this->graphSinks($graph);
+
+        $this->assertCount(2, $sinks, 'Union of bio + title; safe is not sunk.');
+        $this->assertSinkLabelExists($sinks, "'bio'");
+        $this->assertSinkLabelExists($sinks, "'title'");
+    }
+
+    #[Test]
+    public function factory_first_with_unknown_template_falls_back_to_whole_data_sink(): void
+    {
+        // first(['a', 'b']) where 'a' is UNKNOWN — the unsafe-key union loses
+        // soundness, so the call falls back to the whole-data sink.
+        $this->initWithMap([
+            'a' => new BladeViewSafety(
+                'a',
+                '/views/a.blade.php',
+                BladeTemplateAnalysis::unknown([BladeUncertaintyReason::LayoutSectionFlow]),
+            ),
+            'b' => new BladeViewSafety('b', '/views/b.blade.php', BladeTemplateAnalysis::unsafeKeys(['title'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeMethodEvent(\Illuminate\View\Factory::class . '::first', [
+            new Arg($this->viewNameList(['a', 'b'])),
+            new Arg($this->arrayLiteral([
+                'bio' => $this->taintedVariable('bio'),
+                'title' => $this->taintedVariable('title'),
+            ])),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $sinks = $this->graphSinks($graph);
+
+        // Whole-data fallback sinks BOTH keys regardless of which template
+        // tripped the fallback.
+        $this->assertCount(2, $sinks);
+    }
+
+    #[Test]
+    public function factory_first_with_non_literal_array_item_falls_back_to_whole_data(): void
+    {
+        $this->initWithMap([
+            'a' => new BladeViewSafety('a', '/views/a.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        // One literal, one variable item. Whole-data sink fires because the
+        // second template's name is opaque at analysis time.
+        $viewsArray = new Array_([
+            new ArrayItem(new String_('a')),
+            new ArrayItem($this->taintedVariable('dynamicTemplate')),
+        ]);
+
+        $event = $this->makeMethodEvent(\Illuminate\View\Factory::class . '::first', [
+            new Arg($viewsArray),
+            new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $sinks = $this->graphSinks($graph);
+
+        // Whole-data fallback fires. The label carries the first literal
+        // candidate name encountered before the non-literal item (here 'a').
+        // When no literal candidate is resolved first, the dispatcher would
+        // emit '<first-dynamic>' instead.
+        $this->assertSinkLabelExists($sinks, "(a, 'bio')");
+    }
+
+    #[Test]
+    public function factory_first_with_non_array_views_arg_falls_back_to_dynamic(): void
+    {
+        $this->initWithMap([]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeMethodEvent(\Illuminate\View\Factory::class . '::first', [
+            new Arg($this->taintedVariable('views')),
+            new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertSinkLabelExists($this->graphSinks($graph), "(<dynamic>, 'bio')");
+    }
+
+    #[Test]
+    public function factory_first_all_safe_templates_install_no_sink(): void
+    {
+        $this->initWithMap([
+            'a' => new BladeViewSafety('a', '/views/a.blade.php', BladeTemplateAnalysis::safe()),
+            'b' => new BladeViewSafety('b', '/views/b.blade.php', BladeTemplateAnalysis::safe()),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeMethodEvent(\Illuminate\View\Factory::class . '::first', [
+            new Arg($this->viewNameList(['a', 'b'])),
+            new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertSame([], $this->graphSinks($graph));
+    }
+
+    #[Test]
+    public function factory_render_each_with_literal_iterator_matching_unsafe_key(): void
+    {
+        // renderEach('row', $items, 'user'): the child template binds each
+        // $items element under $user. If 'user' is an unsafe key, sink $items.
+        $this->initWithMap([
+            'row' => new BladeViewSafety('row', '/views/row.blade.php', BladeTemplateAnalysis::unsafeKeys(['user'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeMethodEvent(\Illuminate\View\Factory::class . '::rendereach', [
+            new Arg(new String_('row')),
+            new Arg($this->taintedVariable('items')),
+            new Arg(new String_('user')),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertSinkLabelExists($this->graphSinks($graph), "(row, 'user')");
+    }
+
+    #[Test]
+    public function factory_render_each_with_non_matching_iterator_installs_no_sink(): void
+    {
+        $this->initWithMap([
+            'row' => new BladeViewSafety('row', '/views/row.blade.php', BladeTemplateAnalysis::unsafeKeys(['other'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        // 'user' iterator does not match the unsafe key 'other'.
+        $event = $this->makeMethodEvent(\Illuminate\View\Factory::class . '::rendereach', [
+            new Arg(new String_('row')),
+            new Arg($this->taintedVariable('items')),
+            new Arg(new String_('user')),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertSame([], $this->graphSinks($graph));
+    }
+
+    #[Test]
+    public function factory_render_each_with_non_literal_iterator_falls_back_to_whole_data(): void
+    {
+        $this->initWithMap([
+            'row' => new BladeViewSafety('row', '/views/row.blade.php', BladeTemplateAnalysis::unsafeKeys(['user'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeMethodEvent(\Illuminate\View\Factory::class . '::rendereach', [
+            new Arg(new String_('row')),
+            new Arg($this->taintedVariable('items')),
+            new Arg($this->taintedVariable('iteratorName')),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertSinkLabelExists($this->graphSinks($graph), "(row, '<argument>')");
+    }
+
+    #[Test]
+    public function factory_render_each_with_unknown_template_falls_back_to_whole_data(): void
+    {
+        $this->initWithMap([
+            'row' => new BladeViewSafety(
+                'row',
+                '/views/row.blade.php',
+                BladeTemplateAnalysis::unknown([BladeUncertaintyReason::LayoutSectionFlow]),
+            ),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeMethodEvent(\Illuminate\View\Factory::class . '::rendereach', [
+            new Arg(new String_('row')),
+            new Arg($this->taintedVariable('items')),
+            new Arg(new String_('user')),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertSinkLabelExists($this->graphSinks($graph), "(row, '<argument>')");
+    }
+
+    #[Test]
+    public function response_factory_view_installs_per_key_sink(): void
+    {
+        // Same shape as Factory::make() but on a different class. The contract
+        // and concrete class are both registered; both must dispatch.
+        $this->initWithMap([
+            'profile' => new BladeViewSafety(
+                'profile',
+                '/views/profile.blade.php',
+                BladeTemplateAnalysis::unsafeKeys(['bio']),
+            ),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeMethodEvent(
+            \Illuminate\Routing\ResponseFactory::class . '::view',
+            [
+                new Arg(new String_('profile')),
+                new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+            ],
+            $codebase,
+        );
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertSinkLabelExists($this->graphSinks($graph), "(profile, 'bio')");
+    }
+
+    #[Test]
+    public function response_factory_contract_view_installs_per_key_sink(): void
+    {
+        $this->initWithMap([
+            'profile' => new BladeViewSafety(
+                'profile',
+                '/views/profile.blade.php',
+                BladeTemplateAnalysis::unsafeKeys(['bio']),
+            ),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeMethodEvent(
+            \Illuminate\Contracts\Routing\ResponseFactory::class . '::view',
+            [
+                new Arg(new String_('profile')),
+                new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+            ],
+            $codebase,
+        );
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertSinkLabelExists($this->graphSinks($graph), "(profile, 'bio')");
+    }
+
+    #[Test]
+    public function view_with_chained_off_view_helper_installs_single_key_sink(): void
+    {
+        // view('post')->with('bio', $bio) — receiver resolves to 'post' via
+        // FuncCall walk. Single-key sink fires when 'bio' is unsafe.
+        $this->initWithMap([
+            'post' => new BladeViewSafety('post', '/views/post.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $bioVar = $this->taintedVariable('bio');
+
+        // Build the chained receiver expression.
+        $viewCall = new FuncCall(new Name('view'), [new Arg(new String_('post'))]);
+
+        $event = $this->makeInstanceMethodEvent(
+            \Illuminate\View\View::class . '::with',
+            $viewCall,
+            [
+                new Arg(new String_('bio')),
+                new Arg($bioVar),
+            ],
+            $codebase,
+        );
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertSinkLabelExists($this->graphSinks($graph), "(post, 'bio')");
+    }
+
+    #[Test]
+    public function view_with_chained_off_factory_make_installs_single_key_sink(): void
+    {
+        // \Illuminate\Support\Facades\View::make('post')->with('bio', $bio) —
+        // static call receiver.
+        $this->initWithMap([
+            'post' => new BladeViewSafety('post', '/views/post.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $bioVar = $this->taintedVariable('bio');
+
+        $makeCall = new StaticCall(
+            new Name(\Illuminate\Support\Facades\View::class),
+            'make',
+            [new Arg(new String_('post'))],
+        );
+
+        $event = $this->makeInstanceMethodEvent(
+            \Illuminate\View\View::class . '::with',
+            $makeCall,
+            [
+                new Arg(new String_('bio')),
+                new Arg($bioVar),
+            ],
+            $codebase,
+        );
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertSinkLabelExists($this->graphSinks($graph), "(post, 'bio')");
+    }
+
+    #[Test]
+    public function view_with_unresolvable_receiver_installs_no_sink(): void
+    {
+        // $v->with('bio', $bio) — receiver is a bare variable; we can't trace
+        // the view name back through it. No sink, per the documented policy.
+        $this->initWithMap([
+            'post' => new BladeViewSafety('post', '/views/post.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeInstanceMethodEvent(
+            \Illuminate\View\View::class . '::with',
+            $this->taintedVariable('viewInstance'),
+            [
+                new Arg(new String_('bio')),
+                new Arg($this->taintedVariable('bio')),
+            ],
+            $codebase,
+        );
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertSame([], $this->graphSinks($graph));
+    }
+
+    #[Test]
+    public function view_with_non_matching_key_installs_no_sink(): void
+    {
+        $this->initWithMap([
+            'post' => new BladeViewSafety('post', '/views/post.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $viewCall = new FuncCall(new Name('view'), [new Arg(new String_('post'))]);
+
+        $event = $this->makeInstanceMethodEvent(
+            \Illuminate\View\View::class . '::with',
+            $viewCall,
+            [
+                new Arg(new String_('title')),
+                new Arg($this->taintedVariable('title')),
+            ],
+            $codebase,
+        );
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertSame([], $this->graphSinks($graph));
+    }
+
+    #[Test]
+    public function view_with_unknown_template_falls_back_to_value_sink(): void
+    {
+        $this->initWithMap([
+            'broken' => new BladeViewSafety(
+                'broken',
+                '/views/broken.blade.php',
+                BladeTemplateAnalysis::unknown([BladeUncertaintyReason::LayoutSectionFlow]),
+            ),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $viewCall = new FuncCall(new Name('view'), [new Arg(new String_('broken'))]);
+
+        $event = $this->makeInstanceMethodEvent(
+            \Illuminate\View\View::class . '::with',
+            $viewCall,
+            [
+                new Arg(new String_('bio')),
+                new Arg($this->taintedVariable('bio')),
+            ],
+            $codebase,
+        );
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        // UNKNOWN template + literal key → sink installed on $value with the
+        // literal key name (NOT the whole-arg fallback label).
+        $this->assertSinkLabelExists($this->graphSinks($graph), "(broken, 'bio')");
+    }
+
+    #[Test]
+    public function view_with_chained_through_prior_with_call(): void
+    {
+        // view('post')->with('first', 1)->with('bio', $bio) — the receiver of
+        // the outer with() is a MethodCall whose method-name is 'with'. The
+        // resolver recurses into its receiver to recover 'post'.
+        $this->initWithMap([
+            'post' => new BladeViewSafety('post', '/views/post.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $viewCall = new FuncCall(new Name('view'), [new Arg(new String_('post'))]);
+        $innerWith = new \PhpParser\Node\Expr\MethodCall(
+            $viewCall,
+            'with',
+            [new Arg(new String_('first')), new Arg(new String_('1'))],
+        );
+
+        $event = $this->makeInstanceMethodEvent(
+            \Illuminate\View\View::class . '::with',
+            $innerWith,
+            [
+                new Arg(new String_('bio')),
+                new Arg($this->taintedVariable('bio')),
+            ],
+            $codebase,
+        );
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertSinkLabelExists($this->graphSinks($graph), "(post, 'bio')");
+    }
+
+    #[Test]
+    public function mailable_view_installs_per_key_sink(): void
+    {
+        $this->initWithMap([
+            'emails.welcome' => new BladeViewSafety(
+                'emails.welcome',
+                '/views/emails/welcome.blade.php',
+                BladeTemplateAnalysis::unsafeKeys(['bio']),
+            ),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeMethodEvent(
+            \Illuminate\Mail\Mailable::class . '::view',
+            [
+                new Arg(new String_('emails.welcome')),
+                new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+            ],
+            $codebase,
+        );
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertSinkLabelExists($this->graphSinks($graph), "(emails.welcome, 'bio')");
+    }
+
+    #[Test]
+    public function mailable_markdown_installs_per_key_sink(): void
+    {
+        $this->initWithMap([
+            'emails.welcome' => new BladeViewSafety(
+                'emails.welcome',
+                '/views/emails/welcome.blade.php',
+                BladeTemplateAnalysis::unsafeKeys(['bio']),
+            ),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeMethodEvent(
+            \Illuminate\Mail\Mailable::class . '::markdown',
+            [
+                new Arg(new String_('emails.welcome')),
+                new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+            ],
+            $codebase,
+        );
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertSinkLabelExists($this->graphSinks($graph), "(emails.welcome, 'bio')");
+    }
+
+    #[Test]
+    public function mailable_text_installs_per_key_sink(): void
+    {
+        $this->initWithMap([
+            'emails.welcome-text' => new BladeViewSafety(
+                'emails.welcome-text',
+                '/views/emails/welcome-text.blade.php',
+                BladeTemplateAnalysis::unsafeKeys(['bio']),
+            ),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeMethodEvent(
+            \Illuminate\Mail\Mailable::class . '::text',
+            [
+                new Arg(new String_('emails.welcome-text')),
+                new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+            ],
+            $codebase,
+        );
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertSinkLabelExists($this->graphSinks($graph), "(emails.welcome-text, 'bio')");
+    }
+
+    #[Test]
+    public function mail_message_view_installs_per_key_sink(): void
+    {
+        $this->initWithMap([
+            'notification' => new BladeViewSafety(
+                'notification',
+                '/views/notification.blade.php',
+                BladeTemplateAnalysis::unsafeKeys(['user']),
+            ),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeMethodEvent(
+            \Illuminate\Notifications\Messages\MailMessage::class . '::view',
+            [
+                new Arg(new String_('notification')),
+                new Arg($this->arrayLiteral(['user' => $this->taintedVariable('user')])),
+            ],
+            $codebase,
+        );
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertSinkLabelExists($this->graphSinks($graph), "(notification, 'user')");
+    }
+
+    #[Test]
+    public function content_constructor_installs_sinks_for_each_view_slot(): void
+    {
+        // Content(?view, ?html, ?text, ?markdown, with = []). When view AND
+        // text resolve to literal templates and both have an unsafe key
+        // matching $with, one sink per view-slot fires.
+        $this->initWithMap([
+            'emails.welcome' => new BladeViewSafety(
+                'emails.welcome',
+                '/views/emails/welcome.blade.php',
+                BladeTemplateAnalysis::unsafeKeys(['bio']),
+            ),
+            'emails.welcome-text' => new BladeViewSafety(
+                'emails.welcome-text',
+                '/views/emails/welcome-text.blade.php',
+                BladeTemplateAnalysis::unsafeKeys(['bio']),
+            ),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeMethodEvent(
+            \Illuminate\Mail\Mailables\Content::class . '::__construct',
+            [
+                new Arg(new String_('emails.welcome')),
+                new Arg(new String_('')),
+                new Arg(new String_('emails.welcome-text')),
+                new Arg(new String_('')),
+                new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+            ],
+            $codebase,
+        );
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $sinks = $this->graphSinks($graph);
+
+        // Both view slots (index 0 and 2) contribute a sink — markdown (index
+        // 3) is the empty literal '' (treated as a literal string), but since
+        // there's no 'emails.welcome-markdown' or matching name in the map,
+        // it produces no sink. Test asserts only the two confirmed.
+        $this->assertSinkLabelExists($sinks, "(emails.welcome, 'bio')");
+        $this->assertSinkLabelExists($sinks, "(emails.welcome-text, 'bio')");
+    }
+
+    #[Test]
+    public function factory_first_mixed_safe_and_unsafe_takes_union(): void
+    {
+        // 'a' is SAFE (contributes nothing), 'b' has unsafe key 'bio'. The
+        // dispatcher must NOT short-circuit on SAFE and must take the
+        // union, so 'bio' surfaces as the sole sink.
+        $this->initWithMap([
+            'a' => new BladeViewSafety('a', '/views/a.blade.php', BladeTemplateAnalysis::safe()),
+            'b' => new BladeViewSafety('b', '/views/b.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeMethodEvent(\Illuminate\View\Factory::class . '::first', [
+            new Arg($this->viewNameList(['a', 'b'])),
+            new Arg($this->arrayLiteral([
+                'bio' => $this->taintedVariable('bio'),
+                'safe' => $this->taintedVariable('safe'),
+            ])),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $sinks = $this->graphSinks($graph);
+
+        $this->assertCount(1, $sinks);
+        $this->assertSinkLabelExists($sinks, "'bio'");
+    }
+
+    #[Test]
+    public function factory_first_with_mixed_unknown_in_map_and_missing_falls_back_to_whole_data(): void
+    {
+        // One candidate is in-map UNKNOWN (trips the UNKNOWN-fallback);
+        // another is not-in-map (which on its own would silently skip).
+        // The UNKNOWN should dominate regardless of iteration order; the
+        // result is the whole-data fallback. Regression for the policy
+        // boundary documented at dispatchFirstLike's "not in map →
+        // continue" branch.
+        $this->initWithMap([
+            'inMapUnknown' => new BladeViewSafety(
+                'inMapUnknown',
+                '/views/inMapUnknown.blade.php',
+                BladeTemplateAnalysis::unknown([BladeUncertaintyReason::LayoutSectionFlow]),
+            ),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeMethodEvent(\Illuminate\View\Factory::class . '::first', [
+            new Arg($this->viewNameList(['inMapUnknown', 'notInMap'])),
+            new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        // Whole-data fallback fires; the label carries the UNKNOWN
+        // candidate's name (the first to trip the fallback).
+        $this->assertSinkLabelExists($this->graphSinks($graph), "(inMapUnknown,");
+    }
+
+    #[Test]
+    public function factory_first_empty_array_installs_no_sink(): void
+    {
+        // `first([], $data)` — zero candidates. Laravel throws at runtime
+        // (InvalidArgumentException). At analysis time we install nothing:
+        // there is no template to sink against. Documents the boundary.
+        $this->initWithMap([]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeMethodEvent(\Illuminate\View\Factory::class . '::first', [
+            new Arg($this->viewNameList([])),
+            new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+        ], $codebase);
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertSame([], $this->graphSinks($graph));
+    }
+
+    #[Test]
+    public function view_first_chained_with_multiple_literal_candidates_skips_sink(): void
+    {
+        // Receiver-walk soundness: `View::first(['a', 'b'])->with('bio', $bio)`.
+        // The receiver array carries multiple literal candidates; the
+        // dispatcher cannot tell which Laravel will pick at runtime, so it
+        // refuses resolution rather than picking one and risking a missed
+        // XSS in the unpicked template.
+        $this->initWithMap([
+            'a' => new BladeViewSafety('a', '/views/a.blade.php', BladeTemplateAnalysis::safe()),
+            'b' => new BladeViewSafety('b', '/views/b.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $firstCall = new StaticCall(
+            new Name(\Illuminate\Support\Facades\View::class),
+            'first',
+            [new Arg($this->viewNameList(['a', 'b']))],
+        );
+
+        $event = $this->makeInstanceMethodEvent(
+            \Illuminate\View\View::class . '::with',
+            $firstCall,
+            [
+                new Arg(new String_('bio')),
+                new Arg($this->taintedVariable('bio')),
+            ],
+            $codebase,
+        );
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertSame([], $this->graphSinks($graph));
+    }
+
+    #[Test]
+    public function view_with_array_form_installs_per_key_sinks(): void
+    {
+        // Laravel's `View::with($key, $value = null)` accepts $key as a
+        // string OR array. The array form merges every entry into the view
+        // data via `array_merge($this->data, $key)`. Without this dispatch
+        // the array form would silently bypass taint analysis.
+        $this->initWithMap([
+            'post' => new BladeViewSafety('post', '/views/post.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $viewCall = new FuncCall(new Name('view'), [new Arg(new String_('post'))]);
+
+        $event = $this->makeInstanceMethodEvent(
+            \Illuminate\View\View::class . '::with',
+            $viewCall,
+            [
+                new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+            ],
+            $codebase,
+        );
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertSinkLabelExists($this->graphSinks($graph), "(post, 'bio')");
+    }
+
+    #[Test]
+    public function view_with_array_form_on_unknown_template_installs_whole_data_sink(): void
+    {
+        $this->initWithMap([
+            'broken' => new BladeViewSafety(
+                'broken',
+                '/views/broken.blade.php',
+                BladeTemplateAnalysis::unknown([BladeUncertaintyReason::LayoutSectionFlow]),
+            ),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $viewCall = new FuncCall(new Name('view'), [new Arg(new String_('broken'))]);
+
+        $event = $this->makeInstanceMethodEvent(
+            \Illuminate\View\View::class . '::with',
+            $viewCall,
+            [
+                new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+            ],
+            $codebase,
+        );
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertNotEmpty($this->graphSinks($graph));
+    }
+
+    #[Test]
+    public function view_with_array_key_and_non_null_value_still_routes_to_array_dispatch(): void
+    {
+        // Laravel ignores `$value` when `$key` is an array, regardless of
+        // `$value`'s shape: `with(['bio' => $tainted], $unused)` merges only
+        // the array. The dispatcher must NOT sink on $unused.
+        $this->initWithMap([
+            'post' => new BladeViewSafety('post', '/views/post.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $viewCall = new FuncCall(new Name('view'), [new Arg(new String_('post'))]);
+
+        $event = $this->makeInstanceMethodEvent(
+            \Illuminate\View\View::class . '::with',
+            $viewCall,
+            [
+                new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+                new Arg($this->taintedVariable('unusedSecondArg')),
+            ],
+            $codebase,
+        );
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $sinks = $this->graphSinks($graph);
+
+        // Exactly one sink: the array's 'bio' entry. Not the unused $value.
+        $this->assertCount(1, $sinks);
+        $this->assertSinkLabelExists($sinks, "(post, 'bio')");
+    }
+
+    #[Test]
+    public function view_with_string_key_and_explicit_null_value_installs_no_sink(): void
+    {
+        // `with('key', null)` — string key, explicit null value. Laravel
+        // binds null to the literal key; no value flows. The array-form
+        // gate must NOT misroute this through `installSinksForArg`, which
+        // would otherwise install a `<argument>` whole-arg sink on the key
+        // expression and produce a false positive when `$keyVar` is tainted.
+        $this->initWithMap([
+            'post' => new BladeViewSafety('post', '/views/post.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $viewCall = new FuncCall(new Name('view'), [new Arg(new String_('post'))]);
+
+        $event = $this->makeInstanceMethodEvent(
+            \Illuminate\View\View::class . '::with',
+            $viewCall,
+            [
+                new Arg(new String_('bio')),
+                new Arg(new \PhpParser\Node\Expr\ConstFetch(new Name('null'))),
+            ],
+            $codebase,
+        );
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        // Null value has no taintable parent_nodes, so even reaching
+        // installSinkForExpression would short-circuit. Asserting the empty
+        // sink list pins the no-FP boundary against future refactors that
+        // could route the call through a whole-data fallback.
+        $this->assertSame([], $this->graphSinks($graph));
+    }
+
+    #[Test]
+    public function view_with_variable_key_and_explicit_null_value_installs_no_sink(): void
+    {
+        // `with($scalarKeyVar, null)` — variable key, explicit null value.
+        // The dispatcher must NOT enter the array-form branch (the key is
+        // not an array literal) and therefore must NOT install a sink on
+        // the key variable. This is the Round 2 security finding fix.
+        $this->initWithMap([
+            'post' => new BladeViewSafety('post', '/views/post.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $viewCall = new FuncCall(new Name('view'), [new Arg(new String_('post'))]);
+
+        $event = $this->makeInstanceMethodEvent(
+            \Illuminate\View\View::class . '::with',
+            $viewCall,
+            [
+                new Arg($this->taintedVariable('keyName')),
+                new Arg(new \PhpParser\Node\Expr\ConstFetch(new Name('null'))),
+            ],
+            $codebase,
+        );
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertSame([], $this->graphSinks($graph));
+    }
+
+    #[Test]
+    public function view_with_array_form_with_explicit_null_value_routes_to_array_dispatch(): void
+    {
+        // `->with(['bio' => $tainted], null)` — explicit `null` $value with
+        // array $key. Same array-form semantics as the 1-arg shape.
+        $this->initWithMap([
+            'post' => new BladeViewSafety('post', '/views/post.blade.php', BladeTemplateAnalysis::unsafeKeys(['bio'])),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $viewCall = new FuncCall(new Name('view'), [new Arg(new String_('post'))]);
+
+        $event = $this->makeInstanceMethodEvent(
+            \Illuminate\View\View::class . '::with',
+            $viewCall,
+            [
+                new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+                new Arg(new \PhpParser\Node\Expr\ConstFetch(new Name('null'))),
+            ],
+            $codebase,
+        );
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertSinkLabelExists($this->graphSinks($graph), "(post, 'bio')");
+    }
+
+    #[Test]
+    public function content_constructor_with_explicit_null_view_slots_installs_no_dynamic_sink(): void
+    {
+        // `new Content(view: null, text: 'emails.welcome-text', markdown: null,
+        // with: ['bio' => $tainted])` — opt out of two slots with literal
+        // `null`. Each null slot must NOT install a `<dynamic>` whole-data
+        // sink; only the text slot dispatches against its real safety record.
+        $this->initWithMap([
+            'emails.welcome-text' => new BladeViewSafety(
+                'emails.welcome-text',
+                '/views/emails/welcome-text.blade.php',
+                BladeTemplateAnalysis::unsafeKeys(['bio']),
+            ),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $nullConst = new \PhpParser\Node\Expr\ConstFetch(new Name('null'));
+
+        $event = $this->makeMethodEvent(
+            \Illuminate\Mail\Mailables\Content::class . '::__construct',
+            [
+                new Arg($nullConst), // view: null
+                new Arg(new String_('')), // html (pre-rendered, unregistered)
+                new Arg(new String_('emails.welcome-text')), // text: 'emails.welcome-text'
+                new Arg($nullConst), // markdown: null
+                new Arg($this->arrayLiteral(['bio' => $this->taintedVariable('bio')])),
+            ],
+            $codebase,
+        );
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $sinks = $this->graphSinks($graph);
+
+        // Exactly one sink: the text slot's per-key sink. No <dynamic>
+        // whole-data sinks from the null slots.
+        $this->assertCount(1, $sinks);
+        $this->assertSinkLabelExists($sinks, "(emails.welcome-text, 'bio')");
+    }
+
+    #[Test]
+    public function view_nest_with_dynamic_nested_view_falls_back_to_dynamic(): void
+    {
+        $this->initWithMap([]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeMethodEvent(
+            \Illuminate\View\View::class . '::nest',
+            [
+                new Arg(new String_('section')),
+                new Arg($this->taintedVariable('dynamicNestedView')),
+                new Arg($this->arrayLiteral(['html' => $this->taintedVariable('bio')])),
+            ],
+            $codebase,
+        );
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertSinkLabelExists($this->graphSinks($graph), "(<dynamic>, 'html')");
+    }
+
+    #[Test]
+    public function view_nest_installs_sink_on_nested_view_data(): void
+    {
+        // $factory->nest('section', 'partials.row', ['html' => $bio]). The
+        // child template at index 1 is the safety lookup; data at index 2.
+        $this->initWithMap([
+            'partials.row' => new BladeViewSafety(
+                'partials.row',
+                '/views/partials/row.blade.php',
+                BladeTemplateAnalysis::unsafeKeys(['html']),
+            ),
+        ]);
+
+        $graph = new TaintFlowGraph();
+        $codebase = $this->createCodebase($graph);
+
+        $event = $this->makeMethodEvent(
+            \Illuminate\View\View::class . '::nest',
+            [
+                new Arg(new String_('section')),
+                new Arg(new String_('partials.row')),
+                new Arg($this->arrayLiteral(['html' => $this->taintedVariable('bio')])),
+            ],
+            $codebase,
+        );
+
+        BladeAwareViewTaintHandler::afterMethodCallAnalysis($event);
+
+        $this->assertSinkLabelExists($this->graphSinks($graph), "(partials.row, 'html')");
+    }
+
     /**
      * Build the handler with a synthetic safety map. The map is opaque to the
      * scanner here: tests fabricate {@see BladeViewSafety} records directly,
@@ -729,6 +1771,39 @@ final class BladeAwareViewTaintHandlerTest extends TestCase
     private function initWithMap(array $safetyByView): void
     {
         BladeAwareViewTaintHandler::init(new BladeSafetyMap($safetyByView));
+    }
+
+    /**
+     * Build an {@see AfterMethodCallAnalysisEvent} backed by an instance
+     * MethodCall (rather than the StaticCall used by {@see makeMethodEvent}).
+     * The dispatcher's receiver-walk for `View::with` requires a real
+     * `\PhpParser\Node\Expr\MethodCall` so it can inspect `$expr->var`.
+     *
+     * @param list<Arg> $args
+     */
+    private function makeInstanceMethodEvent(
+        string $methodId,
+        \PhpParser\Node\Expr $receiver,
+        array $args,
+        Codebase $codebase,
+    ): AfterMethodCallAnalysisEvent {
+        $methodName = \explode('::', $methodId)[1];
+
+        $methodCall = new \PhpParser\Node\Expr\MethodCall($receiver, $methodName, $args);
+        $methodCall->setAttribute('startFilePos', 0);
+        $methodCall->setAttribute('endFilePos', 100);
+
+        $source = $this->makeSource($args);
+
+        return new AfterMethodCallAnalysisEvent(
+            $methodCall,
+            $methodId,
+            $methodId,
+            $methodId,
+            new Context(),
+            $source,
+            $codebase,
+        );
     }
 
     /**
@@ -891,6 +1966,24 @@ final class BladeAwareViewTaintHandlerTest extends TestCase
 
         foreach ($entries as $key => $value) {
             $items[] = new ArrayItem($value, new String_((string) $key));
+        }
+
+        return new Array_($items);
+    }
+
+    /**
+     * Build a list-style `[String_('a'), String_('b'), ...]` array literal
+     * for `Factory::first()`'s candidate-view array. Distinct from
+     * {@see arrayLiteral()} which expects associative `key => Expr` pairs.
+     *
+     * @param list<string> $names
+     */
+    private function viewNameList(array $names): Array_
+    {
+        $items = [];
+
+        foreach ($names as $name) {
+            $items[] = new ArrayItem(new String_($name));
         }
 
         return new Array_($items);


### PR DESCRIPTION
## Summary

PR-4 of the Blade taint exploration stack (#581). Stacked on PR-3 (#926, merged into the umbrella `worktree-581-blade-taint-exploration`). Targets the umbrella branch, not master, per the merge strategy in `docs/issues/581-blade-taint-exploration.md`.

Two pieces of work:

### 1. New dispatch entrypoints in `BladeAwareViewTaintHandler`

Refactored to a sealed `ViewBindingSinkSpec` union with concrete subclasses:

| Method | Spec | Notes |
|---|---|---|
| `Factory::first(array, $data, $mergeData)` | `FirstLikeMethodSpec` | Union of unsafe keys across literal candidates; UNKNOWN/non-literal/non-array → whole-data fallback; not-in-map skipped (defers to MissingViewHandler) |
| `Factory::renderEach($view, $data, $iterator, $empty)` | `RenderEachLikeMethodSpec` | Iterator literal matched against unsafe keys → sink the iterable; non-literal iterator OR UNKNOWN → whole-data |
| `Routing\ResponseFactory::view()` | `MakeLikeMethodSpec` | Concrete + contract + every facade resolved via `FacadeMapProvider` (catches `\Response::view(...)` route) |
| `View::with($key, $value)` | `WithLikeMethodSpec` | Receiver-resolved single-key sink. Walks chained `view('home')->with(...)`, `View::make('home')->with(...)`, prior `with()` chains. |
| `View::with($key)` array form | (same) | Detects `is_array($key)` via inline `Array_` literal or 1-arg call; routes through `Factory::make`-style per-key dispatch |
| `View::nest($key, $view, $data)` | `MakeLikeMethodSpec` | Dispatches as a child `make()` on the nested view name |
| `Mailable::view/markdown/text` | `MakeLikeMethodSpec` | One spec, three method names |
| `MailMessage::view/markdown/text` | `MakeLikeMethodSpec` | Same |
| `Content::__construct` | `MakeLikeMethodSpec` (multi-slot) | `viewArgIndices=[0, 2, 3]`, `dataArgIndex=4`. Literal-`null` view slots in named-argument form are skipped to avoid a false-positive `<dynamic>` whole-data sink |

`View::first(['a', 'b'])->with(...)` receiver-walk conservatively refuses resolution when the candidate array carries more than one literal (the runtime-picked candidate is opaque at analysis time).

### 2. Scanner extension: literal `@include` propagation in `BladeSafetyMap`

The scanner records `@include('child', [...])` directives as `BladeIncludeEdge` value objects when both the view name and the explicit data array are literal. A new `BladeUncertaintyReason::IncludeResolved` marks the template as "pending propagation" so existing UNKNOWN consumers keep working unchanged.

`BladeSafetyMap::build()` runs a fixed-point propagation pass:

- **DFS** over the include graph detects cycle members. Each is tagged `BladeUncertaintyReason::IncludeCycle` (chosen over the partial fixed-point alternative for the conservative-but-not-noisy default).
- **Eligible templates** (only IncludeResolved as uncertainty) have child unsafe keys folded into the parent. Each child key K is propagated: if the parent's explicit data array binds K via `['K' => $expr]`, the parent's top-level variables in `$expr` are added; otherwise K propagates verbatim because Laravel's `compileInclude()` always appends `array_diff_key(get_defined_vars(), [...])` as mergeData. Without the mergeData treatment, flows through parent-scope variables not bound by the explicit array would be silently missed.
- **Non-eligible templates** have IncludeResolved stripped before exposure so map consumers honour the documented "intermediate marker only" invariant.

### Cycle policy chosen

`UNKNOWN(IncludeCycle)` for cycle members. Templates that include into a cycle member but are not themselves on the cycle inherit `UNKNOWN(IncludeDirective)` through the normal "child is UNKNOWN → parent is UNKNOWN" rule. Documented in `BladeUncertaintyReason::IncludeCycle`.

### Tests added

- `tests/Unit/Blade/BladeSafetyMapTest.php` — 10 new tests for propagation (explicit-data mapping, mergeData pass-through, SAFE child collapse, non-literal target, non-literal data array, UNKNOWN child, cycle, self-loop, multi-hop chain, IncludeResolved stripping).
- `tests/Unit/Blade/BladeTemplateScannerTest.php` — IncludeResolved vs IncludeDirective for literal/non-literal `@include`.
- `tests/Unit/Handlers/Views/BladeAwareViewTaintHandlerTest.php` — ~30 new tests covering each new dispatcher's branches.
- `tests/Type/tests/Blade/` — 3 new PHPT regressions (`first` dynamic-array fallback, `ResponseFactory` dynamic-view fallback, `first` all-literal unknown views = no sink). Fixture-backed PHPTs deferred alongside PR-3's documented Application `--taint-analysis` constraint.

### Out of scope (tracked for PR-5+)

- Component data flow (`<x-foo :bar="$data" />`).
- Variable-bound view-builder chains (`$v = view('home'); $v->with(...)`).
- `Mailable::with()` chained off `view()/markdown()/text()` (registration without receiver-walk support would be a no-op).
- `View::share()` global data.
- Scanner result caching across analysis runs.

### Review process

Two clean rounds of `/psalm-review` completed (security-taint, code, laravel-expert, psalm-expert, architecture, performance, tests, types). Findings applied:

- `View::first(['a','b'])->with()` first-literal walk false-negative XSS (Critical).
- `IncludeResolved` leaking past documented invariant on non-eligible templates (Critical, architecture).
- Dead `BladeTemplateAnalysis::propagated()` factory (Critical, code).
- `View::with(array)` shape silently dropped (Important, laravel-expert).
- Content named-`null` view slot false-positive (Important, security).
- Response facade not routed through `FacadeMapProvider` (Important, laravel-expert).
- `\array_keys` missing leading backslash (Important, code).
- Dead `NullsafeMethodCall` branch in `dispatchWithLike` (Important, psalm-expert).
- Refined `with($scalarKey, null)` false positive introduced by the array-form widening (Round 2 security).

Critical receiver-walk extraction and the larger PR-5-scope refactor (component flow, variable-bound chains, Mailable::with) deferred per the issue plan.