### PR TITLE
fix(stubs): resolve Carbon cascade + narrow dual-purpose method returns #922

### DIFF
--- a/src/Providers/CarbonStubProvider.php
+++ b/src/Providers/CarbonStubProvider.php
@@ -60,8 +60,19 @@ final class CarbonStubProvider
         ];
 
         foreach ($lazyStubs as $stub) {
-            if (\is_file($stub)) {
-                $registration->addStubFile($stub);
+            $realPath = \realpath($stub);
+
+            if ($realPath !== false) {
+                // realpath() is load-bearing. InstalledVersions::getInstallPath() can return
+                // a path containing `..` segments (e.g. `vendor/composer/../nesbot/carbon`).
+                // When Psalm scans the stub it hits `if (!class_exists(X)) { class X {} }`,
+                // calls PHP's class_exists (which returns true because earlier plugin boot
+                // autoloaded Carbon\CarbonPeriod, whose top-level `require` already declared
+                // X), and compares ReflectionClass::getFileName() to the stub's $file_path.
+                // If those paths differ only by `..` normalisation, Psalm assumes the class
+                // lives elsewhere, sets skip_if_descendants, and the guarded class declaration
+                // is silently dropped. Downstream code then sees MissingDependency. See #922.
+                $registration->addStubFile($realPath);
             } else {
                 $output->warning(
                     "Laravel plugin: Carbon lazy stub not found at '{$stub}'. "

--- a/stubs/common/Carbon/CarbonInterface.phpstub
+++ b/stubs/common/Carbon/CarbonInterface.phpstub
@@ -1,0 +1,62 @@
+<?php
+
+namespace Carbon;
+
+use Carbon\Constants\DiffOptions;
+use Carbon\Constants\Format;
+use Carbon\Constants\TranslationOptions;
+use Carbon\Constants\UnitValue;
+use DateTimeInterface;
+use DateTimeZone;
+use JsonSerializable;
+
+/**
+ * Narrow Carbon's dual-purpose getter/setter methods to conditional return
+ * types when callers are typed on `CarbonInterface` rather than the concrete
+ * `Carbon` / `CarbonImmutable` classes. The same narrowing for concrete-typed
+ * callers lives in `Carbon\Traits\Date.phpstub` and
+ * `Carbon\Traits\Localization.phpstub` — interface docblocks do not propagate
+ * down to trait method definitions, so the conditional return must be repeated
+ * at both layers.
+ *
+ * Class redeclaration wipes `class_implements` / `parent_interfaces` (CLAUDE.md),
+ * so the full `extends` clause is copied verbatim from
+ * vendor/nesbot/carbon/src/Carbon/CarbonInterface.php:858. Methods not
+ * redeclared here continue to come from reflection of the real interface.
+ */
+interface CarbonInterface extends DateTimeInterface, JsonSerializable, DiffOptions, Format, TranslationOptions, UnitValue
+{
+    /**
+     * @param WeekDay|int|null $value new value for weekday if using as setter
+     *
+     * @return ($value is null ? int<1, 7> : static)
+     */
+    public function isoWeekday(WeekDay|int|null $value = null): static|int;
+
+    /**
+     * @param WeekDay|int|null $value new value for weekday if using as setter
+     *
+     * @return ($value is null ? int<0, 6> : static)
+     */
+    public function weekday(WeekDay|int|null $value = null): static|int;
+
+    /**
+     * @return ($value is null ? int<1, 366> : static)
+     */
+    public function dayOfYear(?int $value = null): static|int;
+
+    /**
+     * @return ($minuteOffset is null ? int : static)
+     */
+    public function utcOffset(?int $minuteOffset = null): static|int;
+
+    /**
+     * @return ($value is null ? string : static)
+     */
+    public function tz(DateTimeZone|string|int|null $value = null): static|string;
+
+    /**
+     * @return ($locale is null ? string : static)
+     */
+    public function locale(?string $locale = null, string ...$fallbackLocales): static|string;
+}

--- a/stubs/common/Carbon/CarbonPeriod.phpstub
+++ b/stubs/common/Carbon/CarbonPeriod.phpstub
@@ -1,0 +1,56 @@
+<?php
+
+namespace Carbon;
+
+use Carbon\Constants\UnitValue;
+use Carbon\Traits\IntervalRounding;
+use Carbon\Traits\LocalFactory;
+use Carbon\Traits\Mixin;
+use Carbon\Traits\Options;
+use Carbon\Traits\ToStringFormat;
+use Countable;
+use JsonSerializable;
+
+/**
+ * Real signature in vendor/nesbot/carbon/src/Carbon/CarbonPeriod.php:329 is
+ * `public function getIterator(): Generator` with no template — Psalm widens
+ * the yield to `mixed`, which collapses `collect(CarbonPeriod::create(...))`
+ * to `Collection<int, mixed>`. CarbonPeriod's own `current(): ?CarbonInterface`
+ * and `key(): ?int` accessors prove the iterator yields `int => CarbonInterface`
+ * once `valid()` gates it.
+ *
+ * `@implements IteratorAggregate<int, CarbonInterface>` is what `collect()` /
+ * `foreach` actually read to bind the iterable template; the `getIterator`
+ * stub is a backstop for callers that introspect the return type directly.
+ *
+ * `\IteratorAggregate` MUST appear in the explicit `implements` clause here,
+ * not just inherit through `DatePeriodBase → \DatePeriod`. Psalm's
+ * `ClassLikeNodeScanner::implementTemplatedType()` validates `@implements`
+ * against `class_implements` at scan time, *before* parent-storage merging,
+ * and silently rejects the template binding with `InvalidDocblock` if the
+ * interface is not already listed.
+ *
+ * Class declaration redeclaration wipes `class_implements` (CLAUDE.md), so
+ * the `extends` / `implements` / `use` clauses are copied verbatim from
+ * Carbon source. Methods not redeclared here continue to come from
+ * reflection of the real class.
+ *
+ * @implements \IteratorAggregate<int, CarbonInterface>
+ */
+class CarbonPeriod extends DatePeriodBase implements Countable, JsonSerializable, UnitValue, \IteratorAggregate
+{
+    use LocalFactory;
+    use IntervalRounding;
+    use Mixin {
+        Mixin::mixin as baseMixin;
+    }
+    use Options {
+        Options::__debugInfo as baseDebugInfo;
+    }
+    use ToStringFormat;
+
+    /**
+     * @return \Generator<int, CarbonInterface>
+     */
+    public function getIterator(): \Generator {}
+}

--- a/stubs/common/Carbon/Traits/Date.phpstub
+++ b/stubs/common/Carbon/Traits/Date.phpstub
@@ -1,0 +1,48 @@
+<?php
+
+namespace Carbon\Traits;
+
+use Carbon\WeekDay;
+use DateTimeZone;
+
+/**
+ * Narrow Carbon's dual-purpose getter/setter trait methods to conditional
+ * return types. Carbon's source declares unions like `static|int` because
+ * each method does double duty: `null` (default) acts as a getter returning
+ * the unit, any non-null value acts as a setter returning a new instance.
+ *
+ * Stubbing at the trait level propagates the narrowing to every class that
+ * uses the trait (Carbon, CarbonImmutable) without duplicating the
+ * declarations per concrete class.
+ */
+trait Date
+{
+    /**
+     * @param WeekDay|int|null $value new value for weekday if using as setter
+     *
+     * @return ($value is null ? int<1, 7> : static)
+     */
+    public function isoWeekday(WeekDay|int|null $value = null): static|int {}
+
+    /**
+     * @param WeekDay|int|null $value new value for weekday if using as setter
+     *
+     * @return ($value is null ? int<0, 6> : static)
+     */
+    public function weekday(WeekDay|int|null $value = null): static|int {}
+
+    /**
+     * @return ($value is null ? int<1, 366> : static)
+     */
+    public function dayOfYear(?int $value = null): static|int {}
+
+    /**
+     * @return ($minuteOffset is null ? int : static)
+     */
+    public function utcOffset(?int $minuteOffset = null): static|int {}
+
+    /**
+     * @return ($value is null ? string : static)
+     */
+    public function tz(DateTimeZone|string|int|null $value = null): static|string {}
+}

--- a/stubs/common/Carbon/Traits/Localization.phpstub
+++ b/stubs/common/Carbon/Traits/Localization.phpstub
@@ -1,0 +1,20 @@
+<?php
+
+namespace Carbon\Traits;
+
+/**
+ * Narrow `locale()` to a conditional return type. Carbon's source declares
+ * `static|string` because the method does double duty: `null` (default)
+ * acts as a getter returning the current locale, any non-null value acts as
+ * a setter returning `$this`.
+ *
+ * See `Carbon\Traits\Date.phpstub` for the broader rationale on stubbing at
+ * the trait level.
+ */
+trait Localization
+{
+    /**
+     * @return ($locale is null ? string : static)
+     */
+    public function locale(?string $locale = null, string ...$fallbackLocales): static|string {}
+}

--- a/tests/Type/tests/CarbonIsoWeekdayInterfaceTest.phpt
+++ b/tests/Type/tests/CarbonIsoWeekdayInterfaceTest.phpt
@@ -1,0 +1,28 @@
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Same narrowing as `CarbonIsoWeekdayTest.phpt`, but the variable is typed on
+ * `Carbon\CarbonInterface` so the stubs on the interface (not the concrete
+ * Carbon / CarbonImmutable classes) are what's load-bearing.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/922
+ */
+
+use Carbon\CarbonInterface;
+
+function via_iface(CarbonInterface $c): int
+{
+    $dow = $c->isoWeekday();
+    /** @psalm-check-type-exact $dow = int<1, 7> */
+    return $dow;
+}
+
+function set_via_iface(CarbonInterface $c): CarbonInterface
+{
+    $monday = $c->isoWeekday(1);
+    /** @psalm-check-type-exact $monday = \Carbon\CarbonInterface&static */
+    return $monday;
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/CarbonIsoWeekdayTest.phpt
+++ b/tests/Type/tests/CarbonIsoWeekdayTest.phpt
@@ -1,0 +1,27 @@
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Carbon's `CarbonInterface::isoWeekday()` is dual-purpose:
+ *   - `null` (default) → returns ISO weekday `int<1, 7>` (1=Monday..7=Sunday).
+ *   - any other value  → returns a new `static` instance set to that weekday.
+ *
+ * Source declares the union `static|int` so the type narrowing belongs in a
+ * stub.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/922
+ */
+
+use Carbon\Carbon;
+use Carbon\WeekDay;
+
+$_dow = Carbon::now()->isoWeekday();
+/** @psalm-check-type-exact $_dow = int<1, 7> */
+
+$_mondayInt = Carbon::now()->isoWeekday(1);
+/** @psalm-check-type-exact $_mondayInt = \Carbon\Carbon&static */
+
+$_mondayEnum = Carbon::now()->isoWeekday(WeekDay::Monday);
+/** @psalm-check-type-exact $_mondayEnum = \Carbon\Carbon&static */
+?>
+--EXPECTF--

--- a/tests/Type/tests/CarbonPeriodCollectTest.phpt
+++ b/tests/Type/tests/CarbonPeriodCollectTest.phpt
@@ -1,0 +1,27 @@
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Regression for issue #922 — two related defects covered in one expression:
+ *
+ *  1. `MissingDependency` cascade: `Carbon\DatePeriodBase` is declared via
+ *     runtime `require` from `vendor/nesbot/carbon/lazy/`, outside Carbon's
+ *     composer autoload. `CarbonStubProvider` registers Carbon's own lazy
+ *     file as a stub; without it `CarbonPeriod::create()` collapses to
+ *     `never` and every consumer surfaces as dead code.
+ *
+ *  2. `Collection<int, mixed>` widening: Carbon's `CarbonPeriod::getIterator()`
+ *     returns untemplated `Generator`, so Psalm cannot resolve the iterable
+ *     yield type. `stubs/common/Carbon/CarbonPeriod.phpstub` pins
+ *     `@implements IteratorAggregate<int, CarbonInterface>` so `collect()`
+ *     binds `TValue = CarbonInterface`.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/922
+ */
+
+use Carbon\CarbonPeriod;
+
+$_dates = collect(CarbonPeriod::create('2026-01-01', '2026-01-10'));
+/** @psalm-check-type-exact $_dates = \Illuminate\Support\Collection<int, \Carbon\CarbonInterface> */
+?>
+--EXPECTF--


### PR DESCRIPTION
## Summary

Closes #922.

Two layers of Carbon-specific improvements bundled in one PR.

## 1. `CarbonStubProvider` path canonicalisation (the root-cause fix for #922)

`CarbonStubProvider` passed `InstalledVersions::getInstallPath('nesbot/carbon')` straight into `RegistrationInterface::addStubFile()`. Composer returns that path with a `..` segment (e.g. `vendor/composer/../nesbot/carbon`), but PHP's `ReflectionClass::getFileName()` returns the canonical realpath.

When Psalm's stub scanner reaches `if (!class_exists(DatePeriodBase::class, false))` inside Carbon's lazy file:

1. Plugin's `ApplicationProvider::bootApp()` has already autoloaded `Carbon\CarbonPeriod`, whose top-level `require` declared `DatePeriodBase` at PHP runtime, so `class_exists()` returns `true`.
2. `ExpressionResolver::enterConditional()` compares the reflected file name against the scanner's `$file_path`. The `..` segment makes them differ.
3. Psalm treats the class as "declared elsewhere", returns `true`, the surrounding `BooleanNot` flips it to `false`, and `ReflectorVisitor` sets `skip_if_descendants` — the guarded `class DatePeriodBase {}` declaration is silently dropped.
4. `CarbonPeriod`'s `extends DatePeriodBase` stays as `invalid_dependency` and downstream callers see `MissingDependency` plus cascading `MixedAssignment` / `RawObjectIteration` errors.

`CarbonStubProvider` has shipped since v4.8.4 but has been silently ineffective for every real-world Laravel app where the plugin's Testbench boot eagerly loads `CarbonPeriod`.

**Fix:** `realpath()` the path before `addStubFile()` so the string comparison matches.

## 2. Conditional return types for dual-purpose Carbon methods

Carbon declares several methods as `static|int` or `static|string` unions because they double as getters and setters: passing `null` (default) acts as a getter returning the unit, any non-null value acts as a setter returning a new instance. Callers see the raw union.

New stubs pin a conditional return for six methods (trait + interface, since interface docblocks do not propagate to trait method definitions in Psalm):

| Method | Getter (null arg) | Setter (non-null) |
|---|---|---|
| `isoWeekday` | `int<1, 7>` | `static` |
| `weekday` | `int<0, 6>` | `static` |
| `dayOfYear` | `int<1, 366>` | `static` |
| `utcOffset` | `int` | `static` |
| `tz` | `string` | `static` |
| `locale` | `string` | `static` |

`stubs/common/Carbon/CarbonPeriod.phpstub` is also kept (separate, added in commit 1): even with `DatePeriodBase` resolved, Carbon's untemplated `getIterator(): Generator` collapses `collect(CarbonPeriod::create(...))` to `Collection<int, mixed>`. The stub pins `@implements IteratorAggregate<int, CarbonInterface>`.

## Real-world impact (IxDF/people-and-culture)

The codebase that filed #922. Before and after running the worktree plugin against it:

| File | Line | Issue | Master | This PR |
|---|---|---|:-:|:-:|
| `IndividualDailyUpdateReportGenerator.php` | 68 | `MissingDependency: carbon\dateperiodbase` | ✓ | gone |
| same | 70 | `ParadoxicalCondition` | ✓ | gone |
| same | 76 | `NoValue` | ✓ | gone |
| `TeamDailyUpdateReportGenerator.php` | 85 | `MissingDependency: carbon\dateperiodbase` | ✓ | gone |
| same | 89 | `ParadoxicalCondition` | ✓ | gone |
| same | 94 | `NoValue` | ✓ | gone |
| `NullUpdateDTO.php` | 28 | `InvalidCast: CarbonInterface&static cannot be cast to int` | ✓ | gone |

7 → 0 errors. The `InvalidCast` was unattributed in #922 but turned out to be the same union-vs-conditional problem — `(int) $date->isoWeekday()` widened to `(int) (CarbonInterface&static\|int)` before the conditional return stub.

## Regression tests

- `tests/Type/tests/CarbonPeriodCollectTest.phpt` — covers cascade + iterator narrowing on `collect(CarbonPeriod::create(...))`.
- `tests/Type/tests/CarbonIsoWeekdayTest.phpt` — concrete `Carbon::now()->isoWeekday(...)` narrowing.
- `tests/Type/tests/CarbonIsoWeekdayInterfaceTest.phpt` — `CarbonInterface`-typed callers (verifies the interface-layer stub is load-bearing).

Each defect (realpath fix, conditional return on trait, conditional return on interface, IteratorAggregate template) was empirically validated by reverting it independently and watching the corresponding test fail.

## Layering note

The Carbon-specific work in this PR is architecturally wrong for `psalm-plugin-laravel`: Carbon is used outside Laravel and the conditional-return narrowing has nothing to do with Laravel's behaviour. Shipping it here is a pragmatic stopgap because most affected Carbon-on-Psalm users are also Laravel users today.

Long-term home should be one of:

1. **Upstream Carbon.** Add `@psalm-return`/`@phpstan-return` conditional returns to the six dual-purpose methods (PHPStan honours the same syntax). Either move `lazy/Carbon/*.php` into PSR-4 `src/` or ship a Psalm equivalent of Carbon's `extension.neon` bootstrap. Single fix benefits every framework.
2. **A dedicated `psalm/plugin-carbon`.** Mirror of `phpstan/phpstan-symfony`. `psalm-plugin-laravel` would suggest or soft-depend on it.
3. **Upstream Psalm.** Path normalisation in `ExpressionResolver::enterConditional` is a Psalm defect — affects every plugin that hits the autoload-order race against `if (!class_exists())` polyfill blocks (Symfony polyfills, PHP-version polyfills, etc.), not just Carbon.

Treat this PR as the workaround layer with a known sunset path.