### PR TITLE
Resolve vendor facades via container introspection (replaces #951)

### DIFF
--- a/src/Handlers/Facades/AppFacadeRegistrationHandler.php
+++ b/src/Handlers/Facades/AppFacadeRegistrationHandler.php
@@ -6,6 +6,7 @@ namespace Psalm\LaravelPlugin\Handlers\Facades;
 
 use Illuminate\Support\Facades\Facade;
 use Psalm\Codebase;
+use Psalm\LaravelPlugin\Providers\ContainerBindingMapProvider;
 use Psalm\LaravelPlugin\Util\AnonymousClassNameDetector;
 use Psalm\Plugin\EventHandler\AfterClassLikeVisitInterface;
 use Psalm\Plugin\EventHandler\AfterCodebasePopulatedInterface;
@@ -177,14 +178,40 @@ final class AppFacadeRegistrationHandler implements AfterClassLikeVisitInterface
      * - The accessor is a string alias bound in our Testbench container (first-party
      *   services like `'cache'`, `'router'`, package bindings registered via discovered
      *   providers).
+     * - The accessor is a string alias whose binding is in the container map snapshot
+     *   maintained by {@see ContainerBindingMapProvider} — covers vendor facades whose
+     *   `register()` body binds via a factory closure ({@see https://github.com/psalm/psalm-plugin-laravel/issues/942})
+     *   and resolves silently without invoking the runtime probe (which would throw on
+     *   constructors with un-bound interface deps).
      *
-     * Returns null when the accessor is a string alias bound only by a user service
-     * provider that does not run in Testbench — nothing we can do at this layer.
+     * Returns null when the accessor is neither in the snapshot map nor resolvable via
+     * the runtime probe — typically a user provider that does not run inside our
+     * Testbench app at all.
      *
      * @return ?class-string
      */
     public static function tryGetFacadeRootClass(string $facadeClass, ?Progress $progress = null): ?string
     {
+        // Container binding map lookup runs BEFORE the $failedFacades gate so a facade
+        // visited and rejected during scan phase (e.g. before its provider has registered
+        // the alias) can still resolve once the populated map fills in. Map path is
+        // silent: a hit reports nothing because nothing failed. `getFacadeAccessor()`
+        // is protected on Facade subclasses, so we read it by reflection.
+        try {
+            if (\is_subclass_of($facadeClass, Facade::class)) {
+                /** @psalm-var mixed $accessor */
+                $accessor = (new \ReflectionMethod($facadeClass, 'getFacadeAccessor'))->invoke(null);
+                if (\is_string($accessor) && $accessor !== '') {
+                    $fromMap = ContainerBindingMapProvider::getClass($accessor);
+                    if ($fromMap !== null) {
+                        return $fromMap;
+                    }
+                }
+            }
+        } catch (\Throwable) {
+            // Fall through to runtime probe.
+        }
+
         // $failedFacades gates both the short-circuit return AND the warning emission,
         // so each failure reason is surfaced to the user exactly once per facade across
         // scan-phase + populate-phase invocations (issue #787: silent losses of method

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -9,6 +9,7 @@ use Psalm\Internal\Analyzer\ProjectAnalyzer;
 use Psalm\LaravelPlugin\Providers\AliasStubProvider;
 use Psalm\LaravelPlugin\Providers\ApplicationProvider;
 use Psalm\LaravelPlugin\Providers\CarbonStubProvider;
+use Psalm\LaravelPlugin\Providers\ContainerBindingMapProvider;
 use Psalm\LaravelPlugin\Providers\FacadeMapProvider;
 use Psalm\LaravelPlugin\Providers\SchemaStateProvider;
 use Psalm\LaravelPlugin\Util\InternalErrorReporter;
@@ -40,6 +41,12 @@ final class Plugin implements PluginEntryPointInterface
             // Handlers use FacadeMapProvider::getFacadeClasses() in getClassLikeNames()
             // to also register for facade/alias classes that proxy to their service.
             FacadeMapProvider::init($output);
+
+            // Snapshot accessor → service-class bindings from the booted container.
+            // Consumed by AppFacadeRegistrationHandler::tryGetFacadeRootClass() to
+            // resolve vendor facades whose getFacadeAccessor() returns a string
+            // alias (#942) without triggering the runtime probe.
+            ContainerBindingMapProvider::init();
 
             // Always called — provides type narrowing (string vs array) regardless
             // of whether findMissingTranslations is enabled

--- a/src/Providers/ContainerBindingMapProvider.php
+++ b/src/Providers/ContainerBindingMapProvider.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Providers;
+
+use Illuminate\Container\Container;
+use Illuminate\Foundation\Application as LaravelApplication;
+use PhpParser\Node;
+use PhpParser\NodeFinder;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\ParserFactory;
+
+/**
+ * Snapshot of container accessor → concrete class from `$app->getBindings()`,
+ * used to resolve vendor facades whose accessor is a string alias bound by a
+ * service provider (issue #942) without invoking the runtime `Facade::getFacadeRoot()`
+ * probe, which throws on constructors with un-bound deps.
+ *
+ * Known limitations:
+ *  - Factory closure with branching (`fn () => $cond ? new A : new B`) — only the
+ *    first `new` is taken.
+ *  - Instance bindings (`Container::instance($abstract, $obj)`) live in `$instances`,
+ *    not `$bindings`, and are not snapshotted.
+ *
+ * @internal
+ */
+final class ContainerBindingMapProvider
+{
+    /** @var array<string, class-string> */
+    private static array $map = [];
+
+    /**
+     * Build the map. Idempotent — replaces the map on each call so test fixtures
+     * registering extra providers (`tests/Type/macro-fixtures.php`) can refresh
+     * the snapshot.
+     */
+    public static function init(): void
+    {
+        self::$map = [];
+
+        $app = ApplicationProvider::getApp();
+
+        // Container::bind() always wraps non-Closure concretes via getClosure()
+        // before storing, so `concrete` is always Closure.
+        /** @var array<string, array{concrete: \Closure, shared: bool}> $bindings */
+        $bindings = $app->getBindings();
+
+        foreach ($bindings as $accessor => $binding) {
+            if ($accessor === '') {
+                continue;
+            }
+
+            $class = self::introspectClosure($binding['concrete']);
+            if ($class !== null) {
+                self::$map[$accessor] = $class;
+            }
+        }
+
+        // Container::alias($abstract, $alias) stores aliases[$alias] = $abstract;
+        // facade accessors are often the alias, the bindings map holds the abstract.
+        foreach (self::readAliases($app) as $alias => $abstract) {
+            if (isset(self::$map[$alias])) {
+                continue;
+            }
+
+            if (isset(self::$map[$abstract])) {
+                self::$map[$alias] = self::$map[$abstract];
+            } elseif (\class_exists($abstract)) {
+                // alias(X::class, 'short') with no explicit bind — abstract IS the class.
+                self::$map[$alias] = $abstract;
+            }
+        }
+    }
+
+    /**
+     * @return ?class-string
+     * @psalm-external-mutation-free
+     */
+    public static function getClass(string $accessor): ?string
+    {
+        return self::$map[$accessor] ?? null;
+    }
+
+    /** @return ?class-string */
+    private static function introspectClosure(\Closure $closure): ?string
+    {
+        try {
+            $ref = new \ReflectionFunction($closure);
+        } catch (\Throwable) {
+            return null;
+        }
+
+        // Path 1 — class-string concrete: Container::getClosure() wraps with
+        // `use ($abstract, $concrete)`, so $concrete is in static vars.
+        /** @var mixed $concrete */
+        $concrete = $ref->getStaticVariables()['concrete'] ?? null;
+        if (\is_string($concrete) && $concrete !== '' && \class_exists($concrete)) {
+            return $concrete;
+        }
+
+        // Path 2 — user factory closure: parse the host file for a `new X(...)`
+        // inside the closure's line range.
+        $file = $ref->getFileName();
+        $start = $ref->getStartLine();
+        $end = $ref->getEndLine();
+        if ($file === false || $start === false || $end === false) {
+            return null;
+        }
+
+        return self::findReturnedClassInRange($file, $start, $end);
+    }
+
+    /** @return ?class-string */
+    private static function findReturnedClassInRange(string $file, int $start, int $end): ?string
+    {
+        $stmts = self::parsedFile($file);
+        if ($stmts === null) {
+            return null;
+        }
+
+        $newNodes = (new NodeFinder())->find($stmts, static function (Node $node) use ($start, $end): bool {
+            return $node instanceof Node\Expr\New_
+                && $node->class instanceof Node\Name
+                && $node->getStartLine() >= $start
+                && $node->getEndLine() <= $end;
+        });
+
+        foreach ($newNodes as $node) {
+            \assert($node instanceof Node\Expr\New_);
+            \assert($node->class instanceof Node\Name);
+            $class = $node->class->toString();
+            if (\class_exists($class)) {
+                /** @var class-string $class */
+                return $class;
+            }
+        }
+
+        return null;
+    }
+
+    /** @return ?list<Node\Stmt> */
+    private static function parsedFile(string $file): ?array
+    {
+        try {
+            $contents = @\file_get_contents($file);
+            if ($contents === false) {
+                return null;
+            }
+
+            $stmts = (new ParserFactory())->createForHostVersion()->parse($contents);
+            if ($stmts === null) {
+                return null;
+            }
+
+            $traverser = new NodeTraverser();
+            $traverser->addVisitor(new NameResolver());
+            /** @var list<Node\Stmt> $resolved */
+            $resolved = $traverser->traverse($stmts);
+
+            return $resolved;
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /** @return array<string, string> alias → abstract; protected, no public getter */
+    private static function readAliases(LaravelApplication $app): array
+    {
+        try {
+            /** @psalm-var mixed $value */
+            $value = (new \ReflectionProperty(Container::class, 'aliases'))->getValue($app);
+            if (!\is_array($value)) {
+                return [];
+            }
+
+            /** @var array<string, string> $value */
+            return $value;
+        } catch (\Throwable) {
+            return [];
+        }
+    }
+}

--- a/tests/Application/app/Facades/Subscription.php
+++ b/tests/Application/app/Facades/Subscription.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * Test fixture for issue #942. The accessor is the string alias `'subscription'`,
+ * bound by {@see \App\Providers\SubscriptionServiceProvider::register()} — not by
+ * a class-string accessor, so the runtime `Facade::getFacadeRoot()` probe alone
+ * would throw `BindingResolutionException` when the provider has not run.
+ *
+ * Resolution must succeed via the binding map snapshot taken at plugin init by
+ * {@see \Psalm\LaravelPlugin\Providers\ContainerBindingMapProvider}, which reads
+ * the booted container's `$bindings` after each provider's `register()` has run.
+ *
+ * No `@method` catalogue here on purpose — we want to assert that the snapshot
+ * supplies the underlying class so {@see \Psalm\LaravelPlugin\Handlers\Facades\FacadeMethodHandler}
+ * can forward real method signatures from the service class.
+ */
+class Subscription extends Facade
+{
+    #[\Override]
+    protected static function getFacadeAccessor(): string
+    {
+        return 'subscription';
+    }
+}

--- a/tests/Application/app/Providers/SubscriptionServiceProvider.php
+++ b/tests/Application/app/Providers/SubscriptionServiceProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use App\Services\SubscriptionClient;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Stand-in for the kind of vendor provider that issue #942 calls out: a
+ * `ServiceProvider::register()` body that binds an accessor string to a concrete
+ * service class.
+ *
+ * Seeded for type-test runs by `tests/Type/macro-fixtures.php`, which loads
+ * Psalm's plugin application provider and manually invokes
+ * `$app->register(SubscriptionServiceProvider::class)`. After that call,
+ * `'subscription'` is in `$app->getBindings()` and {@see \Psalm\LaravelPlugin\Providers\ContainerBindingMapProvider::init()}
+ * harvests it into the snapshot consulted by {@see \Psalm\LaravelPlugin\Handlers\Facades\AppFacadeRegistrationHandler}.
+ *
+ * In production this seeding happens automatically: composer auto-discovery
+ * registers vendor providers via `Illuminate\Foundation\PackageManifest`, which
+ * the plugin retargets at the project root inside
+ * {@see \Psalm\LaravelPlugin\Providers\ApplicationProvider::retargetPackageManifestAtProjectRoot()}.
+ * The plugin's own test fixtures are not a composer package, so an explicit
+ * `$app->register()` stands in for the discovery step.
+ */
+final class SubscriptionServiceProvider extends ServiceProvider
+{
+    #[\Override]
+    public function register(): void
+    {
+        $this->app->singleton('subscription', SubscriptionClient::class);
+    }
+}

--- a/tests/Application/app/Services/SubscriptionClient.php
+++ b/tests/Application/app/Services/SubscriptionClient.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+/**
+ * Test fixture for {@see \App\Facades\Subscription}.
+ *
+ * The facade's accessor is the string alias `'subscription'`, bound to this
+ * class by {@see \App\Providers\SubscriptionServiceProvider::register()}.
+ * Reproduces the pattern documented in issue #942 (e.g.
+ * `imdhemy/laravel-in-app-purchases` ships a `Subscription` facade backed by a
+ * provider-bound alias).
+ */
+final class SubscriptionClient
+{
+    public function googlePlay(): self
+    {
+        return $this;
+    }
+
+    public function appStore(): self
+    {
+        return $this;
+    }
+
+    public function id(): int
+    {
+        return 0;
+    }
+}

--- a/tests/Type/macro-fixtures.php
+++ b/tests/Type/macro-fixtures.php
@@ -66,3 +66,14 @@ Builder::macro('testBuilderMacro', static fn(): string => 'builder macro OK');
     'testViteFacadeMacro',
     static fn(string $asset): string => "resources/images/{$asset}",
 );
+
+// Seed the container binding map (issue #942) with the type-test fixture
+// provider. In production, vendor `ServiceProvider::register()` methods run
+// during composer auto-discovery (via Illuminate's PackageManifest, retargeted
+// at the project root by ApplicationProvider). The plugin's own fixtures are
+// not a composer package, so register the provider directly on the booted app
+// and re-init the snapshot to pick up the new 'subscription' binding.
+\Psalm\LaravelPlugin\Providers\ApplicationProvider::getApp()->register(
+    \App\Providers\SubscriptionServiceProvider::class,
+);
+\Psalm\LaravelPlugin\Providers\ContainerBindingMapProvider::init();

--- a/tests/Type/tests/Facades/StringAliasFacadeViaContainerMapTest.phpt
+++ b/tests/Type/tests/Facades/StringAliasFacadeViaContainerMapTest.phpt
@@ -1,0 +1,37 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Sandbox;
+
+use App\Facades\Subscription;
+use App\Services\SubscriptionClient;
+
+/**
+ * The `'subscription'` accessor is bound to `SubscriptionClient` by
+ * `App\Providers\SubscriptionServiceProvider::register()`. That provider's
+ * binding reaches the plugin via `ContainerBindingMapProvider`, which snapshots
+ * `$app->getBindings()` after the booted Testbench application's
+ * `register()` cycle. The fixture provider is seeded from
+ * `tests/Type/macro-fixtures.php` (the file Psalm loads via the `autoloader`
+ * attribute in `psalm.xml`). In production, vendor providers reach the same
+ * map via composer auto-discovery (Illuminate's `PackageManifest`, retargeted
+ * at the project root by `ApplicationProvider`).
+ *
+ * `Subscription`'s accessor is a string alias, not a class-string, so the
+ * runtime `Facade::getFacadeRoot()` probe used by `AppFacadeRegistrationHandler`
+ * cannot resolve it on its own when the provider's `register()` is bound via
+ * a factory closure with un-bound deps (the imdhemy/laravel-in-app-purchases
+ * shape cited in issue #942). The binding map snapshot covers that case.
+ *
+ * Methods on `SubscriptionClient` must be forwarded to the facade without an
+ * `@method` catalogue and with the correct return type.
+ */
+function test_facade_resolves_method_via_container_binding_map(): SubscriptionClient
+{
+    /** @psalm-check-type-exact $client = SubscriptionClient */
+    $client = Subscription::googlePlay();
+
+    return $client;
+}
+?>
+--EXPECT--

--- a/tests/Unit/Providers/ContainerBindingMapProviderTest.php
+++ b/tests/Unit/Providers/ContainerBindingMapProviderTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Tests\Unit\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Providers\ApplicationProvider;
+use Psalm\LaravelPlugin\Providers\ContainerBindingMapProvider;
+
+#[CoversClass(ContainerBindingMapProvider::class)]
+final class ContainerBindingMapProviderTest extends TestCase
+{
+    /**
+     * Issue #942 — class-string concrete: `bind('accessor', ConcreteClass::class)`
+     * routes through {@see \Illuminate\Container\Container::getClosure()}, which
+     * captures `$concrete` as a static variable on the wrapper closure. The map
+     * extracts that class-string without resolving (avoids constructor crashes).
+     */
+    #[Test]
+    public function init_maps_accessor_to_class_string_concrete(): void
+    {
+        $app = ApplicationProvider::getApp();
+        $app->bind('binding-map-test/class-string', BindingMapTestFakeService::class);
+
+        try {
+            ContainerBindingMapProvider::init();
+
+            $this->assertSame(BindingMapTestFakeService::class, ContainerBindingMapProvider::getClass('binding-map-test/class-string'));
+        } finally {
+            $this->resetBinding($app, 'binding-map-test/class-string');
+        }
+    }
+
+    /**
+     * Issue #942 — factory closure: `bind('accessor', fn () => new X())` stores
+     * the user-authored closure as-is (no static vars). The map falls back to
+     * PhpParser, re-reads the host file, runs `NameResolver`, and extracts the
+     * first `new X(...)` in the closure's line range. Mirrors the imdhemy/laravel-
+     * in-app-purchases shape.
+     */
+    #[Test]
+    public function init_maps_accessor_to_class_returned_by_factory_closure(): void
+    {
+        $app = ApplicationProvider::getApp();
+        $app->bind('binding-map-test/factory', static fn(): BindingMapTestFakeService => new BindingMapTestFakeService());
+
+        try {
+            ContainerBindingMapProvider::init();
+
+            $this->assertSame(BindingMapTestFakeService::class, ContainerBindingMapProvider::getClass('binding-map-test/factory'));
+        } finally {
+            $this->resetBinding($app, 'binding-map-test/factory');
+        }
+    }
+
+    /**
+     * Aliases share a map entry with the abstract they point to so a facade
+     * looking up the alias name (`Container::alias($abstract, $alias)` stores
+     * `aliases[$alias] = $abstract`) resolves to the same class as the abstract.
+     */
+    #[Test]
+    public function init_forwards_alias_to_bound_abstract(): void
+    {
+        $app = ApplicationProvider::getApp();
+        $app->bind('binding-map-test/aliased-abstract', BindingMapTestFakeService::class);
+        $app->alias('binding-map-test/aliased-abstract', 'binding-map-test/alias-name');
+
+        try {
+            ContainerBindingMapProvider::init();
+
+            $this->assertSame(BindingMapTestFakeService::class, ContainerBindingMapProvider::getClass('binding-map-test/alias-name'), 'Alias must resolve to the same class as its abstract');
+        } finally {
+            $this->resetBinding($app, 'binding-map-test/aliased-abstract');
+            $this->resetAlias($app, 'binding-map-test/alias-name');
+        }
+    }
+
+    /**
+     * A factory closure that doesn't `return new X()` (e.g. resolves from config,
+     * builds conditionally) is unparseable. The map omits the entry rather than
+     * guessing wrong — the runtime probe in `AppFacadeRegistrationHandler` still
+     * gets a chance, falling through to the warning path on its own failure.
+     */
+    #[Test]
+    public function init_skips_factory_closure_with_no_new_expression(): void
+    {
+        $app = ApplicationProvider::getApp();
+        // Pass-through closure: returns an unrelated value, contains no `new` expression
+        $app->bind('binding-map-test/no-new', static fn(): string => 'noop');
+
+        try {
+            ContainerBindingMapProvider::init();
+
+            $this->assertNull(ContainerBindingMapProvider::getClass('binding-map-test/no-new'));
+        } finally {
+            $this->resetBinding($app, 'binding-map-test/no-new');
+        }
+    }
+
+    /**
+     * Lookups for accessors that were never bound (and have no alias entry) return
+     * null. The map MUST NOT throw on misses — the facade handler treats null as
+     * "fall through to runtime probe".
+     */
+    #[Test]
+    public function get_class_returns_null_for_unknown_accessor(): void
+    {
+        ContainerBindingMapProvider::init();
+
+        $this->assertNull(ContainerBindingMapProvider::getClass('binding-map-test/never-bound'));
+    }
+
+    /**
+     * Container has no public binding-removal API; reach into the protected
+     * `$bindings` array to keep the test isolated from other cases. Mirrors
+     * {@see self::resetAlias()} (which the original review pointed out as the
+     * idiomatic pattern for this codebase, vs. the `offsetUnset()` path that
+     * crosses an `@internal` boundary and would need a `@psalm-suppress`).
+     */
+    private function resetBinding(\Illuminate\Foundation\Application $app, string $abstract): void
+    {
+        $bindings = new \ReflectionProperty(\Illuminate\Container\Container::class, 'bindings');
+        /** @var array<string, array{concrete: \Closure, shared: bool}> $current */
+        $current = $bindings->getValue($app);
+        unset($current[$abstract]);
+        $bindings->setValue($app, $current);
+    }
+
+    private function resetAlias(\Illuminate\Foundation\Application $app, string $alias): void
+    {
+        $aliases = new \ReflectionProperty(\Illuminate\Container\Container::class, 'aliases');
+        /** @var array<string, string> $current */
+        $current = $aliases->getValue($app);
+        unset($current[$alias]);
+        $aliases->setValue($app, $current);
+    }
+}
+
+/** Test fixture — never resolved at runtime, only referenced by name in bindings. */
+final class BindingMapTestFakeService
+{
+    public function ping(): string
+    {
+        return 'pong';
+    }
+}
+
+/** Provider variant used to exercise harvester-style provider registration paths. */
+final class BindingMapTestServiceProvider extends ServiceProvider
+{
+    #[\Override]
+    public function register(): void
+    {
+        $this->app->singleton('binding-map-test/from-provider', BindingMapTestFakeService::class);
+    }
+}


### PR DESCRIPTION
## Issue to Solve

Closes #942. Vendor packages (e.g. `imdhemy/laravel-in-app-purchases`) ship `Facade` subclasses whose accessor is a string alias (`'subscription'`) bound by the package's `ServiceProvider::register()`. After #789, the plugin's two existing resolver paths both fail:

1. `@see` docblock pointer (only works when the package author added one)
2. Runtime `Facade::getFacadeRoot()` probe (throws `BindingResolutionException` when the bound concrete has constructor deps that aren't in our Testbench container)

The probe failure emits a noisy warning every run and the plugin falls back to the `@method` catalogue (types drift from the actual service class).

This PR supersedes #951 (which solved the same problem by statically parsing every `ServiceProvider` file with AST tooling — 2050 lines, 14 files). The container-introspection approach ships ~525 added lines and avoids parsing user code that may not match runtime behaviour.

## Solution Description

Two pieces, both small:

### 1. `Psalm\LaravelPlugin\Providers\ContainerBindingMapProvider` (new)

Snapshots `$app->getBindings()` and the container's protected `$aliases` array post-boot. Two extraction paths per binding closure:

- **Class-string concrete** (`bind('subscription', SubscriptionClient::class)`): `Container::getClosure()` wraps with `use ($abstract, $concrete)`, so `ReflectionFunction::getStaticVariables()` exposes the class-string directly.
- **Factory closure** (`bind('subscription', fn () => new SubscriptionClient())`): re-parses the host file with PhpParser, runs `NameResolver`, locates the first `new X(...)` inside the closure's line range. Known limitation: conditional `new` in the closure body takes the first match (documented in the class docblock).

Aliases (`Container::alias($abstract, $alias)` stores `aliases[$alias] = $abstract`) are merged into the map so a lookup by either name resolves.

### 2. `AppFacadeRegistrationHandler::tryGetFacadeRootClass()`

Map lookup runs BEFORE the `$failedFacades` cache short-circuit so a facade visited and rejected during scan phase (before its provider has registered) can still resolve once the snapshot fills in. Falls through to the existing runtime probe + warning path on map miss.

### Verification

End-to-end against `imdhemy/laravel-purchases` (real Laravel 13 app, `composer require imdhemy/laravel-purchases`):

```php
use Imdhemy\Purchases\Facades\Subscription;
$client = Subscription::googlePlay();
/** @psalm-check-type-exact $client = \Imdhemy\Purchases\Subscription */
```

Psalm reports zero errors on this file and no `getFacadeRoot() failed` warning. Wrong-type assertion produces the expected `CheckType` error.

### Scope

This PR targets branch 1 of `ApplicationProvider::doGetApp()` — the common case where the user's `bootstrap/app.php` runs the kernel and registers all vendor providers before the plugin's snapshot. Branch 3 (analyzing a Laravel **package** from inside its source repo, where Testbench's defaults block vendor discovery) is deferred to follow-up #956.

## Related

Closes #942. Supersedes #951 (please close after merging). Branch-3 case tracked in #956.

#766 (`app('alias')` returning `mixed` for the same accessor shape) is structurally adjacent but out of scope.

## Checklist
- [x] Tests cover the change (5 unit tests in `tests/Unit/Providers/ContainerBindingMapProviderTest.php`, 1 type test in `tests/Type/tests/Facades/StringAliasFacadeViaContainerMapTest.phpt`, fixture under `tests/Application/app/{Facades,Services,Providers}/`)
- [x] Documentation is updated (in-class docblock covers extraction paths and known limitations)
