### PR TITLE
Cover Laravel packages in `NoEnvOutsideConfig` fallback

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -67,7 +67,7 @@ Disable if dynamic where resolution conflicts with your codebase.
 
 ## `configDirectory`
 
-**default**: the booted Laravel app's `config_path()`
+**default**: the booted Laravel app's `config_path()` plus the project root's `config/` directory (if it exists)
 
 Controls which directories are treated as config directories by [`NoEnvOutsideConfig`](issues/NoEnvOutsideConfig.md). `env()` calls inside any of these directories are exempt from the check.
 
@@ -75,7 +75,9 @@ Each entry can be an absolute path or a relative path resolved by PHP's `glob()`
 
 **Defining any `<configDirectory>` replaces the default**, so include `config` (or whatever your project's standard config dir is) explicitly if you still want it covered. Test files (paths containing `/tests/`) are always exempt regardless of this setting.
 
-If no entry resolves to an existing directory at boot, the plugin emits a warning so the typo case (`<configDirectory name="cofnig" />`) is surfaced rather than silently flagging every `env()` call.
+The project-root anchor exists primarily for Laravel **packages**, where the plugin's booted-app `config_path()` falls back to Orchestra Testbench's vendored config dir and would never match the package's own `config/*.php`. If the project root has no `config/` directory and `<configDirectory>` is not configured, the plugin emits a one-shot warning at boot pointing here.
+
+If a user-provided `<configDirectory>` resolves to zero existing directories at boot, the plugin emits a separate warning so the typo case (`<configDirectory name="cofnig" />`) is surfaced rather than silently flagging every `env()` call.
 
 ### Examples
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -258,11 +258,28 @@ final class Plugin implements PluginEntryPointInterface
      * Resolve config directory paths and pass them to NoEnvOutsideConfigHandler.
      *
      * When the user has not configured any `<configDirectory>` elements, fall back to
-     * the booted Laravel app's `config_path()`. Relative paths and glob patterns are
-     * left as-is — the handler resolves them via glob() + realpath() at this boot step.
+     * BOTH the booted Laravel app's `config_path()` AND the project root's `config/`.
+     * Two anchors are needed because the plugin is used in two different shapes:
      *
-     * The handler emits a warning via $output if the resolution produces zero directories
-     * for a non-empty input — that's the typo case where every env() call would be flagged.
+     *   - App analysis: `ApplicationProvider::getApp()->configPath()` resolves to the
+     *     analysed app's own `config/`. This is the original #858 behaviour.
+     *   - Package analysis: `getApp()` falls back to Orchestra Testbench's vendored
+     *     Laravel app, whose `configPath()` points into `vendor/orchestra/.../config`
+     *     and never matches the package's own config files. Adding `getcwd()/config`
+     *     covers the package case without requiring `<configDirectory>` opt-in.
+     *
+     * Relative paths and glob patterns are left as-is — the handler resolves them via
+     * glob() + realpath() at boot. Non-existent entries are dropped silently there,
+     * so listing both anchors unconditionally is safe.
+     *
+     * Diagnostics:
+     *   - If neither anchor is a project-relevant directory (no `config/` at `getcwd()`),
+     *     emit a warning pointing to the `<configDirectory>` docs so users with a
+     *     non-standard layout know how to opt in.
+     *   - The handler itself emits a separate warning if a *non-empty* user input
+     *     resolves to zero directories (the typo case).
+     *
+     * @see https://github.com/psalm/psalm-plugin-laravel/issues/940
      */
     private function initNoEnvOutsideConfigHandler(PluginConfig $pluginConfig, \Psalm\Progress\Progress $output): void
     {
@@ -270,6 +287,27 @@ final class Plugin implements PluginEntryPointInterface
 
         if ($directories === []) {
             $directories = [ApplicationProvider::getApp()->configPath()];
+
+            $cwd = \getcwd();
+            $projectConfigDir = \is_string($cwd) ? $cwd . \DIRECTORY_SEPARATOR . 'config' : null;
+
+            if ($projectConfigDir !== null) {
+                $directories[] = $projectConfigDir;
+            }
+
+            // Surface the non-standard-layout case once at boot: the testbench fallback
+            // never matches user files, so without a project-relevant `config/` anchor
+            // every env() call outside the plugin's known dirs gets flagged.
+            if ($projectConfigDir === null || !\is_dir($projectConfigDir)) {
+                $output->warning(
+                    'Laravel plugin: expected a config/ directory at '
+                        . ($projectConfigDir !== null ? "'{$projectConfigDir}'" : 'the project root')
+                        . " but none exists. env() calls outside the plugin's known config directories will be "
+                        . 'reported as NoEnvOutsideConfig. If your project keeps config files elsewhere, declare '
+                        . 'them via <configDirectory name="..."/> inside <pluginClass> in psalm.xml. '
+                        . 'See https://psalm.github.io/psalm-plugin-laravel/config/#configdirectory',
+                );
+            }
         }
 
         require_once __DIR__ . '/Handlers/Rules/NoEnvOutsideConfigHandler.php';

--- a/tests/Unit/Handlers/Rules/NoEnvOutsideConfigHandlerTest.php
+++ b/tests/Unit/Handlers/Rules/NoEnvOutsideConfigHandlerTest.php
@@ -14,6 +14,7 @@ use Psalm\Context;
 use Psalm\LaravelPlugin\Handlers\Rules\NoEnvOutsideConfigHandler;
 use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
 use Psalm\StatementsSource;
+use Tests\Psalm\LaravelPlugin\Unit\Support\RecordingProgress;
 
 /**
  * Tests use real filesystem fixtures because the handler resolves config directories
@@ -353,44 +354,5 @@ final class NoEnvOutsideConfigHandlerTest extends TestCase
         }
 
         \rmdir($path);
-    }
-}
-
-/**
- * Test-only Progress that records warnings without writing to STDERR.
- * Other Progress hooks are no-ops because the handler only uses warning().
- */
-final class RecordingProgress extends \Psalm\Progress\Progress
-{
-    public int $warningCount = 0;
-
-    public string $lastWarning = '';
-
-    #[\Override]
-    public function debug(string $message): void {}
-
-    #[\Override]
-    public function startPhase(\Psalm\Progress\Phase $phase, int $threads = 1): void {}
-
-    #[\Override]
-    public function expand(int $number_of_tasks): void {}
-
-    #[\Override]
-    public function taskDone(int $level): void {}
-
-    #[\Override]
-    public function finish(): void {}
-
-    #[\Override]
-    public function alterFileDone(string $file_name): void {}
-
-    #[\Override]
-    public function write(string $message): void {}
-
-    #[\Override]
-    public function warning(string $message): void
-    {
-        $this->warningCount++;
-        $this->lastWarning = $message;
     }
 }

--- a/tests/Unit/PluginNoEnvFallbackTest.php
+++ b/tests/Unit/PluginNoEnvFallbackTest.php
@@ -18,6 +18,7 @@ use Psalm\LaravelPlugin\Providers\ApplicationProvider;
 use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
 use Psalm\Progress\Progress;
 use Psalm\StatementsSource;
+use Tests\Psalm\LaravelPlugin\Unit\Support\RecordingProgress;
 
 /**
  * Plugin-level coverage for the implicit `<configDirectory>` fallback.
@@ -190,45 +191,5 @@ final class PluginNoEnvFallbackTest extends TestCase
         }
 
         \rmdir($path);
-    }
-}
-
-/**
- * Test-only Progress that records warnings without writing to STDERR.
- * Mirrors the sibling helper in NoEnvOutsideConfigHandlerTest; kept local so
- * the two test files stay independent (different namespaces; no collision).
- */
-final class RecordingProgress extends Progress
-{
-    public int $warningCount = 0;
-
-    public string $lastWarning = '';
-
-    #[\Override]
-    public function debug(string $message): void {}
-
-    #[\Override]
-    public function startPhase(\Psalm\Progress\Phase $phase, int $threads = 1): void {}
-
-    #[\Override]
-    public function expand(int $number_of_tasks): void {}
-
-    #[\Override]
-    public function taskDone(int $level): void {}
-
-    #[\Override]
-    public function finish(): void {}
-
-    #[\Override]
-    public function alterFileDone(string $file_name): void {}
-
-    #[\Override]
-    public function write(string $message): void {}
-
-    #[\Override]
-    public function warning(string $message): void
-    {
-        $this->warningCount++;
-        $this->lastWarning = $message;
     }
 }

--- a/tests/Unit/PluginNoEnvFallbackTest.php
+++ b/tests/Unit/PluginNoEnvFallbackTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit;
+
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\CodeLocation;
+use Psalm\Context;
+use Psalm\LaravelPlugin\Handlers\Rules\NoEnvOutsideConfigHandler;
+use Psalm\LaravelPlugin\Plugin;
+use Psalm\LaravelPlugin\PluginConfig;
+use Psalm\LaravelPlugin\Providers\ApplicationProvider;
+use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
+use Psalm\Progress\Progress;
+use Psalm\StatementsSource;
+
+/**
+ * Plugin-level coverage for the implicit `<configDirectory>` fallback.
+ *
+ * Handler unit tests (NoEnvOutsideConfigHandlerTest) cover the resolution
+ * mechanism. Those tests construct the list themselves, so they cannot catch a
+ * regression where Plugin stops including `getcwd()/config` in the fallback.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/940
+ */
+#[CoversClass(Plugin::class)]
+final class PluginNoEnvFallbackTest extends TestCase
+{
+    private string $tempRoot;
+
+    private string $originalCwd;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The plugin's getApp() requires bootApp() to have run; mirrors the
+        // FacadeMapProviderTest setup pattern.
+        ApplicationProvider::bootApp();
+
+        $cwd = \getcwd();
+        \assert(\is_string($cwd), 'getcwd() must return a string in tests');
+        $this->originalCwd = $cwd;
+
+        $this->tempRoot = \sys_get_temp_dir()
+            . \DIRECTORY_SEPARATOR
+            . \uniqid('psalm-laravel-940-', true);
+
+        \mkdir($this->tempRoot, 0o777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        \chdir($this->originalCwd);
+
+        // init([]) doubles as a reset — empties resolved state without warning.
+        NoEnvOutsideConfigHandler::init([]);
+
+        $this->removeRecursively($this->tempRoot);
+
+        parent::tearDown();
+    }
+
+    /**
+     * The package-analysis regression: without `<configDirectory>` opt-in, every
+     * env() call inside the package's own `config/` was being flagged because the
+     * fallback resolved to Testbench's vendored config dir. With the cwd/config
+     * anchor, the package's actual config dir is also skipped.
+     */
+    #[Test]
+    public function fallback_includes_cwd_config_for_packages(): void
+    {
+        $packageConfigDir = $this->makeDir('config');
+
+        \chdir($this->tempRoot);
+
+        $this->invokeInitNoEnvHandler(PluginConfig::fromXml(null), new RecordingProgress());
+
+        $event = $this->makeEvent($packageConfigDir . \DIRECTORY_SEPARATOR . 'liap.php');
+
+        $this->assertNull(
+            NoEnvOutsideConfigHandler::getFunctionReturnType($event),
+            'env() inside the package\'s own config/ must be skipped under the implicit fallback',
+        );
+    }
+
+    /**
+     * Projects with a non-standard layout (no `config/` at the project root) miss
+     * the cwd anchor. Emit a single one-shot warning pointing them at the
+     * `<configDirectory>` opt-in so the silent miss is surfaced.
+     */
+    #[Test]
+    public function fallback_warns_when_cwd_has_no_config_dir(): void
+    {
+        \chdir($this->tempRoot);
+        $progress = new RecordingProgress();
+
+        $this->invokeInitNoEnvHandler(PluginConfig::fromXml(null), $progress);
+
+        $this->assertSame(1, $progress->warningCount, 'expected exactly one warning');
+        $this->assertStringContainsString('configDirectory', $progress->lastWarning);
+        $this->assertStringContainsString('psalm-plugin-laravel/config/#configdirectory', $progress->lastWarning);
+    }
+
+    /**
+     * When the user has opted in via `<configDirectory>`, the cwd/config anchor
+     * is irrelevant and the diagnostic warning must not fire. This guards against
+     * a regression where the warning unconditionally fires.
+     */
+    #[Test]
+    public function does_not_warn_when_user_configured_explicit_directory(): void
+    {
+        $appConfigDir = $this->makeDir('app/Config');
+        \chdir($this->tempRoot);
+
+        $xml = new \SimpleXMLElement(
+            '<pluginClass><configDirectory name="' . \htmlspecialchars($appConfigDir, \ENT_XML1) . '" /></pluginClass>',
+        );
+
+        $progress = new RecordingProgress();
+
+        $this->invokeInitNoEnvHandler(PluginConfig::fromXml($xml), $progress);
+
+        $this->assertSame(0, $progress->warningCount, 'opt-in must silence the fallback diagnostic');
+    }
+
+    private function invokeInitNoEnvHandler(PluginConfig $pluginConfig, Progress $progress): void
+    {
+        // ReflectionMethod::invoke() can call private methods directly on PHP 8.1+;
+        // setAccessible() is a no-op and no longer required.
+        $method = new \ReflectionMethod(Plugin::class, 'initNoEnvOutsideConfigHandler');
+        $method->invoke(new Plugin(), $pluginConfig, $progress);
+    }
+
+    private function makeDir(string $relativePath): string
+    {
+        $full = $this->tempRoot
+            . \DIRECTORY_SEPARATOR
+            . \str_replace('/', \DIRECTORY_SEPARATOR, $relativePath);
+
+        if (!\is_dir($full)) {
+            \mkdir($full, 0o777, true);
+        }
+
+        $real = \realpath($full);
+        \assert(\is_string($real), "Failed to realpath '{$full}'");
+
+        return $real;
+    }
+
+    private function makeEvent(string $filePath): FunctionReturnTypeProviderEvent
+    {
+        $source = $this->createStub(StatementsSource::class);
+        $source->method('getFilePath')->willReturn($filePath);
+        $source->method('getFileName')->willReturn(\basename($filePath));
+        $source->method('getSuppressedIssues')->willReturn([]);
+
+        $funcCall = new FuncCall(new Name('env'));
+        $funcCall->setAttribute('startFilePos', 0);
+        $funcCall->setAttribute('endFilePos', 10);
+
+        return new FunctionReturnTypeProviderEvent(
+            $source,
+            'env',
+            $funcCall,
+            new Context(),
+            new CodeLocation($source, $funcCall),
+        );
+    }
+
+    private function removeRecursively(string $path): void
+    {
+        if (!\is_dir($path)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        /** @var \SplFileInfo $entry */
+        foreach ($iterator as $entry) {
+            $entry->isDir() ? \rmdir($entry->getPathname()) : \unlink($entry->getPathname());
+        }
+
+        \rmdir($path);
+    }
+}
+
+/**
+ * Test-only Progress that records warnings without writing to STDERR.
+ * Mirrors the sibling helper in NoEnvOutsideConfigHandlerTest; kept local so
+ * the two test files stay independent (different namespaces; no collision).
+ */
+final class RecordingProgress extends Progress
+{
+    public int $warningCount = 0;
+
+    public string $lastWarning = '';
+
+    #[\Override]
+    public function debug(string $message): void {}
+
+    #[\Override]
+    public function startPhase(\Psalm\Progress\Phase $phase, int $threads = 1): void {}
+
+    #[\Override]
+    public function expand(int $number_of_tasks): void {}
+
+    #[\Override]
+    public function taskDone(int $level): void {}
+
+    #[\Override]
+    public function finish(): void {}
+
+    #[\Override]
+    public function alterFileDone(string $file_name): void {}
+
+    #[\Override]
+    public function write(string $message): void {}
+
+    #[\Override]
+    public function warning(string $message): void
+    {
+        $this->warningCount++;
+        $this->lastWarning = $message;
+    }
+}

--- a/tests/Unit/PluginNoEnvFallbackTest.php
+++ b/tests/Unit/PluginNoEnvFallbackTest.php
@@ -85,7 +85,7 @@ final class PluginNoEnvFallbackTest extends TestCase
 
         $this->assertNull(
             NoEnvOutsideConfigHandler::getFunctionReturnType($event),
-            'env() inside the package\'s own config/ must be skipped under the implicit fallback',
+            "env() inside the package's own config/ must be skipped under the implicit fallback",
         );
     }
 

--- a/tests/Unit/Support/RecordingProgress.php
+++ b/tests/Unit/Support/RecordingProgress.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Support;
+
+use Psalm\Progress\Phase;
+use Psalm\Progress\Progress;
+
+/**
+ * Test spy for {@see Progress}: records warnings without writing to STDERR.
+ *
+ * All Psalm `Progress` subclasses must implement every abstract method, so
+ * the other hooks are stubbed as no-ops. Only `warning()` is captured because
+ * that's the surface plugin handlers use to emit user-facing diagnostics
+ * (config typos, missing project `config/` directory, etc).
+ */
+final class RecordingProgress extends Progress
+{
+    public int $warningCount = 0;
+
+    public string $lastWarning = '';
+
+    #[\Override]
+    public function debug(string $message): void {}
+
+    #[\Override]
+    public function startPhase(Phase $phase, int $threads = 1): void {}
+
+    #[\Override]
+    public function expand(int $number_of_tasks): void {}
+
+    #[\Override]
+    public function taskDone(int $level): void {}
+
+    #[\Override]
+    public function finish(): void {}
+
+    #[\Override]
+    public function alterFileDone(string $file_name): void {}
+
+    #[\Override]
+    public function write(string $message): void {}
+
+    #[\Override]
+    public function warning(string $message): void
+    {
+        $this->warningCount++;
+        $this->lastWarning = $message;
+    }
+}


### PR DESCRIPTION
## Issue to Solve

When scanning a Laravel **package** (not an app), `NoEnvOutsideConfig` fired on every `env(...)` call inside the package's own `config/*.php`. `ApplicationProvider::getApp()` falls back to the Orchestra Testbench app whose `configPath()` lives under `vendor/orchestra/.../config`, so the package's own `config/` was never matched and the rule reported every canonical `env()` call.

## Related

Fixes #940

## Solution Description

Add `getcwd()/config` as a second fallback anchor alongside the Testbench `configPath()` in `Plugin::initNoEnvOutsideConfigHandler`. `NoEnvOutsideConfigHandler::init()` already drops non-existent entries via `realpath()` + `is_dir()`, so listing both unconditionally is safe.

When the fallback is used and `getcwd()/config` does not exist, emit a one-shot `Progress::warning()` naming the `NoEnvOutsideConfig` issue and pointing users at the `<configDirectory>` opt-in. Non-standard layouts then surface explicitly instead of silently misreporting.

Behaviour for projects that already declare `<configDirectory>` is unchanged: the user-supplied list still replaces the default, and the existing typo-case warning (non-empty input resolving to zero dirs) is preserved.

Verified by a new unit test `Tests\Psalm\LaravelPlugin\Unit\PluginNoEnvFallbackTest` that exercises:
 - package fallback skips `cwd/config/*.php`,
 - warning fires once when `cwd` has no `config/`,
 - warning stays silent when the user has set `<configDirectory>`.

`docs/config.md` updated to document the new `cwd/config` anchor and the two distinct warning cases.

## Checklist

- [x] Tests cover the change (unit test in `tests/Unit/PluginNoEnvFallbackTest.php`)
- [x] Documentation is updated (`docs/config.md`)
