### PR TITLE
Drop redundant `Collection::random()` stub

### DIFF
--- a/stubs/common/Support/Collection.phpstub
+++ b/stubs/common/Support/Collection.phpstub
@@ -138,17 +138,6 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
     /**
      * @psalm-mutation-free
      *
-     * @param  (callable(self<TKey, TValue>): int)|int|null  $number
-     * @param  bool  $preserveKeys
-     * @return ($number is null ? TValue : static<int, TValue>)
-     *
-     * @throws \InvalidArgumentException
-     */
-    public function random($number = null, $preserveKeys = false) {}
-
-    /**
-     * @psalm-mutation-free
-     *
      * @param  TValue|(callable(TValue,TKey): bool)  $value
      * @param  bool  $strict
      * @return TKey|false

--- a/tests/Type/tests/Collection/CollectionRandomTest.phpt
+++ b/tests/Type/tests/Collection/CollectionRandomTest.phpt
@@ -6,62 +6,33 @@ use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Collection as BaseCollection;
 
 /**
- * Collection::random() stub alignment with Laravel's actual signature.
- *
- * Covers:
- *  - `random()` with no argument returns a single TValue (works correctly today).
- *  - `random(callable)` accepts a closure receiving the whole collection
- *    (callable(self<TKey, TValue>): int), matching Laravel's
- *    `Illuminate\Collections\Collection::random` where `$number($this)` is called.
- *    Before this stub change the param was `callable(TValue): int`, which produced
- *    a spurious `InvalidArgument` on callers like
- *    `$collection->random(fn (Collection $items): int => ...)`.
- *  - `random(int, bool)` compiles without TooManyArguments — the `$preserveKeys`
- *    second parameter was missing from the stub.
- *
- * NOT covered here: the conditional return type `($number is null ? TValue :
- * static<int, TValue>)` does not currently narrow correctly when `$number` is
- * non-null. That is tracked separately in
- * https://github.com/psalm/psalm-plugin-laravel/issues/903 and is out of scope
- * for this stub-signature fix.
+ * Regression guard: ensure Laravel's own random() docblock keeps working without
+ * a plugin stub override. See #903 for the conditional-return narrowing issue.
  */
 final class CollectionRandomTest
 {
     /** @return EloquentCollection<int, Customer> */
-    public function getCustomers(): EloquentCollection
+    public function customers(): EloquentCollection
     {
         return Customer::all();
     }
 
-    /**
-     * No argument: returns a single Customer.
-     *
-     * @psalm-check-type-exact $result = Customer
-     */
-    public function randomNoArg(): Customer
+    /** @psalm-check-type-exact $single = Customer */
+    public function noArg(): Customer
     {
-        $result = $this->getCustomers()->random();
+        $single = $this->customers()->random();
 
-        return $result;
+        return $single;
     }
 
-    /**
-     * Closure argument typed against the parent Support\Collection: no InvalidArgument.
-     * This reproduces the monicahq/monica pattern in VaultIndexViewHelper.
-     */
-    public function randomCallable(): void
+    public function callableReceivesWholeCollection(): void
     {
-        $this->getCustomers()->random(
-            fn (BaseCollection $items): int => min(5, $items->count()),
-        );
+        $this->customers()->random(fn (BaseCollection $items): int => min(5, $items->count()));
     }
 
-    /**
-     * preserveKeys positional argument compiles without TooManyArguments.
-     */
-    public function randomWithPreserveKeys(): void
+    public function preserveKeysArgCompiles(): void
     {
-        $this->getCustomers()->random(3, true);
+        $this->customers()->random(3, true);
     }
 }
 ?>


### PR DESCRIPTION
## Summary

Laravel ships the exact docblock the plugin's `Collection::random()` stub redeclared (`@param (callable(self<TKey, TValue>): int)|int|null`, conditional `@return ($number is null ? TValue : static<int, TValue>)`) at `vendor/laravel/framework/src/Illuminate/Collections/Collection.php:1141-1147`. Psalm reads it directly from framework source when the stub class omits the method, so the override added nothing beyond `@psalm-mutation-free`. No caller in `tests/Type` relies on that annotation.

Slimmed the regression test alongside (dropped 27 lines of prose comments duplicating the previous commit message; pointed at #903 for the conditional-return narrowing issue still tracked there).

## Changes

- Delete `Collection::random()` from `stubs/common/Support/Collection.phpstub` (−11 lines)
- Slim `tests/Type/tests/Collection/CollectionRandomTest.phpt` (−40 lines)

Net: −40 lines, regression coverage preserved.

## Verification

`composer test:type -- --no-progress` → 389 tests pass.

## Trade-off

Loses `@psalm-mutation-free` on `random()`. If a real-world caller surfaces `ImpureMethodCall`, the stub method can be re-added then.

Refs #903.