### PR TITLE
Narrow `pluck($value, $key)` key type and cover relation chains

### DIFF
--- a/src/Handlers/Collections/CollectionPluckHandler.php
+++ b/src/Handlers/Collections/CollectionPluckHandler.php
@@ -46,6 +46,9 @@ final class CollectionPluckHandler implements MethodReturnTypeProviderInterface
             return null;
         }
 
+        $stmt = $event->getStmt();
+        $lhsExpr = $stmt instanceof \PhpParser\Node\Expr\MethodCall ? $stmt->var : null;
+
         // Collection<TKey, TValue> — TValue (the model) is template param at index 1.
         // For non-Model collections, resolvePluckReturnType returns null and Psalm uses
         // its default type inference.
@@ -55,6 +58,7 @@ final class CollectionPluckHandler implements MethodReturnTypeProviderInterface
             modelTemplateIndex: 1,
             nodeTypeProvider: $event->getSource()->getNodeTypeProvider(),
             codebase: $event->getSource()->getCodebase(),
+            lhsExpr: $lhsExpr,
         );
     }
 }

--- a/src/Handlers/Eloquent/BuilderPluckHandler.php
+++ b/src/Handlers/Eloquent/BuilderPluckHandler.php
@@ -42,6 +42,9 @@ final class BuilderPluckHandler implements MethodReturnTypeProviderInterface
             return null;
         }
 
+        $stmt = $event->getStmt();
+        $lhsExpr = $stmt instanceof \PhpParser\Node\Expr\MethodCall ? $stmt->var : null;
+
         // Builder<TModel> — TModel is template param at index 0
         return ModelPropertyResolver::resolvePluckReturnType(
             args: $event->getCallArgs(),
@@ -49,6 +52,7 @@ final class BuilderPluckHandler implements MethodReturnTypeProviderInterface
             modelTemplateIndex: 0,
             nodeTypeProvider: $event->getSource()->getNodeTypeProvider(),
             codebase: $event->getSource()->getCodebase(),
+            lhsExpr: $lhsExpr,
         );
     }
 }

--- a/src/Util/ModelPropertyResolver.php
+++ b/src/Util/ModelPropertyResolver.php
@@ -112,7 +112,7 @@ final class ModelPropertyResolver
         // still contain the *unsubstituted* template (TTemplateParam) instead of the
         // concrete model. Fall back to inspecting the call's LHS expression, whose
         // type carries the concrete generic arguments.
-        if ($modelClass === null && $lhsExpr !== null) {
+        if ($modelClass === null && $lhsExpr instanceof \PhpParser\Node\Expr) {
             $modelClass = self::extractModelFromLhsType(
                 $nodeTypeProvider->getType($lhsExpr),
                 $modelTemplateIndex,
@@ -204,6 +204,7 @@ final class ModelPropertyResolver
             if (!$keyArgType instanceof Union || !$keyArgType->isSingleStringLiteral()) {
                 return Type::getArrayKey();
             }
+
             $keyColumn = $keyArgType->getSingleStringLiteral()->value;
         } else {
             $keyColumn = $keyArg->value->value;

--- a/src/Util/ModelPropertyResolver.php
+++ b/src/Util/ModelPropertyResolver.php
@@ -7,6 +7,11 @@ namespace Psalm\LaravelPlugin\Util;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Psalm\Codebase;
+// UnionTypeComparator is in Psalm\Internal\* but is the established convention for
+// type-containment checks in plugins (Psalm's own bundled providers use it directly,
+// and several other handlers in this codebase already depend on Psalm\Internal\*).
+// Re-verify when bumping Psalm to a new minor/major version.
+use Psalm\Internal\Type\Comparator\UnionTypeComparator;
 use Psalm\NodeTypeProvider;
 use Psalm\Type;
 use Psalm\Type\Atomic\TGenericObject;
@@ -75,6 +80,10 @@ final class ModelPropertyResolver
      * @param non-empty-list<Union>|null $templateParams   Template type parameters from the event
      * @param int $modelTemplateIndex                      Which template parameter holds the Model type
      *                                                     (0 for Builder<TModel>, 1 for Collection<TKey, TModel>)
+     * @param \PhpParser\Node\Expr|null $lhsExpr           The method call's left-hand-side expression
+     *                                                     (e.g. `$customer->vehicles()` for `$customer->vehicles()->pluck()`).
+     *                                                     Used as a fallback when the event's template parameters are
+     *                                                     unsubstituted templates (Psalm's @mixin chain limitation).
      */
     public static function resolvePluckReturnType(
         array $args,
@@ -82,6 +91,7 @@ final class ModelPropertyResolver
         int $modelTemplateIndex,
         NodeTypeProvider $nodeTypeProvider,
         Codebase $codebase,
+        ?\PhpParser\Node\Expr $lhsExpr = null,
     ): ?Union {
         if ($args === []) {
             return null;
@@ -96,6 +106,19 @@ final class ModelPropertyResolver
         $columnName = $argType->getSingleStringLiteral()->value;
 
         $modelClass = self::extractModelFromUnion($templateParams[$modelTemplateIndex] ?? null);
+
+        // When the call is reached via Psalm's @mixin chain (e.g. $relation->pluck()
+        // forwards to Builder<TRelatedModel>), the event's template parameters can
+        // still contain the *unsubstituted* template (TTemplateParam) instead of the
+        // concrete model. Fall back to inspecting the call's LHS expression, whose
+        // type carries the concrete generic arguments.
+        if ($modelClass === null && $lhsExpr !== null) {
+            $modelClass = self::extractModelFromLhsType(
+                $nodeTypeProvider->getType($lhsExpr),
+                $modelTemplateIndex,
+            );
+        }
+
         if ($modelClass === null) {
             return null;
         }
@@ -105,16 +128,96 @@ final class ModelPropertyResolver
             return null;
         }
 
-        // Determine key type: int when no $key argument, array-key when $key is provided.
-        // Laravel does NOT apply casts/mutators to the key column — keys come from raw PDO
-        // results and are always string|int.
+        // Determine key type:
+        //   - no $key argument        → int (positional Laravel key)
+        //   - $key arg with @property → @property type if subset of array-key, else array-key
+        //   - $key arg without @property → array-key
+        //
+        // We only adopt the @property type when it is a subset of int|string, because
+        // Collection<TKey, TValue> requires TKey to be array-key. A property declared as
+        // CarbonInterface|null (cast type) would produce an invalid TKey, so we fall back.
         $keyType = Type::getInt();
         if (\count($args) >= 2) {
-            $keyType = Type::getArrayKey();
+            $keyType = self::resolveKeyType(
+                keyArg: $args[1],
+                modelClass: $modelClass,
+                nodeTypeProvider: $nodeTypeProvider,
+                codebase: $codebase,
+            );
         }
 
         return new Union([
             new TGenericObject(Collection::class, [$keyType, $propertyType]),
         ]);
+    }
+
+    /**
+     * Extract a Model class-string from the call's LHS type at the given template index.
+     *
+     * The LHS type (e.g. HasMany<Vehicle, Customer>) carries concrete generic arguments
+     * even when the event's template parameters do not, because @mixin forwarding can
+     * leave the template unsubstituted by the time the return-type provider runs.
+     *
+     * @return class-string<Model>|null
+     * @psalm-mutation-free
+     */
+    private static function extractModelFromLhsType(?Union $lhsType, int $modelTemplateIndex): ?string
+    {
+        if (!$lhsType instanceof Union) {
+            return null;
+        }
+
+        foreach ($lhsType->getAtomicTypes() as $atomic) {
+            if (!$atomic instanceof TGenericObject) {
+                continue;
+            }
+
+            $modelType = $atomic->type_params[$modelTemplateIndex] ?? null;
+            $modelClass = self::extractModelFromUnion($modelType);
+            if ($modelClass !== null) {
+                return $modelClass;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolve the TKey type for pluck($value, $key) when a key argument is provided.
+     *
+     * Returns the @property type of the key column when it is a subset of array-key
+     * (int|string); otherwise returns array-key. Returns array-key for dynamic/unknown
+     * key columns.
+     *
+     * @param class-string<Model> $modelClass
+     */
+    private static function resolveKeyType(
+        \PhpParser\Node\Arg $keyArg,
+        string $modelClass,
+        NodeTypeProvider $nodeTypeProvider,
+        Codebase $codebase,
+    ): Union {
+        // Cheap AST pre-check: avoid a NodeTypeProvider lookup for non-literal key columns,
+        // which is the common case (variables, expressions).
+        if (!$keyArg->value instanceof \PhpParser\Node\Scalar\String_) {
+            $keyArgType = $nodeTypeProvider->getType($keyArg->value);
+            if (!$keyArgType instanceof Union || !$keyArgType->isSingleStringLiteral()) {
+                return Type::getArrayKey();
+            }
+            $keyColumn = $keyArgType->getSingleStringLiteral()->value;
+        } else {
+            $keyColumn = $keyArg->value->value;
+        }
+
+        $keyPropertyType = self::resolvePropertyType($codebase, $modelClass, $keyColumn);
+        if (!$keyPropertyType instanceof Union) {
+            return Type::getArrayKey();
+        }
+
+        if (!UnionTypeComparator::isContainedBy($codebase, $keyPropertyType, Type::getArrayKey())) {
+            return Type::getArrayKey();
+        }
+
+        return $keyPropertyType;
     }
 }

--- a/tests/Type/tests/Builder/BuilderPluckTest.phpt
+++ b/tests/Type/tests/Builder/BuilderPluckTest.phpt
@@ -2,11 +2,16 @@
 <?php declare(strict_types=1);
 
 use App\Models\Customer;
+use App\Models\Vehicle;
 use Illuminate\Support\Collection;
 
 /**
- * pluck() on Builder and Collection should infer value type from model @property annotations.
+ * pluck() on Builder, Collection, and Relation should infer value type from model
+ * @property annotations, and narrow the key type when an array-key compatible
+ * @property exists for the key column.
+ *
  * @see https://github.com/psalm/psalm-plugin-laravel/issues/486
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/967
  */
 
 // --- Builder::pluck() ---
@@ -40,13 +45,34 @@ function test_pluck_with_dynamic_column(string $column): void
 }
 
 /**
- * Key column uses array-key because Laravel does NOT apply casts to key columns —
- * keys come from raw PDO results and are always string|int.
+ * Key column narrows to the @property type when that type is a subset of array-key
+ * (int|string). Customer has `@property string $id`, so TKey narrows to string.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/967
  */
-function test_pluck_with_key_column(): void
+function test_pluck_with_array_key_compatible_key_column(): void
 {
     $_result = Customer::query()->pluck('email_verified_at', 'id');
-    /** @psalm-check-type-exact $_result = Collection<array-key, \Carbon\CarbonInterface|null> */
+    /** @psalm-check-type-exact $_result = Collection<string, \Carbon\CarbonInterface|null> */
+}
+
+/**
+ * Customer has `@property int<0, max> $vehicles_count` — TKey narrows to int<0, max>.
+ */
+function test_pluck_with_int_range_key_column(): void
+{
+    $_result = Customer::query()->pluck('id', 'vehicles_count');
+    /** @psalm-check-type-exact $_result = Collection<int<0, max>, string> */
+}
+
+/**
+ * Key column @property is CarbonInterface|null, not a subset of array-key. The key
+ * falls back to array-key instead of producing an invalid TKey for Collection.
+ */
+function test_pluck_with_non_array_key_compatible_key_column(): void
+{
+    $_result = Customer::query()->pluck('id', 'email_verified_at');
+    /** @psalm-check-type-exact $_result = Collection<array-key, string> */
 }
 
 /** pluck with an unknown key column should still use array-key for keys */
@@ -89,12 +115,12 @@ function test_pluck_on_eloquent_collection(): void
     /** @psalm-check-type-exact $_result = Collection<int, string> */
 }
 
-/** pluck on Collection with key argument should use array-key */
+/** pluck on Eloquent Collection narrows TKey when key column @property is array-key compatible */
 function test_pluck_on_collection_with_key(): void
 {
     $customers = Customer::all();
     $_result = $customers->pluck('email_verified_at', 'id');
-    /** @psalm-check-type-exact $_result = Collection<array-key, \Carbon\CarbonInterface|null> */
+    /** @psalm-check-type-exact $_result = Collection<string, \Carbon\CarbonInterface|null> */
 }
 
 /** pluck on Collection with unknown column falls back to default */
@@ -110,6 +136,76 @@ function test_pluck_on_get_result(): void
 {
     $_result = Customer::query()->get()->pluck('id');
     /** @psalm-check-type-exact $_result = Collection<int, string> */
+}
+
+// --- Relation::pluck() ---
+
+/**
+ * pluck() chained off a HasMany relation. Vehicle has `@property string $make` and
+ * `@property string $model`, so the result narrows on both axes.
+ *
+ * This is the original repro from #967.
+ */
+function test_pluck_on_has_many_relation_with_both_args(Customer $customer): void
+{
+    $_result = $customer->vehicles()->pluck('make', 'model');
+    /** @psalm-check-type-exact $_result = Collection<string, string> */
+}
+
+/** Single-argument pluck on a HasMany relation narrows value, key stays int. */
+function test_pluck_on_has_many_relation_single_arg(Customer $customer): void
+{
+    $_result = $customer->vehicles()->pluck('make');
+    /** @psalm-check-type-exact $_result = Collection<int, string> */
+}
+
+/** ->all() on the narrowed Collection produces array<string, string> — the issue's expected shape. */
+function test_pluck_all_on_has_many_relation(Customer $customer): void
+{
+    $_result = $customer->vehicles()->pluck('make', 'model')->all();
+    /** @psalm-check-type-exact $_result = array<string, string> */
+}
+
+/**
+ * @param \Illuminate\Database\Eloquent\Relations\BelongsTo<Customer, Vehicle> $belongsTo
+ */
+function test_pluck_on_belongs_to_relation($belongsTo): void
+{
+    $_result = $belongsTo->pluck('id');
+    /** @psalm-check-type-exact $_result = Collection<int, string> */
+}
+
+/**
+ * Two-argument pluck on BelongsTo. Customer has `@property string $id` and
+ * `@property non-empty-string $first_name_using_legacy_accessor` — both array-key
+ * compatible, so TKey narrows.
+ *
+ * @param \Illuminate\Database\Eloquent\Relations\BelongsTo<Customer, Vehicle> $belongsTo
+ */
+function test_pluck_on_belongs_to_relation_with_key($belongsTo): void
+{
+    $_result = $belongsTo->pluck('first_name_using_legacy_accessor', 'id');
+    /** @psalm-check-type-exact $_result = Collection<string, non-empty-string> */
+}
+
+/**
+ * Two-argument pluck on HasOne. Confirms the LHS-type fallback works for relation
+ * subclasses beyond HasMany/BelongsTo.
+ */
+function test_pluck_on_has_one_relation_with_key(Customer $customer): void
+{
+    $_result = $customer->primaryVehicle()->pluck('make', 'model');
+    /** @psalm-check-type-exact $_result = Collection<string, string> */
+}
+
+/**
+ * Dynamic key column on a relation: keys must fall back to array-key, not get
+ * accidentally narrowed by the LHS-type fallback.
+ */
+function test_pluck_on_has_many_relation_dynamic_key(Customer $customer, string $keyColumn): void
+{
+    $_result = $customer->vehicles()->pluck('make', $keyColumn);
+    /** @psalm-check-type-exact $_result = Collection<array-key, string> */
 }
 ?>
 --EXPECTF--


### PR DESCRIPTION
## Issue to Solve

Two-argument `Collection::pluck($value, $key)` collapses to `Collection<array-key, mixed>` and `->all()` to `array<array-key, mixed>`, forcing `LessSpecificReturnStatement` on callers that declare the narrowed shape as the return type. The same problem appears for `$relation->pluck(...)` even when the relation's models have full `@property` metadata.

## Related

Closes #967. Sibling of #486 (single-argument `pluck` value narrowing).

## Solution Description

Two-axis narrowing for `pluck()`:

- **Key column.** `ModelPropertyResolver::resolvePluckReturnType` resolves the second argument's `@property` type. When it is a subset of `array-key` (e.g. `string`, `int<0, max>`, `non-empty-string`), it becomes the new `TKey`. When it is not (e.g. `CarbonInterface|null`), the resolver falls back to `array-key` so the resulting `Collection<TKey, TValue>` never receives an invalid key type.
- **Relation chains.** Psalm rewrites `$relation->pluck(...)` through `@mixin Builder<TRelatedModel>`, but the template stays unsubstituted by the time the `MethodReturnTypeProvider` fires (only `TRelatedModel as Model` survives). The resolver now takes the call's LHS expression as a fallback input and re-extracts the concrete model from the LHS atomic's generic params. `BuilderPluckHandler` and `CollectionPluckHandler` pass `$stmt->var` for `MethodCall` nodes; static calls keep the existing template-parameter path.

Verification: type tests in `tests/Type/tests/Builder/BuilderPluckTest.phpt` cover Builder, Eloquent `Collection`, `HasMany`, `BelongsTo`, and `HasOne` plus negative cases (dynamic key column, non-array-key `@property`, unknown column). `composer test:type`, `composer psalm`, and `composer test:unit` all clean.

## Checklist

- [x] Tests cover the change (type tests in `tests/Type/tests/Builder/BuilderPluckTest.phpt`)
