### PR TITLE
Type SoftDeletes `restore`/`restoreOrCreate`/`createOrRestore` on `Builder`

### DIFF
--- a/src/Handlers/Eloquent/BuilderScopeHandler.php
+++ b/src/Handlers/Eloquent/BuilderScopeHandler.php
@@ -18,11 +18,8 @@ use Psalm\Plugin\EventHandler\MethodParamsProviderInterface;
 use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
 use Psalm\StatementsSource;
 use Psalm\Storage\FunctionLikeParameter;
-use Psalm\Type;
-use Psalm\Type\Atomic\TArray;
 use Psalm\Type\Atomic\TGenericObject;
 use Psalm\Type\Atomic\TNamedObject;
-use Psalm\Type\Atomic\TString;
 use Psalm\Type\Union;
 
 /**
@@ -36,8 +33,8 @@ use Psalm\Type\Union;
  *    (e.g., SoftDeletingScope::extend), and declared via @method static returning
  *    Builder<static> on the model trait.
  * 4. SoftDeletes runtime macros that have no Builder-returning @method declaration:
- *    restore, restoreOrCreate, createOrRestore. Hardcoded in {@see SOFT_DELETES_MACROS},
- *    mirroring Larastan's EloquentBuilderForwardsCallsExtension.
+ *    restore, restoreOrCreate, createOrRestore. Encoded in {@see SoftDeletesMacro},
+ *    which mirrors Larastan's EloquentBuilderForwardsCallsExtension.
  *    See https://github.com/psalm/psalm-plugin-laravel/issues/929.
  * 5. @method PHPDoc scopes are handled natively by Psalm
  *
@@ -85,31 +82,6 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
      * @var array<class-string<Model>, true>
      */
     private static array $softDeletesModels = [];
-
-    /**
-     * SoftDeletingScope runtime macros needing explicit Builder-instance handling.
-     *
-     * Keys are pre-lowercased to match {@see MethodReturnTypeProviderEvent::getMethodNameLowercase()}.
-     * Mirrors Larastan's EloquentBuilderForwardsCallsExtension hardcoded list. Returns:
-     * restore → int (count of restored rows from Builder::update),
-     * restoreOrCreate / createOrRestore → TModel (the model instance).
-     */
-    private const SOFT_DELETES_MACROS = [
-        'restore' => true,
-        'restoreorcreate' => true,
-        'createorrestore' => true,
-    ];
-
-    /**
-     * Lazily-initialised params for the SoftDeletes restore-family macros.
-     *
-     * Built on first read so we don't eagerly construct Union/TArray instances during
-     * class load. Signatures mirror SoftDeletingScope::addRestore* closures: restore
-     * takes no args, restoreOrCreate/createOrRestore take ($attributes = [], $values = []).
-     *
-     * @var array<lowercase-string, list<FunctionLikeParameter>>|null
-     */
-    private static ?array $softDeletesMacroParams = null;
 
     /**
      * Register trait-declared builder methods discovered on a base-Builder model.
@@ -172,19 +144,17 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
         // without forwarding the LHS type params. We recover them from the LHS expression.
         $templateTypeParameters = $event->getTemplateTypeParameters();
 
-        // Cache the macro check: this hook fires for every Builder method call, so even
-        // a three-key array probe is worth doing once across both branches below.
-        $isSoftDeletesMacro = self::isSoftDeletesMacro($methodName);
+        // SoftDeletingScope runtime macros (restore/restoreOrCreate/createOrRestore) and
+        // trait-declared @method static Builder<...> declarations both route through
+        // __call without template params. Recover them from the LHS expression when
+        // missing. Scope methods are skipped here: providing a return type for them via
+        // this path would cause Psalm to call checkMethodArgs for Builder::scopeMethod,
+        // which has no method params and would crash. Scope instance calls
+        // (Customer::query()->active()) remain a known limitation.
+        $softDeletesMacro = SoftDeletesMacro::tryFrom($methodName);
 
-        // For trait-declared builder methods (e.g., withTrashed) and the SoftDeletes
-        // restore-family macros (restore/restoreOrCreate/createOrRestore), extract from
-        // the LHS when template params are missing. Scope methods are skipped here:
-        // providing a return type for scope methods via this path would cause Psalm to
-        // call checkMethodArgs for Builder::scopeMethod, which has no method params and
-        // would crash. Scope instance calls (Customer::query()->active()) remain a
-        // known limitation.
         if ($templateTypeParameters === null && (
-            isset(self::$baseBuilderTraitMethods[$methodName]) || $isSoftDeletesMacro
+            isset(self::$baseBuilderTraitMethods[$methodName]) || $softDeletesMacro !== null
         )) {
             $templateTypeParameters = self::extractTemplateParamsFromCallStmt($event->getStmt(), $source);
         }
@@ -195,12 +165,11 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
             return null;
         }
 
-        // SoftDeletes runtime macros: restore → int, restoreOrCreate / createOrRestore → TModel.
-        // These come from SoftDeletingScope::extend at runtime; restore has no @method declaration
-        // anywhere, while restoreOrCreate/createOrRestore are declared as @method static returning
-        // the model on the SoftDeletes trait but are absent from Builder. See issue #929.
-        if ($isSoftDeletesMacro && isset(self::$softDeletesModels[$modelClass])) {
-            return self::softDeletesMacroReturnType($methodName, $modelClass);
+        // SoftDeletes restore-family resolution: restore → int, restoreOrCreate /
+        // createOrRestore → TModel. Gated by the model registry so non-SoftDeletes
+        // models remain unresolved (Builder::__call surfaces mixed). See #929.
+        if ($softDeletesMacro !== null && isset(self::$softDeletesModels[$modelClass])) {
+            return $softDeletesMacro->returnType($modelClass);
         }
 
         $builderReturn = new Union([
@@ -247,87 +216,16 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
         /** @var lowercase-string $methodName */
         $methodName = $event->getMethodNameLowercase();
 
-        // SoftDeletes restore-family params: gated behind isSoftDeletesMacro so the lazy
-        // initializer in softDeletesMacroParams() is only invoked for the rare matching
-        // names, not for every Builder call (where, get, first, ...). Returning these
-        // regardless of the LHS model is safe — calls on non-SoftDeletes models never
-        // reach checkMethodArgs because the return type provider returns null for them
-        // (Builder::restore/restoreOrCreate/createOrRestore have no real declaration).
-        if (self::isSoftDeletesMacro($methodName)) {
-            return self::softDeletesMacroParams()[$methodName];
+        // SoftDeletes restore-family params: returning these regardless of the LHS model
+        // is safe — calls on non-SoftDeletes models never reach checkMethodArgs because
+        // the return type provider returns null for them (Builder::restore /
+        // restoreOrCreate / createOrRestore have no real declaration).
+        $softDeletesMacro = SoftDeletesMacro::tryFrom($methodName);
+        if ($softDeletesMacro !== null) {
+            return $softDeletesMacro->params();
         }
 
         return self::$baseBuilderTraitMethods[$methodName] ?? null;
-    }
-
-    /**
-     * @psalm-pure
-     */
-    private static function isSoftDeletesMacro(string $methodName): bool
-    {
-        return isset(self::SOFT_DELETES_MACROS[$methodName]);
-    }
-
-    /**
-     * @param class-string<Model> $modelClass
-     * @psalm-pure
-     */
-    private static function softDeletesMacroReturnType(string $methodName, string $modelClass): Union
-    {
-        if ($methodName === 'restore') {
-            return Type::getInt();
-        }
-
-        // restoreOrCreate / createOrRestore both return the model instance.
-        return new Union([new TNamedObject($modelClass)]);
-    }
-
-    /**
-     * Param shapes for the three SoftDeletes runtime macros, mirroring the closures in
-     * SoftDeletingScope::addRestore* (restore takes no args; restoreOrCreate and
-     * createOrRestore take ($attributes = [], $values = []) typed array<string, mixed>).
-     *
-     * Built lazily so we don't allocate Union/TArray instances at class load.
-     *
-     * @return array<lowercase-string, list<FunctionLikeParameter>>
-     * @psalm-external-mutation-free
-     */
-    private static function softDeletesMacroParams(): array
-    {
-        if (self::$softDeletesMacroParams !== null) {
-            return self::$softDeletesMacroParams;
-        }
-
-        // Build `array<string, mixed>` directly: Psalm's Type::getString() factory is not
-        // marked @psalm-pure (unlike its int / mixed siblings), so calling it from a
-        // mutation-free context surfaces ImpureMethodCall during self-analysis.
-        $arrayType = new Union([new TArray([new Union([new TString()]), Type::getMixed()])]);
-        $emptyArray = Type::getEmptyArray();
-
-        $createOrRestoreParams = [
-            new FunctionLikeParameter(
-                name: 'attributes',
-                by_ref: false,
-                type: $arrayType,
-                signature_type: $arrayType,
-                is_optional: true,
-                default_type: $emptyArray,
-            ),
-            new FunctionLikeParameter(
-                name: 'values',
-                by_ref: false,
-                type: $arrayType,
-                signature_type: $arrayType,
-                is_optional: true,
-                default_type: $emptyArray,
-            ),
-        ];
-
-        return self::$softDeletesMacroParams = [
-            'restore' => [],
-            'restoreorcreate' => $createOrRestoreParams,
-            'createorrestore' => $createOrRestoreParams,
-        ];
     }
 
     /**

--- a/src/Handlers/Eloquent/BuilderScopeHandler.php
+++ b/src/Handlers/Eloquent/BuilderScopeHandler.php
@@ -18,8 +18,11 @@ use Psalm\Plugin\EventHandler\MethodParamsProviderInterface;
 use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
 use Psalm\StatementsSource;
 use Psalm\Storage\FunctionLikeParameter;
+use Psalm\Type;
+use Psalm\Type\Atomic\TArray;
 use Psalm\Type\Atomic\TGenericObject;
 use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Atomic\TString;
 use Psalm\Type\Union;
 
 /**
@@ -32,7 +35,11 @@ use Psalm\Type\Union;
  *    These are registered as Builder macros at runtime via global scopes
  *    (e.g., SoftDeletingScope::extend), and declared via @method static returning
  *    Builder<static> on the model trait.
- * 4. @method PHPDoc scopes are handled natively by Psalm
+ * 4. SoftDeletes runtime macros that have no Builder-returning @method declaration:
+ *    restore, restoreOrCreate, createOrRestore. Hardcoded in {@see SOFT_DELETES_MACROS},
+ *    mirroring Larastan's EloquentBuilderForwardsCallsExtension.
+ *    See https://github.com/psalm/psalm-plugin-laravel/issues/929.
+ * 5. @method PHPDoc scopes are handled natively by Psalm
  *
  * @internal
  */
@@ -67,6 +74,44 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
     private static array $baseBuilderTraitMethods = [];
 
     /**
+     * Models known to use the SoftDeletes trait, populated during model registration.
+     *
+     * Used to resolve `Builder::restore()` / `Builder::restoreOrCreate()` /
+     * `Builder::createOrRestore()` — runtime macros registered by SoftDeletingScope::extend
+     * that are NOT covered by the trait's @method static annotations (restore has no
+     * declaration; restoreOrCreate/createOrRestore declare model returns, not Builder
+     * returns, so extractBuilderReturningMethods skips them).
+     *
+     * @var array<class-string<Model>, true>
+     */
+    private static array $softDeletesModels = [];
+
+    /**
+     * SoftDeletingScope runtime macros needing explicit Builder-instance handling.
+     *
+     * Keys are pre-lowercased to match {@see MethodReturnTypeProviderEvent::getMethodNameLowercase()}.
+     * Mirrors Larastan's EloquentBuilderForwardsCallsExtension hardcoded list. Returns:
+     * restore → int (count of restored rows from Builder::update),
+     * restoreOrCreate / createOrRestore → TModel (the model instance).
+     */
+    private const SOFT_DELETES_MACROS = [
+        'restore' => true,
+        'restoreorcreate' => true,
+        'createorrestore' => true,
+    ];
+
+    /**
+     * Lazily-initialised params for the SoftDeletes restore-family macros.
+     *
+     * Built on first read so we don't eagerly construct Union/TArray instances during
+     * class load. Signatures mirror SoftDeletingScope::addRestore* closures: restore
+     * takes no args, restoreOrCreate/createOrRestore take ($attributes = [], $values = []).
+     *
+     * @var array<lowercase-string, list<FunctionLikeParameter>>|null
+     */
+    private static ?array $softDeletesMacroParams = null;
+
+    /**
      * Register trait-declared builder methods discovered on a base-Builder model.
      *
      * Called by {@see ModelRegistrationHandler} after extracting @method static annotations
@@ -80,6 +125,20 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
     {
         // array_merge would re-index; += preserves keys and keeps the first registration.
         self::$baseBuilderTraitMethods += $methods;
+    }
+
+    /**
+     * Register a model as using the SoftDeletes trait.
+     *
+     * Called by {@see ModelRegistrationHandler} during per-model setup so that
+     * Builder-instance restore-family macro calls can be resolved against the model.
+     *
+     * @param class-string<Model> $modelClass
+     * @psalm-external-mutation-free
+     */
+    public static function registerSoftDeletesModel(string $modelClass): void
+    {
+        self::$softDeletesModels[$modelClass] = true;
     }
 
     /**
@@ -113,12 +172,20 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
         // without forwarding the LHS type params. We recover them from the LHS expression.
         $templateTypeParameters = $event->getTemplateTypeParameters();
 
-        // For trait-declared builder methods (e.g., withTrashed), extract from LHS when
-        // template params are missing. Scope methods are skipped here: providing a return
-        // type for scope methods via this path would cause Psalm to call checkMethodArgs
-        // for Builder::scopeMethod, which has no method params and would crash.
-        // Scope instance calls (Customer::query()->active()) remain a known limitation.
-        if ($templateTypeParameters === null && isset(self::$baseBuilderTraitMethods[$methodName])) {
+        // Cache the macro check: this hook fires for every Builder method call, so even
+        // a three-key array probe is worth doing once across both branches below.
+        $isSoftDeletesMacro = self::isSoftDeletesMacro($methodName);
+
+        // For trait-declared builder methods (e.g., withTrashed) and the SoftDeletes
+        // restore-family macros (restore/restoreOrCreate/createOrRestore), extract from
+        // the LHS when template params are missing. Scope methods are skipped here:
+        // providing a return type for scope methods via this path would cause Psalm to
+        // call checkMethodArgs for Builder::scopeMethod, which has no method params and
+        // would crash. Scope instance calls (Customer::query()->active()) remain a
+        // known limitation.
+        if ($templateTypeParameters === null && (
+            isset(self::$baseBuilderTraitMethods[$methodName]) || $isSoftDeletesMacro
+        )) {
             $templateTypeParameters = self::extractTemplateParamsFromCallStmt($event->getStmt(), $source);
         }
 
@@ -126,6 +193,14 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
         $modelClass = ModelPropertyResolver::extractModelFromUnion($templateTypeParameters[0] ?? null);
         if ($modelClass === null) {
             return null;
+        }
+
+        // SoftDeletes runtime macros: restore → int, restoreOrCreate / createOrRestore → TModel.
+        // These come from SoftDeletingScope::extend at runtime; restore has no @method declaration
+        // anywhere, while restoreOrCreate/createOrRestore are declared as @method static returning
+        // the model on the SoftDeletes trait but are absent from Builder. See issue #929.
+        if ($isSoftDeletesMacro && isset(self::$softDeletesModels[$modelClass])) {
+            return self::softDeletesMacroReturnType($methodName, $modelClass);
         }
 
         $builderReturn = new Union([
@@ -171,7 +246,88 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
     {
         /** @var lowercase-string $methodName */
         $methodName = $event->getMethodNameLowercase();
+
+        // SoftDeletes restore-family params: gated behind isSoftDeletesMacro so the lazy
+        // initializer in softDeletesMacroParams() is only invoked for the rare matching
+        // names, not for every Builder call (where, get, first, ...). Returning these
+        // regardless of the LHS model is safe — calls on non-SoftDeletes models never
+        // reach checkMethodArgs because the return type provider returns null for them
+        // (Builder::restore/restoreOrCreate/createOrRestore have no real declaration).
+        if (self::isSoftDeletesMacro($methodName)) {
+            return self::softDeletesMacroParams()[$methodName];
+        }
+
         return self::$baseBuilderTraitMethods[$methodName] ?? null;
+    }
+
+    /**
+     * @psalm-pure
+     */
+    private static function isSoftDeletesMacro(string $methodName): bool
+    {
+        return isset(self::SOFT_DELETES_MACROS[$methodName]);
+    }
+
+    /**
+     * @param class-string<Model> $modelClass
+     * @psalm-pure
+     */
+    private static function softDeletesMacroReturnType(string $methodName, string $modelClass): Union
+    {
+        if ($methodName === 'restore') {
+            return Type::getInt();
+        }
+
+        // restoreOrCreate / createOrRestore both return the model instance.
+        return new Union([new TNamedObject($modelClass)]);
+    }
+
+    /**
+     * Param shapes for the three SoftDeletes runtime macros, mirroring the closures in
+     * SoftDeletingScope::addRestore* (restore takes no args; restoreOrCreate and
+     * createOrRestore take ($attributes = [], $values = []) typed array<string, mixed>).
+     *
+     * Built lazily so we don't allocate Union/TArray instances at class load.
+     *
+     * @return array<lowercase-string, list<FunctionLikeParameter>>
+     * @psalm-external-mutation-free
+     */
+    private static function softDeletesMacroParams(): array
+    {
+        if (self::$softDeletesMacroParams !== null) {
+            return self::$softDeletesMacroParams;
+        }
+
+        // Build `array<string, mixed>` directly: Psalm's Type::getString() factory is not
+        // marked @psalm-pure (unlike its int / mixed siblings), so calling it from a
+        // mutation-free context surfaces ImpureMethodCall during self-analysis.
+        $arrayType = new Union([new TArray([new Union([new TString()]), Type::getMixed()])]);
+        $emptyArray = Type::getEmptyArray();
+
+        $createOrRestoreParams = [
+            new FunctionLikeParameter(
+                name: 'attributes',
+                by_ref: false,
+                type: $arrayType,
+                signature_type: $arrayType,
+                is_optional: true,
+                default_type: $emptyArray,
+            ),
+            new FunctionLikeParameter(
+                name: 'values',
+                by_ref: false,
+                type: $arrayType,
+                signature_type: $arrayType,
+                is_optional: true,
+                default_type: $emptyArray,
+            ),
+        ];
+
+        return self::$softDeletesMacroParams = [
+            'restore' => [],
+            'restoreorcreate' => $createOrRestoreParams,
+            'createorrestore' => $createOrRestoreParams,
+        ];
     }
 
     /**

--- a/src/Handlers/Eloquent/ModelRegistrationHandler.php
+++ b/src/Handlers/Eloquent/ModelRegistrationHandler.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Psalm\Codebase;
 use Psalm\Internal\MethodIdentifier;
 use Psalm\LaravelPlugin\Util\AnonymousClassNameDetector;
@@ -167,6 +168,21 @@ final class ModelRegistrationHandler implements AfterCodebasePopulatedInterface
             if ($traitMethods !== []) {
                 BuilderScopeHandler::registerBaseBuilderTraitMethods($traitMethods);
             }
+        }
+
+        // SoftDeletes registers restore/restoreOrCreate/createOrRestore as runtime Builder
+        // macros via SoftDeletingScope::extend; none surface as Builder-returning trait
+        // declarations, so extractBuilderReturningMethods misses them. See {@see
+        // BuilderScopeHandler::registerSoftDeletesModel} and #929.
+        //
+        // Direct-trait check only: a model that inherits SoftDeletes through a parent
+        // class (no `use SoftDeletes` on the leaf) will not have it in `used_traits` and
+        // won't get the macro typing — this matches the existing convention used in
+        // {@see ModelPropertyHandler::resolveCasts}.
+        // Custom-builder models with SoftDeletes are also out of scope for this PR; the
+        // mirror in CustomBuilderMethodHandler is tracked separately.
+        if (isset($storage->used_traits[\strtolower(SoftDeletes::class)])) {
+            BuilderScopeHandler::registerSoftDeletesModel($className);
         }
 
         // Detect custom collection class via #[CollectedBy] attribute or newCollection() override.

--- a/src/Handlers/Eloquent/SoftDeletesMacro.php
+++ b/src/Handlers/Eloquent/SoftDeletesMacro.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Eloquent;
+
+use Psalm\Storage\FunctionLikeParameter;
+use Psalm\Type;
+use Psalm\Type\Atomic\TArray;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Atomic\TString;
+use Psalm\Type\Union;
+
+/**
+ * SoftDeletingScope runtime macros that have no Builder-returning @method declaration.
+ *
+ * Hardcoded list mirrors Larastan's EloquentBuilderForwardsCallsExtension. Generic
+ * AST scanning of SoftDeletingScope::extend() would generalise to other scope-extension
+ * traits but requires running closure return-type inference inside our handler — much
+ * higher implementation cost for a single Laravel trait. See issue #929.
+ *
+ * Values match Psalm's lowercased method-name convention so {@see self::tryFrom()}
+ * accepts the result of {@see \Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent::getMethodNameLowercase()}
+ * directly.
+ *
+ * @internal Used by {@see BuilderScopeHandler} only.
+ */
+enum SoftDeletesMacro: string
+{
+    case Restore         = 'restore';
+    case RestoreOrCreate = 'restoreorcreate';
+    case CreateOrRestore = 'createorrestore';
+
+    /**
+     * Return type for the macro when invoked on a Builder<TModel> instance.
+     *
+     * - restore returns int (count of restored rows from Builder::update).
+     * - restoreOrCreate / createOrRestore return TModel (firstOrCreate / createOrFirst).
+     *
+     * @param class-string $modelClass
+     * @psalm-mutation-free
+     */
+    public function returnType(string $modelClass): Union
+    {
+        return match ($this) {
+            self::Restore => Type::getInt(),
+            self::RestoreOrCreate, self::CreateOrRestore => new Union([new TNamedObject($modelClass)]),
+        };
+    }
+
+    /**
+     * Synthetic params mirroring the closures in SoftDeletingScope::addRestore* :
+     * restore takes no args; restoreOrCreate / createOrRestore take
+     * (array $attributes = [], array $values = []) typed array<string, mixed>.
+     *
+     * Required so Psalm's checkMethodArgs does not crash when looking up params for
+     * the magic-call route (Builder::restore / restoreOrCreate / createOrRestore have
+     * no real declaration).
+     *
+     * @return list<FunctionLikeParameter>
+     * @psalm-external-mutation-free
+     */
+    public function params(): array
+    {
+        return match ($this) {
+            self::Restore => [],
+            self::RestoreOrCreate, self::CreateOrRestore => self::createOrRestoreParams(),
+        };
+    }
+
+    /**
+     * Lazily-built and method-locally cached so we do not allocate Union/TArray
+     * instances unless a restore-family macro actually appears in the analysed code.
+     *
+     * @return list<FunctionLikeParameter>
+     * @psalm-external-mutation-free
+     */
+    private static function createOrRestoreParams(): array
+    {
+        /** @var list<FunctionLikeParameter>|null $cached */
+        static $cached = null;
+        if ($cached !== null) {
+            return $cached;
+        }
+
+        // Type::getString() is not @psalm-pure (unlike its int / mixed siblings), so
+        // building array<string, mixed> via direct construction keeps callers in pure
+        // / mutation-free contexts when they need it.
+        $arrayType = new Union([new TArray([new Union([new TString()]), Type::getMixed()])]);
+        $emptyArray = Type::getEmptyArray();
+
+        return $cached = [
+            new FunctionLikeParameter(
+                name: 'attributes',
+                by_ref: false,
+                type: $arrayType,
+                signature_type: $arrayType,
+                is_optional: true,
+                default_type: $emptyArray,
+            ),
+            new FunctionLikeParameter(
+                name: 'values',
+                by_ref: false,
+                type: $arrayType,
+                signature_type: $arrayType,
+                is_optional: true,
+                default_type: $emptyArray,
+            ),
+        ];
+    }
+}

--- a/tests/Type/tests/Builder/SoftDeletesRestoreTest.phpt
+++ b/tests/Type/tests/Builder/SoftDeletesRestoreTest.phpt
@@ -1,0 +1,112 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use App\Models\Part;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Tests for SoftDeletingScope-registered macros that are NOT declared as
+ * @method static on the SoftDeletes trait: restore() on Builder instances.
+ *
+ * Also covers restoreOrCreate() and createOrRestore() which ARE declared as
+ * @method static on the trait but only for static-on-model calls; their
+ * Builder-instance forms come through __call -> macro lookup and are not
+ * intercepted by the plugin because extractBuilderReturningMethods filters
+ * to methods whose return type is a Builder (these return the model).
+ *
+ * Laravel source: Illuminate\Database\Eloquent\SoftDeletingScope::addRestore /
+ * addRestoreOrCreate / addCreateOrRestore.
+ *
+ * Compare Larastan EloquentBuilderForwardsCallsExtension:96-129 which hardcodes:
+ *   restore         → int
+ *   restoreOrCreate → TModel
+ *   createOrRestore → TModel
+ */
+
+// --- restore() on builder instance: should return int (count of restored rows) ---
+
+function test_restore_on_query_returns_int(): void
+{
+    $_result = Customer::query()->restore();
+    /** @psalm-check-type-exact $_result = int */
+}
+
+// --- restore() on a model instance is a real method on the SoftDeletes trait that returns
+// bool. Resolved by Psalm normally; the Builder-instance handler must NOT shadow it. ---
+
+function test_restore_on_model_instance_returns_bool(Customer $customer): void
+{
+    $_result = $customer->restore();
+    /** @psalm-check-type-exact $_result = bool */
+}
+
+function test_restore_with_only_trashed_returns_int(): void
+{
+    $_result = Customer::query()->onlyTrashed()->where('id', 1)->restore();
+    /** @psalm-check-type-exact $_result = int */
+}
+
+// --- restoreOrCreate() on builder instance: should return Customer model ---
+
+function test_restore_or_create_on_query_returns_model(): void
+{
+    $_result = Customer::query()->restoreOrCreate(['email' => 'a@b.c']);
+    /** @psalm-check-type-exact $_result = Customer */
+}
+
+// --- zero-arg form exercises both default values declared on the synthesized params ---
+
+function test_restore_or_create_with_no_args_returns_model(): void
+{
+    $_result = Customer::query()->restoreOrCreate();
+    /** @psalm-check-type-exact $_result = Customer */
+}
+
+// --- createOrRestore() on builder instance: should return Customer model ---
+
+function test_create_or_restore_on_query_returns_model(): void
+{
+    $_result = Customer::query()->createOrRestore(['email' => 'a@b.c']);
+    /** @psalm-check-type-exact $_result = Customer */
+}
+
+// --- static-on-model forms work via the SoftDeletes trait's @method static restoreOrCreate /
+// createOrRestore declarations (return type `static`, which Psalm reports as `Customer&static`
+// per its standard handling of trait-declared @method static). ---
+
+function test_restore_or_create_static_on_model(): void
+{
+    $_result = Customer::restoreOrCreate(['email' => 'a@b.c']);
+    /** @psalm-check-type-exact $_result = Customer&static */
+}
+
+function test_create_or_restore_static_on_model(): void
+{
+    $_result = Customer::createOrRestore(['email' => 'a@b.c']);
+    /** @psalm-check-type-exact $_result = Customer&static */
+}
+
+// --- non-SoftDeletes model: handler must NOT narrow restore() to int. Part does not
+// use the SoftDeletes trait, so the registry guard in BuilderScopeHandler should
+// short-circuit and let Builder::__call's mixed return surface. Locks in the guard
+// against a future refactor that drops the model gate. ---
+
+function test_restore_on_non_soft_deletes_model_is_not_narrowed(): void
+{
+    $_result = Part::query()->restore();
+    /** @psalm-check-type-exact $_result = mixed */
+}
+
+// --- arity check: restore() takes no args. Validates that the synthesized params from
+// BuilderScopeHandler::softDeletesMacroParams are picked up by Psalm's checkMethodArgs
+// and surface a TooManyArguments diagnostic on excess arguments. ---
+
+function test_restore_rejects_extra_arguments(): void
+{
+    Customer::query()->restore('bogus');
+}
+
+?>
+--EXPECTF--
+TooManyArguments on line %d: Too many arguments for Illuminate\Database\Eloquent\Builder::restore - expecting 0 but saw 1


### PR DESCRIPTION
## Issue to Solve

`SoftDeletingScope::extend` registers three macros on `Builder` at runtime that the plugin did not type:

- `restore` (no `@method` declaration anywhere)
- `restoreOrCreate` and `createOrRestore` (declared on the `SoftDeletes` trait as `@method static static`, so `extractBuilderReturningMethods` filters them out because the return type is the model, not `Builder`)

Builder-instance calls (`Customer::query()->restore()`, `->restoreOrCreate(...)`, `->createOrRestore(...)`) therefore returned `mixed` and broke argument validation.

## Related

Fixes #929.

## Solution Description

Approach A from the issue (mirroring Larastan's `EloquentBuilderForwardsCallsExtension`):

- Track SoftDeletes-using models in a new registry on `BuilderScopeHandler`, populated during model registration via the existing `$storage->used_traits` direct check (mirrors `ModelPropertyHandler::resolveCasts`).
- Synthesise the macro return types (`restore` -> `int` from `Builder::update`, `restoreOrCreate` / `createOrRestore` -> `TModel` from `firstOrCreate` / `createOrFirst`) and parameter shapes (`array<string, mixed> $attributes = [], array<string, mixed> $values = []`) so `checkMethodArgs` does not crash on the magic-call route.
- Static-on-model forms (`Customer::restoreOrCreate(...)`) keep Psalm's native handling of the trait's `@method static static` declarations and resolve to `Customer&static`.
- The instance method `$model->restore()` continues to return `bool` from the real `SoftDeletes::restore`; the new handler is gated to `Builder` LHS only and never shadows the trait method.

Verified with a new type test (`tests/Type/tests/Builder/SoftDeletesRestoreTest.phpt`) covering:

- Builder-instance forms (`restore` -> `int`, `restoreOrCreate` / `createOrRestore` -> `Customer`).
- Chained `onlyTrashed()->where(...)->restore()` to exercise the LHS template-recovery path.
- Zero-arg `restoreOrCreate()` to validate the synthesised default values.
- Sanity assertion that `$customer->restore()` (instance method) keeps its `bool` return.
- Static-on-model forms (`Customer::restoreOrCreate(...)` -> `Customer&static`).
- Negative case on a non-SoftDeletes model (`Part::query()->restore()` -> `mixed`) to lock in the registry guard.
- Arity check (`Customer::query()->restore('bogus')` -> `TooManyArguments`) to validate the synthesised params.

Known limitations (documented in code comments):

- A model that inherits `SoftDeletes` only through a parent class is not detected (matches the existing `ModelPropertyHandler` convention).
- Models with custom Eloquent builders are not covered yet; the `CustomBuilderMethodHandler` mirror is left for a follow-up.

## Checklist

- [x] Tests cover the change (type test in `tests/Type/`)
