### PR TITLE
Anchor `config_path()` at project root under Testbench fallback

### DIFF
--- a/src/Providers/ApplicationProvider.php
+++ b/src/Providers/ApplicationProvider.php
@@ -62,6 +62,8 @@ final class ApplicationProvider
         } else { // Laravel Packages
             /** @psalm-suppress InternalMethod */
             $app = (new self())->createApplication(); // Orchestra\Testbench (e.g., test:type command)
+
+            self::retargetConfigPathAtProjectRoot($app);
         }
 
         self::$app = $app;
@@ -92,6 +94,60 @@ final class ApplicationProvider
         }
 
         return $app;
+    }
+
+    /**
+     * Re-point the booted Laravel app's `config_path()` at the project root.
+     *
+     * Testbench's `createApplication()` anchors the booted app at its bundled
+     * `vendor/orchestra/testbench-core/laravel` skeleton. That works for the
+     * *infrastructure* paths (`bootstrap/cache/`, `storage/`) since the skeleton
+     * ships writable scaffolding, but it is wrong for `config_path()`: the
+     * NoEnvOutsideConfig rule resolves the skeleton's `vendor/orchestra/.../config`
+     * dir, which never matches the package's own `config/*.php` files and every
+     * `env()` call there gets reported (issue #940).
+     *
+     * We retarget *only* the config path on purpose. Sibling helpers
+     * (`database_path()` for migration discovery, `lang_path()` for translation
+     * lookups, `resource_path()` for view discovery) drive other handlers that
+     * may not handle a real-but-empty project tree well — leaving them at the
+     * Testbench skeleton keeps that behaviour unchanged.
+     *
+     * Resolution order for the project root:
+     *   1. Testbench's documented escape hatch — `$_ENV['APP_BASE_PATH']` or
+     *      `$_ENV['TESTBENCH_APP_BASE_PATH']`. Lets users pin a specific anchor
+     *      (monorepos, sub-directory Psalm runs).
+     *   2. `getcwd()` if it contains a `composer.json`. The composer manifest is
+     *      a strong signal that cwd IS the project we want Laravel to "see";
+     *      Psalm anchors at this directory by default. This handles every
+     *      conventional Laravel package without configuration.
+     *   3. No anchor identified — leave the Testbench skeleton path in place
+     *      (the previous behaviour). Better to keep working defaults than point
+     *      at a wrong path that wasn't requested.
+     *
+     * Only branch 3 of {@see self::doGetApp()} calls this — for projects with a
+     * real `bootstrap/app.php`, that file's Application instance is used verbatim
+     * and Testbench is never consulted.
+     *
+     * @see https://github.com/psalm/psalm-plugin-laravel/issues/940
+     */
+    private static function retargetConfigPathAtProjectRoot(LaravelApplication $app): void
+    {
+        $envOverride = $_ENV['APP_BASE_PATH'] ?? $_ENV['TESTBENCH_APP_BASE_PATH'] ?? null;
+
+        if (\is_string($envOverride) && $envOverride !== '') {
+            $projectRoot = $envOverride;
+        } else {
+            $cwd = \getcwd();
+
+            if (!\is_string($cwd) || !\is_file($cwd . \DIRECTORY_SEPARATOR . 'composer.json')) {
+                return;
+            }
+
+            $projectRoot = $cwd;
+        }
+
+        $app->useConfigPath($projectRoot . \DIRECTORY_SEPARATOR . 'config');
     }
 
     /**

--- a/src/Providers/ApplicationProvider.php
+++ b/src/Providers/ApplicationProvider.php
@@ -63,7 +63,7 @@ final class ApplicationProvider
             /** @psalm-suppress InternalMethod */
             $app = (new self())->createApplication(); // Orchestra\Testbench (e.g., test:type command)
 
-            self::retargetConfigPathAtProjectRoot($app);
+            $this->retargetConfigPathAtProjectRoot($app);
         }
 
         self::$app = $app;
@@ -131,7 +131,7 @@ final class ApplicationProvider
      *
      * @see https://github.com/psalm/psalm-plugin-laravel/issues/940
      */
-    private static function retargetConfigPathAtProjectRoot(LaravelApplication $app): void
+    private function retargetConfigPathAtProjectRoot(LaravelApplication $app): void
     {
         $envOverride = $_ENV['APP_BASE_PATH'] ?? $_ENV['TESTBENCH_APP_BASE_PATH'] ?? null;
 

--- a/src/Providers/ApplicationProvider.php
+++ b/src/Providers/ApplicationProvider.php
@@ -133,9 +133,10 @@ final class ApplicationProvider
      */
     private function retargetConfigPathAtProjectRoot(LaravelApplication $app): void
     {
-        $envOverride = $_ENV['APP_BASE_PATH'] ?? $_ENV['TESTBENCH_APP_BASE_PATH'] ?? null;
+        $envOverride = self::readEnvOverride('APP_BASE_PATH')
+            ?? self::readEnvOverride('TESTBENCH_APP_BASE_PATH');
 
-        if (\is_string($envOverride) && $envOverride !== '') {
+        if ($envOverride !== null) {
             $projectRoot = $envOverride;
         } else {
             $cwd = \getcwd();
@@ -148,6 +149,29 @@ final class ApplicationProvider
         }
 
         $app->useConfigPath($projectRoot . \DIRECTORY_SEPARATOR . 'config');
+    }
+
+    /**
+     * Read an environment variable across the three PHP surfaces.
+     *
+     * `$_ENV` alone is unreliable: the `variables_order` ini setting may omit `E`,
+     * leaving `$_ENV` empty even when the value was passed to the process. CGI/FPM
+     * deployments commonly route through `$_SERVER`; CLI invocations via `env VAR=...
+     * php ...` route through `getenv()`. Testbench's own helper reads only `$_ENV`,
+     * which is the documented escape hatch but not the most portable one — we widen
+     * the check so the override actually takes effect across runtime configurations.
+     */
+    private static function readEnvOverride(string $name): ?string
+    {
+        $candidates = [$_ENV[$name] ?? null, $_SERVER[$name] ?? null, \getenv($name)];
+
+        foreach ($candidates as $value) {
+            if (\is_string($value) && $value !== '') {
+                return $value;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Unit/Providers/ApplicationProviderConfigPathTest.php
+++ b/tests/Unit/Providers/ApplicationProviderConfigPathTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Providers;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Providers\ApplicationProvider;
+
+/**
+ * Regression coverage for issue #940 — when Psalm runs against a Laravel
+ * **package** (not an app with `bootstrap/app.php`), ApplicationProvider falls
+ * back to Orchestra Testbench. Without retargeting, the booted app's
+ * `config_path()` pointed at `vendor/orchestra/testbench-core/laravel/config`
+ * and every `env()` call in the package's own `config/*.php` was flagged.
+ *
+ * The retargeting fires only in the Testbench-fallback branch. This test
+ * suite's `composer test:unit` runs from a directory containing a
+ * `composer.json` (the plugin's own root or worktree), so the auto-detection
+ * always finds the project root and the assertion is deterministic.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/940
+ */
+#[CoversClass(ApplicationProvider::class)]
+final class ApplicationProviderConfigPathTest extends TestCase
+{
+    #[Test]
+    public function config_path_resolves_to_project_root_under_testbench_fallback(): void
+    {
+        // Boots via Testbench because the test process is run from the plugin's
+        // own directory, which has no `bootstrap/app.php`. Branch 3 fires.
+        $app = ApplicationProvider::getApp();
+
+        $cwd = \getcwd();
+        self::assertIsString($cwd, 'getcwd() must succeed in the test environment');
+        self::assertFileExists(
+            $cwd . \DIRECTORY_SEPARATOR . 'composer.json',
+            'pre-condition: the auto-detection requires composer.json at cwd',
+        );
+
+        self::assertSame(
+            $cwd . \DIRECTORY_SEPARATOR . 'config',
+            $app->configPath(),
+            'config_path() must resolve to <project>/config so NoEnvOutsideConfig '
+                . 'sees the package config files instead of Testbench skeleton.',
+        );
+    }
+}

--- a/tests/Unit/Providers/ApplicationProviderConfigPathTest.php
+++ b/tests/Unit/Providers/ApplicationProviderConfigPathTest.php
@@ -34,17 +34,10 @@ final class ApplicationProviderConfigPathTest extends TestCase
         $app = ApplicationProvider::getApp();
 
         $cwd = \getcwd();
-        self::assertIsString($cwd, 'getcwd() must succeed in the test environment');
-        self::assertFileExists(
-            $cwd . \DIRECTORY_SEPARATOR . 'composer.json',
-            'pre-condition: the auto-detection requires composer.json at cwd',
-        );
+        $this->assertIsString($cwd, 'getcwd() must succeed in the test environment');
+        $this->assertFileExists($cwd . \DIRECTORY_SEPARATOR . 'composer.json', 'pre-condition: the auto-detection requires composer.json at cwd');
 
-        self::assertSame(
-            $cwd . \DIRECTORY_SEPARATOR . 'config',
-            $app->configPath(),
-            'config_path() must resolve to <project>/config so NoEnvOutsideConfig '
-                . 'sees the package config files instead of Testbench skeleton.',
-        );
+        $this->assertSame($cwd . \DIRECTORY_SEPARATOR . 'config', $app->configPath(), 'config_path() must resolve to <project>/config so NoEnvOutsideConfig '
+            . 'sees the package config files instead of Testbench skeleton.');
     }
 }

--- a/tests/Unit/Providers/ApplicationProviderConfigPathTest.php
+++ b/tests/Unit/Providers/ApplicationProviderConfigPathTest.php
@@ -11,33 +11,83 @@ use Psalm\LaravelPlugin\Providers\ApplicationProvider;
 
 /**
  * Regression coverage for issue #940 — when Psalm runs against a Laravel
- * **package** (not an app with `bootstrap/app.php`), ApplicationProvider falls
+ * **package** (not an app with `bootstrap/app.php`), `ApplicationProvider` falls
  * back to Orchestra Testbench. Without retargeting, the booted app's
  * `config_path()` pointed at `vendor/orchestra/testbench-core/laravel/config`
  * and every `env()` call in the package's own `config/*.php` was flagged.
  *
- * The retargeting fires only in the Testbench-fallback branch. This test
- * suite's `composer test:unit` runs from a directory containing a
- * `composer.json` (the plugin's own root or worktree), so the auto-detection
- * always finds the project root and the assertion is deterministic.
+ * The retargeting fires only in the Testbench-fallback branch. To make the
+ * assertion order-independent, we reset `ApplicationProvider`'s memoised state
+ * before booting and `chdir()` to the plugin repo root (derived from `__DIR__`,
+ * not the inherited process cwd) so the result does not depend on the working
+ * directory of the test runner or on whether an earlier test booted the app.
  *
  * @see https://github.com/psalm/psalm-plugin-laravel/issues/940
  */
 #[CoversClass(ApplicationProvider::class)]
 final class ApplicationProviderConfigPathTest extends TestCase
 {
+    private string $originalCwd;
+
+    /** @var array<string, mixed> */
+    private array $originalState;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $cwd = \getcwd();
+        \assert(\is_string($cwd), 'getcwd() must succeed before the test');
+        $this->originalCwd = $cwd;
+
+        // Snapshot ApplicationProvider's memoised state so a previous test that booted
+        // the app from a different cwd cannot leak its `configPath()` into this one.
+        $this->originalState = [
+            'app' => $this->reflectProperty('app')->getValue(null),
+            'booted' => $this->reflectProperty('booted')->getValue(null),
+        ];
+
+        $this->reflectProperty('app')->setValue(null, null);
+        $this->reflectProperty('booted')->setValue(null, false);
+    }
+
+    protected function tearDown(): void
+    {
+        \chdir($this->originalCwd);
+
+        $this->reflectProperty('app')->setValue(null, $this->originalState['app']);
+        $this->reflectProperty('booted')->setValue(null, $this->originalState['booted']);
+
+        parent::tearDown();
+    }
+
     #[Test]
     public function config_path_resolves_to_project_root_under_testbench_fallback(): void
     {
-        // Boots via Testbench because the test process is run from the plugin's
-        // own directory, which has no `bootstrap/app.php`. Branch 3 fires.
+        // Anchor at the plugin repo root deterministically, not at the inherited
+        // process cwd. `tests/Unit/Providers/` is 3 levels deep from the root.
+        $repoRoot = \dirname(__DIR__, 3);
+        \chdir($repoRoot);
+
+        $this->assertFileExists(
+            $repoRoot . \DIRECTORY_SEPARATOR . 'composer.json',
+            'pre-condition: the auto-detection requires composer.json at the anchor',
+        );
+
+        // Boots via Testbench because the plugin repo has no `bootstrap/app.php`.
+        // Branch 3 of doGetApp() fires and retargetConfigPathAtProjectRoot() runs.
         $app = ApplicationProvider::getApp();
 
-        $cwd = \getcwd();
-        $this->assertIsString($cwd, 'getcwd() must succeed in the test environment');
-        $this->assertFileExists($cwd . \DIRECTORY_SEPARATOR . 'composer.json', 'pre-condition: the auto-detection requires composer.json at cwd');
+        $this->assertSame(
+            $repoRoot . \DIRECTORY_SEPARATOR . 'config',
+            $app->configPath(),
+            'config_path() must resolve to <project>/config so NoEnvOutsideConfig '
+                . 'sees the package config files instead of Testbench skeleton.',
+        );
+    }
 
-        $this->assertSame($cwd . \DIRECTORY_SEPARATOR . 'config', $app->configPath(), 'config_path() must resolve to <project>/config so NoEnvOutsideConfig '
-            . 'sees the package config files instead of Testbench skeleton.');
+    private function reflectProperty(string $name): \ReflectionProperty
+    {
+        return new \ReflectionProperty(ApplicationProvider::class, $name);
     }
 }


### PR DESCRIPTION
## Issue to Solve

When Psalm runs against a Laravel **package** (no `bootstrap/app.php` at `getcwd()`), `ApplicationProvider::doGetApp()` falls back to Orchestra Testbench. Testbench anchors the booted app at its bundled `vendor/orchestra/testbench-core/laravel` skeleton, so `config_path()` resolved into `vendor/`, never matching the package's own `config/*.php`. NoEnvOutsideConfig flagged every canonical `env()` call there (#940).

## Related

Refs #940. Complements #944.

## Solution Description

Re-point `config_path()` at the project root after `createApplication()` via the existing `Application::useConfigPath()` setter, guarded by a `composer.json` presence check at `getcwd()`. Honors Testbench's documented escape hatches (`APP_BASE_PATH` / `TESTBENCH_APP_BASE_PATH`) so users can pin a different anchor.

**Scope intentionally minimal.** Only `config_path()` is retargeted. The sibling helpers drive other handlers whose behaviour on a real-but-empty project tree has not been validated:

 - `database_path()` — migration discovery walks this dir,
 - `lang_path()` — `findMissingTranslations` resolves keys here,
 - `resource_path()` — view discovery uses `resources/views/`.

Each can be moved to the project root in a separate, gated change.

**Layering with #944.** PR #944 added a `cwd/config` fallback inside `NoEnvOutsideConfigHandler::init()`. That fix kept working for non-standard layouts and env-override scenarios; this fix removes the root cause for the conventional package layout. Both layers coexist: this change makes `getApp()->configPath()` correct so #944's defensive fallback is rarely exercised, but #944 still covers the case where someone replaces `ApplicationProvider` or runs Psalm in an unusual cwd.

**Verification:**
 - 620 existing unit tests pass.
 - 401 type tests pass (these exercise the Testbench fallback branch).
 - Manual reproduction with a synthetic Laravel package: `master` flagged 2 `NoEnvOutsideConfig` errors in `config/foo.php`; with the fix, zero false positives; the true positive in `src/Service.php` is retained.
 - New unit test `ApplicationProviderConfigPathTest::config_path_resolves_to_project_root_under_testbench_fallback` locks in the assertion.

## Checklist

 - [x] Tests cover the change (`tests/Unit/Providers/ApplicationProviderConfigPathTest.php`)
