### PR TITLE
Treat `ServiceProvider::$app` as initialized

### DIFF
--- a/src/Handlers/SuppressHandler.php
+++ b/src/Handlers/SuppressHandler.php
@@ -105,10 +105,12 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
     ];
 
     /**
-     * Properties that Laravel populates during a framework-driven lifecycle hook (e.g. testing
-     * setUp(), createApplication()) rather than from any constructor. Listing them by the class
-     * the user typically extends; the entry is resolved to the actual declaring class storage
-     * (trait or parent) at codebase-populated time.
+     * Properties that Laravel populates through a framework-driven mechanism — a testing
+     * lifecycle hook (setUp(), createApplication()), a trait lifecycle hook (setUpFaker()), or
+     * a parent constructor chain (ServiceProvider::__construct() assigning $this->app) — rather
+     * than from the user subclass's own constructor. Listing them by the class the user
+     * typically extends or composes; the entry is resolved to the actual declaring class
+     * storage (trait or parent) at codebase-populated time.
      *
      * Marking a property as "initialized" on its declaring class storage is what Psalm itself
      * does for properties with a default value or promoted constructor params (see
@@ -140,6 +142,18 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
         // storage and propagates to every user class that composes it.
         'Illuminate\Foundation\Testing\WithFaker' => [
             'faker',
+        ],
+        // `$app` is declared on `Illuminate\Support\ServiceProvider` and assigned in its
+        // `__construct($app)`. Subclasses that declare their own constructor and call
+        // `parent::__construct($app)` (the documented pattern — packages routinely subclass
+        // EventServiceProvider / AuthServiceProvider / RouteServiceProvider and add their own
+        // constructor for runtime registration) get `PropertyNotSetInConstructor` because Psalm
+        // does not trace `parent::__construct` through to parent-property assignments when
+        // checking the child. Marking the property as initialized on the declaring class
+        // storage skips the check for every subclass without touching their own un-initialized
+        // property reports. See psalm/psalm-plugin-laravel#945.
+        'Illuminate\Support\ServiceProvider' => [
+            'app',
         ],
     ];
 

--- a/stubs/common/Support/ServiceProvider.phpstub
+++ b/stubs/common/Support/ServiceProvider.phpstub
@@ -2,8 +2,39 @@
 
 namespace Illuminate\Support;
 
+/**
+ * Property + constructor declarations mirror Laravel's source so the stub-merged storage Psalm
+ * uses keeps a visible `$app` slot with its declaring-class link intact. Init propagation for
+ * subclasses that override `__construct` and call `parent::__construct($app)` is patched in
+ * SuppressHandler::FRAMEWORK_INITIALIZED_PROPERTIES_BY_FQCN (see psalm/psalm-plugin-laravel#945)
+ * because Psalm does not trace `parent::__construct` through to parent-property assignments
+ * when checking the child.
+ */
 abstract class ServiceProvider
 {
+    /**
+     * The application instance.
+     *
+     * @var \Illuminate\Contracts\Foundation\Application
+     */
+    protected $app;
+
+    /** @var array<int, \Closure> */
+    protected $bootingCallbacks = [];
+
+    /** @var array<int, \Closure> */
+    protected $bootedCallbacks = [];
+
+    /**
+     * Create a new service provider instance.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     */
+    public function __construct($app)
+    {
+        $this->app = $app;
+    }
+
     /**
      * Register the package's custom Artisan commands.
      *

--- a/tests/Type/tests/Support/ServiceProviderPropertyNotSetInConstructorNegativeTest.phpt
+++ b/tests/Type/tests/Support/ServiceProviderPropertyNotSetInConstructorNegativeTest.phpt
@@ -1,0 +1,54 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Providers;
+
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Negative-path guard for psalm/psalm-plugin-laravel#945.
+ *
+ * The fix must NOT hide user-declared properties on a ServiceProvider subclass — only the
+ * framework-managed `$app` should be silently treated as initialized. User-declared properties
+ * with no default value and no constructor assignment must still raise
+ * `PropertyNotSetInConstructor`.
+ *
+ * If a future refactor accidentally regresses to a class-level suppression on ServiceProvider
+ * subclasses, this test fails. Visibility matters for the emitted error string: Psalm appends
+ * "private or final " to the message when any uninitialized property is private; both branches
+ * are exercised to guard against a regression that narrows by visibility.
+ */
+final class UnInitializedPrivatePropertyProvider extends ServiceProvider
+{
+    private int $privateField;
+
+    public function __construct(Application $app)
+    {
+        parent::__construct($app);
+    }
+
+    public function value(): int
+    {
+        return $this->privateField;
+    }
+}
+
+final class UnInitializedProtectedPropertyProvider extends ServiceProvider
+{
+    protected int $protectedField;
+
+    public function __construct(Application $app)
+    {
+        parent::__construct($app);
+    }
+
+    public function value(): int
+    {
+        return $this->protectedField;
+    }
+}
+?>
+--EXPECTF--
+PropertyNotSetInConstructor on line %d: Property App\Providers\UnInitializedPrivatePropertyProvider::$privateField is not defined in constructor of App\Providers\UnInitializedPrivatePropertyProvider or in any private or final methods called in the constructor
+PropertyNotSetInConstructor on line %d: Property App\Providers\UnInitializedProtectedPropertyProvider::$protectedField is not defined in constructor of App\Providers\UnInitializedProtectedPropertyProvider or in any methods called in the constructor

--- a/tests/Type/tests/Support/ServiceProviderPropertyNotSetInConstructorTest.phpt
+++ b/tests/Type/tests/Support/ServiceProviderPropertyNotSetInConstructorTest.phpt
@@ -1,0 +1,82 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Providers;
+
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Foundation\Support\Providers\AuthServiceProvider as BaseAuthServiceProvider;
+use Illuminate\Foundation\Support\Providers\EventServiceProvider as BaseEventServiceProvider;
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider as BaseRouteServiceProvider;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Regression guard for psalm/psalm-plugin-laravel#945.
+ *
+ * Subclasses of `Illuminate\Support\ServiceProvider` (directly or via the framework's
+ * EventServiceProvider / AuthServiceProvider / RouteServiceProvider intermediates) that declare
+ * their own `__construct` and call `parent::__construct($app)` should NOT trigger
+ * `PropertyNotSetInConstructor`. The `$app` property is declared on the parent and assigned in
+ * its constructor; Psalm just does not trace `parent::__construct` to parent-property
+ * assignments when checking the child.
+ *
+ * The fix marks `$app` as initialized on its declaring class storage
+ * (`Illuminate\Support\ServiceProvider`) so the un-init check skips it for every subclass
+ * without hiding any other un-initialised properties the user might declare.
+ */
+final class DirectSubclassWithConstructor extends ServiceProvider
+{
+    public function __construct(Application $app)
+    {
+        parent::__construct($app);
+    }
+}
+
+final class EventServiceProviderWithConstructor extends BaseEventServiceProvider
+{
+    public function __construct(Application $app)
+    {
+        parent::__construct($app);
+
+        $this->listen = [];
+    }
+}
+
+final class AuthServiceProviderWithConstructor extends BaseAuthServiceProvider
+{
+    public function __construct(Application $app)
+    {
+        parent::__construct($app);
+    }
+}
+
+final class RouteServiceProviderWithConstructor extends BaseRouteServiceProvider
+{
+    public function __construct(Application $app)
+    {
+        parent::__construct($app);
+    }
+}
+
+/**
+ * Multi-level inheritance check. The intermediate abstract base sits between
+ * `Illuminate\Support\ServiceProvider` and the leaf provider, so a regression that
+ * walks only one level of the parent chain instead of writing to the declaring storage
+ * would fail this case.
+ */
+abstract class IntermediateServiceProvider extends ServiceProvider
+{
+    public function __construct(Application $app)
+    {
+        parent::__construct($app);
+    }
+}
+
+final class DeeplyNestedServiceProvider extends IntermediateServiceProvider
+{
+    public function __construct(Application $app)
+    {
+        parent::__construct($app);
+    }
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

`PropertyNotSetInConstructor` fires on any user `ServiceProvider` subclass that declares its own `__construct` and calls `parent::__construct($app)` (the documented Laravel pattern — packages routinely subclass `EventServiceProvider` / `AuthServiceProvider` / `RouteServiceProvider` and add their own constructor for runtime registration). `$app` is declared on `Illuminate\Support\ServiceProvider` and assigned in its parent constructor; Psalm just does not trace `parent::__construct` to parent-property assignments when checking the child.

## Related

Closes #945. Same shape as #912 (which applied the fix to `TestCase::$app`).

## Solution Description

Two changes:

1. `src/Handlers/SuppressHandler.php`: add `'Illuminate\Support\ServiceProvider' => ['app']` to `FRAMEWORK_INITIALIZED_PROPERTIES_BY_FQCN`. The existing `markFrameworkInitializedProperties()` machinery resolves the entry to the actual declaring class storage and sets `$storage->initialized_properties['app'] = true`, which `ClassAnalyzer::checkPropertyInitialization()` honours for every subclass without touching their own `suppressed_issues`. Genuinely uninitialised user properties on a `ServiceProvider` subclass keep being flagged.
2. `stubs/common/Support/ServiceProvider.phpstub`: mirror Laravel's source for `$app`, `__construct($app)`, `$bootingCallbacks`, `$bootedCallbacks`. Per the project rule "Class declarations wipe reflected metadata", redeclaring a class can drop storage that other plugin code expects to read. Keeping the stub aligned with the framework shape removes a latent dependency on Reflection winning the merge for `declaring_property_ids['app']`.

Test coverage (`tests/Type/tests/Support/`):

- **Positive** (`ServiceProviderPropertyNotSetInConstructorTest.phpt`): direct `ServiceProvider` subclass with own ctor, all three `Illuminate\Foundation\Support\Providers\*ServiceProvider` intermediates (`Auth`, `Event`, `Route`), and a multi-level abstract chain. The multi-level case guards against a regression that walks the parent chain one level instead of writing to the declaring storage.
- **Negative** (`ServiceProviderPropertyNotSetInConstructorNegativeTest.phpt`): user-declared `private int` and `protected int` properties on a `ServiceProvider` subclass must still raise `PropertyNotSetInConstructor`. Both visibilities are exercised because Psalm's error message differs between them.

Verified: `composer test:type` (401/401), `composer test:unit` (620/620), `composer psalm` (clean), `composer test:app` (clean).

## Checklist
- [x] Tests cover the change (positive + negative type tests in `tests/Type/tests/Support/`)
