### PR TITLE
Type-check dynamic `where{Column}` arguments on Eloquent relations

### DIFF
--- a/src/Handlers/Magic/MethodForwardingHandler.php
+++ b/src/Handlers/Magic/MethodForwardingHandler.php
@@ -560,8 +560,11 @@ final class MethodForwardingHandler implements
         //   (b) Skip non-scalar column types (Carbon, BackedEnum, json-cast arrays).
         //       Laravel coerces strings/ints to these at the query layer, so narrowing
         //       to the declared property type would mass-regress real codebases.
-        //   (c) Skip when there is no first argument — nothing to type-check, and the
-        //       hand-off key derives from `spl_object_id($firstArg)`.
+        //   (c) Only enqueue when the call has exactly one argument — the only shape
+        //       consumeDynamicWhereTypedParams() actually consumes. Without this gate,
+        //       2+ arg calls would deposit entries that the consumer skips, leaking
+        //       across the analysis run (and risking a wrong-type lookup later if PHP
+        //       reuses the spl_object_id of a freed Arg node).
         if (\strtolower($event->getFqClasslikeName()) !== \strtolower($relationClass)) {
             return new Union([new TGenericObject($relationClass, $templateParams)]);
         }
@@ -572,10 +575,10 @@ final class MethodForwardingHandler implements
 
         $stmt = $event->getStmt();
         if ($stmt instanceof MethodCall) {
-            $firstArg = $stmt->getArgs()[0] ?? null;
+            $args = $stmt->getArgs();
 
-            if ($firstArg !== null) {
-                self::$pendingDynamicWhereColumnType[\spl_object_id($firstArg)] = $columnType;
+            if (\count($args) === 1) {
+                self::$pendingDynamicWhereColumnType[\spl_object_id($args[0])] = $columnType;
             }
         }
 
@@ -603,6 +606,7 @@ final class MethodForwardingHandler implements
      *
      * @param list<\PhpParser\Node\Arg>|null $callArgs
      * @return list<FunctionLikeParameter>|null
+     * @psalm-external-mutation-free
      */
     private static function consumeDynamicWhereTypedParams(?array $callArgs): ?array
     {

--- a/src/Handlers/Magic/MethodForwardingHandler.php
+++ b/src/Handlers/Magic/MethodForwardingHandler.php
@@ -65,12 +65,13 @@ final class MethodForwardingHandler implements
     private static bool $enableDynamicWhere = false;
 
     /**
-     * Cache: "ModelClass:methodName" → bool (column matched).
+     * Cache: "ModelClass:methodName" → column type (or null when no column matched).
      *
      * Keyed by model class + method name to avoid repeating the property-name normalisation
-     * loop on subsequent calls with the same (model, method) pair.
+     * loop on subsequent calls with the same (model, method) pair. A null value records a
+     * negative match so we skip the loop on subsequent misses too.
      *
-     * @var array<string, bool>
+     * @var array<string, ?Union>
      */
     private static array $dynamicWhereCache = [];
 
@@ -89,6 +90,34 @@ final class MethodForwardingHandler implements
      * @var array<string, class-string<\Illuminate\Database\Eloquent\Model>>
      */
     private static array $scopeParamsCache = [];
+
+    /**
+     * Hand-off cache: spl_object_id of the call's first {@see \PhpParser\Node\Arg} → column type.
+     *
+     * Populated by {@see resolveDynamicWhereOnRelation} during return-type resolution and
+     * consumed by {@see getMethodParams} immediately after.
+     *
+     * Lifecycle (verified against vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/
+     * Statements/Expression/Call/Method/MissingMethodCallHandler.php):
+     *   1. `handleMagicMethod` line 70 invokes the return-type provider — we store.
+     *   2. Line 94 invokes `CallAnalyzer::checkMethodArgs` synchronously in the same
+     *      worker; this routes through `Methods::getMethodParams` and fires our params
+     *      provider, which consumes and `unset()`s the entry.
+     *
+     * The key is `spl_object_id($firstArg)` because both events read args from the same
+     * `$stmt->getArgs()` array, so the {@see \PhpParser\Node\Arg} nodes are object-identical.
+     * Using object identity avoids the false sharing that a `file_path:line:method` key
+     * would have for two dynamic-where calls on the same source line that target relations
+     * to different models — the previous keying could swap column types between calls.
+     *
+     * Issue #928: the variadic-mixed signature previously returned by getMethodParams()
+     * accepted any value type. With this hand-off, getMethodParams returns typed params
+     * derived from the resolved column type and lets Psalm's standard argument checker
+     * emit InvalidArgument / InvalidScalarArgument on type mismatch.
+     *
+     * @var array<int, Union>
+     */
+    private static array $pendingDynamicWhereColumnType = [];
 
     /** @psalm-external-mutation-free */
     public static function init(ForwardingRule $rule): void
@@ -209,7 +238,7 @@ final class MethodForwardingHandler implements
         // Dynamic where{Column} fallback for Path 2 (opt-in).
         // This handles the case where the method arrives via __call rather than @mixin.
         if (self::$enableDynamicWhere && $templateParams !== null && self::isDynamicWhereMethod($methodName)) {
-            return self::resolveDynamicWhereOnRelation($codebase, $methodName, $fqClassName, $templateParams);
+            return self::resolveDynamicWhereOnRelation($event, $codebase, $methodName, $fqClassName, $templateParams);
         }
 
         return null;
@@ -221,9 +250,13 @@ final class MethodForwardingHandler implements
      * Only fires for Path 2 (QueryBuilder-only methods like orderBy, limit, groupBy).
      * Mixin-resolved methods (Path 1) already have params from the target class.
      *
-     * When resolveDynamicWhereClauses is enabled, also provides a permissive variadic signature
-     * for where{Column} methods so Psalm confirms they exist and doesn't emit
-     * UndefinedMagicMethod or TooManyArguments. This path does not validate value types.
+     * When resolveDynamicWhereClauses is enabled and the return-type provider has
+     * resolved a scalar column on the related model for a single-argument call,
+     * returns a typed param derived from the column type so Psalm's argument
+     * checker can emit InvalidArgument / InvalidScalarArgument on type mismatch
+     * (issue #928). All other shapes (0 or 2+ args, multi-segment, unknown column,
+     * non-scalar column) fall back to a permissive variadic-mixed signature so
+     * Psalm still confirms the call exists without spurious TooManyArguments.
      *
      * @return list<FunctionLikeParameter>|null
      */
@@ -294,6 +327,18 @@ final class MethodForwardingHandler implements
         // A variadic signature accepts both single-column (whereTitle($v)) and multi-column
         // (whereFirstNameAndLastName($a, $b)) patterns without raising TooManyArguments.
         if (self::$enableDynamicWhere && self::isDynamicWhereMethod($methodName)) {
+            // Issue #928: when the return-type provider resolved a scalar column on the
+            // related model and the call has exactly one argument, return a typed param
+            // so Psalm's argument checker can emit InvalidArgument / InvalidScalarArgument
+            // on type mismatch. Everything else (multi-segment, unknown column, non-scalar
+            // column, 0 or 2+ args) falls through to the permissive variadic-mixed
+            // signature. {@see consumeDynamicWhereTypedParams} for the full rationale.
+            $typedParams = self::consumeDynamicWhereTypedParams($event->getCallArgs());
+
+            if ($typedParams !== null) {
+                return $typedParams;
+            }
+
             return [new FunctionLikeParameter('args', by_ref: false, type: Type::getMixed(), is_variadic: true)];
         }
 
@@ -388,6 +433,7 @@ final class MethodForwardingHandler implements
             // for non-where* methods (orderBy, limit, etc.) when dynamic where is enabled.
             if (self::$enableDynamicWhere && self::isDynamicWhereMethod($methodName)) {
                 return self::resolveDynamicWhereOnRelation(
+                    $event,
                     $codebase,
                     $methodName,
                     $atomicType->value,
@@ -473,10 +519,13 @@ final class MethodForwardingHandler implements
      *   - whereEmailAddress → matches @property string $email_address
      *   - whereFirstName   → matches @property string $first_name
      *
+     * When a column type is resolved, also queues it in {@see $pendingDynamicWhereColumnType}
+     * so {@see getMethodParams} can return typed params for argument validation. Issue #928.
+     *
      * @param non-empty-list<Union>|list<Union>|null $templateParams Relation's template type parameters
-     * @psalm-external-mutation-free
      */
     private static function resolveDynamicWhereOnRelation(
+        MethodReturnTypeProviderEvent $event,
         Codebase $codebase,
         string $methodName,
         string $relationClass,
@@ -493,14 +542,84 @@ final class MethodForwardingHandler implements
             return null;
         }
 
-        if (!self::columnMatchesDynamicWhere($codebase, $modelClass, $methodName)) {
+        $columnType = self::resolveDynamicWhereColumnType($codebase, $modelClass, $methodName);
+
+        if (!$columnType instanceof Union) {
             return null;
+        }
+
+        // Hand off the column type to getMethodParams() so it can build a typed parameter
+        // list and let Psalm validate arguments. See $pendingDynamicWhereColumnType for the
+        // lifecycle and rationale. Issue #928.
+        //
+        // Two gates on the store:
+        //   (a) Path 1 (mixin interception) writes are unconsumable — Builder is in
+        //       searchClassIndex, not sourceClassIndex, so our MethodParamsProvider
+        //       early-returns for it and the entry would leak. Only store when the event
+        //       fires for the relation class itself (Path 2 / direct __call).
+        //   (b) Skip non-scalar column types (Carbon, BackedEnum, json-cast arrays).
+        //       Laravel coerces strings/ints to these at the query layer, so narrowing
+        //       to the declared property type would mass-regress real codebases.
+        //   (c) Skip when there is no first argument — nothing to type-check, and the
+        //       hand-off key derives from `spl_object_id($firstArg)`.
+        if (\strtolower($event->getFqClasslikeName()) !== \strtolower($relationClass)) {
+            return new Union([new TGenericObject($relationClass, $templateParams)]);
+        }
+
+        if ($columnType->hasObjectType() || $columnType->hasArray()) {
+            return new Union([new TGenericObject($relationClass, $templateParams)]);
+        }
+
+        $stmt = $event->getStmt();
+        if ($stmt instanceof MethodCall) {
+            $firstArg = $stmt->getArgs()[0] ?? null;
+
+            if ($firstArg !== null) {
+                self::$pendingDynamicWhereColumnType[\spl_object_id($firstArg)] = $columnType;
+            }
         }
 
         // Column exists on the model → method is fluent, return the full Relation type.
         return new Union([
             new TGenericObject($relationClass, $templateParams),
         ]);
+    }
+
+    /**
+     * Read and remove the column type queued by {@see resolveDynamicWhereOnRelation},
+     * returning a typed single-parameter list when the call has exactly one argument.
+     * Returns null otherwise so the caller falls back to the permissive variadic-mixed
+     * signature.
+     *
+     * Only the 1-argument value form is type-checked. Laravel's runtime
+     * `Builder::dynamicWhere` always uses `=` as the operator and silently drops every
+     * argument past the first (see `Query\Builder::addDynamic`), so the 2-arg "operator
+     * form" (`whereTitle('=', 'foo')`) is a runtime bug. Rather than blessing it (which
+     * would over-accept invalid types in the value position) or rejecting it (which
+     * would surface as TooManyArguments on legacy code patterns that issue #928's
+     * caveats explicitly ask us to tolerate), we leave 2+ arg calls to the variadic
+     * fallback. Larastan does the same via a single-optional-mixed-variadic
+     * `DynamicWhereParameterReflection`.
+     *
+     * @param list<\PhpParser\Node\Arg>|null $callArgs
+     * @return list<FunctionLikeParameter>|null
+     */
+    private static function consumeDynamicWhereTypedParams(?array $callArgs): ?array
+    {
+        if ($callArgs === null || \count($callArgs) !== 1) {
+            return null;
+        }
+
+        $key = \spl_object_id($callArgs[0]);
+
+        if (!isset(self::$pendingDynamicWhereColumnType[$key])) {
+            return null;
+        }
+
+        $columnType = self::$pendingDynamicWhereColumnType[$key];
+        unset(self::$pendingDynamicWhereColumnType[$key]);
+
+        return [new FunctionLikeParameter('value', by_ref: false, type: $columnType, is_optional: false)];
     }
 
     /**
@@ -560,7 +679,8 @@ final class MethodForwardingHandler implements
     }
 
     /**
-     * Check if the column referenced by a dynamic where{Column} method exists on the model.
+     * Resolve the column type for a dynamic where{Column} method call, or null when no
+     * @property entry matches the suffix.
      *
      * The column suffix (method name minus "where") is compared against the model's
      * pseudo_property_get_types (populated from @property / @property-read annotations).
@@ -578,11 +698,11 @@ final class MethodForwardingHandler implements
      * @param class-string<\Illuminate\Database\Eloquent\Model> $modelClass
      * @psalm-external-mutation-free
      */
-    private static function columnMatchesDynamicWhere(
+    private static function resolveDynamicWhereColumnType(
         Codebase $codebase,
         string $modelClass,
         string $methodName,
-    ): bool {
+    ): ?Union {
         $key = $modelClass . ':' . $methodName;
 
         if (\array_key_exists($key, self::$dynamicWhereCache)) {
@@ -595,8 +715,8 @@ final class MethodForwardingHandler implements
         try {
             $storage = $codebase->classlike_storage_provider->get(\strtolower($modelClass));
         } catch (\InvalidArgumentException) {
-            self::$dynamicWhereCache[$key] = false;
-            return false;
+            self::$dynamicWhereCache[$key] = null;
+            return null;
         }
 
         // Use pseudo_property_get_types (from @property and @property-read) rather than
@@ -609,16 +729,17 @@ final class MethodForwardingHandler implements
         // snapshot taken on the first call could be incomplete for subsequent method checks.
         // The per-(model, method) $dynamicWhereCache still prevents redundant lookups.
         // "$first_name" → "firstname", "$title" → "title"
-        foreach (array_keys($storage->pseudo_property_get_types) as $propName) {
+        foreach ($storage->pseudo_property_get_types as $propName => $propType) {
             $normalized = \strtolower(\str_replace(['$', '_'], '', $propName));
 
             if ($normalized === $columnSuffix) {
-                self::$dynamicWhereCache[$key] = true;
-                return true;
+                self::$dynamicWhereCache[$key] = $propType;
+                return $propType;
             }
         }
 
-        self::$dynamicWhereCache[$key] = false;
-        return false;
+        self::$dynamicWhereCache[$key] = null;
+        return null;
     }
+
 }

--- a/src/Handlers/Magic/MethodForwardingHandler.php
+++ b/src/Handlers/Magic/MethodForwardingHandler.php
@@ -104,18 +104,19 @@ final class MethodForwardingHandler implements
      *      worker; this routes through `Methods::getMethodParams` and fires our params
      *      provider, which consumes and `unset()`s the entry.
      *
-     * The key is `spl_object_id($firstArg)` because both events read args from the same
-     * `$stmt->getArgs()` array, so the {@see \PhpParser\Node\Arg} nodes are object-identical.
-     * Using object identity avoids the false sharing that a `file_path:line:method` key
-     * would have for two dynamic-where calls on the same source line that target relations
-     * to different models — the previous keying could swap column types between calls.
+     * The key is `methodName . ':' . spl_object_id($firstArg)`. Both events read args
+     * from the same `$stmt->getArgs()` array, so the {@see \PhpParser\Node\Arg} nodes
+     * are object-identical and the id matches across the producer/consumer pair. The
+     * method-name prefix defends against PHP recycling an spl_object_id from a freed Arg
+     * node into an unrelated later call — without it, the consumer could pick up a stale
+     * column type from a different where{Column} method whose Arg node had the same id.
      *
      * Issue #928: the variadic-mixed signature previously returned by getMethodParams()
      * accepted any value type. With this hand-off, getMethodParams returns typed params
      * derived from the resolved column type and lets Psalm's standard argument checker
      * emit InvalidArgument / InvalidScalarArgument on type mismatch.
      *
-     * @var array<int, Union>
+     * @var array<string, Union>
      */
     private static array $pendingDynamicWhereColumnType = [];
 
@@ -333,7 +334,7 @@ final class MethodForwardingHandler implements
             // on type mismatch. Everything else (multi-segment, unknown column, non-scalar
             // column, 0 or 2+ args) falls through to the permissive variadic-mixed
             // signature. {@see consumeDynamicWhereTypedParams} for the full rationale.
-            $typedParams = self::consumeDynamicWhereTypedParams($event->getCallArgs());
+            $typedParams = self::consumeDynamicWhereTypedParams($methodName, $event->getCallArgs());
 
             if ($typedParams !== null) {
                 return $typedParams;
@@ -578,7 +579,7 @@ final class MethodForwardingHandler implements
             $args = $stmt->getArgs();
 
             if (\count($args) === 1) {
-                self::$pendingDynamicWhereColumnType[\spl_object_id($args[0])] = $columnType;
+                self::$pendingDynamicWhereColumnType[$methodName . ':' . \spl_object_id($args[0])] = $columnType;
             }
         }
 
@@ -608,13 +609,13 @@ final class MethodForwardingHandler implements
      * @return list<FunctionLikeParameter>|null
      * @psalm-external-mutation-free
      */
-    private static function consumeDynamicWhereTypedParams(?array $callArgs): ?array
+    private static function consumeDynamicWhereTypedParams(string $methodName, ?array $callArgs): ?array
     {
         if ($callArgs === null || \count($callArgs) !== 1) {
             return null;
         }
 
-        $key = \spl_object_id($callArgs[0]);
+        $key = $methodName . ':' . \spl_object_id($callArgs[0]);
 
         if (!isset(self::$pendingDynamicWhereColumnType[$key])) {
             return null;

--- a/tests/Type/tests/Relation/DynamicWhereArgumentTypingTest.phpt
+++ b/tests/Type/tests/Relation/DynamicWhereArgumentTypingTest.phpt
@@ -1,0 +1,91 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Admin;
+use App\Models\Invoice;
+use App\Models\WorkOrder;
+
+/**
+ * Dynamic where{Column} method arguments must be type-checked against the
+ * model's declared @property type. Before #928 the handler returned a variadic
+ * mixed signature so any value (e.g. int passed to a string column) was
+ * silently accepted.
+ *
+ * Scope: Relation chains only (where MethodForwardingHandler fires) and only
+ * the single-argument value form. Multi-argument forms (Laravel's runtime
+ * `dynamicWhere` silently drops everything past the first parameter anyway)
+ * fall through to the permissive variadic-mixed signature so users coming
+ * from Larastan or relying on the operator-form pattern aren't broken.
+ *
+ * Object/array/iterable column types (Carbon, BackedEnum, json casts) also
+ * fall through — Laravel accepts coerced strings/ints at the query layer and
+ * narrowing to the property type would mass-regress real codebases.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/928
+ */
+
+function test_dynamic_where_value_form_matches_column_type(): void {
+    $r = (new WorkOrder())->invoice();
+    // OK — invoice_number is @property string $invoice_number
+    $r->whereInvoiceNumber('INV-2024-001');
+    // OK — status is @property string $status
+    $r->whereStatus('paid');
+}
+
+function test_dynamic_where_value_form_rejects_wrong_string_type(): void {
+    $r = (new WorkOrder())->invoice();
+    // Error — invoice_number is string, int provided
+    $r->whereInvoiceNumber(123);
+    // Error — status is string, int provided
+    $r->whereStatus(123);
+}
+
+function test_dynamic_where_propagates_float_column_type(): void {
+    // Part::$unit_price is @property float — typed param must come from the resolved
+    // column type, not a hardcoded scalar. A regression that returned `string` for
+    // every column would not catch the int- or string-against-float mismatches below.
+    $r = (new WorkOrder())->parts();
+    // OK — passes a float literal to a float column
+    $r->whereUnitPrice(9.99);
+    // OK — Psalm's scalar coercion accepts int for a float param
+    $r->whereUnitPrice(10);
+    // Error — string is not a float
+    $r->whereUnitPrice('not-a-float');
+}
+
+function test_dynamic_where_skips_non_scalar_columns(): void {
+    // Customer::$email_verified_at is @property CarbonInterface|null. Laravel accepts a
+    // string at the query layer and coerces it; emitting InvalidArgument here would
+    // mass-regress real Laravel codebases that pass ISO date strings to whereXxx().
+    // The handler must fall through to the variadic-mixed fallback for non-scalar
+    // column types (objects, arrays, iterables).
+    $r = (new Admin())->customers();
+    $r->whereEmailVerifiedAt('2024-01-01');
+    $r->whereEmailVerifiedAt(null);
+}
+
+function test_dynamic_where_unknown_column_skips_validation(): void {
+    $r = (new WorkOrder())->invoice();
+    // No @property nonExistentColumn — handler returns null, Psalm falls back
+    // to the variadic-mixed signature; no validation performed.
+    $r->whereNonExistentColumn(123);
+}
+
+function test_dynamic_where_multi_arg_form_falls_back_to_variadic(): void {
+    // Laravel's Builder::dynamicWhere silently drops the second+ arguments and
+    // always uses '=' as the operator (see Query\Builder::addDynamic). The 2-arg
+    // operator form is a runtime bug, but emitting TooManyArguments here would
+    // break the issue caveat that asks for operator-form tolerance. Both args
+    // pass through the variadic-mixed fallback without type validation.
+    $r = (new WorkOrder())->invoice();
+    $r->whereStatus('=', 'paid');
+    $r->whereStatus('like', '%paid%');
+    // Even with a value-position type mismatch the variadic-mixed fallback
+    // accepts the call; type-checking 2-arg forms is out of scope.
+    $r->whereStatus('=', 123);
+}
+?>
+--EXPECTF--
+InvalidArgument on line %d: Argument 1 of %s::whereinvoicenumber expects %s, but %s provided
+InvalidArgument on line %d: Argument 1 of %s::wherestatus expects %s, but %s provided
+InvalidArgument on line %d: Argument 1 of %s::whereunitprice expects %s, but %s provided

--- a/tests/Type/tests/Relation/DynamicWhereArgumentTypingTest.phpt
+++ b/tests/Type/tests/Relation/DynamicWhereArgumentTypingTest.phpt
@@ -2,7 +2,6 @@
 <?php declare(strict_types=1);
 
 use App\Models\Admin;
-use App\Models\Invoice;
 use App\Models\WorkOrder;
 
 /**


### PR DESCRIPTION
## Issue to Solve
Dynamic `where{Column}()` calls on Eloquent relation chains accepted any value type. `MethodForwardingHandler::getMethodParams` returned a variadic `mixed` signature, so `$user->posts()->whereTitle(123)` silently passed analysis even when `title` is `@property string`.

## Related
Fixes #928

## Solution Description
`MethodReturnTypeProvider` now resolves the column type from the related model's `@property` annotation and hands it off to `MethodParamsProvider` via a transient cache keyed by `spl_object_id` of the call's first `Arg` node (object identity, set by both events from the same `$stmt->getArgs()`). `getMethodParams` returns a typed parameter so Psalm's standard argument checker emits `InvalidArgument` / `InvalidScalarArgument` on type mismatch.

**Scope choices (informed by review):**
- **1-arg value form only.** Laravel's runtime `Builder::dynamicWhere` silently drops everything past the first argument and always uses `=` as operator. The 2-arg "operator form" is a runtime bug, so we leave it to the variadic-mixed fallback rather than blessing it (would over-accept) or rejecting it (would surface as `TooManyArguments` on legacy patterns the issue caveats ask us to tolerate). Matches Larastan's permissive `DynamicWhereParameterReflection`.
- **Scalar column types only.** Non-scalar columns (`Carbon`, `BackedEnum`, json-cast arrays) skip the hand-off via `Union::hasObjectType() || hasArray()`. Laravel coerces strings/ints at the query layer; emitting `InvalidArgument` on `whereCreatedAt('2024-01-01')` would mass-regress real codebases.
- **Path 2 (direct `__call`) only.** Path 1 mixin interception fires for `Builder` where `MethodParamsProvider` does not run for us, so writing the hand-off there would leak unconsumed entries.
- **Multi-segment forms** (`whereXxxAndYyy`) keep the variadic-mixed fallback and are tracked separately.

**Test coverage** (`tests/Type/tests/Relation/DynamicWhereArgumentTypingTest.phpt`):
- String column match + mismatch (`Invoice::$invoice_number`, `$status`).
- Float column propagation (`Part::$unit_price`) — locks down "param uses resolved column type", not a hard-coded scalar; covers both float and int (via scalar coercion).
- Carbon non-regression (`Customer::$email_verified_at`: `CarbonInterface|null`) — verifies the scalar-only filter.
- Unknown column falls through.
- 2-arg variadic fallback (no error on `whereStatus('=', 'paid')`).

Verified locally: `composer test:type` (399 tests), `composer test:unit` (620 tests), `composer psalm`, `composer cs`.

## Checklist
- [x] Tests cover the change (`tests/Type/tests/Relation/DynamicWhereArgumentTypingTest.phpt`)
