### PR TITLE
Fix `Model::factory()->count(N)->make()` collapse on bare `HasFactory`

### DIFF
--- a/src/Handlers/Eloquent/FactoryCountTypeProvider.php
+++ b/src/Handlers/Eloquent/FactoryCountTypeProvider.php
@@ -108,6 +108,19 @@ final class FactoryCountTypeProvider implements MethodReturnTypeProviderInterfac
      *  2. The called class's `extends Factory<X>` binding (covers user
      *     subclasses like `class UserFactory extends Factory<User>` and
      *     static calls `UserFactory::times(N)`).
+     *  3. Last-resort fallback to base `Model`. Without this, an unbound
+     *     receiver (bare `Factory` with no template params and no subclass
+     *     binding — produced e.g. when a model uses `HasFactory` without
+     *     `@use HasFactory<XFactory>`) collapses through the stub's
+     *     `@return Factory<TModel, int|null>` and `make()`'s conditional
+     *     picks the single-model branch. Falling back to `Model` keeps the
+     *     `TCount` narrowing intact so `count(N)->make()` still resolves to
+     *     `Collection<int, Model>` (downgraded but iterable) rather than a
+     *     bare `Model`. Companion handler `ModelFactoryMethodTypeProvider`
+     *     covers the common case with precise `Factory<ConcreteModel>`.
+     *
+     * @see ModelFactoryMethodTypeProvider
+     * @see https://github.com/psalm/psalm-plugin-laravel/issues/960
      *
      * @psalm-mutation-free
      */
@@ -117,25 +130,53 @@ final class FactoryCountTypeProvider implements MethodReturnTypeProviderInterfac
 
         if ($templateParams !== null) {
             $modelType = $templateParams[0] ?? null;
-            if (self::isModelType($modelType)) {
+            if (self::isModelType($modelType, $codebase)) {
                 return $modelType;
             }
         }
 
         $calledClass = $event->getCalledFqClasslikeName() ?? $event->getFqClasslikeName();
+        $resolved = self::resolveModelFromClass($calledClass, $codebase);
+        if ($resolved instanceof Union) {
+            return $resolved;
+        }
 
-        return self::resolveModelFromClass($calledClass, $codebase);
+        // Allocated per-fallback (rather than cached as a static) to keep
+        // resolveModelType()'s @psalm-mutation-free contract intact. This
+        // path only fires for unresolvable receivers — uncommon enough that
+        // the extra allocation does not warrant relaxing the purity marker.
+        return new Union([new TNamedObject(Model::class)]);
     }
 
-    /** @psalm-mutation-free */
-    private static function isModelType(?Union $type): bool
+    /**
+     * Lineage check via Psalm's class storage. `is_a()` was previously used here
+     * but breaks for classes Psalm scans yet PHP's autoloader cannot resolve
+     * at handler runtime (e.g. PHPT fixture models declared inline).
+     *
+     * @psalm-mutation-free
+     */
+    private static function isModelType(?Union $type, Codebase $codebase): bool
     {
         if (!$type instanceof Union) {
             return false;
         }
 
         foreach ($type->getAtomicTypes() as $atomic) {
-            if (!$atomic instanceof TNamedObject || !\is_a($atomic->value, Model::class, true)) {
+            if (!$atomic instanceof TNamedObject) {
+                return false;
+            }
+
+            if ($atomic->value === Model::class) {
+                continue;
+            }
+
+            try {
+                $storage = $codebase->classlike_storage_provider->get($atomic->value);
+            } catch (\InvalidArgumentException) {
+                return false;
+            }
+
+            if (!isset($storage->parent_classes[\strtolower(Model::class)])) {
                 return false;
             }
         }
@@ -170,7 +211,7 @@ final class FactoryCountTypeProvider implements MethodReturnTypeProviderInterfac
 
         $modelType = $extended['TModel'] ?? null;
 
-        return self::isModelType($modelType) ? $modelType : null;
+        return self::isModelType($modelType, $codebase) ? $modelType : null;
     }
 
     /**

--- a/src/Handlers/Eloquent/ModelFactoryMethodTypeProvider.php
+++ b/src/Handlers/Eloquent/ModelFactoryMethodTypeProvider.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Eloquent;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\Storage\ClassLikeStorage;
+use Psalm\Type\Atomic\TGenericObject;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Atomic\TNull;
+use Psalm\Type\Union;
+
+/**
+ * Binds Model::factory() to Factory<static, null> for every model that uses
+ * the HasFactory trait without an explicit template argument.
+ *
+ * HasFactory::factory() declares @return TFactory with @template TFactory of
+ * Factory. Models that omit the template argument (the framework default)
+ * collapse TFactory to the bound Factory, losing the TModel binding the
+ * downstream chain needs: FactoryCountTypeProvider cannot recover TModel
+ * from a bare Factory, and the create()/make() conditional return picks the
+ * single-model branch because the receiver's TCount is unbound.
+ *
+ * Skipped paths (deferred to the stub or noted as limitations):
+ *   - When the user wrote an explicit @use HasFactory<XFactory> binding,
+ *     XFactory is strictly more precise than Factory<Model> because it
+ *     preserves subclass-specific state methods. Return null in that case
+ *     so the stub's @return TFactory flows through.
+ *   - Model::factory($count) with a numeric first arg should resolve to
+ *     Collection (Laravel forwards $count to ->count() internally). Not
+ *     handled here; users writing factory(3)->make() get Factory<Model>
+ *     and need to switch to factory()->count(3)->make() for the precise
+ *     Collection type. See issue #960 for the broader chain coverage.
+ *
+ * Dispatch note: Psalm's MethodReturnTypeProvider lookup falls back to the
+ * declaring_method_id when the called class has no registered hook. For a
+ * trait method invoked via the using class (Article::factory()), the
+ * declaring class is the trait itself, and Psalm passes the actual called
+ * class through $event->getCalledFqClasslikeName(). See vendor/vimeo/psalm
+ * MethodCallReturnTypeFetcher.php and ExistingAtomicStaticCallAnalyzer.php
+ * for the dispatch sequence.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/960
+ * @see FactoryCountTypeProvider
+ * @internal
+ */
+final class ModelFactoryMethodTypeProvider implements MethodReturnTypeProviderInterface
+{
+    /** Pre-lowercased Model FQCN for parent_classes lookups. */
+    private const MODEL_FQCN_LOWERCASE = 'illuminate\\database\\eloquent\\model';
+
+    /**
+     * Cached Factory<ModelFqcn, null> Unions keyed by the model FQCN.
+     * Bounded by the number of HasFactory models in the project.
+     *
+     * @var array<string, Union>
+     */
+    private static array $factoryUnionCache = [];
+
+    /**
+     * @return list<string>
+     * @psalm-pure
+     */
+    #[\Override]
+    public static function getClassLikeNames(): array
+    {
+        return [HasFactory::class];
+    }
+
+    #[\Override]
+    public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        if ($event->getMethodNameLowercase() !== 'factory') {
+            return null;
+        }
+
+        $modelFqcn = $event->getCalledFqClasslikeName() ?? $event->getFqClasslikeName();
+        $codebase = $event->getSource()->getCodebase();
+
+        // has() pre-check avoids constructing an InvalidArgumentException for
+        // classes Psalm has not scanned.
+        if (!$codebase->classlike_storage_provider->has($modelFqcn)) {
+            return null;
+        }
+
+        $storage = $codebase->classlike_storage_provider->get($modelFqcn);
+
+        // Only fire for Model subclasses. Skip non-Model HasFactory hosts.
+        if (!isset($storage->parent_classes[self::MODEL_FQCN_LOWERCASE])) {
+            return null;
+        }
+
+        // Defer to the stub when the user wrote an explicit
+        // @use HasFactory<XFactory> binding. The stub returns TFactory which
+        // resolves to the user-chosen Factory subclass, strictly more
+        // precise than Factory<Model>.
+        if (self::hasUserBoundTFactory($storage)) {
+            return null;
+        }
+
+        // Emit both template params explicitly: Factory<Model, null>. Psalm 7
+        // does not reliably substitute the TCount default from a 1-arg
+        // TGenericObject, so an unbound TCount leaks into make()/create() and
+        // forces a union of both conditional branches.
+        return self::$factoryUnionCache[$modelFqcn] ??= new Union([
+            new TGenericObject(Factory::class, [
+                new Union([new TNamedObject($modelFqcn)]),
+                new Union([new TNull()]),
+            ]),
+        ]);
+    }
+
+    /**
+     * True when the model carries an explicit HasFactory template binding to
+     * a Factory subclass. Psalm's populator copies user-supplied offsets into
+     * template_extended_params[HasFactory::class]['TFactory']; the unbound
+     * default fills the same slot with the bound (bare Factory), so a value
+     * other than bare Factory signals a user binding.
+     *
+     * @psalm-mutation-free
+     */
+    private static function hasUserBoundTFactory(ClassLikeStorage $storage): bool
+    {
+        $binding = $storage->template_extended_params[HasFactory::class]['TFactory'] ?? null;
+        if (!$binding instanceof Union) {
+            return false;
+        }
+
+        foreach ($binding->getAtomicTypes() as $atomic) {
+            if ($atomic instanceof TNamedObject && $atomic->value !== Factory::class) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -96,6 +96,7 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Eloquent/CustomCollectionHandler.php';
         require_once __DIR__ . '/Handlers/Eloquent/ModelRelationshipPropertyHandler.php';
         require_once __DIR__ . '/Handlers/Eloquent/ModelFactoryTypeProvider.php';
+        require_once __DIR__ . '/Handlers/Eloquent/ModelFactoryMethodTypeProvider.php';
         require_once __DIR__ . '/Handlers/Eloquent/FactoryCountTypeProvider.php';
         require_once __DIR__ . '/Handlers/Eloquent/ModelPropertyAccessorHandler.php';
         require_once __DIR__ . '/Handlers/Eloquent/ModelAttributeSubsetHandler.php';
@@ -105,6 +106,7 @@ final class Plugin implements PluginEntryPointInterface
         }
 
         $registration->registerHooksFromClass(Handlers\Eloquent\ModelRegistrationHandler::class);
+        $registration->registerHooksFromClass(Handlers\Eloquent\ModelFactoryMethodTypeProvider::class);
         $registration->registerHooksFromClass(Handlers\Eloquent\FactoryCountTypeProvider::class);
 
         // Magic method forwarding: Relation -> Builder (decorated forwarding).

--- a/tests/Type/tests/HasFactoryTemplateParamTest.phpt
+++ b/tests/Type/tests/HasFactoryTemplateParamTest.phpt
@@ -35,10 +35,17 @@ class ExplicitArticleFactory extends Factory
     }
 }
 
-/** @use HasFactory<ExplicitArticleFactory> */
 class ExplicitArticle extends Model
 {
+    /** @use HasFactory<ExplicitArticleFactory> */
     use HasFactory;
 }
+
+// Explicit binding wins over ModelFactoryMethodTypeProvider's default — the
+// handler returns null when @use HasFactory<X> is set, so the stub's @return
+// TFactory resolves to the user's Factory subclass (more precise than the
+// plugin's Factory<Model>). Guards the documented escape hatch from #960.
+$_explicitFactory = ExplicitArticle::factory();
+/** @psalm-check-type-exact $_explicitFactory = ExplicitArticleFactory */;
 ?>
 --EXPECTF--

--- a/tests/Type/tests/Model/FactoryCountFallbackToBaseModelTest.phpt
+++ b/tests/Type/tests/Model/FactoryCountFallbackToBaseModelTest.phpt
@@ -1,0 +1,46 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Sandbox;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * Direct exercise of FactoryCountTypeProvider's third-tier Model fallback
+ * (Option B in issue #960). Simulates a bare `Factory` receiver — no
+ * template params on the type and no `extends Factory<X>` binding on the
+ * called class.
+ *
+ * Without the fallback, the unbound receiver collapses through the stub's
+ * `@return Factory<TModel, int|null>` and `make()`'s conditional picks the
+ * single-model branch (`TModel = Model` because Psalm uses the template
+ * bound when no binding is supplied). With the fallback, the handler still
+ * returns `Factory<Model, 2>` so the conditional resolves to the plural
+ * branch and the caller gets `Collection<int, Model>` instead of a bare
+ * `Model`. Downgraded compared to ModelFactoryMethodTypeProvider's precise
+ * resolution, but still iterable — avoids the `PossibleRawObjectIteration`
+ * false positive on every `foreach`.
+ *
+ * The bare `Factory` parameter shape arises in real code via __callStatic
+ * on a Facade, a 3rd-party stub lacking template args, etc., and is
+ * genuinely outside the user's control.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/960
+ */
+function bareFactoryReceiver(Factory $f): void
+{
+    // Tier 1 (template params) and Tier 2 (extends binding) both fail.
+    // Tier 3 fallback gives `Factory<Model, 2>`, and `make()` picks the
+    // collection branch from the conditional.
+    $_collection = $f->count(5)->make();
+    /** @psalm-check-type-exact $_collection = \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model> */;
+
+    // Foreach over the fallback collection result must not trigger
+    // PossibleRawObjectIteration — the whole point of the fallback.
+    foreach ($f->count(5)->make() as $_model) {
+        /** @psalm-check-type-exact $_model = \Illuminate\Database\Eloquent\Model */;
+    }
+}
+
+?>
+--EXPECTF--

--- a/tests/Type/tests/Model/FactoryMakeOnHasFactoryWithoutTemplateArgTest.phpt
+++ b/tests/Type/tests/Model/FactoryMakeOnHasFactoryWithoutTemplateArgTest.phpt
@@ -1,0 +1,80 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Sandbox;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Standard Laravel scaffold: `use HasFactory;` without the template arg.
+ * `php artisan make:model -f` produces this shape, so it covers the common
+ * case where downstream `Model::factory()->count(N)->make()` chains break
+ * without plugin intervention.
+ *
+ * Tracked by ModelFactoryMethodTypeProvider (Option A) and the
+ * FactoryCountTypeProvider Model fallback (Option B).
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/960
+ */
+class Bookshelf extends Model
+{
+    use HasFactory;
+}
+
+/**
+ * @extends Factory<Bookshelf>
+ */
+final class BookshelfFactory extends Factory
+{
+    /** @var class-string<Bookshelf> */
+    protected $model = Bookshelf::class;
+
+    /** @return array<string, mixed> */
+    #[\Override]
+    public function definition(): array
+    {
+        return [];
+    }
+}
+
+// ----- Option A: factory() returns Factory<Bookshelf> even without `@use HasFactory<...>` -----
+$_factory = Bookshelf::factory();
+/** @psalm-check-type-exact $_factory = \Illuminate\Database\Eloquent\Factories\Factory<\App\Sandbox\Bookshelf> */;
+
+// ----- Option A: count(N)->make() chains through to Collection<int, Bookshelf> -----
+$_shelves = Bookshelf::factory()->count(10)->make();
+/** @psalm-check-type-exact $_shelves = \Illuminate\Database\Eloquent\Collection<int, \App\Sandbox\Bookshelf> */;
+
+// ----- Option A: bare make() (no count) returns the single model -----
+$_single = Bookshelf::factory()->make();
+/** @psalm-check-type-exact $_single = \App\Sandbox\Bookshelf */;
+
+// ----- foreach over the count(N) result must not trigger PossibleRawObjectIteration -----
+foreach (Bookshelf::factory()->count(10)->make() as $_shelf) {
+    /** @psalm-check-type-exact $_shelf = \App\Sandbox\Bookshelf */;
+}
+
+// ----- create() chain mirrors make() -----
+$_created = Bookshelf::factory()->count(3)->create();
+/** @psalm-check-type-exact $_created = \Illuminate\Database\Eloquent\Collection<int, \App\Sandbox\Bookshelf> */;
+
+// ----- LSB: HasFactory inherited via abstract base, still resolves to subclass -----
+abstract class Entity extends Model
+{
+    use HasFactory;
+}
+
+class Page extends Entity
+{
+}
+
+$_pageFactory = Page::factory();
+/** @psalm-check-type-exact $_pageFactory = \Illuminate\Database\Eloquent\Factories\Factory<\App\Sandbox\Page> */;
+
+$_pages = Page::factory()->count(3)->make();
+/** @psalm-check-type-exact $_pages = \Illuminate\Database\Eloquent\Collection<int, \App\Sandbox\Page> */;
+
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

`Model::factory()->count(N)->make()` collapsed to a single `Model` instead of `Collection<int, Model>` when the model wrote `use HasFactory;` without an explicit `@use HasFactory<XFactory>` template arg (the default that `php artisan make:model -f` generates). Every `foreach` over the chain result triggered `PossibleRawObjectIteration`, and `$result->pluck(...)` triggered `MixedMethodCall`. Real-world example: [BookStack v26.03.3 `DummyContentSeeder.php:63`](https://github.com/BookStackApp/BookStack/blob/v26.03.3/database/seeders/DummyContentSeeder.php#L63-L66).

Root cause is a three-stage chain failure documented in the linked issue: the stub's `TFactory` template default falls back to bare `Factory`, which `FactoryCountTypeProvider` cannot bind `TModel` from, and the `make()` conditional then picks the single-model branch because `TCount` is also unbound.

## Related

Closes #960. Downstream of #517 / #612 (which silenced `MissingTemplateParam` on `use HasFactory;` but did not auto-resolve `TFactory`).

## Solution Description

Two-pronged, covering both the common case and any other path that produces a bare `Factory`.

### Option A: new `ModelFactoryMethodTypeProvider`

Hooks `HasFactory::factory()` via the trait FQCN (Psalm dispatches return-type providers through the `declaring_method_id` branch when a trait method is invoked on the using class). Returns `Factory<ModelFqcn, null>` so the downstream chain has both `TModel` and `TCount` to work with. Defers to the stub when the user has written `@use HasFactory<XFactory>` (the documented escape hatch) — `XFactory` is strictly more precise than `Factory<Model>` because it preserves any subclass-specific state methods.

### Option B: `FactoryCountTypeProvider` `Model` fallback

`resolveModelType()` gains a third tier returning `Union[Model]` when both the receiver template lookup and the `extends Factory<X>` binding fail. Keeps the `TCount` narrowing intact for any other path that emits a bare `Factory` (e.g. `__callStatic` on a Facade losing template context). Downgraded vs Option A's precise `Factory<ConcreteModel>` but still iterable, so `foreach` no longer trips `PossibleRawObjectIteration`.

While in the same function, `isModelType()` was switched from `is_a()` (PHP autoload, fails for classes Psalm has scanned but PHP cannot resolve at handler runtime — including the PHPT test fixtures) to a `classlike_storage_provider` lineage check that matches the new handler's lookup shape.

### Known limitation (follow-up candidate)

`Model::factory($count)->make()` with a numeric first arg is not folded into `TCount` here. Laravel's runtime forwards `$count` to `->count()` internally (`HasFactory::factory()` does `$factory->count(is_numeric($count) ? $count : null)`), so `Bookshelf::factory(3)->make()` is functionally identical to `Bookshelf::factory()->count(3)->make()` and should resolve to `Collection<int, Bookshelf>`. With this PR it resolves to `Bookshelf` (the single-model branch of the conditional). Users writing `factory(N)->make()` should switch to `factory()->count(N)->make()` for now; the symmetric handling can be added in a follow-up.

### Verification

- `tests/Type/tests/Model/FactoryMakeOnHasFactoryWithoutTemplateArgTest.phpt` (new) — Option A: `factory()`, `count(N)->make()`, `create()`, `foreach`, plus LSB through an abstract base class (`Subclass extends Base extends Model` where `Base` uses `HasFactory`).
- `tests/Type/tests/Model/FactoryCountFallbackToBaseModelTest.phpt` (new) — Option B: bare `Factory` parameter, fallback to `Collection<int, Model>`, foreach yields `Model`.
- `tests/Type/tests/HasFactoryTemplateParamTest.phpt` (extended) — locks the explicit `@use HasFactory<X>` escape hatch (the prior fixture had `@use` on the class instead of the `use` statement; Psalm only populates `template_extended_params` from the `use`-statement docblock, so the binding was previously untested).
- Full type suite (`composer test:type`): 404/404 pass.
- Psalm self-analysis (`composer psalm`): no errors.
- Unit suite (`composer test:unit`): 624/624 pass.

## Checklist

- [x] Tests cover the change (3 type tests in `tests/Type/tests/Model/` and an extension to `HasFactoryTemplateParamTest.phpt`)
