### PR TITLE
Suppress `PossiblyUnusedMethod` on container-bound `__construct`

### DIFF
--- a/src/Handlers/Application/ContainerBoundConstructorHandler.php
+++ b/src/Handlers/Application/ContainerBoundConstructorHandler.php
@@ -1,0 +1,306 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Application;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use Psalm\Plugin\EventHandler\AfterMethodCallAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterMethodCallAnalysisEvent;
+
+/**
+ * Records a synthetic call-graph reference to the `__construct` of every concrete
+ * class registered through Laravel's container binding methods.
+ *
+ * Why: Laravel resolves container-bound classes through `Container::build()`,
+ * which reflects on `__construct`. The class name only appears as a string FQCN
+ * argument to `bind()`/`singleton()`/`scoped()` etc., never as `new Concrete(...)`
+ * in user code, so Psalm's reference graph never picks up the constructor and
+ * reports `PossiblyUnusedMethod`. Adding a synthetic
+ * {@see \Psalm\Internal\Provider\FileReferenceProvider::addMethodReferenceToClassMember()}
+ * entry from the calling site (typically `ServiceProvider::register`) lets the
+ * existing unused-method check short-circuit naturally. See psalm/psalm-plugin-laravel#943.
+ *
+ * Scope:
+ *  - Two-arg form: `bind(Interface::class, Concrete::class)` — Concrete recorded.
+ *  - Single-arg form: `bind(Concrete::class)` — Concrete recorded.
+ *  - Contextual fluent form: `$app->when(X)->needs(Y)->give(Concrete::class)` —
+ *    Concrete recorded via ContextualBindingBuilder::give.
+ *  - Variadic contextual form: `give([Concrete1::class, Concrete2::class])` —
+ *    each class-string item recorded. The Laravel docs document this as the
+ *    standard pattern for typed-variadic injection, so the array branch is
+ *    only enabled for `give()`; `bind()` is `Closure|string|null` (Laravel
+ *    even type-errors on arrays at Container.php:380), so no array branch there.
+ *  - Closure / instance second-arg forms are skipped: the closure body or the
+ *    pre-built instance already contains the `new` expression that Psalm tracks
+ *    naturally, so no synthetic reference is needed.
+ *  - `instance()` and `register()` are intentionally NOT here: `instance()`
+ *    receives a pre-built object whose construction site is visible to Psalm,
+ *    and `register()` always targets a ServiceProvider whose `__construct` is
+ *    already suppressed in SuppressHandler via METHOD_LEVEL_BY_PARENT_CLASS.
+ *
+ * Method-id gate covers both the concrete Container and the contract, matching
+ * the dispatch behaviour of {@see OctaneIncompatibleBindingHandler}: the
+ * `declaring_method_id` points at whichever one is in scope for the receiver.
+ */
+final class ContainerBoundConstructorHandler implements AfterMethodCallAnalysisInterface
+{
+    /**
+     * Method names this handler reacts to. Keys are lowercase.
+     *
+     * `instance` and `register` are intentionally absent — see the class docblock.
+     * `give` is included to cover contextual bindings:
+     * `$this->app->when(X::class)->needs(Y::class)->give(Concrete::class)` reaches
+     * Concrete's `__construct` through the same `Container::build()` reflection path.
+     */
+    private const BINDING_METHOD_NAMES = [
+        'bind' => true,
+        'bindif' => true,
+        'singleton' => true,
+        'singletonif' => true,
+        'scoped' => true,
+        'scopedif' => true,
+        'give' => true,
+    ];
+
+    /**
+     * Declaring method ids (lowercase) that count as "container binding". Covers both
+     * the concrete container and the contract; the user's receiver type determines
+     * which the declaring_method_id resolves to.
+     *
+     * Includes `ContextualBindingBuilder::give` (contract + concrete) because the
+     * fluent `$app->when(...)->needs(...)->give(Concrete::class)` chain hands a
+     * concrete class-string to `Container::build()` exactly like the direct
+     * `bind(...)` family does.
+     */
+    private const CONTAINER_METHOD_IDS_LOWER = [
+        'illuminate\\container\\container::bind' => true,
+        'illuminate\\container\\container::bindif' => true,
+        'illuminate\\container\\container::singleton' => true,
+        'illuminate\\container\\container::singletonif' => true,
+        'illuminate\\container\\container::scoped' => true,
+        'illuminate\\container\\container::scopedif' => true,
+        'illuminate\\contracts\\container\\container::bind' => true,
+        'illuminate\\contracts\\container\\container::bindif' => true,
+        'illuminate\\contracts\\container\\container::singleton' => true,
+        'illuminate\\contracts\\container\\container::singletonif' => true,
+        'illuminate\\contracts\\container\\container::scoped' => true,
+        'illuminate\\contracts\\container\\container::scopedif' => true,
+        'illuminate\\container\\contextualbindingbuilder::give' => true,
+        'illuminate\\contracts\\container\\contextualbindingbuilder::give' => true,
+    ];
+
+    /** @inheritDoc */
+    #[\Override]
+    public static function afterMethodCallAnalysis(AfterMethodCallAnalysisEvent $event): void
+    {
+        $expr = $event->getExpr();
+
+        // The event also fires for StaticCall; facade-form `App::bind(...)` is
+        // out of scope here (rare in practice, declaring_method_id wouldn't match
+        // anyway because the call routes through __callStatic on the facade).
+        if (!$expr instanceof MethodCall) {
+            return;
+        }
+
+        // Hot-path gate on the cheap method-name token before the lowercased
+        // FQN id, mirroring OctaneIncompatibleBindingHandler. The handler fires
+        // for every resolved MethodCall in the codebase; >99% are not bindings.
+        if (!$expr->name instanceof Identifier) {
+            return;
+        }
+
+        $methodNameLower = \strtolower($expr->name->name);
+
+        if (!isset(self::BINDING_METHOD_NAMES[$methodNameLower])) {
+            return;
+        }
+
+        if (!isset(self::CONTAINER_METHOD_IDS_LOWER[\strtolower($event->getDeclaringMethodId())])) {
+            return;
+        }
+
+        $args = $expr->getArgs();
+        $argCount = \count($args);
+
+        if ($argCount === 0) {
+            return;
+        }
+
+        // Concrete-target extraction:
+        //  - two-arg form (bind/singleton/scoped + If variants): second arg is the
+        //    concrete; first is the abstract/interface
+        //  - single-arg form (bind(C::class), give(C::class)): first arg is both
+        //    abstract AND concrete
+        //  - variadic give([C1::class, C2::class]): array of concretes (give() only)
+        // If the second arg is a closure/array/variable for the bind() family, the
+        // concrete is dynamic and Psalm tracks it through the closure body naturally.
+        $targetNode = $argCount >= 2 ? $args[1]->value : $args[0]->value;
+        $targetFqcns = self::extractTargetFqcns($targetNode, $methodNameLower);
+
+        if ($targetFqcns === []) {
+            return;
+        }
+
+        $codebase = $event->getCodebase();
+        $callingMethodId = $event->getContext()->calling_method_id;
+        $sourceFilePath = $event->getStatementsSource()->getFilePath();
+        $referenceProvider = $codebase->file_reference_provider;
+
+        foreach ($targetFqcns as $targetFqcn) {
+            // Only suppress when the target's `__construct` is public. Laravel's container
+            // builds instances via `ReflectionClass::newInstanceArgs()`, which throws on
+            // non-public constructors — so a `private` or `protected` `__construct` on a
+            // bound class is a real runtime bug, not a false positive. Mirrors the
+            // visibility filter SuppressHandler::suppressFrameworkHookMethod() applies
+            // to `Mailable::__construct` and other framework-dispatched hooks.
+            if (!self::targetHasPublicConstructor($codebase, $targetFqcn)) {
+                continue;
+            }
+
+            $referencedConstructorId = \strtolower($targetFqcn) . '::__construct';
+
+            // `calling_method_id` is null for top-level code (rare in service providers,
+            // since binds usually live inside register()/boot()). Fall back to a file-level
+            // reference so the synthetic edge survives either way.
+            if ($callingMethodId !== null) {
+                $referenceProvider->addMethodReferenceToClassMember(
+                    $callingMethodId,
+                    $referencedConstructorId,
+                    false,
+                );
+
+                continue;
+            }
+
+            $referenceProvider->addFileReferenceToClassMember(
+                $sourceFilePath,
+                $referencedConstructorId,
+                false,
+            );
+        }
+    }
+
+    /**
+     * Resolve the list of concrete FQCNs from the target arg of a binding call.
+     *
+     * For every binding method except `give`, returns at most one FQCN (extracted from
+     * a `Foo::class` constant fetch) or an empty list. For `give`, additionally accepts
+     * an `Array_` literal whose every item value is `Foo::class`, returning the list
+     * of resolved FQCNs — this is Laravel's documented pattern for typed-variadic
+     * contextual binding (`->give([NullFilter::class, ProfanityFilter::class])`).
+     * If any item in the array isn't a class-const fetch (closure, variable, string
+     * literal), the entire array is treated as dynamic and an empty list is returned.
+     *
+     * @return list<string>
+     */
+    private static function extractTargetFqcns(Node $node, string $methodNameLower): array
+    {
+        $singleFqcn = self::extractClassConstFqcn($node);
+
+        if ($singleFqcn !== null) {
+            return [$singleFqcn];
+        }
+
+        // Array form is only meaningful for `give()`'s variadic shape.
+        if ($methodNameLower !== 'give' || !$node instanceof Array_) {
+            return [];
+        }
+
+        $fqcns = [];
+
+        foreach ($node->items as $item) {
+            // PhpParser models trailing commas / empty slots as `null` items. We're
+            // not parsing a list comprehension here, so a null slot means "give up,
+            // bail to dynamic" — same all-or-nothing rule as below.
+            if ($item === null) {
+                return [];
+            }
+
+            // Skip spread (`...$classes`) and other non-literal item shapes; we can't
+            // statically enumerate them, and partial coverage would create surprising
+            // asymmetry. Same all-or-nothing rule as the OctaneIncompatibleBindingHandler
+            // applies to closure introspection.
+            if ($item->unpack) {
+                return [];
+            }
+
+            $itemFqcn = self::extractClassConstFqcn($item->value);
+
+            if ($itemFqcn === null) {
+                return [];
+            }
+
+            $fqcns[] = $itemFqcn;
+        }
+
+        return $fqcns;
+    }
+
+    /**
+     * Look up the target's `__construct` MethodStorage and check it is public.
+     *
+     * Returns true when the class either has no declared `__construct` (the default
+     * public no-arg constructor is fine for Container reflection) or has one declared
+     * as `public`. Returns false for `private`/`protected` constructors, and for any
+     * lookup failure (target not yet scanned, class not in the codebase) — better to
+     * leave the issue surfaced than to silently mask it.
+     *
+     * @psalm-mutation-free
+     */
+    private static function targetHasPublicConstructor(\Psalm\Codebase $codebase, string $targetFqcn): bool
+    {
+        try {
+            $storage = $codebase->classlike_storage_provider->get($targetFqcn);
+        } catch (\InvalidArgumentException) {
+            // Target wasn't scanned (out-of-tree reference, typo, etc.). The
+            // PossiblyUnusedMethod check itself won't fire on something Psalm
+            // can't see, so the conservative answer is "don't add a synthetic
+            // reference we can't justify".
+            return false;
+        }
+
+        $constructorStorage = $storage->methods['__construct'] ?? null;
+
+        if ($constructorStorage === null) {
+            // No explicit constructor — Container builds it without parameters via the
+            // implicit public no-arg form. PossiblyUnusedMethod doesn't fire on absent
+            // methods anyway, so the answer is "safe to proceed" (no-op downstream).
+            return true;
+        }
+
+        return $constructorStorage->visibility === \Psalm\Internal\Analyzer\ClassLikeAnalyzer::VISIBILITY_PUBLIC;
+    }
+
+    /**
+     * Extract the resolved FQCN from a `Foo::class` constant fetch.
+     *
+     * Returns null for any other expression shape (closures, variables, string
+     * literals, dynamic class constants). String-literal FQCNs (`bind('App\Foo')`)
+     * are intentionally not supported: they're rare and surfacing them would
+     * require namespace-aware resolution we don't otherwise need.
+     */
+    private static function extractClassConstFqcn(Node $node): ?string
+    {
+        if (!$node instanceof ClassConstFetch
+            || !$node->class instanceof Name
+            || !$node->name instanceof Identifier
+            || \strtolower($node->name->name) !== 'class'
+        ) {
+            return null;
+        }
+
+        // Psalm's SimpleNameResolver sets `resolvedName` as a string before storing,
+        // so under Psalm analysis the attribute is always `?string`. Matches the
+        // pattern used by OctaneIncompatibleBindingHandler::literalAbstractFrom().
+        /** @psalm-var ?string $resolved */
+        $resolved = $node->class->getAttribute('resolvedName');
+
+        return \is_string($resolved) ? $resolved : null;
+    }
+}

--- a/src/Handlers/SuppressHandler.php
+++ b/src/Handlers/SuppressHandler.php
@@ -160,7 +160,13 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
     /** @var array<string, array<string, list<string>>> */
     private const METHOD_LEVEL_BY_PARENT_CLASS = [
         'PossiblyUnusedMethod' => [
-            'Illuminate\Console\Command' => ['handle'],
+            // __construct included because Console commands are instantiated by the framework
+            // exclusively through the container: `Console\Kernel::resolve()` and `Application::call()`
+            // route through `Container::build()`, which reflects on `__construct` to inject
+            // dependencies. The class name never appears as `new ConcreteCommand(...)` in user code,
+            // so Psalm marks the constructor unreachable from any visible entry point. `handle`
+            // is here for the same dispatch reason (called via Container::call). See psalm/psalm-plugin-laravel#943.
+            'Illuminate\Console\Command' => ['__construct', 'handle'],
             'Illuminate\Database\Migrations\Migration' => ['up', 'down'],
             'Illuminate\Database\Seeder' => ['run'],
             'Illuminate\Foundation\Http\FormRequest' => [
@@ -208,7 +214,14 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
                 'shouldSend',
                 'via',
             ],
-            'Illuminate\Support\ServiceProvider' => ['boot'],
+            // __construct included because service providers are instantiated by the framework
+            // via `Application::resolveProvider()`, which does `new $providerClass($this)` against
+            // the FQCN registered through `$this->app->register(Provider::class)` or
+            // `extra.laravel.providers` in composer.json. The class name never appears as
+            // `new ConcreteProvider(...)` in user code, so Psalm marks the constructor unreachable.
+            // `boot` is here for the same dispatch reason (called via Container::call).
+            // See psalm/psalm-plugin-laravel#943.
+            'Illuminate\Support\ServiceProvider' => ['__construct', 'boot'],
         ],
     ];
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -82,6 +82,8 @@ final class Plugin implements PluginEntryPointInterface
         $registration->registerHooksFromClass(Handlers\Application\ContainerHandler::class);
         require_once __DIR__ . '/Handlers/Application/OffsetHandler.php';
         $registration->registerHooksFromClass(Handlers\Application\OffsetHandler::class);
+        require_once __DIR__ . '/Handlers/Application/ContainerBoundConstructorHandler.php';
+        $registration->registerHooksFromClass(Handlers\Application\ContainerBoundConstructorHandler::class);
 
         require_once __DIR__ . '/Handlers/Auth/AuthHandler.php';
         $registration->registerHooksFromClass(Handlers\Auth\AuthHandler::class);

--- a/src/Providers/ApplicationProvider.php
+++ b/src/Providers/ApplicationProvider.php
@@ -133,8 +133,8 @@ final class ApplicationProvider
      */
     private function retargetConfigPathAtProjectRoot(LaravelApplication $app): void
     {
-        $envOverride = self::readEnvOverride('APP_BASE_PATH')
-            ?? self::readEnvOverride('TESTBENCH_APP_BASE_PATH');
+        $envOverride = $this->readEnvOverride('APP_BASE_PATH')
+            ?? $this->readEnvOverride('TESTBENCH_APP_BASE_PATH');
 
         if ($envOverride !== null) {
             $projectRoot = $envOverride;
@@ -161,7 +161,7 @@ final class ApplicationProvider
      * which is the documented escape hatch but not the most portable one — we widen
      * the check so the override actually takes effect across runtime configurations.
      */
-    private static function readEnvOverride(string $name): ?string
+    private function readEnvOverride(string $name): ?string
     {
         $candidates = [$_ENV[$name] ?? null, $_SERVER[$name] ?? null, \getenv($name)];
 

--- a/tests/Type/tests/ServiceProviderTest.phpt
+++ b/tests/Type/tests/ServiceProviderTest.phpt
@@ -16,5 +16,170 @@ class ExampleServiceProvider extends ServiceProvider
         //
     }
 }
+
+/**
+ * Smoke fixture for psalm/psalm-plugin-laravel#943 — exercises every binding shape
+ * `ContainerBoundConstructorHandler` covers. The injected `__construct` body is the
+ * documented Laravel pattern used by packages that subclass EventServiceProvider /
+ * AuthServiceProvider / RouteServiceProvider; it also exercises the Item-4
+ * `Illuminate\Support\ServiceProvider::__construct` parent-class suppression in
+ * SuppressHandler.
+ *
+ * Becomes a hard regression guard once #869 enables findUnusedCode in type tests.
+ */
+class BindingServiceProvider extends ServiceProvider
+{
+    public function __construct(\Illuminate\Contracts\Foundation\Application $app)
+    {
+        parent::__construct($app);
+    }
+
+    #[\Override]
+    public function register(): void
+    {
+        // Two-arg form: ContainerBoundConstructorHandler records a synthetic ref
+        // to the concrete `__construct` from this method.
+        $this->app->bind(BoundContract::class, BoundConcreteService::class);
+        $this->app->singleton(SingletonContract::class, SingletonConcreteService::class);
+        $this->app->scoped(ScopedContract::class, ScopedConcreteService::class);
+
+        // Single-arg form: bind(Concrete::class) — Concrete is both abstract and concrete.
+        $this->app->bind(StandaloneService::class);
+        $this->app->bindIf(StandaloneServiceIf::class);
+
+        // Closure-as-second-arg: the body holds its own `new` expression, so Psalm's
+        // natural reference tracking handles the constructor without our help. The
+        // handler is intentionally a no-op for this shape.
+        $this->app->singleton(ClosureBoundContract::class, function (): ClosureBoundService {
+            return new ClosureBoundService();
+        });
+
+        // commands(): registered classes extend Console\Command, which is covered
+        // by METHOD_LEVEL_BY_PARENT_CLASS for `__construct` + `handle`.
+        $this->commands([
+            \App\Console\Commands\ExampleRegisteredCommand::class,
+        ]);
+
+        // register(): the nested provider extends ServiceProvider, so its
+        // `__construct` is suppressed by the parent-class rule that protects
+        // every ServiceProvider subclass.
+        $this->app->register(NestedServiceProvider::class);
+
+        // Contextual binding: ContextualBindingBuilder::give(Concrete::class) reaches
+        // Concrete's `__construct` through Container::build() reflection, same as
+        // the direct bind() family.
+        $this->app->when(BoundContract::class)
+            ->needs(StandaloneService::class)
+            ->give(ContextualConcreteService::class);
+
+        // Variadic contextual binding: give([C1::class, C2::class]) — Laravel's
+        // documented pattern for typed-variadic injection. Each concrete reaches
+        // `Container::build()` via `resolveVariadicClass()`.
+        $this->app->when(BoundContract::class)
+            ->needs(SingletonContract::class)
+            ->give([VariadicFilterA::class, VariadicFilterB::class]);
+    }
+}
+
+class NestedServiceProvider extends ServiceProvider
+{
+    #[\Override]
+    public function register(): void
+    {
+    }
+}
+
+interface BoundContract {}
+interface SingletonContract {}
+interface ScopedContract {}
+interface ClosureBoundContract {}
+
+class BoundConcreteService implements BoundContract
+{
+    public function __construct(public readonly \Illuminate\Http\Request $request)
+    {
+    }
+}
+
+class SingletonConcreteService implements SingletonContract
+{
+    public function __construct(public readonly \Illuminate\Contracts\Config\Repository $config)
+    {
+    }
+}
+
+class ScopedConcreteService implements ScopedContract
+{
+    public function __construct()
+    {
+    }
+}
+
+class StandaloneService
+{
+    public function __construct(public readonly \Illuminate\Contracts\Config\Repository $config)
+    {
+    }
+}
+
+class StandaloneServiceIf
+{
+    public function __construct()
+    {
+    }
+}
+
+class ClosureBoundService implements ClosureBoundContract
+{
+    public function __construct()
+    {
+    }
+}
+
+class ContextualConcreteService
+{
+    public function __construct(public readonly \Illuminate\Contracts\Config\Repository $config)
+    {
+    }
+}
+
+class VariadicFilterA
+{
+    public function __construct(public readonly \Illuminate\Http\Request $request)
+    {
+    }
+}
+
+class VariadicFilterB
+{
+    public function __construct()
+    {
+    }
+}
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+/**
+ * Registered through `ServiceProvider::commands([...])`. Suppressed under
+ * METHOD_LEVEL_BY_PARENT_CLASS for `__construct` because Console\Kernel resolves
+ * the FQCN through the container, never as a literal `new` in user code.
+ */
+class ExampleRegisteredCommand extends Command
+{
+    /** @var string */
+    protected $signature = 'app:registered-via-commands';
+
+    public function __construct(public readonly \Illuminate\Contracts\Config\Repository $config)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        return 0;
+    }
+}
 ?>
 --EXPECTF--

--- a/tests/Unit/Providers/ApplicationProviderConfigPathTest.php
+++ b/tests/Unit/Providers/ApplicationProviderConfigPathTest.php
@@ -43,8 +43,8 @@ final class ApplicationProviderConfigPathTest extends TestCase
         // Snapshot ApplicationProvider's memoised state so a previous test that booted
         // the app from a different cwd cannot leak its `configPath()` into this one.
         $this->originalState = [
-            'app' => $this->reflectProperty('app')->getValue(null),
-            'booted' => $this->reflectProperty('booted')->getValue(null),
+            'app' => $this->reflectProperty('app')->getValue(),
+            'booted' => $this->reflectProperty('booted')->getValue(),
         ];
 
         $this->reflectProperty('app')->setValue(null, null);


### PR DESCRIPTION
## Issue to Solve

`PossiblyUnusedMethod` fires on the `__construct` of every class that Laravel instantiates through the container, even though every such instantiation reflects on `__construct` to inject dependencies. The constructor is the contract Laravel uses to build the object, so flagging it as unused is wrong.

Three call sites trigger the noise today:

1. **Concrete classes** on the RHS of `bind()` / `singleton()` / `scoped()` / `instance()` / `bindIf()` / `singletonIf()` / `scopedIf()` in a service provider.
2. **Console commands** registered via `$this->commands([...])`.
3. **Service providers** registered via `$this->app->register(...)` or `extra.laravel.providers` in `composer.json`.

A mid-sized application's service providers fan this out to dozens of false positives, forcing maintainers to add `@psalm-api` to every container-bound class, baseline the issue, or disable `PossiblyUnusedMethod` entirely.

## Related

Closes #943.

Builds on #947 (which stopped `PropertyNotSetInConstructor` from firing on `ServiceProvider::$app` for subclasses that override `__construct`).

## Solution Description

Two complementary mechanisms.

### Parent-class suppression for framework-discovered classes

`SuppressHandler::METHOD_LEVEL_BY_PARENT_CLASS` gains `__construct` for `Illuminate\Console\Command` and `Illuminate\Support\ServiceProvider`. These are framework-discovered at runtime (`Console\Kernel::resolve()`, `Application::resolveProvider()`, `extra.laravel.providers`), so a blanket parent-class suppression is the right shape. The existing `suppressFrameworkHookMethod()` visibility filter keeps non-public constructors flagged (Container reflection would fail at runtime anyway).

### Synthetic call-graph reference for explicit container bindings

A new `ContainerBoundConstructorHandler` listens on `AfterMethodCallAnalysis`. When it sees:

- `Container::{bind,bindIf,singleton,singletonIf,scoped,scopedIf}(X::class, Concrete::class)` — two-arg form
- `Container::{bind,bindIf,singleton,singletonIf,scoped,scopedIf}(Concrete::class)` — single-arg form
- `ContextualBindingBuilder::give(Concrete::class)` — fluent contextual binding
- `ContextualBindingBuilder::give([C1::class, C2::class])` — variadic contextual binding (Laravel's [documented typed-variadic pattern](https://laravel.com/docs/master/container#binding-typed-variadics))

it records a synthetic reference to `Concrete::__construct` via `FileReferenceProvider::addMethodReferenceToClassMember()`. The synthetic edge piggybacks on Psalm's existing `ShutdownAnalyzerTask` aggregation, so it survives fork-pool workers and reaches the parent process before `checkMethodReferences()` runs.

Out of scope by design:
- **`instance()`** receives a pre-built object whose `new` site Psalm already tracks.
- **`register()`** always targets a `ServiceProvider`, already covered by the parent-class rule.
- **Closure-as-second-arg** and **array-with-closure** forms — Psalm sees the inner `new` naturally.

A public-constructor check (`ClassLikeStorageProvider::get()` + `MethodStorage::$visibility`) guards the synthetic write, so a `private` or `protected` `__construct` on a bound class still surfaces as a real bug — Container reflection via `ReflectionClass::newInstanceArgs()` would throw at runtime.

The new handler is registered alongside `ContainerHandler` / `OffsetHandler` in `Plugin::registerHandlers()`, following the project's `require_once` pattern for psalm.phar compatibility.

### Verification

- **Type tests**: extended `tests/Type/tests/ServiceProviderTest.phpt` with a `BindingServiceProvider` whose `register()` body exercises every binding shape (two-arg, single-arg, closure, `commands([])`, nested `register()`, single `give()`, variadic `give([])`), plus an `__construct(Application $app)` override demonstrating the Item-4 parent-class suppression. `composer test:type` passes (401 tests).
- **Empirical end-to-end check**: a throwaway Laravel project with `findUnusedCode="true"` confirmed:
  - Before the patch: `PossiblyUnusedMethod` on every bound concrete's `__construct`.
  - After the patch: silenced for public constructors across all the shapes above.
  - Protected `__construct` on a bound class is still flagged.
  - `--threads=4` reproduces the suppression (worker aggregation works).
- **Self-analysis + style**: `composer psalm`, `composer cs`, `composer test:unit` all clean.

## Checklist

- [x] Tests cover the change (type test in `tests/Type/`)
