### PR TITLE
Resolve vendor facades and `app()` aliases via static provider harvest

### DIFF
--- a/src/Handlers/Facades/AppFacadeRegistrationHandler.php
+++ b/src/Handlers/Facades/AppFacadeRegistrationHandler.php
@@ -6,6 +6,7 @@ namespace Psalm\LaravelPlugin\Handlers\Facades;
 
 use Illuminate\Support\Facades\Facade;
 use Psalm\Codebase;
+use Psalm\LaravelPlugin\Providers\ContainerBindingMapProvider;
 use Psalm\LaravelPlugin\Util\AnonymousClassNameDetector;
 use Psalm\Plugin\EventHandler\AfterClassLikeVisitInterface;
 use Psalm\Plugin\EventHandler\AfterCodebasePopulatedInterface;
@@ -185,21 +186,40 @@ final class AppFacadeRegistrationHandler implements AfterClassLikeVisitInterface
      */
     public static function tryGetFacadeRootClass(string $facadeClass, ?Progress $progress = null): ?string
     {
-        // $failedFacades gates both the short-circuit return AND the warning emission,
-        // so each failure reason is surfaced to the user exactly once per facade across
-        // scan-phase + populate-phase invocations (issue #787: silent losses of method
-        // resolution must be visible, not swallowed by the default progress sink).
-        if (isset(self::$failedFacades[$facadeClass])) {
-            return null;
-        }
-
         // is_subclass_of() invokes the autoloader; guard per FacadeMapProvider::init().
         try {
             if (!\is_subclass_of($facadeClass, Facade::class)) {
-                self::$failedFacades[$facadeClass] = true;
-                $progress?->warning(
-                    "Laravel plugin: skipping facade '{$facadeClass}': not a subclass of " . Facade::class,
-                );
+                if (!isset(self::$failedFacades[$facadeClass])) {
+                    self::$failedFacades[$facadeClass] = true;
+                    $progress?->warning(
+                        "Laravel plugin: skipping facade '{$facadeClass}': not a subclass of " . Facade::class,
+                    );
+                }
+                return null;
+            }
+
+            // Short-circuit via the statically-harvested binding map before the runtime
+            // probe. For facades whose accessor is a string alias bound by a vendor or
+            // user provider that doesn't run inside Testbench, `Facade::getFacadeRoot()`
+            // throws `BindingResolutionException` and the existing flow emits a warning
+            // on every Psalm run (issue #942). The map is populated at plugin init by
+            // {@see \Psalm\LaravelPlugin\Providers\BootTimeProviderHarvester}.
+            //
+            // Map lookup must happen BEFORE the `$failedFacades` short-circuit. Both this
+            // method and its populate-phase caller may run after a scan-phase invocation
+            // already tripped the runtime probe; reading the map first lets a later call
+            // succeed once the map answer arrives, instead of being permanently poisoned
+            // by the earlier failure (the regression that motivated reordering this gate).
+            $mappedRoot = self::resolveViaBindingMap($facadeClass);
+            if ($mappedRoot !== null) {
+                return $mappedRoot;
+            }
+
+            // $failedFacades gates both the short-circuit return AND the warning emission,
+            // so each failure reason is surfaced to the user exactly once per facade across
+            // scan-phase + populate-phase invocations (issue #787: silent losses of method
+            // resolution must be visible, not swallowed by the default progress sink).
+            if (isset(self::$failedFacades[$facadeClass])) {
                 return null;
             }
 
@@ -224,6 +244,44 @@ final class AppFacadeRegistrationHandler implements AfterClassLikeVisitInterface
             );
             return null;
         }
+    }
+
+    /**
+     * Resolve the facade's underlying class via the statically-harvested binding map
+     * populated at plugin boot by {@see \Psalm\LaravelPlugin\Providers\BootTimeProviderHarvester}.
+     *
+     * Calls `getFacadeAccessor()` reflectively (it is `protected static` on `Facade`),
+     * looks the returned alias up in `ContainerBindingMapProvider`, returns the mapped
+     * service class. All failure modes (non-existent method, non-string return, missing
+     * mapping, reflection error) collapse to null so the caller falls through to the
+     * runtime probe — this path is a silent enrichment, not a hard authority.
+     *
+     * `getFacadeAccessor()` is documented (by Laravel) to be deterministic and free of
+     * container access, so calling it has no side effects in practice. Wrapping in
+     * `Throwable` is defensive against subclasses that override the contract.
+     *
+     * @param class-string $facadeClass
+     * @return ?class-string
+     */
+    private static function resolveViaBindingMap(string $facadeClass): ?string
+    {
+        try {
+            $reflection = new \ReflectionMethod($facadeClass, 'getFacadeAccessor');
+        } catch (\ReflectionException) {
+            return null;
+        }
+
+        try {
+            $accessor = $reflection->invoke(null);
+        } catch (\Throwable) {
+            return null;
+        }
+
+        if (!\is_string($accessor) || $accessor === '') {
+            return null;
+        }
+
+        return ContainerBindingMapProvider::lookup($accessor);
     }
 
     /**

--- a/src/Handlers/Facades/AppFacadeRegistrationHandler.php
+++ b/src/Handlers/Facades/AppFacadeRegistrationHandler.php
@@ -195,6 +195,7 @@ final class AppFacadeRegistrationHandler implements AfterClassLikeVisitInterface
                         "Laravel plugin: skipping facade '{$facadeClass}': not a subclass of " . Facade::class,
                     );
                 }
+
                 return null;
             }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Application;
 use Psalm\Internal\Analyzer\ProjectAnalyzer;
 use Psalm\LaravelPlugin\Providers\AliasStubProvider;
 use Psalm\LaravelPlugin\Providers\ApplicationProvider;
+use Psalm\LaravelPlugin\Providers\BootTimeProviderHarvester;
 use Psalm\LaravelPlugin\Providers\CarbonStubProvider;
 use Psalm\LaravelPlugin\Providers\FacadeMapProvider;
 use Psalm\LaravelPlugin\Providers\SchemaStateProvider;
@@ -40,6 +41,16 @@ final class Plugin implements PluginEntryPointInterface
             // Handlers use FacadeMapProvider::getFacadeClasses() in getClassLikeNames()
             // to also register for facade/alias classes that proxy to their service.
             FacadeMapProvider::init($output);
+
+            // Statically parse every discoverable `ServiceProvider::register()` (and
+            // sibling methods) to extract accessor → service-class bindings, so the
+            // Facade resolver (issue #942) and `app('alias')` resolver (issue #766)
+            // can answer correctly without depending on Testbench having booted the
+            // vendor/user provider. Must run in the main process, before scan/analysis
+            // forks, so the populated map propagates via copy-on-write to every worker —
+            // see BootTimeProviderHarvester docblock for why an `AfterClassLikeVisit`
+            // hook would not work here.
+            BootTimeProviderHarvester::harvestAll($output);
 
             // Always called — provides type narrowing (string vs array) regardless
             // of whether findMissingTranslations is enabled

--- a/src/Providers/BootTimeProviderHarvester.php
+++ b/src/Providers/BootTimeProviderHarvester.php
@@ -7,7 +7,6 @@ namespace Psalm\LaravelPlugin\Providers;
 use PhpParser\Node\ArrayItem;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ClassConstFetch;
-use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
@@ -192,7 +191,7 @@ final class BootTimeProviderHarvester
         $resolved = $traverser->traverse($stmts);
 
         $classNode = self::findClassNode($resolved, $providerFqcn);
-        if ($classNode === null) {
+        if (!$classNode instanceof \PhpParser\Node\Stmt\Class_) {
             // Warning, not debug: reflection said this class lives in this file and the
             // parser successfully parsed the file, yet `findClassNode` cannot find it.
             // The only plausible causes are a stale autoloader pointing at the wrong
@@ -217,13 +216,7 @@ final class BootTimeProviderHarvester
      */
     private static function collectProviderFqcns(array $extraProviders, Progress $progress): array
     {
-        /** @var list<class-string> $providers */
-        $providers = [];
-
-        foreach ($extraProviders as $fqcn) {
-            $providers[] = $fqcn;
-        }
-
+        $providers = $extraProviders;
         foreach (self::readVendorProviders($progress) as $fqcn) {
             $providers[] = $fqcn;
         }
@@ -575,12 +568,12 @@ final class BootTimeProviderHarvester
         $resolved = $traverser->traverse($stmts);
 
         $returnedArray = self::findTopLevelReturnArray($resolved);
-        if ($returnedArray === null) {
+        if (!$returnedArray instanceof \PhpParser\Node\Expr\Array_) {
             return [];
         }
 
         $targetArray = self::descendArrayByKeyPath($returnedArray, $keyPath);
-        if ($targetArray === null) {
+        if (!$targetArray instanceof \PhpParser\Node\Expr\Array_) {
             return [];
         }
 
@@ -630,18 +623,20 @@ final class BootTimeProviderHarvester
         foreach ($keyPath as $key) {
             $next = null;
             foreach ($current->items as $item) {
-                if (!$item instanceof ArrayItem || $item->key === null) {
+                if (!$item instanceof ArrayItem || !$item->key instanceof \PhpParser\Node\Expr) {
                     continue;
                 }
+
                 if ($item->key instanceof String_ && $item->key->value === $key) {
                     if ($item->value instanceof Array_) {
                         $next = $item->value;
                     }
+
                     break;
                 }
             }
 
-            if ($next === null) {
+            if (!$next instanceof \PhpParser\Node\Expr\Array_) {
                 return null;
             }
 
@@ -671,19 +666,14 @@ final class BootTimeProviderHarvester
                 /** @var class-string */
                 return \ltrim($resolved, '\\');
             }
+
             $raw = $expr->class->toString();
             /** @var class-string */
             return \ltrim($raw, '\\');
         }
 
         if ($expr instanceof String_ && $expr->value !== '') {
-            /** @var class-string */
             return $expr->value;
-        }
-
-        if ($expr instanceof ConstFetch) {
-            // `null`, `true`, etc. — not a provider.
-            return null;
         }
 
         return null;
@@ -705,17 +695,18 @@ final class BootTimeProviderHarvester
             if ($stmt instanceof Namespace_) {
                 foreach ($stmt->stmts as $inner) {
                     if ($inner instanceof Class_
-                        && $inner->name !== null
+                        && $inner->name instanceof \PhpParser\Node\Identifier
                         && $inner->name->toString() === $expectedShort
                     ) {
                         return $inner;
                     }
                 }
+
                 continue;
             }
 
             if ($stmt instanceof Class_
-                && $stmt->name !== null
+                && $stmt->name instanceof \PhpParser\Node\Identifier
                 && $stmt->name->toString() === $expectedShort
             ) {
                 return $stmt;

--- a/src/Providers/BootTimeProviderHarvester.php
+++ b/src/Providers/BootTimeProviderHarvester.php
@@ -1,0 +1,734 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Providers;
+
+use PhpParser\Node\ArrayItem;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\Node\Stmt\Return_;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\ParserFactory;
+use Psalm\LaravelPlugin\Util\ProviderBindingHarvester;
+use Psalm\Progress\Progress;
+
+/**
+ * Boot-time enumeration of every Laravel `ServiceProvider` in scope, used to
+ * populate {@see \Psalm\LaravelPlugin\Providers\ContainerBindingMapProvider}
+ * via {@see ProviderBindingHarvester} before Psalm forks any scan/analysis worker.
+ *
+ * # Why boot-time and not scan-time?
+ *
+ * The original prototype lived in an `AfterClassLikeVisit` hook. Two failure
+ * modes made that approach a silent no-op for the real audience of issues
+ * #942 / #766:
+ *
+ * 1. **Worker IPC.** Psalm forks scanner workers when `pool_size > 1` and
+ *    `files > 512` (see `Scanner::scanFiles`). The shutdown task that ships
+ *    worker state back to the parent (`ShutdownScannerTask`) only carries
+ *    Psalm-internal storage; plugin static state stays in the worker. By the
+ *    time consumers read the map in the analysis phase (which runs in the
+ *    parent + its own workers), the map is empty.
+ * 2. **Warm cache.** `ReflectorVisitor::dispatchEvent` only fires
+ *    `AfterClassLikeVisit` while the class is being freshly scanned. On any
+ *    run where the file's cached storage is reused, the hook never fires and
+ *    the map is empty. Psalm even ships `--no-reflection-cache` specifically
+ *    as a debug switch for plugin authors hitting this.
+ *
+ * Running in the main process at plugin init, before `ApplicationProvider::bootApp()`
+ * returns, sidesteps both: static state is set up once in the parent and inherited
+ * via copy-on-write into every fork; warm cache state has no bearing because we
+ * never touch a Psalm hook.
+ *
+ * # Provider discovery
+ *
+ * Three sources, all read in the main process:
+ *
+ * 1. **Vendor packages** — `vendor/composer/installed.json` carries
+ *    `extra.laravel.providers[]` for every package that opts into Laravel's
+ *    auto-discovery mechanism. This is the canonical answer to "which vendor
+ *    providers does Laravel boot" and is what `Illuminate\Foundation\PackageManifest`
+ *    reads at runtime. We bypass `PackageManifest` itself because it requires a
+ *    booted `Application` and we want this to work even when the Testbench app
+ *    is misconfigured.
+ *
+ *    Honours `extra.laravel.dont-discover` exactly as
+ *    `PackageManifest::packagesToIgnore()` does: per-package opt-outs are
+ *    merged with the root `composer.json`'s `extra.laravel.dont-discover`, and
+ *    the literal `"*"` disables every package.
+ * 2. **First-party providers** — `bootstrap/providers.php` (Laravel 11+) and
+ *    `config/app.php`'s `providers` array (Laravel ≤10). Both files are read
+ *    via PhpParser AST rather than `include`d — we never execute user code at
+ *    plugin init.
+ * 3. **Explicit list** — caller can pass `$extraProviders` for tests or for
+ *    advanced users with non-standard provider registration.
+ *
+ * # Why static parsing instead of running `register()`?
+ *
+ * `ApplicationProvider::doGetApp()` does boot a Laravel application that runs
+ * provider `register()` methods, so in principle the container already knows
+ * every binding by the time the plugin starts. In practice (see issue #942)
+ * provider boot regularly fails inside Testbench because vendor packages
+ * depend on missing config / env / extensions. Errors are swallowed by
+ * `withErrorExceptionsSuppressed`; the binding goes missing; downstream
+ * `Facade::getFacadeRoot()` and `app('alias')` calls then fail with the
+ * `BindingResolutionException` that the plugin currently surfaces as a warning.
+ *
+ * Static parsing extracts the binding intent from source — no env, no runtime —
+ * so it succeeds for any provider whose source file is present, even when the
+ * runtime boot would have failed.
+ *
+ * # Known coverage gaps (intentional, with workarounds)
+ *
+ * - **Laravel 11+ `$app->withProviders([...])` inline in `bootstrap/app.php`** —
+ *   not parsed. Workaround: list providers in `bootstrap/providers.php` instead.
+ * - **`$this->app->register(SubProvider::class)` chains** — not followed.
+ *   Workaround: add the sub-provider to `bootstrap/providers.php` or
+ *   `extra.laravel.providers` in its package's `composer.json`.
+ * - **Trait-imported binding helpers** — `Class_::getMethods()` returns only
+ *   directly-declared methods. Bindings inside a trait method invoked from a
+ *   `ServiceProvider` are not harvested.
+ * - **Monorepo `cwd`-bound discovery** — first-party discovery is anchored at
+ *   the current working directory. Psalm's CLI `chdir`s to the project root
+ *   under default `resolve_from_config_file` behaviour, so the standard case
+ *   works; users running Psalm from outside the project root may miss
+ *   first-party providers.
+ *
+ * @internal
+ */
+final class BootTimeProviderHarvester
+{
+    /**
+     * Populate {@see \Psalm\LaravelPlugin\Providers\ContainerBindingMapProvider}
+     * from every discoverable provider.
+     *
+     * @param list<class-string> $extraProviders explicit provider FQCNs to harvest in
+     *     addition to the auto-discovered set, useful for tests and for custom user
+     *     registration paths the discovery probe doesn't cover.
+     */
+    public static function harvestAll(Progress $progress, array $extraProviders = []): void
+    {
+        $providers = self::collectProviderFqcns($extraProviders, $progress);
+
+        foreach ($providers as $providerFqcn) {
+            self::harvestProvider($providerFqcn, $progress);
+        }
+    }
+
+    /**
+     * Public test/integration hook for forcing a single provider into the map.
+     * Used by the type-test bootstrap to seed the fixture provider without going
+     * through composer auto-discovery (which fixtures aren't part of).
+     *
+     * @param class-string $providerFqcn
+     */
+    public static function harvestProvider(string $providerFqcn, Progress $progress): void
+    {
+        try {
+            $reflection = new \ReflectionClass($providerFqcn);
+        } catch (\Throwable $throwable) {
+            // Catch widened from `ReflectionException` to `Throwable` deliberately:
+            // `new ReflectionClass($fqcn)` triggers autoload, and autoload can throw
+            // `\Error` / `\ParseError` / `\CompileError` (PHP-version-only attributes,
+            // syntax errors in vendor code, broken `use` references) — none of which
+            // are subclasses of `ReflectionException`. A `\Error` would escape this
+            // method, bubble through `harvestAll`, and trip the top-level Throwable
+            // catch in `Plugin::__invoke`, disabling registerHandlers/registerStubs
+            // for the rest of the run. A single broken vendor provider would no-op
+            // the entire plugin. Per-provider catch contains that blast radius.
+            //
+            // Debug, not warning: stale autoloaders and half-installed packages are
+            // common enough that a warning per missing provider would storm. Surfacing
+            // at debug level keeps it diagnosable under `--debug` without flooding
+            // normal output.
+            $progress->debug("Laravel plugin: provider harvest skipped {$providerFqcn}: reflection failed: {$throwable->getMessage()}\n");
+            return;
+        }
+
+        $file = $reflection->getFileName();
+
+        if ($file === false || !\is_file($file)) {
+            // Internal class or eval'd source — no file to parse. Skip silently.
+            return;
+        }
+
+        $source = @\file_get_contents($file);
+
+        if ($source === false || $source === '') {
+            $progress->debug("Laravel plugin: provider harvest skipped {$providerFqcn}: cannot read {$file}\n");
+            return;
+        }
+
+        try {
+            $parser = (new ParserFactory())->createForNewestSupportedVersion();
+            $stmts = $parser->parse($source);
+        } catch (\Throwable $throwable) {
+            // Warning, not debug: parse failure on already-installed vendor PHP is
+            // rare (usually a PhpParser version mismatch the user can fix by
+            // updating the plugin) and bounded per-file, so the storm risk is low
+            // while the diagnostic value is high.
+            $progress->warning("Laravel plugin: failed to parse {$file} for provider {$providerFqcn}: {$throwable->getMessage()}");
+            return;
+        }
+
+        if ($stmts === null) {
+            return;
+        }
+
+        // Run the same NameResolver pass Psalm runs at scan time so `Foo::class`
+        // expressions inside the provider's methods carry a `resolvedName` attribute
+        // that the harvester can read.
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver());
+
+        /** @var list<\PhpParser\Node> $resolved */
+        $resolved = $traverser->traverse($stmts);
+
+        $classNode = self::findClassNode($resolved, $providerFqcn);
+        if ($classNode === null) {
+            // Warning, not debug: reflection said this class lives in this file and the
+            // parser successfully parsed the file, yet `findClassNode` cannot find it.
+            // The only plausible causes are a stale autoloader pointing at the wrong
+            // file or a namespace shape (`namespace Foo { ... }` block syntax) that the
+            // single-level walker in `findClassNode` doesn't handle. Both are worth
+            // surfacing.
+            $progress->warning("Laravel plugin: failed to find class {$providerFqcn} in {$file}");
+            return;
+        }
+
+        // Walk every method, not just register(). Several real-world packages
+        // (imdhemy/laravel-in-app-purchases is the cited example in #942) put their
+        // bindings in private helpers called from register(): walking only register()
+        // misses them. Walking every method is harmless because the harvester
+        // matches only well-formed binding shapes.
+        ProviderBindingHarvester::harvestClassMethods($classNode);
+    }
+
+    /**
+     * @param list<class-string> $extraProviders
+     * @return list<class-string>
+     */
+    private static function collectProviderFqcns(array $extraProviders, Progress $progress): array
+    {
+        /** @var list<class-string> $providers */
+        $providers = [];
+
+        foreach ($extraProviders as $fqcn) {
+            $providers[] = $fqcn;
+        }
+
+        foreach (self::readVendorProviders($progress) as $fqcn) {
+            $providers[] = $fqcn;
+        }
+
+        foreach (self::readFirstPartyProviders($progress) as $fqcn) {
+            $providers[] = $fqcn;
+        }
+
+        // Dedupe + drop framework providers. The framework's own providers are
+        // already bound by the booted Testbench app; the runtime probe in
+        // AppFacadeRegistrationHandler resolves their facades fine, and their
+        // accessor strings (`'cache'`, `'router'`, etc.) are already mapped by
+        // FacadeMapProvider. Re-harvesting them would just churn the map for
+        // no behavioural difference.
+        return \array_values(\array_unique(\array_filter(
+            $providers,
+            static fn(string $fqcn): bool => !\str_starts_with($fqcn, 'Illuminate\\'),
+        )));
+    }
+
+    /**
+     * Read `vendor/composer/installed.json` and harvest every
+     * `extra.laravel.providers[]` entry, honouring Laravel's
+     * `extra.laravel.dont-discover` exclusion list the same way
+     * `Illuminate\Foundation\PackageManifest::packagesToIgnore()` does. Without
+     * this filter, a user who opted out of auto-discovery for a package would
+     * still see that package's accessors in the static map, producing false
+     * positives at every `app('alias')` call site.
+     *
+     * @return list<class-string>
+     */
+    private static function readVendorProviders(Progress $progress): array
+    {
+        $installedJsonPath = self::locateInstalledJson();
+
+        if ($installedJsonPath === null) {
+            return [];
+        }
+
+        $raw = @\file_get_contents($installedJsonPath);
+        if ($raw === false || $raw === '') {
+            // `is_file` upstream already proved this exists. A read failure here
+            // points at a permissions problem worth surfacing — silent fallback
+            // would wipe out the entire vendor channel without explanation.
+            $progress->warning("Laravel plugin: cannot read {$installedJsonPath} — vendor provider discovery skipped");
+            return [];
+        }
+
+        try {
+            /** @var mixed $decoded */
+            $decoded = \json_decode($raw, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $jsonException) {
+            $progress->warning("Laravel plugin: {$installedJsonPath} is not valid JSON: {$jsonException->getMessage()} — vendor provider discovery skipped");
+            return [];
+        }
+
+        if (!\is_array($decoded)) {
+            return [];
+        }
+
+        // installed.json shape: { "packages": [ { "name": ..., "extra": { "laravel": { "providers": [...] } } } ] }
+        // Some older Composer versions write the top-level as the package list directly.
+        $packages = $decoded['packages'] ?? $decoded;
+
+        if (!\is_array($packages)) {
+            return [];
+        }
+
+        $ignoredPackages = self::collectDontDiscoverPackages($packages);
+        $ignoreAllPackages = isset($ignoredPackages['*']);
+
+        /** @var list<class-string> $providers */
+        $providers = [];
+
+        foreach ($packages as $package) {
+            if (!\is_array($package)) {
+                continue;
+            }
+
+            /** @psalm-var mixed $packageName */
+            $packageName = $package['name'] ?? null;
+
+            if ($ignoreAllPackages
+                || (\is_string($packageName) && isset($ignoredPackages[$packageName]))
+            ) {
+                continue;
+            }
+
+            $extra = $package['extra'] ?? null;
+            if (!\is_array($extra)) {
+                continue;
+            }
+
+            $laravel = $extra['laravel'] ?? null;
+            if (!\is_array($laravel)) {
+                continue;
+            }
+
+            $packageProviders = $laravel['providers'] ?? null;
+            if (!\is_array($packageProviders)) {
+                continue;
+            }
+
+            /** @var mixed $providerFqcn */
+            foreach ($packageProviders as $providerFqcn) {
+                if (\is_string($providerFqcn) && $providerFqcn !== '') {
+                    /** @var class-string $providerFqcn */
+                    $providers[] = $providerFqcn;
+                }
+            }
+        }
+
+        return $providers;
+    }
+
+    /**
+     * Build the set of package names to exclude from auto-discovery, mirroring
+     * `Illuminate\Foundation\PackageManifest::packagesToIgnore()`. Two sources are
+     * merged: every per-package `extra.laravel.dont-discover` array (a package can
+     * declare that ANOTHER package should not be discovered) and the root
+     * `composer.json`'s `extra.laravel.dont-discover` (the canonical user-opt-out).
+     *
+     * The literal `"*"` is the documented Laravel idiom for "disable all
+     * auto-discovery" and is honoured the same way (callers check for it as a
+     * shortcut to skip every package).
+     *
+     * @param list<mixed>|array<string, mixed> $packages installed.json's package list
+     * @return array<string, true> set of package names to skip (plus optionally `"*"`)
+     */
+    private static function collectDontDiscoverPackages(array $packages): array
+    {
+        /** @var array<string, true> $ignored */
+        $ignored = [];
+
+        foreach ($packages as $package) {
+            if (!\is_array($package)) {
+                continue;
+            }
+
+            $extra = $package['extra'] ?? null;
+            if (!\is_array($extra)) {
+                continue;
+            }
+
+            $laravel = $extra['laravel'] ?? null;
+            if (!\is_array($laravel)) {
+                continue;
+            }
+
+            $dontDiscover = $laravel['dont-discover'] ?? null;
+            if (!\is_array($dontDiscover)) {
+                continue;
+            }
+
+            /** @var mixed $entry */
+            foreach ($dontDiscover as $entry) {
+                if (\is_string($entry) && $entry !== '') {
+                    $ignored[$entry] = true;
+                }
+            }
+        }
+
+        // Root composer.json's `extra.laravel.dont-discover` is the user-visible
+        // opt-out and trumps per-package declarations. Without this branch, a user
+        // disabling auto-discovery for a package they have installed would still
+        // see that package's accessors in the static map.
+        foreach (self::readRootDontDiscover() as $packageName) {
+            $ignored[$packageName] = true;
+        }
+
+        return $ignored;
+    }
+
+    /**
+     * Read `extra.laravel.dont-discover` from the analyzed project's root
+     * `composer.json`. Returns `[]` when the file is missing, malformed, or
+     * declares no opt-outs.
+     *
+     * @return list<string>
+     */
+    private static function readRootDontDiscover(): array
+    {
+        $cwd = \getcwd();
+        if ($cwd === false) {
+            return [];
+        }
+
+        $composerJsonPath = $cwd . '/composer.json';
+        if (!\is_file($composerJsonPath)) {
+            return [];
+        }
+
+        $raw = @\file_get_contents($composerJsonPath);
+        if ($raw === false || $raw === '') {
+            return [];
+        }
+
+        try {
+            /** @var mixed $decoded */
+            $decoded = \json_decode($raw, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return [];
+        }
+
+        if (!\is_array($decoded)) {
+            return [];
+        }
+
+        $extra = $decoded['extra'] ?? null;
+        if (!\is_array($extra)) {
+            return [];
+        }
+
+        $laravel = $extra['laravel'] ?? null;
+        if (!\is_array($laravel)) {
+            return [];
+        }
+
+        $dontDiscover = $laravel['dont-discover'] ?? null;
+        if (!\is_array($dontDiscover)) {
+            return [];
+        }
+
+        /** @var list<string> $names */
+        $names = [];
+        /** @var mixed $entry */
+        foreach ($dontDiscover as $entry) {
+            if (\is_string($entry) && $entry !== '') {
+                $names[] = $entry;
+            }
+        }
+
+        return $names;
+    }
+
+    /**
+     * Resolve the path to `vendor/composer/installed.json` for the analyzed
+     * project. Walks up from the current working directory looking for a
+     * `vendor/composer/installed.json` — matches how Composer's own
+     * `InstalledVersions::class` locates the runtime classmap.
+     */
+    private static function locateInstalledJson(): ?string
+    {
+        $cwd = \getcwd();
+        if ($cwd !== false) {
+            $candidate = $cwd . '/vendor/composer/installed.json';
+            if (\is_file($candidate)) {
+                return $candidate;
+            }
+        }
+
+        // Fallback: locate via the InstalledVersions class file (Composer ships it
+        // inside vendor/composer/ alongside installed.json).
+        try {
+            $reflection = new \ReflectionClass(\Composer\InstalledVersions::class);
+            $file = $reflection->getFileName();
+            if (\is_string($file)) {
+                $candidate = \dirname($file) . '/installed.json';
+                if (\is_file($candidate)) {
+                    return $candidate;
+                }
+            }
+        } catch (\ReflectionException) {
+            // Composer autoloader not installed — extremely unlikely in a Psalm
+            // project, but tolerated.
+        }
+
+        return null;
+    }
+
+    /**
+     * Read first-party provider FQCNs from `bootstrap/providers.php` (Laravel 11+)
+     * or fall back to `config/app.php`'s `providers` array (Laravel ≤10).
+     *
+     * Both files are parsed statically (PhpParser AST → `return [...]` extraction)
+     * rather than `include`d. Two reasons: (a) `include` would execute the user's
+     * application code at plugin-init time, which is a footgun and arguably a
+     * security risk; (b) Psalm's `UnresolvableInclude` issue would fire on the
+     * dynamic path. AST parsing satisfies both concerns and is sufficient because
+     * both files are conventionally pure return-array files.
+     *
+     * @return list<class-string>
+     */
+    private static function readFirstPartyProviders(Progress $progress): array
+    {
+        // Both file paths are anchored at the current working directory. Psalm's
+        // CLI `chdir`s to the project root before plugin init (Config.php
+        // resolve_from_config_file), so cwd is the analyzed project's root in the
+        // standard configuration. A user invoking Psalm from outside the project
+        // root (rare; some monorepos do this) will see their first-party providers
+        // silently missed — they can work around by adding an explicit `--config`
+        // pointing at the project's psalm.xml.
+        $cwd = \getcwd();
+        if ($cwd === false) {
+            return [];
+        }
+
+        $bootstrapPath = $cwd . '/bootstrap/providers.php';
+        if (\is_file($bootstrapPath)) {
+            return self::extractProvidersFromAst($bootstrapPath, [], $progress);
+        }
+
+        $configPath = $cwd . '/config/app.php';
+        if (\is_file($configPath)) {
+            // config/app.php returns `['app' => ..., 'providers' => [...], ...]`, so
+            // descend through the `'providers'` key before reading the list.
+            return self::extractProvidersFromAst($configPath, ['providers'], $progress);
+        }
+
+        return [];
+    }
+
+    /**
+     * Parse a user config file as PHP, locate its top-level `return` statement,
+     * descend the literal array under `$keyPath`, and extract every class-string
+     * literal it contains. No code is executed; the file's runtime side effects
+     * (if any) are deliberately not observed.
+     *
+     * @param list<string> $keyPath nested string keys to descend before treating the
+     *     reached value as the provider list. `[]` means use the top-level return.
+     * @return list<class-string>
+     */
+    private static function extractProvidersFromAst(string $path, array $keyPath, Progress $progress): array
+    {
+        $source = @\file_get_contents($path);
+        if ($source === false || $source === '') {
+            $progress->warning("Laravel plugin: cannot read provider list at {$path}");
+            return [];
+        }
+
+        try {
+            $parser = (new ParserFactory())->createForNewestSupportedVersion();
+            $stmts = $parser->parse($source);
+        } catch (\Throwable $throwable) {
+            // Warning, not silent: a parse failure here loses every first-party
+            // provider in one shot. The user authored this file; a broken parse is
+            // also breaking their app, so surfacing it from the plugin is fair.
+            $progress->warning("Laravel plugin: failed to parse provider list at {$path}: {$throwable->getMessage()}");
+            return [];
+        }
+
+        if ($stmts === null) {
+            return [];
+        }
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver());
+        /** @var list<\PhpParser\Node> $resolved */
+        $resolved = $traverser->traverse($stmts);
+
+        $returnedArray = self::findTopLevelReturnArray($resolved);
+        if ($returnedArray === null) {
+            return [];
+        }
+
+        $targetArray = self::descendArrayByKeyPath($returnedArray, $keyPath);
+        if ($targetArray === null) {
+            return [];
+        }
+
+        /** @var list<class-string> $providers */
+        $providers = [];
+
+        foreach ($targetArray->items as $item) {
+            if (!$item instanceof ArrayItem) {
+                continue;
+            }
+
+            $fqcn = self::classStringFromExpr($item->value);
+            if ($fqcn !== null) {
+                $providers[] = $fqcn;
+            }
+        }
+
+        return $providers;
+    }
+
+    /**
+     * @param list<\PhpParser\Node> $stmts
+     * @psalm-mutation-free
+     */
+    private static function findTopLevelReturnArray(array $stmts): ?Array_
+    {
+        foreach ($stmts as $stmt) {
+            if ($stmt instanceof Return_ && $stmt->expr instanceof Array_) {
+                return $stmt->expr;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Descend `$array` through `$keyPath` of string keys. Returns the inner
+     * `Array_` node, or null if any segment is missing or non-array.
+     *
+     * @param list<string> $keyPath
+     * @psalm-mutation-free
+     */
+    private static function descendArrayByKeyPath(Array_ $array, array $keyPath): ?Array_
+    {
+        $current = $array;
+
+        foreach ($keyPath as $key) {
+            $next = null;
+            foreach ($current->items as $item) {
+                if (!$item instanceof ArrayItem || $item->key === null) {
+                    continue;
+                }
+                if ($item->key instanceof String_ && $item->key->value === $key) {
+                    if ($item->value instanceof Array_) {
+                        $next = $item->value;
+                    }
+                    break;
+                }
+            }
+
+            if ($next === null) {
+                return null;
+            }
+
+            $current = $next;
+        }
+
+        return $current;
+    }
+
+    /**
+     * Extract a class-string FQCN from an array-item expression. Accepts both
+     * `Foo\Bar::class` (the canonical Laravel form) and a plain string literal
+     * `'Foo\\Bar'` (legacy / docs-example form).
+     *
+     * @return ?class-string
+     */
+    private static function classStringFromExpr(\PhpParser\Node\Expr $expr): ?string
+    {
+        if ($expr instanceof ClassConstFetch
+            && $expr->name instanceof Identifier
+            && \strtolower($expr->name->toString()) === 'class'
+            && $expr->class instanceof \PhpParser\Node\Name
+        ) {
+            /** @psalm-var mixed $resolved */
+            $resolved = $expr->class->getAttribute('resolvedName');
+            if (\is_string($resolved) && $resolved !== '') {
+                /** @var class-string */
+                return \ltrim($resolved, '\\');
+            }
+            $raw = $expr->class->toString();
+            /** @var class-string */
+            return \ltrim($raw, '\\');
+        }
+
+        if ($expr instanceof String_ && $expr->value !== '') {
+            /** @var class-string */
+            return $expr->value;
+        }
+
+        if ($expr instanceof ConstFetch) {
+            // `null`, `true`, etc. — not a provider.
+            return null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Find the AST `Class_` node matching a given provider FQCN inside a parsed file.
+     * Walks one level of namespaces; nested namespaces aren't a valid PHP shape so
+     * a flat lookup is sufficient.
+     *
+     * @param list<\PhpParser\Node> $stmts
+     * @psalm-mutation-free
+     */
+    private static function findClassNode(array $stmts, string $providerFqcn): ?Class_
+    {
+        $expectedShort = self::shortName($providerFqcn);
+
+        foreach ($stmts as $stmt) {
+            if ($stmt instanceof Namespace_) {
+                foreach ($stmt->stmts as $inner) {
+                    if ($inner instanceof Class_
+                        && $inner->name !== null
+                        && $inner->name->toString() === $expectedShort
+                    ) {
+                        return $inner;
+                    }
+                }
+                continue;
+            }
+
+            if ($stmt instanceof Class_
+                && $stmt->name !== null
+                && $stmt->name->toString() === $expectedShort
+            ) {
+                return $stmt;
+            }
+        }
+
+        return null;
+    }
+
+    /** @psalm-pure */
+    private static function shortName(string $fqcn): string
+    {
+        $pos = \strrpos($fqcn, '\\');
+        return $pos === false ? $fqcn : \substr($fqcn, $pos + 1);
+    }
+}

--- a/src/Providers/ContainerBindingMapProvider.php
+++ b/src/Providers/ContainerBindingMapProvider.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Providers;
+
+/**
+ * Static map of container accessor strings to their concrete service classes,
+ * harvested at scan time from `ServiceProvider::register()` bodies.
+ *
+ * Solves two related issues both rooted in the Testbench app not reliably
+ * running vendor/user service providers' bindings:
+ *
+ * - {@see \Psalm\LaravelPlugin\Handlers\Facades\AppFacadeRegistrationHandler::tryGetFacadeRootClass()}
+ *   reads it before the `Facade::getFacadeRoot()` runtime probe — when the
+ *   facade's accessor is a string alias (e.g. `'subscription'`) bound by a
+ *   package provider, the runtime probe throws `BindingResolutionException`
+ *   and emits a warning on every Psalm run. A map hit short-circuits the
+ *   probe, silences the warning, and supplies the underlying service class
+ *   so {@see \Psalm\LaravelPlugin\Handlers\Facades\FacadeMethodHandler}
+ *   forwards real method signatures. See issue #942.
+ *
+ * - {@see \Psalm\LaravelPlugin\Util\ContainerResolver::resolveFromApplicationContainer()}
+ *   reads it before its Testbench `make()` call — `app('datatables.request')`
+ *   would otherwise return `mixed` and cascade into `MixedAssignment` /
+ *   `MixedMethodCall` at every call site. See issue #766.
+ *
+ * Population is driven by {@see BootTimeProviderHarvester}, which runs in
+ * `Plugin::__invoke` (main process, before any Psalm fork) and enumerates every
+ * `ServiceProvider` reachable through composer auto-discovery,
+ * `bootstrap/providers.php`, or `config/app.php`. Each provider's class body
+ * is parsed and handed to {@see \Psalm\LaravelPlugin\Util\ProviderBindingHarvester}
+ * for binding-shape extraction.
+ *
+ * Mutation is gated behind `@internal record()` to keep the surface tiny while
+ * still allowing the scanner handler to populate from scan-time events. Mirrors
+ * the simple `SchemaStateProvider` pattern rather than the ModelMetadataRegistry
+ * builder split — there's only one mutation site and one piece of state.
+ *
+ * @internal
+ * @psalm-external-mutation-free
+ */
+final class ContainerBindingMapProvider
+{
+    /** @var array<string, class-string> accessor string => concrete service class FQCN */
+    private static array $map = [];
+
+    /**
+     * Record an accessor → service class mapping discovered by the scanner.
+     *
+     * First write wins. Subsequent attempts to overwrite the same accessor are
+     * ignored — a single accessor can be re-bound by multiple providers (e.g.
+     * package provider binds `'cache'`, user provider overrides with a wrapper),
+     * but the scanner has no ordering guarantee, so deterministic behaviour is
+     * better served by stable first-write semantics than by last-write race.
+     *
+     * @param class-string $serviceClass
+     * @psalm-external-mutation-free
+     */
+    public static function record(string $accessor, string $serviceClass): void
+    {
+        if ($accessor === '' || isset(self::$map[$accessor])) {
+            return;
+        }
+
+        self::$map[$accessor] = $serviceClass;
+    }
+
+    /**
+     * @return ?class-string concrete service class for the accessor, or null when unknown.
+     * @psalm-external-mutation-free
+     */
+    public static function lookup(string $accessor): ?string
+    {
+        return self::$map[$accessor] ?? null;
+    }
+
+    /**
+     * Test helper. Production code never resets the map mid-run — scanner
+     * populates it during scan phase and consumers read it during analysis.
+     *
+     * @internal
+     * @psalm-api Tests only.
+     * @psalm-external-mutation-free
+     */
+    public static function reset(): void
+    {
+        self::$map = [];
+    }
+}

--- a/src/Util/ContainerResolver.php
+++ b/src/Util/ContainerResolver.php
@@ -6,6 +6,7 @@ namespace Psalm\LaravelPlugin\Util;
 
 use PhpParser\Node\Arg;
 use Psalm\LaravelPlugin\Providers\ApplicationProvider;
+use Psalm\LaravelPlugin\Providers\ContainerBindingMapProvider;
 use Psalm\NodeTypeProvider;
 use Psalm\Type\Atomic\TClassString;
 use Psalm\Type\Atomic\TLiteralString;
@@ -28,6 +29,18 @@ final class ContainerResolver
     {
         if (\array_key_exists($abstract, self::$cache)) {
             return self::$cache[$abstract];
+        }
+
+        // Statically-harvested bindings from vendor/user `ServiceProvider` classes
+        // (populated by `Psalm\LaravelPlugin\Providers\BootTimeProviderHarvester`).
+        // The Testbench app booted below cannot reliably run third-party providers
+        // (they often need real env/config), so `app('datatables.request')`-style
+        // calls would otherwise return `mixed` and cascade through every call site
+        // (issue #766). Checked before the Testbench `make()` to avoid catching
+        // and swallowing the BindingResolutionException we'd otherwise throw.
+        $mapped = ContainerBindingMapProvider::lookup($abstract);
+        if ($mapped !== null) {
+            return self::$cache[$abstract] = $mapped;
         }
 
         // dynamic analysis to resolve the actual type from the container.

--- a/src/Util/ProviderBindingHarvester.php
+++ b/src/Util/ProviderBindingHarvester.php
@@ -232,16 +232,10 @@ final class ProviderBindingHarvester
         ) {
             return true;
         }
-
         // app()->bind(...)
-        if ($receiver instanceof FuncCall
+        return $receiver instanceof FuncCall
             && $receiver->name instanceof Node\Name
-            && \strcasecmp((string) ($receiver->name->getAttribute('resolvedName') ?? $receiver->name->toString()), 'app') === 0
-        ) {
-            return true;
-        }
-
-        return false;
+            && \strcasecmp((string) ($receiver->name->getAttribute('resolvedName') ?? $receiver->name->toString()), 'app') === 0;
     }
 
     /**
@@ -273,7 +267,7 @@ final class ProviderBindingHarvester
 
         if ($expr instanceof Closure) {
             $lastReturn = self::findLastReturnExpr($expr->stmts);
-            return $lastReturn !== null ? self::classFromNewExpr($lastReturn) : null;
+            return $lastReturn instanceof \PhpParser\Node\Expr ? self::classFromNewExpr($lastReturn) : null;
         }
 
         return null;
@@ -321,9 +315,9 @@ final class ProviderBindingHarvester
      * to the raw text when the attribute is absent — happens for global-namespace names
      * resolved without a NameResolver run, which is unusual but defensively handled.
      *
-     * @return ?class-string
+     * @return class-string
      */
-    private static function resolveNameToClassString(Node\Name $name): ?string
+    private static function resolveNameToClassString(Node\Name $name): string
     {
         /** @psalm-var mixed $resolved */
         $resolved = $name->getAttribute('resolvedName');

--- a/src/Util/ProviderBindingHarvester.php
+++ b/src/Util/ProviderBindingHarvester.php
@@ -1,0 +1,380 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Util;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Return_;
+use Psalm\LaravelPlugin\Providers\ContainerBindingMapProvider;
+
+/**
+ * Pure AST → accessor-string → class-string harvester driven by
+ * {@see \Psalm\LaravelPlugin\Providers\BootTimeProviderHarvester}.
+ *
+ * Kept separate so it can be unit-tested with just PhpParser + NameResolver,
+ * no Composer / file-system / `Codebase` plumbing required. The driver class
+ * is responsible for "which providers are in scope, how do we get their AST";
+ * this class is responsible for "given the body of a provider method, which
+ * `accessor → service-class` pairs can we statically prove".
+ *
+ * Binding shapes recognised by {@see inspectBindingCall()}:
+ *
+ *   $this->app->bind|singleton|instance|scoped|bindIf|singletonIf|scopedIf($accessor, ServiceClass::class)
+ *   $this->app->bind|singleton('accessor', fn () => new ServiceClass(...))
+ *   $this->app->bind|singleton('accessor', function () { return new ServiceClass(...); })
+ *   $this->app->alias(ServiceClass::class, 'accessor')          // reverse argument order
+ *   app()->bind(...) / \Illuminate\Support\Facades\App::bind(...)
+ *
+ * Shapes intentionally skipped (would need runtime evaluation or branch analysis):
+ *
+ *   $this->app->bind('accessor', config('foo.driver'))          // dynamic concrete
+ *   $this->app->bind('accessor', function () {
+ *       return match (...) { 'a' => new A, 'b' => new B };      // branching closure
+ *   })
+ *   $this->app->bind($abstract, ...);                           // dynamic accessor
+ *   $this->app->register(SubProvider::class);                   // see BootTimeProviderHarvester docblock
+ *
+ * @internal
+ */
+final class ProviderBindingHarvester
+{
+    /** Methods on the container that bind an accessor → class in their first two args. */
+    private const FORWARD_BINDING_METHODS = [
+        'bind' => true,
+        'singleton' => true,
+        'instance' => true,
+        'scoped' => true,
+        'bindif' => true,
+        'singletonif' => true,
+        'scopedif' => true,
+    ];
+
+    /** `alias($abstract, $alias)` swaps the argument order vs. forward bindings. */
+    private const ALIAS_METHOD = 'alias';
+
+    /**
+     * Walk the statements of a single method body (usually `register()`) and
+     * record every binding it exposes into {@see ContainerBindingMapProvider}.
+     * Walks recursively so bindings nested in `if (config(...))` / `try` / loop
+     * blocks are still captured — the consumer side can't see those conditions
+     * either, so the static-best-effort answer is to record the binding either way.
+     *
+     * Prefer {@see harvestClassMethods()} when a full provider class is available;
+     * it walks every method, which catches the common Laravel pattern of `register()`
+     * delegating to private helpers like `bindFacades()` / `bindConcretes()` (issue #942
+     * cites `imdhemy/laravel-in-app-purchases` doing exactly that).
+     *
+     * @param array<array-key, Stmt> $stmts
+     */
+    public static function harvest(array $stmts): void
+    {
+        foreach ($stmts as $stmt) {
+            self::visitNode($stmt);
+        }
+    }
+
+    /**
+     * Walk every method body declared on a `ServiceProvider` subclass and harvest
+     * bindings from each. Catches the delegated-binding pattern where `register()`
+     * is a thin dispatcher (`$this->bindFacades(); $this->bindConcretes();`) and
+     * the actual `bind(...)` calls live in sibling methods. Walking `boot()` too
+     * is intentional: some packages bind in `boot()` rather than `register()`, and
+     * over-coverage is harmless (the harvester records only well-formed binding
+     * shapes, abstract methods have no body, etc.).
+     */
+    public static function harvestClassMethods(Class_ $class): void
+    {
+        foreach ($class->getMethods() as $method) {
+            if ($method->stmts !== null) {
+                self::harvest($method->stmts);
+            }
+        }
+    }
+
+    /**
+     * Cheap, hand-written recursive visitor. NodeFinder + NodeTraverser would do
+     * this generically but allocate iterators per node; this code runs on every
+     * scanned `ServiceProvider` subclass on every cold scan, so the loop body is
+     * kept tight on purpose.
+     */
+    private static function visitNode(Node $node): void
+    {
+        if ($node instanceof MethodCall || $node instanceof StaticCall) {
+            self::inspectBindingCall($node);
+        }
+
+        foreach ($node->getSubNodeNames() as $name) {
+            /** @psalm-var mixed $child */
+            $child = $node->{$name};
+
+            if ($child instanceof Node) {
+                self::visitNode($child);
+                continue;
+            }
+
+            if (!\is_array($child)) {
+                continue;
+            }
+
+            /** @var mixed $element */
+            foreach ($child as $element) {
+                if ($element instanceof Node) {
+                    self::visitNode($element);
+                }
+            }
+        }
+    }
+
+    /**
+     * Inspect a call site that might be one of the container's binding methods.
+     *
+     * Receiver shapes accepted:
+     *   - `$this->app->bind(...)` (MethodCall on a PropertyFetch on `$this`)
+     *   - `app()->bind(...)`      (MethodCall on a `FuncCall` whose name is `app`)
+     *   - `App::bind(...)`        (StaticCall on `Illuminate\Support\Facades\App`)
+     */
+    private static function inspectBindingCall(MethodCall|StaticCall $call): void
+    {
+        $methodName = self::methodNameLower($call);
+        if ($methodName === null) {
+            return;
+        }
+
+        $isAlias = $methodName === self::ALIAS_METHOD;
+
+        if (!$isAlias && !isset(self::FORWARD_BINDING_METHODS[$methodName])) {
+            return;
+        }
+
+        if (!self::receivesContainer($call)) {
+            return;
+        }
+
+        $args = $call->getArgs();
+        if (\count($args) < 2) {
+            return;
+        }
+
+        $first = $args[0];
+        $second = $args[1];
+
+        if ($isAlias) {
+            // alias($abstract, $alias): first arg is the class, second is the accessor.
+            $serviceClass = self::extractClassFromArg($first);
+            $accessor = self::extractLiteralString($second->value);
+        } else {
+            // bind|singleton|instance|scoped|bindif|singletonif($accessor, $concrete):
+            // first is accessor, second is the concrete (class-string or factory closure).
+            $accessor = self::extractLiteralString($first->value);
+            $serviceClass = self::extractClassFromArg($second);
+        }
+
+        if ($accessor === null || $serviceClass === null) {
+            return;
+        }
+
+        ContainerBindingMapProvider::record($accessor, $serviceClass);
+    }
+
+    /** @psalm-mutation-free */
+    private static function methodNameLower(MethodCall|StaticCall $call): ?string
+    {
+        return $call->name instanceof Identifier
+            ? \strtolower($call->name->toString())
+            : null;
+    }
+
+    /**
+     * True when the call receiver looks like the container instance.
+     *
+     * `$this->app->...` is the canonical form inside a `ServiceProvider`. Helpers
+     * (`app()->...`) and the `App` facade are also accepted because they resolve to the
+     * same container at runtime. The check is deliberately lenient: harvest is already
+     * gated to `ServiceProvider::register()` bodies, so the small risk of matching an
+     * unrelated `$this->app->bind(...)` (a non-container `app` property happens to live
+     * on `$this`) is minimal.
+     */
+    private static function receivesContainer(MethodCall|StaticCall $call): bool
+    {
+        if ($call instanceof StaticCall) {
+            return $call->class instanceof Node\Name
+                && \in_array(
+                    \strtolower((string) ($call->class->getAttribute('resolvedName') ?? $call->class->toString())),
+                    ['illuminate\\support\\facades\\app', 'app'],
+                    true,
+                );
+        }
+
+        $receiver = $call->var;
+
+        // $this->app->bind(...)
+        if ($receiver instanceof PropertyFetch
+            && $receiver->var instanceof Variable
+            && \is_string($receiver->var->name)
+            && $receiver->var->name === 'this'
+            && $receiver->name instanceof Identifier
+            && $receiver->name->toString() === 'app'
+        ) {
+            return true;
+        }
+
+        // app()->bind(...)
+        if ($receiver instanceof FuncCall
+            && $receiver->name instanceof Node\Name
+            && \strcasecmp((string) ($receiver->name->getAttribute('resolvedName') ?? $receiver->name->toString()), 'app') === 0
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Extract the concrete service class from a binding's second argument.
+     *
+     * Two shapes succeed:
+     *   - `ServiceClass::class` — a direct {@see ClassConstFetch} whose target is a Name.
+     *   - Closure / arrow fn whose body returns `new ServiceClass(...)`.
+     *
+     * Anything else (string literal class names, variables, complex factories) returns
+     * null. String FQCN literals are intentionally excluded — Laravel accepts them, but
+     * they're rare in modern code and supporting them would force us to validate that
+     * the literal references an existing class, which adds a `class_exists` check on a
+     * hot path for marginal coverage gain.
+     *
+     * @return ?class-string
+     */
+    private static function extractClassFromArg(Arg $arg): ?string
+    {
+        $expr = $arg->value;
+
+        if ($class = self::classFromConstFetch($expr)) {
+            return $class;
+        }
+
+        if ($expr instanceof ArrowFunction) {
+            return self::classFromNewExpr($expr->expr);
+        }
+
+        if ($expr instanceof Closure) {
+            $lastReturn = self::findLastReturnExpr($expr->stmts);
+            return $lastReturn !== null ? self::classFromNewExpr($lastReturn) : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolve a `Foo::class` expression to its FQCN. Relies on Psalm's NameResolver
+     * pass having attached `resolvedName` during scan — the attribute is set for every
+     * `Name` node by the time `afterClassLikeVisit` fires.
+     *
+     * @return ?class-string
+     */
+    private static function classFromConstFetch(Expr $expr): ?string
+    {
+        if (!$expr instanceof ClassConstFetch
+            || !$expr->name instanceof Identifier
+            || \strtolower($expr->name->toString()) !== 'class'
+            || !$expr->class instanceof Node\Name
+        ) {
+            return null;
+        }
+
+        return self::resolveNameToClassString($expr->class);
+    }
+
+    /**
+     * `new ServiceClass(...)` → `ServiceClass` FQCN. Anonymous classes (`new class { }`)
+     * and dynamic targets (`new $variable(...)`) are skipped — neither yields a stable
+     * class-string we can pair with an accessor.
+     *
+     * @return ?class-string
+     */
+    private static function classFromNewExpr(?Expr $expr): ?string
+    {
+        if (!$expr instanceof New_ || !$expr->class instanceof Node\Name) {
+            return null;
+        }
+
+        return self::resolveNameToClassString($expr->class);
+    }
+
+    /**
+     * Pull the FQCN off a `Name` node. Prefers the NameResolver-attached `resolvedName`
+     * (which already accounts for `use` aliasing and namespace prefixes) and falls back
+     * to the raw text when the attribute is absent — happens for global-namespace names
+     * resolved without a NameResolver run, which is unusual but defensively handled.
+     *
+     * @return ?class-string
+     */
+    private static function resolveNameToClassString(Node\Name $name): ?string
+    {
+        /** @psalm-var mixed $resolved */
+        $resolved = $name->getAttribute('resolvedName');
+
+        if (\is_string($resolved) && $resolved !== '') {
+            /** @var class-string */
+            return \ltrim($resolved, '\\');
+        }
+
+        /** @var class-string */
+        return \ltrim($name->toString(), '\\');
+    }
+
+    /**
+     * Find the expression returned by the last `return` statement in a closure body.
+     * Walks bottom-up so a final `return` after side-effecting setup wins over earlier
+     * returns inside conditionals — matches the common "guard plus return" pattern
+     * without trying to interpret branching.
+     *
+     * Returns null when the closure has no return or its last return is `return;` or
+     * `return $variable;` — anything other than a direct `new X(...)` we can't pin to
+     * a class without dataflow analysis we don't run here.
+     *
+     * @param array<array-key, Stmt> $stmts
+     * @psalm-mutation-free
+     */
+    private static function findLastReturnExpr(array $stmts): ?Expr
+    {
+        $values = \array_values($stmts);
+
+        for ($i = \count($values) - 1; $i >= 0; $i--) {
+            $stmt = $values[$i];
+
+            if ($stmt instanceof Return_) {
+                return $stmt->expr;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return ?non-empty-string
+     * @psalm-mutation-free
+     */
+    private static function extractLiteralString(Expr $expr): ?string
+    {
+        if (!$expr instanceof Node\Scalar\String_) {
+            return null;
+        }
+
+        return $expr->value === '' ? null : $expr->value;
+    }
+}

--- a/tests/Application/app/Facades/Subscription.php
+++ b/tests/Application/app/Facades/Subscription.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * Test fixture for issue #942. The accessor is the string alias `'subscription'`,
+ * bound by {@see \App\Providers\SubscriptionServiceProvider::register()} — not by
+ * a class-string, so the runtime `Facade::getFacadeRoot()` probe fails inside the
+ * plugin's Testbench app. Resolution must succeed via the statically-harvested
+ * binding map maintained by
+ * {@see \Psalm\LaravelPlugin\Providers\BootTimeProviderHarvester}.
+ *
+ * No `@method` catalogue here on purpose — we want to assert that the harvester
+ * supplies the underlying class so {@see \Psalm\LaravelPlugin\Handlers\Facades\FacadeMethodHandler}
+ * can forward real method signatures from the service class.
+ */
+class Subscription extends Facade
+{
+    #[\Override]
+    protected static function getFacadeAccessor(): string
+    {
+        return 'subscription';
+    }
+}

--- a/tests/Application/app/Providers/SubscriptionServiceProvider.php
+++ b/tests/Application/app/Providers/SubscriptionServiceProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use App\Services\SubscriptionClient;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Stand-in for the kind of vendor provider that issue #942 calls out: a
+ * `ServiceProvider::register()` body that binds an accessor string to a concrete
+ * service class. The provider itself is never booted inside the plugin's
+ * Testbench app — its bindings reach the plugin only via the static AST harvest
+ * performed by
+ * {@see \Psalm\LaravelPlugin\Providers\BootTimeProviderHarvester}.
+ */
+final class SubscriptionServiceProvider extends ServiceProvider
+{
+    #[\Override]
+    public function register(): void
+    {
+        $this->app->singleton('subscription', SubscriptionClient::class);
+    }
+}

--- a/tests/Application/app/Services/SubscriptionClient.php
+++ b/tests/Application/app/Services/SubscriptionClient.php
@@ -15,12 +15,12 @@ namespace App\Services;
  */
 final class SubscriptionClient
 {
-    public function googlePlay(?string $token = null): self
+    public function googlePlay(): self
     {
         return $this;
     }
 
-    public function appStore(?string $token = null): self
+    public function appStore(): self
     {
         return $this;
     }

--- a/tests/Application/app/Services/SubscriptionClient.php
+++ b/tests/Application/app/Services/SubscriptionClient.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+/**
+ * Test fixture for {@see \App\Facades\Subscription}.
+ *
+ * The facade's accessor is the string alias `'subscription'`, bound to this
+ * class by {@see \App\Providers\SubscriptionServiceProvider::register()}.
+ * Reproduces the pattern documented in issue #942 (e.g.
+ * `imdhemy/laravel-in-app-purchases` ships a `Subscription` facade backed by a
+ * provider-bound alias).
+ */
+final class SubscriptionClient
+{
+    public function googlePlay(?string $token = null): self
+    {
+        return $this;
+    }
+
+    public function appStore(?string $token = null): self
+    {
+        return $this;
+    }
+
+    public function id(): int
+    {
+        return 0;
+    }
+}

--- a/tests/Type/macro-fixtures.php
+++ b/tests/Type/macro-fixtures.php
@@ -66,3 +66,15 @@ Builder::macro('testBuilderMacro', static fn(): string => 'builder macro OK');
     'testViteFacadeMacro',
     static fn(string $asset): string => "resources/images/{$asset}",
 );
+
+// Seed the static binding map used by AppFacadeRegistrationHandler (issue #942)
+// and ContainerResolver (issue #766) with the type-test fixture provider. In
+// production, BootTimeProviderHarvester discovers providers via composer
+// auto-discovery + bootstrap/providers.php / config/app.php. Neither file
+// exists for the plugin's own test fixtures, so we seed explicitly here. The
+// runtime call into harvestProvider() is the same one production uses for each
+// discovered FQCN.
+\Psalm\LaravelPlugin\Providers\BootTimeProviderHarvester::harvestProvider(
+    \App\Providers\SubscriptionServiceProvider::class,
+    new \Psalm\Progress\VoidProgress(),
+);

--- a/tests/Type/tests/Facades/StringAliasFacadeViaStaticBindingsTest.phpt
+++ b/tests/Type/tests/Facades/StringAliasFacadeViaStaticBindingsTest.phpt
@@ -1,0 +1,48 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Sandbox;
+
+use App\Facades\Subscription;
+use App\Services\SubscriptionClient;
+
+/**
+ * The `'subscription'` accessor is bound to `SubscriptionClient` by
+ * `App\Providers\SubscriptionServiceProvider::register()`. That provider's
+ * bindings reach the plugin via the static AST harvest in
+ * `BootTimeProviderHarvester`, which is seeded for type-test runs from
+ * `tests/Type/macro-fixtures.php` (the file Psalm loads via the `autoloader`
+ * attribute in `psalm.xml`). In production, the same harvester reads composer
+ * `extra.laravel.providers[]` and `bootstrap/providers.php`.
+ *
+ * `Subscription`'s accessor is a string alias, not a class-string, so the
+ * runtime `Facade::getFacadeRoot()` probe used by `AppFacadeRegistrationHandler`
+ * throws `BindingResolutionException` inside the plugin's Testbench app — issue
+ * #942 — and resolution falls to the binding map.
+ *
+ * Methods on `SubscriptionClient` must be forwarded to the facade without an
+ * `@method` catalogue and with the correct return type.
+ */
+function test_facade_resolves_method_via_static_binding_map(): SubscriptionClient
+{
+    /** @psalm-check-type-exact $client = SubscriptionClient */
+    $client = Subscription::googlePlay('token');
+
+    return $client;
+}
+
+/**
+ * `app('subscription')` is the issue #766 path: `ContainerResolver` queries the
+ * Testbench app's `make()`, which would throw because the provider is not booted.
+ * With the static binding map seeded by the same harvester, the resolver returns
+ * the concrete `SubscriptionClient` type instead of cascading into `mixed`.
+ */
+function test_app_helper_resolves_alias_via_static_binding_map(): SubscriptionClient
+{
+    /** @psalm-check-type-exact $client = SubscriptionClient */
+    $client = \app('subscription');
+
+    return $client;
+}
+?>
+--EXPECT--

--- a/tests/Unit/Providers/BootTimeProviderHarvesterTest.php
+++ b/tests/Unit/Providers/BootTimeProviderHarvesterTest.php
@@ -23,14 +23,12 @@ use Psalm\Progress\VoidProgress;
 #[CoversClass(BootTimeProviderHarvester::class)]
 final class BootTimeProviderHarvesterTest extends TestCase
 {
-    #[\Override]
     protected function setUp(): void
     {
         parent::setUp();
         ContainerBindingMapProvider::reset();
     }
 
-    #[\Override]
     protected function tearDown(): void
     {
         ContainerBindingMapProvider::reset();
@@ -45,10 +43,7 @@ final class BootTimeProviderHarvesterTest extends TestCase
             new VoidProgress(),
         );
 
-        self::assertSame(
-            SubscriptionClient::class,
-            ContainerBindingMapProvider::lookup('subscription'),
-        );
+        $this->assertSame(SubscriptionClient::class, ContainerBindingMapProvider::lookup('subscription'));
     }
 
     #[Test]
@@ -61,7 +56,7 @@ final class BootTimeProviderHarvesterTest extends TestCase
         );
 
         // No crash; map remains empty.
-        self::assertNull(ContainerBindingMapProvider::lookup('subscription'));
+        $this->assertNull(ContainerBindingMapProvider::lookup('subscription'));
     }
 
     #[Test]
@@ -83,9 +78,6 @@ final class BootTimeProviderHarvesterTest extends TestCase
             [SubscriptionServiceProvider::class],
         );
 
-        self::assertSame(
-            SubscriptionClient::class,
-            ContainerBindingMapProvider::lookup('subscription'),
-        );
+        $this->assertSame(SubscriptionClient::class, ContainerBindingMapProvider::lookup('subscription'));
     }
 }

--- a/tests/Unit/Providers/BootTimeProviderHarvesterTest.php
+++ b/tests/Unit/Providers/BootTimeProviderHarvesterTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Tests\Unit\Providers;
+
+use App\Providers\SubscriptionServiceProvider;
+use App\Services\SubscriptionClient;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Providers\BootTimeProviderHarvester;
+use Psalm\LaravelPlugin\Providers\ContainerBindingMapProvider;
+use Psalm\Progress\VoidProgress;
+
+/**
+ * Smoke tests for the boot-time entry point. The autoloader fixture seeds the
+ * map via the same `harvestProvider()` path the type-test bootstrap uses, so
+ * the assertions here both verify the public API works in isolation AND act as
+ * a regression gate: if `BootTimeProviderHarvester::harvestProvider()` stops
+ * populating the map for the fixture, the type tests fail downstream too.
+ */
+#[CoversClass(BootTimeProviderHarvester::class)]
+final class BootTimeProviderHarvesterTest extends TestCase
+{
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        ContainerBindingMapProvider::reset();
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        ContainerBindingMapProvider::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function harvest_provider_populates_map_from_fixture_provider(): void
+    {
+        BootTimeProviderHarvester::harvestProvider(
+            SubscriptionServiceProvider::class,
+            new VoidProgress(),
+        );
+
+        self::assertSame(
+            SubscriptionClient::class,
+            ContainerBindingMapProvider::lookup('subscription'),
+        );
+    }
+
+    #[Test]
+    public function harvest_provider_swallows_missing_class(): void
+    {
+        BootTimeProviderHarvester::harvestProvider(
+            // @phpstan-ignore-next-line — intentional non-existent FQCN
+            'Nonexistent\\Provider\\DoesNotExist',
+            new VoidProgress(),
+        );
+
+        // No crash; map remains empty.
+        self::assertNull(ContainerBindingMapProvider::lookup('subscription'));
+    }
+
+    #[Test]
+    public function harvest_all_runs_without_error_in_empty_environment(): void
+    {
+        // The plugin's own dev environment has no first-party `bootstrap/providers.php`
+        // or `config/app.php`, so harvestAll() exercises the vendor-only path. The
+        // call should succeed and not throw regardless of what's in installed.json.
+        BootTimeProviderHarvester::harvestAll(new VoidProgress());
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function harvest_all_with_extra_providers_seeds_map(): void
+    {
+        BootTimeProviderHarvester::harvestAll(
+            new VoidProgress(),
+            [SubscriptionServiceProvider::class],
+        );
+
+        self::assertSame(
+            SubscriptionClient::class,
+            ContainerBindingMapProvider::lookup('subscription'),
+        );
+    }
+}

--- a/tests/Unit/Providers/ContainerBindingMapProviderTest.php
+++ b/tests/Unit/Providers/ContainerBindingMapProviderTest.php
@@ -12,14 +12,12 @@ use Psalm\LaravelPlugin\Providers\ContainerBindingMapProvider;
 #[CoversClass(ContainerBindingMapProvider::class)]
 final class ContainerBindingMapProviderTest extends TestCase
 {
-    #[\Override]
     protected function setUp(): void
     {
         parent::setUp();
         ContainerBindingMapProvider::reset();
     }
 
-    #[\Override]
     protected function tearDown(): void
     {
         ContainerBindingMapProvider::reset();
@@ -29,7 +27,7 @@ final class ContainerBindingMapProviderTest extends TestCase
     #[Test]
     public function lookup_returns_null_for_unknown_accessor(): void
     {
-        self::assertNull(ContainerBindingMapProvider::lookup('unknown.alias'));
+        $this->assertNull(ContainerBindingMapProvider::lookup('unknown.alias'));
     }
 
     #[Test]
@@ -37,7 +35,7 @@ final class ContainerBindingMapProviderTest extends TestCase
     {
         ContainerBindingMapProvider::record('subscription', \stdClass::class);
 
-        self::assertSame(\stdClass::class, ContainerBindingMapProvider::lookup('subscription'));
+        $this->assertSame(\stdClass::class, ContainerBindingMapProvider::lookup('subscription'));
     }
 
     #[Test]
@@ -46,11 +44,7 @@ final class ContainerBindingMapProviderTest extends TestCase
         ContainerBindingMapProvider::record('alias', \stdClass::class);
         ContainerBindingMapProvider::record('alias', \ArrayObject::class);
 
-        self::assertSame(
-            \stdClass::class,
-            ContainerBindingMapProvider::lookup('alias'),
-            'subsequent writes must be ignored so scan ordering does not produce non-deterministic maps',
-        );
+        $this->assertSame(\stdClass::class, ContainerBindingMapProvider::lookup('alias'), 'subsequent writes must be ignored so scan ordering does not produce non-deterministic maps');
     }
 
     #[Test]
@@ -58,6 +52,6 @@ final class ContainerBindingMapProviderTest extends TestCase
     {
         ContainerBindingMapProvider::record('', \stdClass::class);
 
-        self::assertNull(ContainerBindingMapProvider::lookup(''));
+        $this->assertNull(ContainerBindingMapProvider::lookup(''));
     }
 }

--- a/tests/Unit/Providers/ContainerBindingMapProviderTest.php
+++ b/tests/Unit/Providers/ContainerBindingMapProviderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Tests\Unit\Providers;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Providers\ContainerBindingMapProvider;
+
+#[CoversClass(ContainerBindingMapProvider::class)]
+final class ContainerBindingMapProviderTest extends TestCase
+{
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        ContainerBindingMapProvider::reset();
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        ContainerBindingMapProvider::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function lookup_returns_null_for_unknown_accessor(): void
+    {
+        self::assertNull(ContainerBindingMapProvider::lookup('unknown.alias'));
+    }
+
+    #[Test]
+    public function record_then_lookup_round_trips(): void
+    {
+        ContainerBindingMapProvider::record('subscription', \stdClass::class);
+
+        self::assertSame(\stdClass::class, ContainerBindingMapProvider::lookup('subscription'));
+    }
+
+    #[Test]
+    public function record_first_write_wins(): void
+    {
+        ContainerBindingMapProvider::record('alias', \stdClass::class);
+        ContainerBindingMapProvider::record('alias', \ArrayObject::class);
+
+        self::assertSame(
+            \stdClass::class,
+            ContainerBindingMapProvider::lookup('alias'),
+            'subsequent writes must be ignored so scan ordering does not produce non-deterministic maps',
+        );
+    }
+
+    #[Test]
+    public function empty_accessor_is_rejected(): void
+    {
+        ContainerBindingMapProvider::record('', \stdClass::class);
+
+        self::assertNull(ContainerBindingMapProvider::lookup(''));
+    }
+}

--- a/tests/Unit/Util/ProviderBindingHarvesterTest.php
+++ b/tests/Unit/Util/ProviderBindingHarvesterTest.php
@@ -27,14 +27,12 @@ use Psalm\LaravelPlugin\Util\ProviderBindingHarvester;
 #[CoversClass(ProviderBindingHarvester::class)]
 final class ProviderBindingHarvesterTest extends TestCase
 {
-    #[\Override]
     protected function setUp(): void
     {
         parent::setUp();
         ContainerBindingMapProvider::reset();
     }
 
-    #[\Override]
     protected function tearDown(): void
     {
         ContainerBindingMapProvider::reset();
@@ -55,7 +53,7 @@ final class ProviderBindingHarvesterTest extends TestCase
             class SubscriptionClient {}
         PHP);
 
-        self::assertSame('Acme\\SubscriptionClient', ContainerBindingMapProvider::lookup('subscription'));
+        $this->assertSame('Acme\\SubscriptionClient', ContainerBindingMapProvider::lookup('subscription'));
     }
 
     #[Test]
@@ -72,7 +70,7 @@ final class ProviderBindingHarvesterTest extends TestCase
             class DriverConfig {}
         PHP);
 
-        self::assertSame('Acme\\DriverConfig', ContainerBindingMapProvider::lookup('config.driver'));
+        $this->assertSame('Acme\\DriverConfig', ContainerBindingMapProvider::lookup('config.driver'));
     }
 
     #[Test]
@@ -89,7 +87,7 @@ final class ProviderBindingHarvesterTest extends TestCase
             class Cfg {}
         PHP);
 
-        self::assertSame('Acme\\Cfg', ContainerBindingMapProvider::lookup('cfg'));
+        $this->assertSame('Acme\\Cfg', ContainerBindingMapProvider::lookup('cfg'));
     }
 
     #[Test]
@@ -106,7 +104,7 @@ final class ProviderBindingHarvesterTest extends TestCase
             class Real {}
         PHP);
 
-        self::assertSame('Acme\\Real', ContainerBindingMapProvider::lookup('real.alias'));
+        $this->assertSame('Acme\\Real', ContainerBindingMapProvider::lookup('real.alias'));
     }
 
     #[Test]
@@ -123,7 +121,7 @@ final class ProviderBindingHarvesterTest extends TestCase
             class Request {}
         PHP);
 
-        self::assertSame('Acme\\Request', ContainerBindingMapProvider::lookup('datatables.request'));
+        $this->assertSame('Acme\\Request', ContainerBindingMapProvider::lookup('datatables.request'));
     }
 
     #[Test]
@@ -143,7 +141,7 @@ final class ProviderBindingHarvesterTest extends TestCase
             class Builder { public function __construct(array $opts) {} }
         PHP);
 
-        self::assertSame('Acme\\Builder', ContainerBindingMapProvider::lookup('builder'));
+        $this->assertSame('Acme\\Builder', ContainerBindingMapProvider::lookup('builder'));
     }
 
     #[Test]
@@ -162,7 +160,7 @@ final class ProviderBindingHarvesterTest extends TestCase
             class Alpha {}
         PHP);
 
-        self::assertSame('Acme\\Alpha', ContainerBindingMapProvider::lookup('alpha'));
+        $this->assertSame('Acme\\Alpha', ContainerBindingMapProvider::lookup('alpha'));
     }
 
     #[Test]
@@ -179,7 +177,7 @@ final class ProviderBindingHarvesterTest extends TestCase
             class PerRequest {}
         PHP);
 
-        self::assertSame('Acme\\PerRequest', ContainerBindingMapProvider::lookup('per-request'));
+        $this->assertSame('Acme\\PerRequest', ContainerBindingMapProvider::lookup('per-request'));
     }
 
     #[Test]
@@ -196,7 +194,7 @@ final class ProviderBindingHarvesterTest extends TestCase
             class MaybeImpl {}
         PHP);
 
-        self::assertSame('Acme\\MaybeImpl', ContainerBindingMapProvider::lookup('maybe'));
+        $this->assertSame('Acme\\MaybeImpl', ContainerBindingMapProvider::lookup('maybe'));
     }
 
     #[Test]
@@ -213,7 +211,7 @@ final class ProviderBindingHarvesterTest extends TestCase
             class OnceImpl {}
         PHP);
 
-        self::assertSame('Acme\\OnceImpl', ContainerBindingMapProvider::lookup('once'));
+        $this->assertSame('Acme\\OnceImpl', ContainerBindingMapProvider::lookup('once'));
     }
 
     #[Test]
@@ -230,7 +228,7 @@ final class ProviderBindingHarvesterTest extends TestCase
             class ScopedOnceImpl {}
         PHP);
 
-        self::assertSame('Acme\\ScopedOnceImpl', ContainerBindingMapProvider::lookup('per-request-once'));
+        $this->assertSame('Acme\\ScopedOnceImpl', ContainerBindingMapProvider::lookup('per-request-once'));
     }
 
     #[Test]
@@ -248,7 +246,7 @@ final class ProviderBindingHarvesterTest extends TestCase
             class FacadeImpl {}
         PHP);
 
-        self::assertSame('Acme\\FacadeImpl', ContainerBindingMapProvider::lookup('via-facade'));
+        $this->assertSame('Acme\\FacadeImpl', ContainerBindingMapProvider::lookup('via-facade'));
     }
 
     #[Test]
@@ -280,8 +278,8 @@ final class ProviderBindingHarvesterTest extends TestCase
             class SomeImpl {}
         PHP);
 
-        self::assertSame('Acme\\SubscriptionClient', ContainerBindingMapProvider::lookup('subscription'));
-        self::assertSame('Acme\\ProductClient', ContainerBindingMapProvider::lookup('product'));
+        $this->assertSame('Acme\\SubscriptionClient', ContainerBindingMapProvider::lookup('subscription'));
+        $this->assertSame('Acme\\ProductClient', ContainerBindingMapProvider::lookup('product'));
     }
 
     #[Test]
@@ -298,7 +296,7 @@ final class ProviderBindingHarvesterTest extends TestCase
             class HelperImpl {}
         PHP);
 
-        self::assertSame('Acme\\HelperImpl', ContainerBindingMapProvider::lookup('helper.alias'));
+        $this->assertSame('Acme\\HelperImpl', ContainerBindingMapProvider::lookup('helper.alias'));
     }
 
     #[Test]
@@ -316,7 +314,7 @@ final class ProviderBindingHarvesterTest extends TestCase
             class Impl {}
         PHP);
 
-        self::assertNull(ContainerBindingMapProvider::lookup('dynamic'));
+        $this->assertNull(ContainerBindingMapProvider::lookup('dynamic'));
     }
 
     #[Test]
@@ -334,7 +332,7 @@ final class ProviderBindingHarvesterTest extends TestCase
             }
         PHP);
 
-        self::assertNull(ContainerBindingMapProvider::lookup('foo'));
+        $this->assertNull(ContainerBindingMapProvider::lookup('foo'));
     }
 
     #[Test]
@@ -353,7 +351,7 @@ final class ProviderBindingHarvesterTest extends TestCase
             class Impl {}
         PHP);
 
-        self::assertNull(ContainerBindingMapProvider::lookup('not.container'));
+        $this->assertNull(ContainerBindingMapProvider::lookup('not.container'));
     }
 
     /**
@@ -366,7 +364,7 @@ final class ProviderBindingHarvesterTest extends TestCase
     {
         $parser = (new ParserFactory())->createForNewestSupportedVersion();
         $stmts = $parser->parse("<?php\n" . $source);
-        self::assertIsArray($stmts, 'fixture failed to parse');
+        $this->assertIsArray($stmts, 'fixture failed to parse');
 
         $traverser = new NodeTraverser();
         $traverser->addVisitor(new NameResolver());
@@ -374,7 +372,7 @@ final class ProviderBindingHarvesterTest extends TestCase
         $resolved = $traverser->traverse($stmts);
 
         $registerStmts = $this->findRegisterStmts($resolved);
-        self::assertNotNull($registerStmts, 'fixture must declare a register() method');
+        $this->assertNotNull($registerStmts, 'fixture must declare a register() method');
 
         ProviderBindingHarvester::harvest($registerStmts);
     }
@@ -390,7 +388,7 @@ final class ProviderBindingHarvesterTest extends TestCase
     {
         $parser = (new ParserFactory())->createForNewestSupportedVersion();
         $stmts = $parser->parse("<?php\n" . $source);
-        self::assertIsArray($stmts, 'fixture failed to parse');
+        $this->assertIsArray($stmts, 'fixture failed to parse');
 
         $traverser = new NodeTraverser();
         $traverser->addVisitor(new NameResolver());
@@ -398,7 +396,7 @@ final class ProviderBindingHarvesterTest extends TestCase
         $resolved = $traverser->traverse($stmts);
 
         $class = $this->findClassNode($resolved);
-        self::assertNotNull($class, 'fixture must declare at least one class');
+        $this->assertNotNull($class, 'fixture must declare at least one class');
 
         ProviderBindingHarvester::harvestClassMethods($class);
     }
@@ -411,9 +409,10 @@ final class ProviderBindingHarvesterTest extends TestCase
         foreach ($stmts as $stmt) {
             if ($stmt instanceof Namespace_) {
                 $found = $this->findClassNode($stmt->stmts);
-                if ($found !== null) {
+                if ($found instanceof \PhpParser\Node\Stmt\Class_) {
                     return $found;
                 }
+
                 continue;
             }
 
@@ -437,6 +436,7 @@ final class ProviderBindingHarvesterTest extends TestCase
                 if ($found !== null) {
                     return $found;
                 }
+
                 continue;
             }
 

--- a/tests/Unit/Util/ProviderBindingHarvesterTest.php
+++ b/tests/Unit/Util/ProviderBindingHarvesterTest.php
@@ -1,0 +1,453 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Tests\Unit\Util;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Providers\ContainerBindingMapProvider;
+use Psalm\LaravelPlugin\Util\ProviderBindingHarvester;
+
+/**
+ * Exercises {@see ProviderBindingHarvester} against synthesised
+ * `ServiceProvider::register()` bodies. We don't construct a `Codebase` here —
+ * the harvester is deliberately decoupled from Psalm so it can be tested with
+ * just PhpParser + a manual `NameResolver` pass (the same pass Psalm runs at
+ * scan time, which attaches the `resolvedName` attribute used by the resolver).
+ */
+#[CoversClass(ProviderBindingHarvester::class)]
+final class ProviderBindingHarvesterTest extends TestCase
+{
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        ContainerBindingMapProvider::reset();
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        ContainerBindingMapProvider::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function harvests_bind_with_class_string_second_arg(): void
+    {
+        $this->harvestRegister(<<<'PHP'
+            namespace Acme;
+            use Illuminate\Support\ServiceProvider;
+            class Provider extends ServiceProvider {
+                public function register() {
+                    $this->app->bind('subscription', SubscriptionClient::class);
+                }
+            }
+            class SubscriptionClient {}
+        PHP);
+
+        self::assertSame('Acme\\SubscriptionClient', ContainerBindingMapProvider::lookup('subscription'));
+    }
+
+    #[Test]
+    public function harvests_singleton_with_class_string_second_arg(): void
+    {
+        $this->harvestRegister(<<<'PHP'
+            namespace Acme;
+            use Illuminate\Support\ServiceProvider;
+            class Provider extends ServiceProvider {
+                public function register() {
+                    $this->app->singleton('config.driver', DriverConfig::class);
+                }
+            }
+            class DriverConfig {}
+        PHP);
+
+        self::assertSame('Acme\\DriverConfig', ContainerBindingMapProvider::lookup('config.driver'));
+    }
+
+    #[Test]
+    public function harvests_instance_binding(): void
+    {
+        $this->harvestRegister(<<<'PHP'
+            namespace Acme;
+            use Illuminate\Support\ServiceProvider;
+            class Provider extends ServiceProvider {
+                public function register() {
+                    $this->app->instance('cfg', Cfg::class);
+                }
+            }
+            class Cfg {}
+        PHP);
+
+        self::assertSame('Acme\\Cfg', ContainerBindingMapProvider::lookup('cfg'));
+    }
+
+    #[Test]
+    public function harvests_alias_with_swapped_argument_order(): void
+    {
+        $this->harvestRegister(<<<'PHP'
+            namespace Acme;
+            use Illuminate\Support\ServiceProvider;
+            class Provider extends ServiceProvider {
+                public function register() {
+                    $this->app->alias(\Acme\Real::class, 'real.alias');
+                }
+            }
+            class Real {}
+        PHP);
+
+        self::assertSame('Acme\\Real', ContainerBindingMapProvider::lookup('real.alias'));
+    }
+
+    #[Test]
+    public function harvests_arrow_function_factory(): void
+    {
+        $this->harvestRegister(<<<'PHP'
+            namespace Acme;
+            use Illuminate\Support\ServiceProvider;
+            class Provider extends ServiceProvider {
+                public function register() {
+                    $this->app->singleton('datatables.request', fn () => new Request());
+                }
+            }
+            class Request {}
+        PHP);
+
+        self::assertSame('Acme\\Request', ContainerBindingMapProvider::lookup('datatables.request'));
+    }
+
+    #[Test]
+    public function harvests_closure_factory_with_setup_then_return(): void
+    {
+        $this->harvestRegister(<<<'PHP'
+            namespace Acme;
+            use Illuminate\Support\ServiceProvider;
+            class Provider extends ServiceProvider {
+                public function register() {
+                    $this->app->singleton('builder', function ($app) {
+                        $opts = ['k' => 'v'];
+                        return new Builder($opts);
+                    });
+                }
+            }
+            class Builder { public function __construct(array $opts) {} }
+        PHP);
+
+        self::assertSame('Acme\\Builder', ContainerBindingMapProvider::lookup('builder'));
+    }
+
+    #[Test]
+    public function harvests_bindings_nested_in_if_block(): void
+    {
+        $this->harvestRegister(<<<'PHP'
+            namespace Acme;
+            use Illuminate\Support\ServiceProvider;
+            class Provider extends ServiceProvider {
+                public function register() {
+                    if (true) {
+                        $this->app->bind('alpha', Alpha::class);
+                    }
+                }
+            }
+            class Alpha {}
+        PHP);
+
+        self::assertSame('Acme\\Alpha', ContainerBindingMapProvider::lookup('alpha'));
+    }
+
+    #[Test]
+    public function harvests_scoped_binding(): void
+    {
+        $this->harvestRegister(<<<'PHP'
+            namespace Acme;
+            use Illuminate\Support\ServiceProvider;
+            class Provider extends ServiceProvider {
+                public function register() {
+                    $this->app->scoped('per-request', PerRequest::class);
+                }
+            }
+            class PerRequest {}
+        PHP);
+
+        self::assertSame('Acme\\PerRequest', ContainerBindingMapProvider::lookup('per-request'));
+    }
+
+    #[Test]
+    public function harvests_bindif_binding(): void
+    {
+        $this->harvestRegister(<<<'PHP'
+            namespace Acme;
+            use Illuminate\Support\ServiceProvider;
+            class Provider extends ServiceProvider {
+                public function register() {
+                    $this->app->bindIf('maybe', MaybeImpl::class);
+                }
+            }
+            class MaybeImpl {}
+        PHP);
+
+        self::assertSame('Acme\\MaybeImpl', ContainerBindingMapProvider::lookup('maybe'));
+    }
+
+    #[Test]
+    public function harvests_singletonif_binding(): void
+    {
+        $this->harvestRegister(<<<'PHP'
+            namespace Acme;
+            use Illuminate\Support\ServiceProvider;
+            class Provider extends ServiceProvider {
+                public function register() {
+                    $this->app->singletonIf('once', OnceImpl::class);
+                }
+            }
+            class OnceImpl {}
+        PHP);
+
+        self::assertSame('Acme\\OnceImpl', ContainerBindingMapProvider::lookup('once'));
+    }
+
+    #[Test]
+    public function harvests_scopedif_binding(): void
+    {
+        $this->harvestRegister(<<<'PHP'
+            namespace Acme;
+            use Illuminate\Support\ServiceProvider;
+            class Provider extends ServiceProvider {
+                public function register() {
+                    $this->app->scopedIf('per-request-once', ScopedOnceImpl::class);
+                }
+            }
+            class ScopedOnceImpl {}
+        PHP);
+
+        self::assertSame('Acme\\ScopedOnceImpl', ContainerBindingMapProvider::lookup('per-request-once'));
+    }
+
+    #[Test]
+    public function harvests_app_facade_static_call(): void
+    {
+        $this->harvestRegister(<<<'PHP'
+            namespace Acme;
+            use Illuminate\Support\Facades\App;
+            use Illuminate\Support\ServiceProvider;
+            class Provider extends ServiceProvider {
+                public function register() {
+                    App::singleton('via-facade', FacadeImpl::class);
+                }
+            }
+            class FacadeImpl {}
+        PHP);
+
+        self::assertSame('Acme\\FacadeImpl', ContainerBindingMapProvider::lookup('via-facade'));
+    }
+
+    #[Test]
+    public function harvests_delegated_bindings_via_class_method_walk(): void
+    {
+        // imdhemy/laravel-in-app-purchases pattern: register() is a dispatcher that
+        // calls private bind*() helpers where the real container::bind() calls live.
+        // The harvester's per-method `harvest()` walker would miss these — we use
+        // `harvestClassMethods()` here to walk every method body.
+        $this->harvestClassMethods(<<<'PHP'
+            namespace Acme;
+            use Illuminate\Support\ServiceProvider;
+            class Provider extends ServiceProvider {
+                public function register() {
+                    $this->bindFacades();
+                    $this->bindConcretes();
+                }
+                private function bindFacades() {
+                    $this->app->bind('subscription', SubscriptionClient::class);
+                    $this->app->bind('product', ProductClient::class);
+                }
+                private function bindConcretes() {
+                    $this->app->singleton(SomeContract::class, SomeImpl::class);
+                }
+            }
+            class SubscriptionClient {}
+            class ProductClient {}
+            class SomeContract {}
+            class SomeImpl {}
+        PHP);
+
+        self::assertSame('Acme\\SubscriptionClient', ContainerBindingMapProvider::lookup('subscription'));
+        self::assertSame('Acme\\ProductClient', ContainerBindingMapProvider::lookup('product'));
+    }
+
+    #[Test]
+    public function harvests_app_helper_receiver(): void
+    {
+        $this->harvestRegister(<<<'PHP'
+            namespace Acme;
+            use Illuminate\Support\ServiceProvider;
+            class Provider extends ServiceProvider {
+                public function register() {
+                    app()->singleton('helper.alias', HelperImpl::class);
+                }
+            }
+            class HelperImpl {}
+        PHP);
+
+        self::assertSame('Acme\\HelperImpl', ContainerBindingMapProvider::lookup('helper.alias'));
+    }
+
+    #[Test]
+    public function ignores_dynamic_accessor(): void
+    {
+        $this->harvestRegister(<<<'PHP'
+            namespace Acme;
+            use Illuminate\Support\ServiceProvider;
+            class Provider extends ServiceProvider {
+                public function register() {
+                    $name = 'dynamic';
+                    $this->app->bind($name, Impl::class);
+                }
+            }
+            class Impl {}
+        PHP);
+
+        self::assertNull(ContainerBindingMapProvider::lookup('dynamic'));
+    }
+
+    #[Test]
+    public function ignores_unrecognised_concrete_shape(): void
+    {
+        $this->harvestRegister(<<<'PHP'
+            namespace Acme;
+            use Illuminate\Support\ServiceProvider;
+            class Provider extends ServiceProvider {
+                public function register() {
+                    $maker = $this->resolveMaker();
+                    $this->app->bind('foo', $maker);
+                }
+                private function resolveMaker(): string { return 'never'; }
+            }
+        PHP);
+
+        self::assertNull(ContainerBindingMapProvider::lookup('foo'));
+    }
+
+    #[Test]
+    public function ignores_calls_on_non_container_receiver(): void
+    {
+        $this->harvestRegister(<<<'PHP'
+            namespace Acme;
+            use Illuminate\Support\ServiceProvider;
+            class Provider extends ServiceProvider {
+                public function register() {
+                    $other = new SomeOther();
+                    $other->bind('not.container', Impl::class);
+                }
+            }
+            class SomeOther { public function bind($a, $b) {} }
+            class Impl {}
+        PHP);
+
+        self::assertNull(ContainerBindingMapProvider::lookup('not.container'));
+    }
+
+    /**
+     * Parses a PHP source snippet, runs the NameResolver pass (so `Foo::class`
+     * expressions get a `resolvedName` attribute exactly like under Psalm's
+     * scan phase), locates the `register()` method body, and feeds it to the
+     * harvester. Each test asserts the resulting map state.
+     */
+    private function harvestRegister(string $source): void
+    {
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
+        $stmts = $parser->parse("<?php\n" . $source);
+        self::assertIsArray($stmts, 'fixture failed to parse');
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver());
+        /** @var list<Node> $resolved */
+        $resolved = $traverser->traverse($stmts);
+
+        $registerStmts = $this->findRegisterStmts($resolved);
+        self::assertNotNull($registerStmts, 'fixture must declare a register() method');
+
+        ProviderBindingHarvester::harvest($registerStmts);
+    }
+
+    /**
+     * Variant of {@see harvestRegister} that hands the whole `Class_` to
+     * `harvestClassMethods()`, exercising the per-class entry point used by
+     * `BootTimeProviderHarvester` for real provider files. Use this when the
+     * fixture's bindings live in methods other than `register()` (the common
+     * delegated-binding pattern in third-party providers).
+     */
+    private function harvestClassMethods(string $source): void
+    {
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
+        $stmts = $parser->parse("<?php\n" . $source);
+        self::assertIsArray($stmts, 'fixture failed to parse');
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver());
+        /** @var list<Node> $resolved */
+        $resolved = $traverser->traverse($stmts);
+
+        $class = $this->findClassNode($resolved);
+        self::assertNotNull($class, 'fixture must declare at least one class');
+
+        ProviderBindingHarvester::harvestClassMethods($class);
+    }
+
+    /**
+     * @param list<Node> $stmts
+     */
+    private function findClassNode(array $stmts): ?Class_
+    {
+        foreach ($stmts as $stmt) {
+            if ($stmt instanceof Namespace_) {
+                $found = $this->findClassNode($stmt->stmts);
+                if ($found !== null) {
+                    return $found;
+                }
+                continue;
+            }
+
+            if ($stmt instanceof Class_) {
+                return $stmt;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<Node> $stmts
+     * @return list<Node\Stmt>|null
+     */
+    private function findRegisterStmts(array $stmts): ?array
+    {
+        foreach ($stmts as $stmt) {
+            if ($stmt instanceof Namespace_) {
+                $found = $this->findRegisterStmts($stmt->stmts);
+                if ($found !== null) {
+                    return $found;
+                }
+                continue;
+            }
+
+            if ($stmt instanceof Class_) {
+                $method = $stmt->getMethod('register');
+                if ($method instanceof ClassMethod && $method->stmts !== null) {
+                    return $method->stmts;
+                }
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Issue to Solve

Two related issues, both rooted in the plugin's Testbench app not reliably running vendor/user `ServiceProvider::register()` bindings:

- **#942** — `Facade::getFacadeRoot()` probe throws `BindingResolutionException` for facades whose accessor is a string alias (e.g. `'subscription'`) bound by a vendor provider. The plugin emits a noisy warning on every Psalm run and falls back to whatever `@method` catalogue the package ships. The cited package `imdhemy/laravel-in-app-purchases` is exactly this shape.
- **#766** — `app('alias')` / `resolve('alias')` / `make('alias')` against the same kind of accessor returns `mixed`, cascading into `MixedAssignment` and `MixedMethodCall` at every call site (audited on `yajra/laravel-datatables`).

## Related

Closes #942
Closes #766

## Solution Description

Add a boot-time static AST harvester that extracts `accessor → service-class` bindings from every discoverable `ServiceProvider` and exposes them through a shared `ContainerBindingMapProvider`. Two existing resolvers query the map before falling through to their runtime probes:

- `AppFacadeRegistrationHandler::tryGetFacadeRootClass()` reads the map before `Facade::getFacadeRoot()` (fixes #942 — silences the warning AND derives types from the actual service class instead of relying on a `@method` catalogue).
- `ContainerResolver::resolveFromApplicationContainer()` reads the map before its Testbench `make()` call (fixes #766 — returns the concrete class type instead of `mixed`).

### Why boot-time and not a scan-time `AfterClassLikeVisit` hook

An earlier prototype lived in an `AfterClassLikeVisit` handler. Two failure modes made that approach a silent no-op for the real audience:

1. **Worker IPC** — when Psalm forks scanner workers (`pool_size > 1`, `files > 512`), plugin static state populated in workers does not propagate back via `ShutdownScannerTask`. Consumers in the parent's analysis phase see an empty map.
2. **Warm cache** — `AfterClassLikeVisit` only fires when a class is freshly scanned. On any run reusing the cached storage, the hook never fires and the map is empty.

Running in the main process at plugin init, before any fork, sidesteps both: the static map is set up once in the parent and inherited via copy-on-write into every worker; warm-cache state has no bearing because no Psalm hook is touched.

### Provider discovery

`BootTimeProviderHarvester` reads three sources, all in the main process:

1. **Vendor packages** — `vendor/composer/installed.json` `extra.laravel.providers[]`, honouring `extra.laravel.dont-discover` exactly as `Illuminate\Foundation\PackageManifest::packagesToIgnore()` does (per-package opt-outs merged with the root `composer.json` opt-outs and the literal `"*"` short-circuit).
2. **First-party providers** — `bootstrap/providers.php` (Laravel 11+) or `config/app.php` `providers` key (Laravel ≤10), parsed via PhpParser AST. User files are never `include`d, so user code is not executed at plugin init.
3. **Explicit list** — `harvestAll($extraProviders)` accepts an explicit FQCN list, used by `tests/Type/macro-fixtures.php` to seed the type-test fixture provider.

### Binding-shape coverage

`ProviderBindingHarvester` walks every method body of the provider class (not just `register()`) and recognises:

- `$this->app->bind|singleton|instance|scoped|bindIf|singletonIf|scopedIf($accessor, ServiceClass::class)`
- `$this->app->bind|singleton('accessor', fn () => new ServiceClass(...))`
- `$this->app->bind|singleton('accessor', function () { return new ServiceClass(...); })`
- `$this->app->alias(ServiceClass::class, 'accessor')` (reverse argument order)
- `app()->bind(...)` and `\Illuminate\Support\Facades\App::bind(...)` receivers

Walking every method (not just `register()`) catches the common delegated-binding pattern where `register()` is a thin dispatcher and the real container calls live in private helpers like `bindFacades()` / `bindConcretes()` (the `imdhemy/laravel-in-app-purchases` shape cited in #942).

### Known coverage gaps

Documented in the `BootTimeProviderHarvester` class docblock with workarounds:

- Laravel 11+ `$app->withProviders([...])` inline in `bootstrap/app.php` (workaround: list providers in `bootstrap/providers.php`)
- `$this->app->register(SubProvider::class)` chains (workaround: add to `bootstrap/providers.php` or `extra.laravel.providers`)
- Trait-imported binding helpers (`Class_::getMethods()` returns only directly-declared methods)
- Monorepo runs from outside the project root (psalm's CLI `chdir`s to the project root in the default configuration; non-default invocations may miss first-party providers)

### Other fixes folded in

- `AppFacadeRegistrationHandler::tryGetFacadeRootClass()` reorders the map lookup ahead of the `$failedFacades` cache gate so a facade visited before its provider isn't permanently poisoned by the earlier runtime-probe failure once the map fills in.
- `harvestProvider()` catches `\Throwable` (not just `\ReflectionException`) around `new \ReflectionClass($fqcn)` so a vendor provider with a `\ParseError` / `\Error` during autoload doesn't escape and disable the rest of plugin init.
- Silent failure modes in `extractProvidersFromAst()`, `readVendorProviders()`, and `harvestProvider()` surface via `$progress->warning(...)` so the user can see what happened.

### Test coverage

- **`tests/Unit/Util/ProviderBindingHarvesterTest.php`** — 17 unit tests covering every binding shape (forward methods, alias-reversed, arrow/closure factories, nested-if, App static-call receiver, app() helper, delegated bindings via `harvestClassMethods()`, dynamic-accessor rejection, non-container-receiver rejection).
- **`tests/Unit/Providers/ContainerBindingMapProviderTest.php`** — 5 unit tests for the static map (record/lookup, first-write-wins, empty-accessor rejection).
- **`tests/Unit/Providers/BootTimeProviderHarvesterTest.php`** — 4 smoke tests for the boot-time entry point (fixture seed, missing-class swallow, empty environment, explicit `$extraProviders`).
- **`tests/Type/tests/Facades/StringAliasFacadeViaStaticBindingsTest.phpt`** — end-to-end type test: `Subscription::googlePlay()` and `app('subscription')` both resolve to `SubscriptionClient` without any `@method` catalogue.

All suites pass: 646 unit tests, 403 type tests, app integration test green. Self-Psalm clean. `composer cs` clean.

## Checklist
- [x] Tests cover the change (type test + unit tests across both `tests/Type/` and `tests/Unit/`)
- [x] Documentation is updated (extensive in-code docblocks covering rationale, known gaps, workarounds)
