### PR TITLE
Add stub FQCN collision detection to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ on:
       - '**.phpt'
       - '**.yml'
       - 'composer.json'
+      - 'tests/scripts/**'
   pull_request:
     paths:
       - '**.php'
@@ -16,6 +17,7 @@ on:
       - '**.phpt'
       - 'composer.json'
       - '.github/workflows/tests.yml'
+      - 'tests/scripts/**'
   schedule:
     # Weekly on Friday at 06:00 UTC
     - cron: "0 6 * * 5"
@@ -54,6 +56,9 @@ jobs:
 
       - name: Run Unit tests
         run: composer test:unit
+
+      - name: Detect stub FQCN collisions
+        run: composer detect:collisions
 
 
   type_tests:

--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,7 @@
         "phpunit/phpunit": "^11.5 || ^12.5 || ^13.0",
         "ramsey/collection": "^1.3",
         "rector/rector": "^2.3",
+        "shipmonk/name-collision-detector": "^2.1",
         "symfony/http-foundation": "^7.1 || ^8.0"
     },
     "repositories": [
@@ -86,6 +87,7 @@
         "cs": "@php-cs-fixer:run",
         "cs:check": "@php-cs-fixer:dry",
         "cs:fix": "@php-cs-fixer:run",
+        "detect:collisions": "./tests/scripts/detect-stub-collisions.sh",
         "php-cs-fixer:dry": "php-cs-fixer fix --no-interaction --ansi --verbose --dry-run",
         "php-cs-fixer:run": "php-cs-fixer fix --no-interaction --ansi --quiet",
         "psalm": "psalm --find-dead-code --find-unused-psalm-suppress --long-progress",
@@ -96,6 +98,7 @@
         "test": [
             "@cs:check",
             "@psalm",
+            "@detect:collisions",
             "@test:unit",
             "@test:type",
             "echo '\n\nThese tests do not include testing on a real Laravel app. You can run that via `composer test:app`'"
@@ -103,6 +106,7 @@
         "test:all": [
             "@cs:check",
             "@psalm",
+            "@detect:collisions",
             "@test:unit",
             "@test:type",
             "@test:app"

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -113,6 +113,10 @@ When a **class stub and a trait stub** both declare the same method, Psalm creat
 
 Stub files are loaded in alphabetical order (sorted by full path) to ensure deterministic results across OSes.
 
+### Duplicate FQCN detection
+
+Stubs are outside Composer's PSR-4 reach, so duplicate class declarations cause no autoloader error. Psalm silently lets the last-loaded one win. `composer detect:collisions` catches them. It runs per stub bucket (`stubs/common/`, each `stubs/<version>/`, each `stubs/integrations/<package>/`) so intentional cross-bucket overrides do not flag. Part of `composer test` and CI.
+
 ## How to add a handler
 
 Handlers implement Psalm event interfaces to override type inference.

--- a/tests/scripts/detect-stub-collisions.sh
+++ b/tests/scripts/detect-stub-collisions.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Run shipmonk/name-collision-detector once per stub bucket.
+#
+# Buckets are independent because stub layout intentionally re-declares
+# Laravel classes across versions and integrations:
+#   - stubs/common/                      strict, no duplicates
+#   - stubs/<laravel-version>/           may override stubs/common/ (per Plugin.php loader)
+#   - stubs/integrations/<package>/      may re-declare third-party classes
+# Running the detector on the union would surface those overrides as false
+# positives. Scoping each bucket separately keeps duplicate detection useful
+# without fighting the intentional layering.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+CONFIG="tests/scripts/name-collision-detector.json"
+DETECTOR="vendor/bin/detect-collisions"
+
+if [ ! -x "$DETECTOR" ]; then
+    echo "ERROR: $DETECTOR not found. Run 'composer install' first." >&2
+    exit 2
+fi
+
+if [ ! -r "$CONFIG" ]; then
+    echo "ERROR: $CONFIG not found or unreadable." >&2
+    exit 2
+fi
+
+# nullglob so empty globs (e.g. no stubs/integrations/*) expand to nothing
+# instead of leaving the literal pattern.
+shopt -s nullglob
+
+buckets=()
+[ -d stubs/common ] && buckets+=(stubs/common)
+for dir in stubs/*/; do
+    name="${dir%/}"
+    case "$name" in
+        stubs/common|stubs/integrations) continue ;;
+    esac
+    buckets+=("$name")
+done
+for dir in stubs/integrations/*/; do
+    buckets+=("${dir%/}")
+done
+
+if [ "${#buckets[@]}" -eq 0 ]; then
+    echo "ERROR: no stub buckets found under stubs/." >&2
+    exit 2
+fi
+
+status=0
+failed_buckets=()
+for bucket in "${buckets[@]}"; do
+    echo "=== Scanning $bucket ==="
+    # Capture exit code without tripping `set -e`. `cmd || rc=$?` keeps the
+    # real exit code (vs `if ! cmd; then $?` which always reads 0 inside the
+    # then-branch because `!` flips the pipeline's status).
+    rc=0
+    "$DETECTOR" --configuration="$CONFIG" "$bucket" || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "ERROR: detector exited $rc for $bucket" >&2
+        failed_buckets+=("$bucket")
+        status=1
+    fi
+done
+
+if [ "${#failed_buckets[@]}" -gt 0 ]; then
+    echo "FAILED buckets: ${failed_buckets[*]}" >&2
+fi
+
+exit "$status"

--- a/tests/scripts/name-collision-detector.json
+++ b/tests/scripts/name-collision-detector.json
@@ -1,0 +1,3 @@
+{
+    "fileExtensions": ["phpstub"]
+}


### PR DESCRIPTION
## Issue to Solve

Stub files load via `Plugin::getCommonStubs()` outside Composer's PSR-4 reach. If two stub files declare the same fully-qualified class name, Psalm silently lets the last-loaded one win. No build error, no warning. The bug only surfaces downstream as wrong-type reports from callers.

Concrete failure mode: contributor copies `stubs/common/Foo/Bar.phpstub` to `stubs/common/Foo/BarV2.phpstub` to draft a change and forgets to delete the original. CI stays green, the wrong stub ships.

`src/`, `tests/Unit/`, and `tests/Application/app/` are PSR-4 and protected by the Composer autoloader. `tests/Type/tests/*.phpt` runs each file in a separate `psalm-tester` process. Only `stubs/` is exposed.

## Related

Closes #954

## Solution Description

Add `shipmonk/name-collision-detector ^2.1` as a dev dependency. Wire it via `composer detect:collisions` and a small bash wrapper at `tests/scripts/detect-stub-collisions.sh`. The wrapper runs the detector once per stub bucket rather than across the union, because the layout intentionally re-declares classes across buckets per `CLAUDE.md`:

  - `stubs/common/`: strict, no duplicates
  - each `stubs/<laravel-version>/`: may override `stubs/common/`
  - each `stubs/integrations/<package>/`: may re-declare third-party classes

Running the detector on the union would surface those overrides as false positives. Per-bucket scoping keeps the check useful without fighting the intentional layering.

Configuration at `tests/scripts/name-collision-detector.json` only sets `fileExtensions: ["phpstub"]`; the wrapper passes paths via CLI per bucket.

The script uses `set -euo pipefail` plus `shopt -s nullglob` to avoid literal-pattern leakage when a bucket directory is empty or absent. Per-bucket exit codes are captured via `cmd || rc=$?` (an `if !` would mask the real `rc` to `0` inside the `then` branch because `!` flips the pipeline's status). A "FAILED buckets:" summary line lists which buckets failed so CI logs stay debuggable.

Wired into the `composer test` and `composer test:all` aggregates and the `unit_tests` job in `.github/workflows/tests.yml`. Added `tests/scripts/**` to the workflow's `paths` filter so changes to the script or config retrigger the workflow. The whole `tests/` directory is already covered by the existing `/tests  export-ignore` in `.gitattributes`, so the script and config stay out of dist tarballs.

### Verification

  - Clean tree: `composer detect:collisions` exits 0 (scans 102 `.phpstub` files across `stubs/common/` and `stubs/12.42.0/`)
  - Seeded duplicate (copy of `stubs/common/Support/Collection.phpstub`): exits 1, error line `detector exited 1 for stubs/common`, summary line `FAILED buckets: stubs/common`
  - `shellcheck tests/scripts/detect-stub-collisions.sh` clean
  - `composer psalm`, `composer cs`, `composer test:unit` all pass

## Checklist

- [x] Documentation is updated (`docs/contributing/README.md` gains a brief "Duplicate FQCN detection" subsection)
