### PR TITLE
Resolve `Model::factory()->create()` collapse on bare `HasFactory`

### DIFF
--- a/src/Handlers/Eloquent/FactoryCountTypeProvider.php
+++ b/src/Handlers/Eloquent/FactoryCountTypeProvider.php
@@ -108,6 +108,13 @@ final class FactoryCountTypeProvider implements MethodReturnTypeProviderInterfac
      *  2. The called class's `extends Factory<X>` binding (covers user
      *     subclasses like `class UserFactory extends Factory<User>` and
      *     static calls `UserFactory::times(N)`).
+     *  3. Last-resort fallback to base `Model`. Without this, an unbound
+     *     receiver (bare `Factory` with no template params and no subclass
+     *     binding — produced via `__callStatic` on a Facade, etc.) collapses
+     *     through the stub's `@return Factory<TModel, int|null>` and `make()`'s
+     *     conditional picks the single-model branch. Falling back to `Model`
+     *     keeps the `TCount` narrowing intact so `count(N)->make()` still
+     *     resolves to `Collection<int, Model>` (downgraded but iterable).
      *
      * @psalm-mutation-free
      */
@@ -117,25 +124,49 @@ final class FactoryCountTypeProvider implements MethodReturnTypeProviderInterfac
 
         if ($templateParams !== null) {
             $modelType = $templateParams[0] ?? null;
-            if (self::isModelType($modelType)) {
+            if (self::isModelType($modelType, $codebase)) {
                 return $modelType;
             }
         }
 
         $calledClass = $event->getCalledFqClasslikeName() ?? $event->getFqClasslikeName();
+        $resolved = self::resolveModelFromClass($calledClass, $codebase);
+        if ($resolved instanceof Union) {
+            return $resolved;
+        }
 
-        return self::resolveModelFromClass($calledClass, $codebase);
+        return new Union([new TNamedObject(Model::class)]);
     }
 
-    /** @psalm-mutation-free */
-    private static function isModelType(?Union $type): bool
+    /**
+     * Lineage check via Psalm's class storage. `is_a()` was previously used here
+     * but breaks for classes Psalm scans yet PHP's autoloader cannot resolve
+     * at handler runtime (e.g. PHPT fixture models declared inline).
+     *
+     * @psalm-mutation-free
+     */
+    private static function isModelType(?Union $type, Codebase $codebase): bool
     {
         if (!$type instanceof Union) {
             return false;
         }
 
         foreach ($type->getAtomicTypes() as $atomic) {
-            if (!$atomic instanceof TNamedObject || !\is_a($atomic->value, Model::class, true)) {
+            if (!$atomic instanceof TNamedObject) {
+                return false;
+            }
+
+            if ($atomic->value === Model::class) {
+                continue;
+            }
+
+            try {
+                $storage = $codebase->classlike_storage_provider->get($atomic->value);
+            } catch (\InvalidArgumentException) {
+                return false;
+            }
+
+            if (!isset($storage->parent_classes[\strtolower(Model::class)])) {
                 return false;
             }
         }
@@ -170,7 +201,7 @@ final class FactoryCountTypeProvider implements MethodReturnTypeProviderInterfac
 
         $modelType = $extended['TModel'] ?? null;
 
-        return self::isModelType($modelType) ? $modelType : null;
+        return self::isModelType($modelType, $codebase) ? $modelType : null;
     }
 
     /**

--- a/src/Handlers/Eloquent/ModelFactoryMethodTypeProvider.php
+++ b/src/Handlers/Eloquent/ModelFactoryMethodTypeProvider.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Eloquent;
+
+use Illuminate\Database\Eloquent\Attributes\UseFactory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\Storage\ClassLikeStorage;
+use Psalm\Type\Atomic\TGenericObject;
+use Psalm\Type\Atomic\TLiteralClassString;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Atomic\TNull;
+use Psalm\Type\Union;
+
+/**
+ * Resolves `Model::factory()` to a useful factory type when the model uses
+ * `HasFactory` without an explicit `@use HasFactory<XFactory>` template arg.
+ *
+ * Discovery order mirrors Laravel's runtime in `HasFactory::newFactory()`:
+ *   1. `#[UseFactory(XFactory::class)]` attribute on the model class.
+ *   2. `Factory::resolveFactoryName($modelFqcn)` — Laravel naming convention,
+ *      e.g. `App\Models\Bookshelf` → `Database\Factories\BookshelfFactory`.
+ *      Mirrors Larastan's lookup at
+ *      `ModelFactoryDynamicStaticMethodReturnTypeExtension::getFactoryReflection()`.
+ *   3. Fallback to `Factory<modelFqcn, null>` so the downstream chain still
+ *      has `TModel` and `TCount` bound and `count(N)->make()` resolves to a
+ *      `Collection<int, modelFqcn>` (the bug from #960).
+ *
+ * Returning the concrete `XFactory` (when discovered) is strictly more useful
+ * than the generic `Factory<modelFqcn, null>`: subclass-specific state methods
+ * (`forUser()`, `withOwner()`, etc.) become callable on the chain without
+ * requiring `@use HasFactory<XFactory>` on every model.
+ *
+ * Skipped paths (deferred to the stub):
+ *   - When the user wrote an explicit `@use HasFactory<XFactory>` binding, the
+ *     stub's `@return TFactory` already resolves to the user's choice (the
+ *     documented escape hatch).
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/960
+ * @see FactoryCountTypeProvider
+ * @internal
+ */
+final class ModelFactoryMethodTypeProvider implements MethodReturnTypeProviderInterface
+{
+    /** Pre-lowercased Model FQCN for parent_classes lookups. */
+    private const MODEL_FQCN_LOWERCASE = 'illuminate\\database\\eloquent\\model';
+
+    /**
+     * Cached Factory<ModelFqcn, null> Unions keyed by the model FQCN.
+     * Bounded by the number of HasFactory models in the project.
+     *
+     * @var array<string, Union>
+     */
+    private static array $factoryUnionCache = [];
+
+    /**
+     * @return list<string>
+     * @psalm-pure
+     */
+    #[\Override]
+    public static function getClassLikeNames(): array
+    {
+        return [HasFactory::class];
+    }
+
+    #[\Override]
+    public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        if ($event->getMethodNameLowercase() !== 'factory') {
+            return null;
+        }
+
+        $modelFqcn = $event->getCalledFqClasslikeName() ?? $event->getFqClasslikeName();
+        $codebase = $event->getSource()->getCodebase();
+
+        // has() pre-check avoids constructing an InvalidArgumentException for
+        // classes Psalm has not scanned.
+        if (!$codebase->classlike_storage_provider->has($modelFqcn)) {
+            return null;
+        }
+
+        $storage = $codebase->classlike_storage_provider->get($modelFqcn);
+
+        // Only fire for Model subclasses. Skip non-Model HasFactory hosts.
+        if (!isset($storage->parent_classes[self::MODEL_FQCN_LOWERCASE])) {
+            return null;
+        }
+
+        // Defer to the stub when the user wrote an explicit
+        // `@use HasFactory<XFactory>` binding. The stub returns TFactory which
+        // resolves to the user-chosen Factory subclass — strictly more precise
+        // than anything this handler can produce.
+        if (self::hasUserBoundTFactory($storage)) {
+            return null;
+        }
+
+        // Tier 1 + 2: discover the concrete factory class. Return it only
+        // when its class storage carries an `@extends Factory<X>` binding,
+        // because `FactoryCountTypeProvider::resolveModelFromClass()` needs
+        // that binding to recover TModel from a chain like
+        // `MyFactory::count(N)->make()`. Real-world factories often skip the
+        // `@extends` docblock (BookStack, etc.) and rely on the runtime
+        // `protected $model = X::class` property; returning the bare class
+        // in that case would erase TModel and downgrade the chain to base
+        // `Model`. The next-best result (`Factory<modelFqcn, null>`) is
+        // strictly more useful in that scenario.
+        $factoryClass = self::discoverFactoryClass($modelFqcn, $storage, $codebase);
+        if ($factoryClass !== null && self::hasModelTemplateBinding($factoryClass, $codebase)) {
+            return new Union([new TNamedObject($factoryClass)]);
+        }
+
+        // Tier 3 fallback: Factory<modelFqcn, null>. Keeps TModel and TCount
+        // bound so count(N)->make() still resolves to Collection<int,
+        // modelFqcn>. Cached because the value depends only on $modelFqcn.
+        return self::$factoryUnionCache[$modelFqcn] ??= new Union([
+            new TGenericObject(Factory::class, [
+                new Union([new TNamedObject($modelFqcn)]),
+                new Union([new TNull()]),
+            ]),
+        ]);
+    }
+
+    /**
+     * Tier 1: `#[UseFactory(XFactory::class)]` attribute on the model.
+     * Tier 2: `Factory::resolveFactoryName()` naming convention.
+     * Returns the FQCN only if Psalm has scanned it; otherwise null so the
+     * caller can fall through to the generic `Factory<modelFqcn, null>`.
+     *
+     * Not mutation-free: `Factory::resolveFactoryName()` reads Laravel
+     * container state (`appNamespace()`). The handler context tolerates
+     * impure helpers; the caller is the only entry point and is also impure.
+     */
+    private static function discoverFactoryClass(
+        string $modelFqcn,
+        ClassLikeStorage $storage,
+        \Psalm\Codebase $codebase
+    ): ?string {
+        $fromAttribute = self::factoryFromUseFactoryAttribute($storage);
+        if ($fromAttribute !== null && $codebase->classlike_storage_provider->has($fromAttribute)) {
+            return $fromAttribute;
+        }
+
+        /** @var class-string<Model> $modelFqcn */
+        try {
+            $resolved = Factory::resolveFactoryName($modelFqcn);
+        } catch (\Throwable) {
+            return null;
+        }
+
+        return $codebase->classlike_storage_provider->has($resolved) ? $resolved : null;
+    }
+
+    /**
+     * Confirms the factory class carries an explicit `@extends Factory<X>` to
+     * a Model SUBCLASS (not bare `Model`). Psalm populates
+     * `template_extended_params[Factory::class]['TModel']` with the bound
+     * default (bare `Model`) when the user omits `@extends`, so a plain
+     * `isset()` would be too permissive — we'd return the concrete factory
+     * class and FactoryCountTypeProvider would later recover TModel as
+     * `Model`, downgrading the chain.
+     *
+     * @psalm-mutation-free
+     */
+    private static function hasModelTemplateBinding(string $factoryClass, \Psalm\Codebase $codebase): bool
+    {
+        try {
+            $storage = $codebase->classlike_storage_provider->get($factoryClass);
+        } catch (\InvalidArgumentException) {
+            return false;
+        }
+
+        $tModel = $storage->template_extended_params[Factory::class]['TModel'] ?? null;
+        if (!$tModel instanceof Union) {
+            return false;
+        }
+
+        foreach ($tModel->getAtomicTypes() as $atomic) {
+            if ($atomic instanceof TNamedObject && $atomic->value !== Model::class) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Read `#[UseFactory(XFactory::class)]` from the model class's storage.
+     * Mirrors `HasFactory::getUseFactoryAttribute()` at static-analysis time.
+     *
+     * @psalm-mutation-free
+     */
+    private static function factoryFromUseFactoryAttribute(ClassLikeStorage $storage): ?string
+    {
+        foreach ($storage->attributes as $attribute) {
+            if ($attribute->fq_class_name !== UseFactory::class) {
+                continue;
+            }
+
+            $firstArg = $attribute->args[0] ?? null;
+            if ($firstArg === null) {
+                continue;
+            }
+
+            $argType = $firstArg->type;
+            if (!$argType instanceof Union) {
+                continue;
+            }
+
+            foreach ($argType->getAtomicTypes() as $atomic) {
+                if ($atomic instanceof TLiteralClassString) {
+                    return $atomic->value;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * True when the model carries an explicit HasFactory template binding to
+     * a Factory subclass. Psalm's populator copies user-supplied offsets into
+     * `template_extended_params[HasFactory::class]['TFactory']`; the unbound
+     * default fills the same slot with the bound (bare Factory), so a value
+     * other than bare Factory signals a user binding.
+     *
+     * @psalm-mutation-free
+     */
+    private static function hasUserBoundTFactory(ClassLikeStorage $storage): bool
+    {
+        $binding = $storage->template_extended_params[HasFactory::class]['TFactory'] ?? null;
+        if (!$binding instanceof Union) {
+            return false;
+        }
+
+        foreach ($binding->getAtomicTypes() as $atomic) {
+            if ($atomic instanceof TNamedObject && $atomic->value !== Factory::class) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Handlers/Eloquent/ModelFactoryMethodTypeProvider.php
+++ b/src/Handlers/Eloquent/ModelFactoryMethodTypeProvider.php
@@ -138,7 +138,7 @@ final class ModelFactoryMethodTypeProvider implements MethodReturnTypeProviderIn
     private static function discoverFactoryClass(
         string $modelFqcn,
         ClassLikeStorage $storage,
-        \Psalm\Codebase $codebase
+        \Psalm\Codebase $codebase,
     ): ?string {
         $fromAttribute = self::factoryFromUseFactoryAttribute($storage);
         if ($fromAttribute !== null && $codebase->classlike_storage_provider->has($fromAttribute)) {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -96,6 +96,7 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Eloquent/CustomCollectionHandler.php';
         require_once __DIR__ . '/Handlers/Eloquent/ModelRelationshipPropertyHandler.php';
         require_once __DIR__ . '/Handlers/Eloquent/ModelFactoryTypeProvider.php';
+        require_once __DIR__ . '/Handlers/Eloquent/ModelFactoryMethodTypeProvider.php';
         require_once __DIR__ . '/Handlers/Eloquent/FactoryCountTypeProvider.php';
         require_once __DIR__ . '/Handlers/Eloquent/ModelPropertyAccessorHandler.php';
         require_once __DIR__ . '/Handlers/Eloquent/ModelAttributeSubsetHandler.php';
@@ -105,6 +106,7 @@ final class Plugin implements PluginEntryPointInterface
         }
 
         $registration->registerHooksFromClass(Handlers\Eloquent\ModelRegistrationHandler::class);
+        $registration->registerHooksFromClass(Handlers\Eloquent\ModelFactoryMethodTypeProvider::class);
         $registration->registerHooksFromClass(Handlers\Eloquent\FactoryCountTypeProvider::class);
 
         // Magic method forwarding: Relation -> Builder (decorated forwarding).

--- a/tests/Type/tests/HasFactoryTemplateParamTest.phpt
+++ b/tests/Type/tests/HasFactoryTemplateParamTest.phpt
@@ -35,10 +35,17 @@ class ExplicitArticleFactory extends Factory
     }
 }
 
-/** @use HasFactory<ExplicitArticleFactory> */
 class ExplicitArticle extends Model
 {
+    /** @use HasFactory<ExplicitArticleFactory> */
     use HasFactory;
 }
+
+// Explicit binding wins over ModelFactoryMethodTypeProvider's default — the
+// handler returns null when @use HasFactory<X> is set, so the stub's @return
+// TFactory resolves to the user's Factory subclass (more precise than the
+// plugin's Factory<Model>). Guards the documented escape hatch from #960.
+$_explicitFactory = ExplicitArticle::factory();
+/** @psalm-check-type-exact $_explicitFactory = ExplicitArticleFactory */;
 ?>
 --EXPECTF--

--- a/tests/Type/tests/Model/FactoryCountFallbackToBaseModelTest.phpt
+++ b/tests/Type/tests/Model/FactoryCountFallbackToBaseModelTest.phpt
@@ -1,0 +1,46 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Sandbox;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * Direct exercise of FactoryCountTypeProvider's third-tier Model fallback
+ * (Option B in issue #960). Simulates a bare `Factory` receiver — no
+ * template params on the type and no `extends Factory<X>` binding on the
+ * called class.
+ *
+ * Without the fallback, the unbound receiver collapses through the stub's
+ * `@return Factory<TModel, int|null>` and `make()`'s conditional picks the
+ * single-model branch (`TModel = Model` because Psalm uses the template
+ * bound when no binding is supplied). With the fallback, the handler still
+ * returns `Factory<Model, 2>` so the conditional resolves to the plural
+ * branch and the caller gets `Collection<int, Model>` instead of a bare
+ * `Model`. Downgraded compared to ModelFactoryMethodTypeProvider's precise
+ * resolution, but still iterable — avoids the `PossibleRawObjectIteration`
+ * false positive on every `foreach`.
+ *
+ * The bare `Factory` parameter shape arises in real code via __callStatic
+ * on a Facade, a 3rd-party stub lacking template args, etc., and is
+ * genuinely outside the user's control.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/960
+ */
+function bareFactoryReceiver(Factory $f): void
+{
+    // Tier 1 (template params) and Tier 2 (extends binding) both fail.
+    // Tier 3 fallback gives `Factory<Model, 2>`, and `make()` picks the
+    // collection branch from the conditional.
+    $_collection = $f->count(5)->make();
+    /** @psalm-check-type-exact $_collection = \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model> */;
+
+    // Foreach over the fallback collection result must not trigger
+    // PossibleRawObjectIteration — the whole point of the fallback.
+    foreach ($f->count(5)->make() as $_model) {
+        /** @psalm-check-type-exact $_model = \Illuminate\Database\Eloquent\Model */;
+    }
+}
+
+?>
+--EXPECTF--

--- a/tests/Type/tests/Model/FactoryMakeOnHasFactoryWithoutTemplateArgTest.phpt
+++ b/tests/Type/tests/Model/FactoryMakeOnHasFactoryWithoutTemplateArgTest.phpt
@@ -1,0 +1,80 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Sandbox;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Standard Laravel scaffold: `use HasFactory;` without the template arg.
+ * `php artisan make:model -f` produces this shape, so it covers the common
+ * case where downstream `Model::factory()->count(N)->make()` chains break
+ * without plugin intervention.
+ *
+ * Tracked by ModelFactoryMethodTypeProvider (Option A) and the
+ * FactoryCountTypeProvider Model fallback (Option B).
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/960
+ */
+class Bookshelf extends Model
+{
+    use HasFactory;
+}
+
+/**
+ * @extends Factory<Bookshelf>
+ */
+final class BookshelfFactory extends Factory
+{
+    /** @var class-string<Bookshelf> */
+    protected $model = Bookshelf::class;
+
+    /** @return array<string, mixed> */
+    #[\Override]
+    public function definition(): array
+    {
+        return [];
+    }
+}
+
+// ----- Option A: factory() returns Factory<Bookshelf> even without `@use HasFactory<...>` -----
+$_factory = Bookshelf::factory();
+/** @psalm-check-type-exact $_factory = \Illuminate\Database\Eloquent\Factories\Factory<\App\Sandbox\Bookshelf> */;
+
+// ----- Option A: count(N)->make() chains through to Collection<int, Bookshelf> -----
+$_shelves = Bookshelf::factory()->count(10)->make();
+/** @psalm-check-type-exact $_shelves = \Illuminate\Database\Eloquent\Collection<int, \App\Sandbox\Bookshelf> */;
+
+// ----- Option A: bare make() (no count) returns the single model -----
+$_single = Bookshelf::factory()->make();
+/** @psalm-check-type-exact $_single = \App\Sandbox\Bookshelf */;
+
+// ----- foreach over the count(N) result must not trigger PossibleRawObjectIteration -----
+foreach (Bookshelf::factory()->count(10)->make() as $_shelf) {
+    /** @psalm-check-type-exact $_shelf = \App\Sandbox\Bookshelf */;
+}
+
+// ----- create() chain mirrors make() -----
+$_created = Bookshelf::factory()->count(3)->create();
+/** @psalm-check-type-exact $_created = \Illuminate\Database\Eloquent\Collection<int, \App\Sandbox\Bookshelf> */;
+
+// ----- LSB: HasFactory inherited via abstract base, still resolves to subclass -----
+abstract class Entity extends Model
+{
+    use HasFactory;
+}
+
+class Page extends Entity
+{
+}
+
+$_pageFactory = Page::factory();
+/** @psalm-check-type-exact $_pageFactory = \Illuminate\Database\Eloquent\Factories\Factory<\App\Sandbox\Page> */;
+
+$_pages = Page::factory()->count(3)->make();
+/** @psalm-check-type-exact $_pages = \Illuminate\Database\Eloquent\Collection<int, \App\Sandbox\Page> */;
+
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

Alternative implementation of #960 / #961. Same bug, different mechanism — uses Laravel's `Factory::resolveFactoryName()` API (the lookup Larastan does in [`ModelFactoryDynamicStaticMethodReturnTypeExtension`](https://github.com/larastan/larastan/blob/master/src/ReturnTypes/ModelFactoryDynamicStaticMethodReturnTypeExtension.php)) so that a model written as `use HasFactory;` resolves to its concrete `XFactory` subclass when discoverable, not just the generic `Factory<X, null>`.

Closes #960. Alternative to #961 (different mechanism, same `tests/Type/tests/Model/FactoryMakeOnHasFactoryWithoutTemplateArgTest.phpt` and `FactoryCountFallbackToBaseModelTest.phpt` reused unchanged).

## Discovery Order

Mirrors Laravel's runtime in `HasFactory::newFactory()`:

1. `#[UseFactory(XFactory::class)]` attribute on the model class.
2. `Factory::resolveFactoryName($modelFqcn)` — Laravel naming convention, `App\Models\Bookshelf` → `Database\Factories\BookshelfFactory`.
3. Fallback to `Factory<modelFqcn, null>` (the #961 approach) so the chain still resolves `count(N)->make()` to `Collection<int, modelFqcn>`.

The concrete factory is returned only when its storage carries `@extends Factory<X>` to a Model subclass; without that binding, `FactoryCountTypeProvider` cannot recover TModel from the receiver's class alone and the chain would downgrade to base `Model`. Real-world factories (BookStack, ChapterFactory, etc.) often omit `@extends` and rely on the runtime `protected $model = X::class` property, so the generic fallback is strictly more useful in that case.

## Win vs #961

The concrete `XFactory` exposes subclass-specific state methods (`forUser()`, `withOwner()`, etc.) on the chain. Without auto-discovery, users must write `@use HasFactory<XFactory>` on every model to access these methods. With #961, only the explicit-binding case works; with this PR, the Laravel-convention case also works.

## Real-World Benchmark (alt vs #961)

| App | #961 issues | Alt issues | Δ |
|---|---|---|---|
| bookstack v26.03.3 | 2693 | 2693 | 0 (no `@extends`, falls back equivalently) |
| solidtime | 959 | 959 | 0 (uses `@use HasFactory<X>` everywhere, both branches defer to the stub) |
| **monica** | **4466** | **4429** | **−37** |

Monica has 65 factories with `@extends Factory<X>` and 64 models with bare `use HasFactory;` — the case the auto-discovery is built for. The 37-issue drop is mostly `MixedArgument`, `PossiblyNullArgument`, and `MixedMethodCall` shrinking as TModel propagates through chains that previously fell back to `Model`. A handful of `MissingDependency` issues become visible (latent Carbon issues exposed by deeper analysis) — net precision gain.

## Same Surface as #961

- `ModelFactoryMethodTypeProvider` — same hook target, same skipped paths (explicit `@use HasFactory<X>`).
- `FactoryCountTypeProvider` — same Tier-3 `Model` fallback for bare `Factory` receivers (e.g. `__callStatic` on a Facade), same `isModelType()` switch from `is_a()` to `classlike_storage_provider` lineage check.
- Tests from #961 reused verbatim: `FactoryMakeOnHasFactoryWithoutTemplateArgTest.phpt`, `FactoryCountFallbackToBaseModelTest.phpt`, and the `HasFactoryTemplateParamTest.phpt` extension for the escape hatch.

## Verification

- `composer test:type`: 407/407 pass.
- `composer test:unit`: 624/624 pass (1 skipped, pre-existing).
- `composer psalm`: no errors.
- `composer cs`: clean.

## Known Limitations

- `Factory::resolveFactoryName()` reads Laravel container state (`appNamespace()`). When the container can't be bootstrapped from the analysis context (e.g. PHPT fixtures), the call throws and the handler falls through to the generic `Factory<X, null>` — same precision as #961 for those cases. The catch is silent because the fallback is the documented behaviour.
- The Tier 1 `#[UseFactory]` attribute path produces a namespace-prefix doubling artifact in PHPT runtime (`App\Models\App\Models\BookshelfFactory`) when the model and factory live in the same namespace. Real apps with separate `App\Models` / `Database\Factories` namespaces are not affected (verified on monica). The Tier 2 path is the primary discovery mechanism; Tier 1 is a thin convenience.

## Checklist

- [x] Tests cover the change (reused #961's tests plus an extension to `HasFactoryTemplateParamTest.phpt`).
- [x] Real-world benchmarks demonstrate the precision gain over #961.