### PR TITLE
Defer facade scan-phase warnings off Psalm progress counter

### DIFF
--- a/src/Handlers/Facades/AppFacadeRegistrationHandler.php
+++ b/src/Handlers/Facades/AppFacadeRegistrationHandler.php
@@ -56,6 +56,36 @@ final class AppFacadeRegistrationHandler implements AfterClassLikeVisitInterface
     private static array $failedFacades = [];
 
     /**
+     * Scan-phase warnings deferred until {@see self::afterCodebasePopulated()} so they do
+     * not splice into Psalm's open `\rN / total...` progress counter (issue #941).
+     * `LongProgress::taskDone()` writes the counter without a trailing newline; emitting a
+     * warning from `afterClassLikeVisit` would otherwise glue `Warning: ...` onto the same
+     * line. Flushed at the top of `afterCodebasePopulated`, between the scan and analysis
+     * phases, where the output buffer is between progress writes.
+     *
+     * @var list<string>
+     */
+    private static array $pendingScanWarnings = [];
+
+    /**
+     * Lazy separator gate: the first warning emission writes a single `PHP_EOL` to terminate
+     * an open `\rN / total...` line. Zero-warning runs leave output untouched (no stray blank
+     * line). Persists for the lifetime of the process — additional warnings after the first
+     * already start at column 0.
+     */
+    private static bool $wroteScanSeparator = false;
+
+    /**
+     * Guards a one-time `register_shutdown_function` registration. Scan workers
+     * (`--threads N > 1`) fork the main process; the worker's copy of
+     * {@see self::$pendingScanWarnings} never propagates back, so without a shutdown hook a
+     * buffered warning would vanish when the worker exits. The hook flushes pending warnings
+     * directly to STDERR at worker exit; in the main process the same hook fires after
+     * `afterCodebasePopulated` already drained the buffer, so it's a no-op there.
+     */
+    private static bool $shutdownHookRegistered = false;
+
+    /**
      * Probe `Facade::getFacadeRoot()` at scan time and queue the resolved root class for
      * scanning. We can't do this in {@see self::afterCodebasePopulated()} because by then
      * the scanner has stopped — a root class not already pulled in via other references
@@ -87,7 +117,7 @@ final class AppFacadeRegistrationHandler implements AfterClassLikeVisitInterface
         }
 
         $progress = $event->getCodebase()->progress;
-        $rootClass = self::tryGetFacadeRootClass($storage->name, $progress);
+        $rootClass = self::tryGetFacadeRootClass($storage->name, $progress, true);
 
         if ($rootClass === null) {
             return;
@@ -101,6 +131,12 @@ final class AppFacadeRegistrationHandler implements AfterClassLikeVisitInterface
     {
         $codebase = $event->getCodebase();
         $progress = $codebase->progress;
+
+        // Drain warnings that the scan-phase hook deferred. Runs first so the lazy
+        // separator terminates Psalm's open `\rN / total...` progress line (issue #941)
+        // before any populate-phase warning could emit its own separator. Also re-arms
+        // the separator gate so a second analysis in the same process re-emits it.
+        self::flushScanWarnings($progress);
 
         foreach ($codebase->classlike_storage_provider::getAll() as $storage) {
             // Abstract classes include the base Facade itself and user-defined abstract
@@ -132,14 +168,20 @@ final class AppFacadeRegistrationHandler implements AfterClassLikeVisitInterface
                     // warning (not debug) — debug is a no-op in the default progress, and a user
                     // facade silently losing method resolution is exactly the class of failure
                     // issue #787 was filed to fix. Match ModelRegistrationHandler's convention.
-                    $progress->warning(
+                    // Routed through `emitWarning` so the lazy separator stays consistent with
+                    // scan-phase warnings flushed just above (issue #941).
+                    self::emitWarning(
+                        $progress,
                         "Laravel plugin: skipping facade '{$storage->name}': class could not be loaded by autoloader",
+                        false,
                     );
                     continue;
                 }
             } catch (\Error|\Exception $error) {
-                $progress->warning(
+                self::emitWarning(
+                    $progress,
                     "Laravel plugin: skipping facade '{$storage->name}': {$error->getMessage()}",
+                    false,
                 );
                 continue;
             }
@@ -151,7 +193,7 @@ final class AppFacadeRegistrationHandler implements AfterClassLikeVisitInterface
             // process may re-probe; `$failedFacades` below prevents user-provider factories
             // from running a second time in that case. `tryGetFacadeRootClass()` emits its
             // own warning on first failure, so we simply `continue` here.
-            $rootClass = self::tryGetFacadeRootClass($storage->name, $progress);
+            $rootClass = self::tryGetFacadeRootClass($storage->name, $progress, false);
 
             if ($rootClass === null) {
                 continue;
@@ -181,10 +223,19 @@ final class AppFacadeRegistrationHandler implements AfterClassLikeVisitInterface
      * Returns null when the accessor is a string alias bound only by a user service
      * provider that does not run in Testbench — nothing we can do at this layer.
      *
+     * `$deferWarnings` defers warning emission until {@see self::flushScanWarnings()} drains
+     * the buffer at the start of `afterCodebasePopulated`. `afterClassLikeVisit` passes
+     * `true` (issue #941: scan-phase warnings would otherwise glue onto the open `\rN / N...`
+     * progress line). `afterCodebasePopulated` passes `false` because the scan phase has
+     * already ended by then.
+     *
      * @return ?class-string
      */
-    public static function tryGetFacadeRootClass(string $facadeClass, ?Progress $progress = null): ?string
-    {
+    public static function tryGetFacadeRootClass(
+        string $facadeClass,
+        ?Progress $progress = null,
+        bool $deferWarnings = false,
+    ): ?string {
         // $failedFacades gates both the short-circuit return AND the warning emission,
         // so each failure reason is surfaced to the user exactly once per facade across
         // scan-phase + populate-phase invocations (issue #787: silent losses of method
@@ -197,9 +248,14 @@ final class AppFacadeRegistrationHandler implements AfterClassLikeVisitInterface
         try {
             if (!\is_subclass_of($facadeClass, Facade::class)) {
                 self::$failedFacades[$facadeClass] = true;
-                $progress?->warning(
-                    "Laravel plugin: skipping facade '{$facadeClass}': not a subclass of " . Facade::class,
-                );
+                if ($progress instanceof \Psalm\Progress\Progress) {
+                    self::emitWarning(
+                        $progress,
+                        "Laravel plugin: skipping facade '{$facadeClass}': not a subclass of " . Facade::class,
+                        $deferWarnings,
+                    );
+                }
+
                 return null;
             }
 
@@ -210,20 +266,152 @@ final class AppFacadeRegistrationHandler implements AfterClassLikeVisitInterface
 
             if ($rootClass === null) {
                 self::$failedFacades[$facadeClass] = true;
-                $progress?->warning(
-                    "Laravel plugin: skipping facade '{$facadeClass}': getFacadeRoot() returned a non-object value",
-                );
+                if ($progress instanceof \Psalm\Progress\Progress) {
+                    self::emitWarning(
+                        $progress,
+                        "Laravel plugin: skipping facade '{$facadeClass}': getFacadeRoot() returned a non-object value",
+                        $deferWarnings,
+                    );
+                }
+
                 return null;
             }
 
             return $rootClass;
         } catch (\Throwable $throwable) {
             self::$failedFacades[$facadeClass] = true;
-            $progress?->warning(
-                "Laravel plugin: getFacadeRoot() failed for '{$facadeClass}': {$throwable->getMessage()}",
-            );
+            if ($progress instanceof \Psalm\Progress\Progress) {
+                self::emitWarning(
+                    $progress,
+                    "Laravel plugin: getFacadeRoot() failed for '{$facadeClass}': {$throwable->getMessage()}",
+                    $deferWarnings,
+                );
+            }
+
             return null;
         }
+    }
+
+    /**
+     * Emit a plugin warning through Psalm's `Progress` sink, optionally deferring it until
+     * `afterCodebasePopulated` flushes the scan-phase buffer (issue #941).
+     *
+     * When emitting directly, the first call writes a single `PHP_EOL` to terminate Psalm's
+     * open `\rN / total...` scan-progress line. Subsequent direct emissions skip the
+     * separator — they already start at column 0.
+     *
+     * `@internal` so the surface area stays inside this handler. `tryGetFacadeRootClass`
+     * and the populate-phase autoload checks are the only call sites.
+     *
+     * @internal
+     */
+    private static function emitWarning(Progress $progress, string $message, bool $defer): void
+    {
+        if ($defer) {
+            self::registerShutdownFlushOnce();
+            self::$pendingScanWarnings[] = $message;
+            return;
+        }
+
+        if (!self::$wroteScanSeparator) {
+            self::$wroteScanSeparator = true;
+            $progress->write(\PHP_EOL);
+        }
+
+        $progress->warning($message);
+    }
+
+    /**
+     * Drain {@see self::$pendingScanWarnings} into the given progress sink. Called from
+     * {@see self::afterCodebasePopulated()} between the scan and analysis phases — that
+     * window is the only place where the output stream is guaranteed to be between
+     * `\rN / total...` writes, so the lazy separator can cleanly terminate the open line.
+     *
+     * Each drained message routes through {@see self::emitWarning()} with `$defer = false`
+     * so the separator is written once for the whole batch.
+     *
+     * Also re-arms {@see self::$wroteScanSeparator} so a second analysis run in the same
+     * process (CLI `checkPaths()` re-entry, daemon / LSP re-analyze loops) writes a fresh
+     * separator. Without this, the gate would stay `true` from the prior run and the new
+     * run's open `\rN / total...` line would not be terminated — reintroducing #941.
+     *
+     * @internal
+     */
+    private static function flushScanWarnings(Progress $progress): void
+    {
+        // Re-arm the gate first so the first emission below writes the terminating
+        // `PHP_EOL`. Skipping the early-return path: even when the buffer is empty, a
+        // prior run may have left the gate `true`; resetting unconditionally guarantees
+        // the next direct emission in this run (e.g. populate-phase autoload warnings)
+        // can still terminate the scan-counter line if one is open.
+        self::$wroteScanSeparator = false;
+
+        if (self::$pendingScanWarnings === []) {
+            return;
+        }
+
+        $messages = self::$pendingScanWarnings;
+        self::$pendingScanWarnings = [];
+
+        foreach ($messages as $message) {
+            self::emitWarning($progress, $message, false);
+        }
+    }
+
+    /**
+     * Last-resort drain for scan worker processes (`--threads N > 1`). Workers fork from
+     * the main process and inherit a copy of {@see self::$pendingScanWarnings} via
+     * copy-on-write; any push the worker makes is discarded on `exit`. Registering a
+     * shutdown function ensures the worker prints its buffered warnings to STDERR before
+     * dying. In the main process this fires only after `afterCodebasePopulated` already
+     * flushed the buffer, so the loop is a no-op.
+     *
+     * Direct `fwrite($stream, ...)` instead of `Progress::warning()` because we don't hold
+     * a `Progress` reference at PHP shutdown — and worker progress output is already wedged
+     * with its own per-task counter line at this point, so a wedged warning is the best we
+     * can do without leaking the data entirely.
+     *
+     * `$stream` defaults to `STDERR` for production use; the parameter is a test seam so
+     * unit tests can verify the format and drain semantics against a buffer they own.
+     * `register_shutdown_function` invokes this with no arguments, so the default is what
+     * fires in real runs.
+     *
+     * @param resource|null $stream
+     * @internal
+     */
+    public static function flushPendingOnShutdown($stream = null): void
+    {
+        // Symmetry with `flushScanWarnings`: any drain site that empties the buffer also
+        // re-arms the separator gate so subsequent emissions know to terminate an open
+        // scan-counter line. The worker process exits right after this drain so the gate's
+        // state never matters in practice; the reset hardens against future callers that
+        // might invoke this drain mid-process.
+        self::$wroteScanSeparator = false;
+
+        if (self::$pendingScanWarnings === []) {
+            return;
+        }
+
+        // Resolve at call time, not as a default parameter value — PHP disallows resource
+        // constants like `STDERR` in parameter defaults.
+        $stream ??= \STDERR;
+
+        $messages = self::$pendingScanWarnings;
+        self::$pendingScanWarnings = [];
+
+        foreach ($messages as $message) {
+            \fwrite($stream, \PHP_EOL . 'Warning: ' . $message . \PHP_EOL);
+        }
+    }
+
+    private static function registerShutdownFlushOnce(): void
+    {
+        if (self::$shutdownHookRegistered) {
+            return;
+        }
+
+        self::$shutdownHookRegistered = true;
+        \register_shutdown_function([self::class, 'flushPendingOnShutdown']);
     }
 
     /**

--- a/tests/Unit/Handlers/Facades/AppFacadeWarningBufferTest.php
+++ b/tests/Unit/Handlers/Facades/AppFacadeWarningBufferTest.php
@@ -1,0 +1,302 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Facades;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Handlers\Facades\AppFacadeRegistrationHandler;
+use Psalm\Progress\Phase;
+use Psalm\Progress\Progress;
+
+/**
+ * Covers issue #941: warnings emitted from the scan-phase `afterClassLikeVisit` hook
+ * must not splice onto Psalm's open `\rN / total...` progress counter. We verify the
+ * scan-phase deferral, the lazy `PHP_EOL` separator that terminates the open counter
+ * line, and that zero-warning runs leave output untouched.
+ *
+ * The handler stores its buffer + separator gate in static properties because the same
+ * pipeline runs across thousands of `afterClassLikeVisit` calls per scan; reflection is
+ * used here only to scope each test case to a clean state — production callers reach
+ * the same fields through `afterClassLikeVisit` / `afterCodebasePopulated`.
+ */
+#[CoversClass(AppFacadeRegistrationHandler::class)]
+final class AppFacadeWarningBufferTest extends TestCase
+{
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->resetHandlerState();
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        $this->resetHandlerState();
+    }
+
+    #[Test]
+    public function deferred_warning_is_not_written_until_flush(): void
+    {
+        $progress = new CapturingProgress();
+
+        // stdClass is loadable but not a Facade subclass — hits the "not a subclass of"
+        // branch in tryGetFacadeRootClass, which emits a warning through emitWarning().
+        AppFacadeRegistrationHandler::tryGetFacadeRootClass(\stdClass::class, $progress, true);
+
+        $this->assertSame('', $progress->captured, 'Deferred warning must not write immediately.');
+        $this->assertSame([\stdClass::class], \array_keys($this->getFailedFacades()));
+        $this->assertCount(1, $this->getPendingScanWarnings());
+    }
+
+    #[Test]
+    public function flush_emits_separator_then_warning(): void
+    {
+        $progress = new CapturingProgress();
+
+        AppFacadeRegistrationHandler::tryGetFacadeRootClass(\stdClass::class, $progress, true);
+
+        $this->invokeFlush($progress);
+
+        $this->assertStringStartsWith(\PHP_EOL, $progress->captured, "First emission must lead with PHP_EOL to terminate Psalm's open scan-counter line.");
+        $this->assertStringContainsString('Warning: Laravel plugin', $progress->captured);
+        $this->assertStringContainsString("not a subclass of Illuminate\\Support\\Facades\\Facade", $progress->captured);
+        $this->assertSame([], $this->getPendingScanWarnings(), 'Buffer must drain on flush.');
+    }
+
+    #[Test]
+    public function direct_emission_writes_separator_once_for_multiple_warnings(): void
+    {
+        $progress = new CapturingProgress();
+
+        // Two distinct classes so failedFacades does not short-circuit the second call.
+        AppFacadeRegistrationHandler::tryGetFacadeRootClass(\stdClass::class, $progress, false);
+        AppFacadeRegistrationHandler::tryGetFacadeRootClass(\ArrayObject::class, $progress, false);
+
+        $this->assertStringStartsWith(\PHP_EOL, $progress->captured);
+        // Exactly one separator PHP_EOL at the start; the two `Warning:` lines each carry
+        // their own trailing PHP_EOL from Progress::warning(). So there should be three
+        // PHP_EOL bytes total: leading separator + two warning terminators.
+        $eolCount = \substr_count($progress->captured, \PHP_EOL);
+        $this->assertSame(3, $eolCount, 'Only one leading separator PHP_EOL should be written across the batch.');
+    }
+
+    #[Test]
+    public function flush_with_empty_buffer_writes_nothing(): void
+    {
+        $progress = new CapturingProgress();
+        $this->invokeFlush($progress);
+
+        $this->assertSame('', $progress->captured, 'Zero-warning run must not leak a stray blank line.');
+        $this->assertFalse($this->getWroteScanSeparator(), 'Separator gate must remain unset when no warning was flushed.');
+    }
+
+    #[Test]
+    public function deferred_then_direct_share_the_same_separator(): void
+    {
+        $progress = new CapturingProgress();
+
+        // Scan-phase: deferred warning queued, buffer holds the message.
+        AppFacadeRegistrationHandler::tryGetFacadeRootClass(\stdClass::class, $progress, true);
+        // Populate-phase: flush drains buffer (writes separator + first warning) then
+        // a populate-phase emission (separate class) writes a second warning. Both must
+        // share the same leading separator.
+        $this->invokeFlush($progress);
+        AppFacadeRegistrationHandler::tryGetFacadeRootClass(\ArrayObject::class, $progress, false);
+
+        $eolCount = \substr_count($progress->captured, \PHP_EOL);
+        $this->assertSame(3, $eolCount, 'Flush + subsequent direct emission must not duplicate the separator.');
+    }
+
+    /**
+     * Regression guard for the cross-run gate leak surfaced by the psalm-expert agent
+     * during review: `checkPaths()` re-entry (CLI re-analysis) and daemon/LSP loops run
+     * the populate phase multiple times in one PHP process. Without re-arming the gate at
+     * each flush, run #2 would skip the separator and splice into the new scan-counter
+     * line — reintroducing #941.
+     */
+    #[Test]
+    public function flush_rearms_separator_gate_for_next_run(): void
+    {
+        $progress1 = new CapturingProgress();
+        AppFacadeRegistrationHandler::tryGetFacadeRootClass(\stdClass::class, $progress1, true);
+        $this->invokeFlush($progress1);
+        $this->assertTrue($this->getWroteScanSeparator(), 'Gate must be set after first flush so populate-phase warnings share the separator.');
+
+        // Simulate a second analysis run on the same handler: fresh Progress, fresh
+        // deferred warning. Buffer state was already drained by the first flush; rebuild
+        // it so the second flush has something to emit (production reaches this state
+        // via afterClassLikeVisit firing again in run 2). $failedFacades is intentionally
+        // *not* reset — the prior failure was on stdClass, so use a different class.
+        $progress2 = new CapturingProgress();
+        AppFacadeRegistrationHandler::tryGetFacadeRootClass(\ArrayObject::class, $progress2, true);
+        $this->invokeFlush($progress2);
+
+        $this->assertStringStartsWith(\PHP_EOL, $progress2->captured, 'Second-run flush must write its own separator to terminate the new scan-counter line.');
+    }
+
+    #[Test]
+    public function throwable_from_get_facade_root_emits_failure_warning(): void
+    {
+        $progress = new CapturingProgress();
+
+        // Subclass of Facade whose getFacadeAccessor() throws. `Facade::getFacadeRoot()`
+        // resolves the accessor through the container; the exception thrown by the
+        // accessor lookup propagates out of `getFacadeRoot()`. This is the path that
+        // wedged onto Psalm's progress counter in the original bug report — third-party
+        // facades whose accessor binding lives in a service provider that does not run
+        // under Testbench.
+        AppFacadeRegistrationHandler::tryGetFacadeRootClass(ThrowingFacadeFixture::class, $progress, true);
+        $this->invokeFlush($progress);
+
+        $this->assertStringContainsString("getFacadeRoot() failed for '", $progress->captured);
+        $this->assertStringContainsString(ThrowingFacadeFixture::class, $progress->captured);
+        $this->assertArrayHasKey(ThrowingFacadeFixture::class, $this->getFailedFacades());
+    }
+
+    /**
+     * Cross-phase deduplication invariant: a facade that already failed once (e.g. during
+     * scan) must not buffer a second message when probed again (e.g. during populate).
+     * Without this guarantee the user sees the same warning twice per facade.
+     */
+    #[Test]
+    public function repeated_probe_of_same_facade_buffers_only_once(): void
+    {
+        $progress = new CapturingProgress();
+
+        AppFacadeRegistrationHandler::tryGetFacadeRootClass(\stdClass::class, $progress, true);
+        AppFacadeRegistrationHandler::tryGetFacadeRootClass(\stdClass::class, $progress, true);
+
+        $this->assertCount(1, $this->getPendingScanWarnings(), 'failedFacades must short-circuit subsequent probes before they reach the buffer.');
+    }
+
+    /**
+     * Direct probe of {@see AppFacadeRegistrationHandler::flushPendingOnShutdown()} — the
+     * STDERR-fallback path used when a scan worker (`--threads N > 1`) exits with
+     * buffered warnings the main process will never see. The method exposes an
+     * `$stream` test seam so we can substitute an in-memory stream for STDERR and read
+     * back what would have been written; `register_shutdown_function` invokes the method
+     * with no arguments, so production behaviour is unchanged.
+     */
+    #[Test]
+    public function shutdown_drain_writes_buffered_warnings_to_stream(): void
+    {
+        $reflection = new \ReflectionClass(AppFacadeRegistrationHandler::class);
+        $reflection->setStaticPropertyValue('pendingScanWarnings', [
+            "Laravel plugin: getFacadeRoot() failed for 'Acme\\Foo': bound to unresolved alias",
+            "Laravel plugin: getFacadeRoot() failed for 'Acme\\Bar': bound to unresolved alias",
+        ]);
+
+        $stream = \fopen('php://memory', 'w+');
+        $this->assertNotFalse($stream);
+
+        AppFacadeRegistrationHandler::flushPendingOnShutdown($stream);
+
+        \rewind($stream);
+        $captured = (string) \stream_get_contents($stream);
+        \fclose($stream);
+
+        $this->assertStringContainsString("Warning: Laravel plugin: getFacadeRoot() failed for 'Acme\\Foo'", $captured);
+        $this->assertStringContainsString("Warning: Laravel plugin: getFacadeRoot() failed for 'Acme\\Bar'", $captured);
+        // Each message is wrapped with a leading + trailing PHP_EOL, so two messages
+        // produce four newlines total. Verifying the count guards against future drift in
+        // the wedged-but-visible output shape.
+        $this->assertSame(4, \substr_count($captured, \PHP_EOL));
+        $this->assertSame([], $this->getPendingScanWarnings(), 'Shutdown drain must empty the buffer to avoid double-emission.');
+    }
+
+    private function resetHandlerState(): void
+    {
+        $reflection = new \ReflectionClass(AppFacadeRegistrationHandler::class);
+        $reflection->setStaticPropertyValue('failedFacades', []);
+        $reflection->setStaticPropertyValue('pendingScanWarnings', []);
+        $reflection->setStaticPropertyValue('wroteScanSeparator', false);
+        // Leave $shutdownHookRegistered alone — register_shutdown_function() cannot be
+        // unregistered, and re-registering across tests would attach multiple callbacks
+        // to PHP shutdown. The hook itself is a no-op when the buffer is empty.
+    }
+
+    private function invokeFlush(Progress $progress): void
+    {
+        $method = new \ReflectionMethod(AppFacadeRegistrationHandler::class, 'flushScanWarnings');
+        $method->invoke(null, $progress);
+    }
+
+    /** @return array<string, true> */
+    private function getFailedFacades(): array
+    {
+        /** @var array<string, true> $value */
+        $value = (new \ReflectionClass(AppFacadeRegistrationHandler::class))->getStaticPropertyValue('failedFacades');
+        return $value;
+    }
+
+    /** @return list<string> */
+    private function getPendingScanWarnings(): array
+    {
+        /** @var list<string> $value */
+        $value = (new \ReflectionClass(AppFacadeRegistrationHandler::class))->getStaticPropertyValue('pendingScanWarnings');
+        return $value;
+    }
+
+    private function getWroteScanSeparator(): bool
+    {
+        /** @var bool $value */
+        $value = (new \ReflectionClass(AppFacadeRegistrationHandler::class))->getStaticPropertyValue('wroteScanSeparator');
+        return $value;
+    }
+}
+
+/**
+ * Captures every Progress::write() call into a single buffer so tests can assert on the
+ * raw stderr output the handler would produce. Inherits Progress directly because
+ * Psalm's VoidProgress is final.
+ *
+ * @internal
+ */
+final class CapturingProgress extends Progress
+{
+    public string $captured = '';
+
+    #[\Override]
+    public function write(string $message): void
+    {
+        $this->captured .= $message;
+    }
+
+    #[\Override]
+    public function debug(string $message): void {}
+
+    #[\Override]
+    public function startPhase(Phase $phase, int $threads = 1): void {}
+
+    #[\Override]
+    public function expand(int $number_of_tasks): void {}
+
+    #[\Override]
+    public function taskDone(int $level): void {}
+
+    #[\Override]
+    public function finish(): void {}
+
+    #[\Override]
+    public function alterFileDone(string $file_name): void {}
+}
+
+/**
+ * Minimal Facade subclass whose accessor throws — mirrors the third-party facades from
+ * the original bug report whose accessor binding only exists in a service provider that
+ * does not run under the plugin's Testbench application. The handler should catch the
+ * Throwable and emit a `"getFacadeRoot() failed for ..."` warning through `emitWarning`.
+ *
+ * @internal
+ */
+final class ThrowingFacadeFixture extends \Illuminate\Support\Facades\Facade
+{
+    #[\Override]
+    protected static function getFacadeAccessor(): string
+    {
+        throw new \RuntimeException('unbound accessor for ThrowingFacadeFixture');
+    }
+}


### PR DESCRIPTION
## Issue to Solve

Running Psalm with the plugin against codebases that contain third-party facades whose accessors are bound by service providers Testbench doesn't run (e.g. [imdhemy/laravel-in-app-purchases](https://github.com/imdhemy/laravel-in-app-purchases)) produces malformed progress output:

```
Scanning files...

2743 / 2743...Warning: Laravel plugin: getFacadeRoot() failed for 'Imdhemy\Purchases\Facades\Subscription': Target class [subscription] does not exist.
Warning: Laravel plugin: getFacadeRoot() failed for 'Imdhemy\Purchases\Facades\Product': Target class [product] does not exist.


Analyzing files...
```

The warnings themselves are legitimate (third-party facades with provider-bound accessors and no `@see` tag, surfaced by the resolver added in #789). Only the rendering is broken: `LongProgress::taskDone()` writes `\rN / total...` with no trailing newline, and `Progress::warning()` writes `'Warning: ' . $message . PHP_EOL` with no leading newline, so the warning glues directly onto the open counter line.

## Related

Closes #941. Builds on #787 / #789 (the facade resolver that surfaces these warnings).

## Solution Description

Buffer scan-phase warnings into a static array, drain them at the top of `afterCodebasePopulated()` (runs between scan and analyze phases). Lazy `PHP_EOL` separator before the first emission terminates Psalm's open counter line; zero-warning runs leave output untouched.

Key design points:

- `tryGetFacadeRootClass()` gains a `bool $deferWarnings = false` parameter. `afterClassLikeVisit` passes `true`, `afterCodebasePopulated` passes `false`.
- All emission sites in the handler (the three branches of `tryGetFacadeRootClass`, plus the populate-phase autoload checks) now route through a single private `emitWarning(Progress, string, bool $defer)` helper, so the lazy separator stays consistent.
- `flushScanWarnings()` re-arms the separator gate at every call, so a second `checkPaths()` re-entry (CLI re-analysis, daemon/LSP loops) gets a fresh separator instead of splicing into the new scan-counter line.
- Forked scan workers (`--threads N > 1`) inherit the buffer via copy-on-write but their mutations never reach the main process. A `register_shutdown_function` fallback prints buffered warnings directly to STDERR before the worker exits, so threaded mode degrades to "wedged but visible" instead of "silently lost". The shutdown drain also accepts an optional `$stream` test seam (defaults to STDERR) so it can be exercised in a unit test.

### Verification

Nine unit tests in `tests/Unit/Handlers/Facades/AppFacadeWarningBufferTest.php`:

- `deferred_warning_is_not_written_until_flush` and `flush_emits_separator_then_warning` cover the core defer / drain lifecycle.
- `direct_emission_writes_separator_once_for_multiple_warnings` and `deferred_then_direct_share_the_same_separator` cover the lazy separator across multiple emission paths.
- `flush_with_empty_buffer_writes_nothing` guards the zero-warning case.
- `flush_rearms_separator_gate_for_next_run` covers the cross-run reset.
- `throwable_from_get_facade_root_emits_failure_warning` covers the `Throwable` catch branch via a `ThrowingFacadeFixture` whose accessor throws.
- `repeated_probe_of_same_facade_buffers_only_once` asserts the `failedFacades` short-circuit prevents duplicate buffer entries.
- `shutdown_drain_writes_buffered_warnings_to_stream` covers the worker-shutdown fallback via the `$stream` test seam.

All existing type/unit/psalm/cs/rector checks pass.

## Checklist

- [x] Tests cover the change (9 new unit tests in `tests/Unit/Handlers/Facades/AppFacadeWarningBufferTest.php`)
