### PR TITLE
Add Pest test framework support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,11 +111,11 @@ See [docs/issues/index.md](docs/issues/index.md) for the full catalog.
 
 ## Pest framework support
 
-The plugin auto-enables Pest support when `pestphp/pest` is installed in your project. Inside files identified as Pest tests (any file with a top-level `test()`, `it()`, `describe()`, `uses()`, `beforeEach()`, `afterEach()`, `beforeAll()`, `afterAll()`, `todo()`, or `dataset()` call), it drops two classes of false positives.
+The plugin auto-enables Pest support when `pestphp/pest` is installed in your project. Inside files identified as Pest tests (any file with a top-level call to one of the Pest DSL functions: `test()`, `it()`, `describe()`, `uses()`, `beforeEach()`, `afterEach()`, `beforeAll()`, `afterAll()`, `todo()`, `dataset()`, `pest()`, `expect()`, `covers()`, or `mutates()`), it drops two classes of false positives.
 
-The first is `InvalidScope` on `$this` inside Pest closures. Pest binds the closure to the test case at runtime via `Closure::bind()`, which Psalm cannot see.
+The first is `InvalidScope` on `$this` inside Pest closures that Pest binds to the test case at runtime (`test`, `it`, `beforeEach`, `afterEach` callbacks). Pest performs the bind via `Closure::bind()`, which Psalm cannot see. Closures Pest does not bind, namely `beforeAll`/`afterAll` (static context) and the body of `describe`, are unaffected: a stray `$this` there stays reported as the real bug it is.
 
-The second is `InternalMethod` on calls into Pest's documented DSL surface (`Pest\PendingCalls\TestCall`, `Pest\PendingCalls\UsesCall`, `Pest\PendingCalls\BeforeEachCall`, `Pest\PendingCalls\AfterEachCall`, `Pest\Mixins\Expectation`, and the higher-order helpers under `Pest\Expectations\`). Pest tags these classes `@internal` but they are the only way to use the DSL.
+The second is `InternalMethod` on calls into Pest's documented DSL surface (`Pest\PendingCalls\*`, including `TestCall`, `UsesCall`, `BeforeEachCall`, `AfterEachCall`, and `DescribeCall`; `Pest\Mixins\Expectation`; the higher-order helpers under `Pest\Expectations\`; and `Pest\Configuration` returned by `pest()`). Pest tags these classes `@internal` but they are the only way to use the DSL.
 
 Non-Pest files in your `tests/` directory (for example, PHPUnit-style `TestCase` subclasses or fixture helpers) are unaffected.
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,16 @@ See [docs/config.md](docs/config.md) for all configuration options.
 The plugin ships advanced Laravel-aware static analysis checks that extend Psalm's built-in diagnostics.
 See [docs/issues/index.md](docs/issues/index.md) for the full catalog.
 
+## Pest framework support
+
+The plugin auto-enables Pest support when `pestphp/pest` is installed in your project. Inside files identified as Pest tests (any file with a top-level `test()`, `it()`, `describe()`, `uses()`, `beforeEach`, `afterEach`, `beforeAll`, or `afterAll` call), it drops two classes of false positive.
+
+The first is `InvalidScope` on `$this` inside Pest closures. Pest binds the closure to the test case at runtime via `Closure::bind()`, which Psalm cannot see.
+
+The second is `InternalMethod` on calls into Pest's documented DSL surface (`Pest\PendingCalls\TestCall`, `UsesCall`, `BeforeEachCall`, `AfterEachCall`, `Pest\Mixins\Expectation`, and the higher-order helpers under `Pest\Expectations\`). Pest tags these classes `@internal` but they are the only way to use the DSL.
+
+Non-Pest files in your `tests/` directory (for example, PHPUnit-style `TestCase` subclasses or fixture helpers) are unaffected.
+
 ## Versions & Dependencies
 
 Maintained versions:

--- a/README.md
+++ b/README.md
@@ -111,11 +111,11 @@ See [docs/issues/index.md](docs/issues/index.md) for the full catalog.
 
 ## Pest framework support
 
-The plugin auto-enables Pest support when `pestphp/pest` is installed in your project. Inside files identified as Pest tests (any file with a top-level `test()`, `it()`, `describe()`, `uses()`, `beforeEach`, `afterEach`, `beforeAll`, or `afterAll` call), it drops two classes of false positive.
+The plugin auto-enables Pest support when `pestphp/pest` is installed in your project. Inside files identified as Pest tests (any file with a top-level `test()`, `it()`, `describe()`, `uses()`, `beforeEach()`, `afterEach()`, `beforeAll()`, `afterAll()`, `todo()`, or `dataset()` call), it drops two classes of false positives.
 
 The first is `InvalidScope` on `$this` inside Pest closures. Pest binds the closure to the test case at runtime via `Closure::bind()`, which Psalm cannot see.
 
-The second is `InternalMethod` on calls into Pest's documented DSL surface (`Pest\PendingCalls\TestCall`, `UsesCall`, `BeforeEachCall`, `AfterEachCall`, `Pest\Mixins\Expectation`, and the higher-order helpers under `Pest\Expectations\`). Pest tags these classes `@internal` but they are the only way to use the DSL.
+The second is `InternalMethod` on calls into Pest's documented DSL surface (`Pest\PendingCalls\TestCall`, `Pest\PendingCalls\UsesCall`, `Pest\PendingCalls\BeforeEachCall`, `Pest\PendingCalls\AfterEachCall`, `Pest\Mixins\Expectation`, and the higher-order helpers under `Pest\Expectations\`). Pest tags these classes `@internal` but they are the only way to use the DSL.
 
 Non-Pest files in your `tests/` directory (for example, PHPUnit-style `TestCase` subclasses or fixture helpers) are unaffected.
 

--- a/src/Handlers/Pest/PestSupportHandler.php
+++ b/src/Handlers/Pest/PestSupportHandler.php
@@ -4,14 +4,16 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Handlers\Pest;
 
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
-use PhpParser\Node\Stmt\Expression;
-use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\NodeFinder;
 use Psalm\Issue\InternalMethod;
 use Psalm\Issue\InvalidScope;
 use Psalm\Plugin\EventHandler\BeforeAddIssueInterface;
@@ -31,17 +33,22 @@ use Psalm\Plugin\EventHandler\Event\BeforeFileAnalysisEvent;
  *
  * Two Psalm checks misfire on this pattern:
  *
- *  1. InvalidScope on `$this` inside Pest closures, because Psalm cannot see the runtime
- *     `Closure::bind()` Pest performs in `Pest\TestSuite::test()`.
+ *  1. InvalidScope on `$this` inside Pest closures that Pest binds to the TestCase at
+ *     runtime (`test`, `it`, `beforeEach`, `afterEach`). Suppressed only when the offending
+ *     `$this` reference is inside a binding closure's file range — `beforeAll`/`afterAll`
+ *     run in static context (no `$this`), `describe`'s own closure is unbound, so `$this`
+ *     there stays flagged.
  *
  *  2. InternalMethod on the Pest DSL surface (`Pest\PendingCalls\*`, `Pest\Mixins\Expectation`,
- *     and `Pest\Expectations\*` higher-order helpers).
+ *     `Pest\Expectations\*` higher-order helpers, `Pest\Configuration` returned by `pest()`).
+ *     Suppressed file-wide inside Pest test files because these DSL chains pepper the whole
+ *     file and unrelated `@internal` namespaces are excluded by the prefix list.
  *
  * Detection happens once per file in `beforeAnalyzeFile()` via AST inspection of the parsed
- * top-level statements (Psalm already parsed the file at this point; we read its AST). The
- * result is stored in a per-process static map. The hot `beforeAddIssue()` path is then a
- * single `isset()` lookup against that map, so the handler costs O(1) per issue and zero I/O
- * during analysis. Non-Pest files are unaffected.
+ * statements (Psalm already parsed the file at this point; we read its AST). Results are
+ * stored in two per-process static maps: one boolean "is Pest file" status, one list of
+ * binding-closure byte ranges. The hot `beforeAddIssue()` path is then an O(1) lookup
+ * plus, for InvalidScope only, a linear scan over the binding ranges of the issue's file.
  *
  * Out of scope (potential follow-ups):
  *  - Resolving `$this` inside Pest closures to the bound `TestCase` type, which would
@@ -60,21 +67,22 @@ final class PestSupportHandler implements BeforeFileAnalysisInterface, BeforeAdd
      * guard against the casing invariant silently breaking.
      */
     private const PEST_INTERNAL_METHOD_PREFIXES = [
-        // PendingCalls: TestCall, UsesCall, BeforeEachCall, AfterEachCall.
+        // PendingCalls: TestCall, UsesCall, BeforeEachCall, AfterEachCall, DescribeCall.
         'pest\\pendingcalls\\',
         // Single class — back of `expect(...)->toX()` calls.
         'pest\\mixins\\expectation::',
         // Higher-order helpers: HigherOrderExpectation, EachExpectation, OppositeExpectation.
         // All three are `@internal` in Pest source.
         'pest\\expectations\\',
+        // Returned by `pest()` for the tests/Pest.php config-style DSL
+        // (e.g. `pest()->extend(TestCase::class)`).
+        'pest\\configuration::',
     ];
 
     /**
-     * Lowercased Pest DSL function names recognised at the top level of a file as the
-     * "this is a Pest test" signature. Matches Pest's own dispatch convention in
-     * `Pest\Functions`. `todo()` and `dataset()` are included because they routinely
-     * stand alone in a file (placeholder test or extracted dataset definitions) and
-     * are the only Pest DSL call those files contain.
+     * Lowercased Pest top-level function names. A file containing ANY of these as a
+     * top-level call (including inside a namespace declaration) is treated as a Pest
+     * test file. Sourced from `Pest\Functions` (vendor/pestphp/pest/src/Functions.php).
      */
     private const PEST_DSL_FUNCTIONS = [
         'test' => true,
@@ -87,85 +95,75 @@ final class PestSupportHandler implements BeforeFileAnalysisInterface, BeforeAdd
         'afterall' => true,
         'todo' => true,
         'dataset' => true,
+        'pest' => true,
+        'expect' => true,
+        'covers' => true,
+        'mutates' => true,
     ];
 
     /**
-     * Per-file detection results, keyed by the file_path Psalm passes through
-     * `StatementsSource::getFilePath()`. Populated lazily during file analysis. Each
-     * Psalm worker process (pcntl_fork) keeps its own copy; correctness does not depend
-     * on cross-worker sharing.
+     * Pest DSL functions whose closure argument is bound to the TestCase at runtime, so
+     * `$this` inside the closure body is valid. Value is the 0-based index of the closure
+     * argument in the function signature.
      *
-     * @var array<string, true>
+     * Deliberately excludes:
+     *  - `beforeAll` / `afterAll`: run in static context per Pest source
+     *    (`TestSuite::getInstance()->beforeAll->set($closure)`), no `$this`.
+     *  - `describe`: groups inner test calls; the describe closure itself has no `$this`.
+     *    Inner `test()` / `it()` calls inside are detected separately.
+     *  - `dataset`: closure returns data, not bound to a test context.
      */
-    private static array $pestFilePaths = [];
+    private const PEST_BINDING_DSL_FUNCTIONS = [
+        'test' => 1,
+        'it' => 1,
+        'beforeeach' => 0,
+        'aftereach' => 0,
+    ];
 
     /**
-     * Inspect each file's parsed top-level statements once. If any is a call to a Pest
-     * DSL function in the root namespace, mark the file as Pest. AST inspection is
-     * precise — no false positives from comments, strings, or function names that
-     * happen to match a Pest DSL identifier elsewhere in the source.
+     * Per-file detection status, keyed by the file path Psalm reports on the
+     * CodeLocation / StatementsSource. `true` = detected Pest file; `false` = inspected
+     * and not Pest (cached so long-lived processes don't re-walk the AST). Each Psalm
+     * worker process (pcntl_fork) keeps its own copy.
      *
-     * A Pest test file may have a namespace declaration (Pest 3 supports this); in that
-     * case the file-level statement is a Namespace_ node whose own stmts contain the
-     * DSL calls. We walk one level into namespace blocks but no further (nested PHP
-     * function bodies are not Pest scope).
+     * @var array<string, bool>
+     */
+    private static array $pestFileStatus = [];
+
+    /**
+     * Per-file byte ranges of binding closures. An `$this` reference whose CodeLocation's
+     * raw_file_start falls inside any recorded range is treated as TestCase-bound and the
+     * InvalidScope check is suppressed for it.
+     *
+     * @var array<string, list<array{int, int}>>
+     */
+    private static array $pestBindingRanges = [];
+
+    /**
+     * Walk each file's AST once. Mark the file as Pest if it contains a top-level Pest
+     * DSL call (or a Pest DSL call inside a top-level `namespace { ... }` block for the
+     * Pest-3 style). Collect the byte ranges of every binding closure so InvalidScope
+     * can be suppressed precisely.
      */
     #[\Override]
     public static function beforeAnalyzeFile(BeforeFileAnalysisEvent $event): void
     {
         $filePath = $event->getStatementsSource()->getFilePath();
 
-        if (isset(self::$pestFilePaths[$filePath])) {
+        if (isset(self::$pestFileStatus[$filePath])) {
             return;
         }
 
-        if (self::containsPestDslCall($event->getStmts())) {
-            self::$pestFilePaths[$filePath] = true;
-        }
-    }
+        $stmts = $event->getStmts();
 
-    /**
-     * @param array<Stmt> $stmts
-     */
-    private static function containsPestDslCall(array $stmts): bool
-    {
-        foreach ($stmts as $stmt) {
-            if ($stmt instanceof Namespace_) {
-                if (self::containsPestDslCall($stmt->stmts)) {
-                    return true;
-                }
+        if (! self::containsTopLevelPestCall($stmts)) {
+            self::$pestFileStatus[$filePath] = false;
 
-                continue;
-            }
-
-            if ($stmt instanceof Expression && self::isPestDslExpression($stmt->expr)) {
-                return true;
-            }
+            return;
         }
 
-        return false;
-    }
-
-    /**
-     * Walk a top-level expression to find a Pest DSL func call at the root.
-     *
-     * The Pest DSL is chainable: `uses(...)->in(...)`, `test('a', fn () => null)->with([...])`,
-     * `expect($x)->toBe(1)->not->toBeFalse()`. We must unwrap the method-call chain
-     * back to its leftmost receiver, which (for a Pest statement) is a `FuncCall`
-     * to one of the Pest DSL functions. Anything else (a fluent builder, a
-     * static-resolved object) is not Pest.
-     */
-    private static function isPestDslExpression(Expr $expr): bool
-    {
-        while ($expr instanceof MethodCall || $expr instanceof NullsafeMethodCall) {
-            $expr = $expr->var;
-        }
-
-        if (! $expr instanceof FuncCall || ! $expr->name instanceof Name) {
-            return false;
-        }
-
-        return isset(self::PEST_DSL_FUNCTIONS[$expr->name->toLowerString()]);
+        self::$pestFileStatus[$filePath] = true;
+        self::$pestBindingRanges[$filePath] = self::collectBindingClosureRanges($stmts);
     }
 
     /**
@@ -182,16 +180,15 @@ final class PestSupportHandler implements BeforeFileAnalysisInterface, BeforeAdd
             return null;
         }
 
-        if (! isset(self::$pestFilePaths[$issue->code_location->file_path])) {
+        $filePath = $issue->code_location->file_path;
+        if (! (self::$pestFileStatus[$filePath] ?? false)) {
             return null;
         }
 
         if ($issue instanceof InvalidScope) {
-            // `$this` in a Pest test closure is bound to the TestCase at runtime via
-            // Closure::bind(). The only other way to trip InvalidScope inside a Pest
-            // file is genuinely buggy user code with `$this` in a stray top-level
-            // closure, which is rare enough that losing the signal is acceptable.
-            return false;
+            return self::isInsideBindingClosure($filePath, $issue->code_location->raw_file_start)
+                ? false
+                : null;
         }
 
         // InternalMethod: only suppress Pest's own DSL. A user calling some unrelated
@@ -208,5 +205,109 @@ final class PestSupportHandler implements BeforeFileAnalysisInterface, BeforeAdd
         }
 
         return null;
+    }
+
+    /**
+     * @param array<Stmt> $stmts
+     */
+    private static function containsTopLevelPestCall(array $stmts): bool
+    {
+        foreach ($stmts as $stmt) {
+            if ($stmt instanceof Stmt\Namespace_) {
+                if (self::containsTopLevelPestCall($stmt->stmts)) {
+                    return true;
+                }
+                continue;
+            }
+
+            if ($stmt instanceof Stmt\Expression && self::isPestDslExpression($stmt->expr)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Walk a top-level expression to find a Pest DSL func call at the root.
+     *
+     * The Pest DSL is chainable: `uses(...)->in(...)`, `test('a', fn () => null)->with([...])`,
+     * `pest()->extend(...)`. We unwrap the method-call chain back to its leftmost receiver,
+     * which (for a Pest statement) is a `FuncCall` to one of the Pest DSL functions.
+     */
+    private static function isPestDslExpression(Expr $expr): bool
+    {
+        while ($expr instanceof MethodCall || $expr instanceof NullsafeMethodCall) {
+            $expr = $expr->var;
+        }
+
+        if (! $expr instanceof FuncCall || ! $expr->name instanceof Name) {
+            return false;
+        }
+
+        return isset(self::PEST_DSL_FUNCTIONS[$expr->name->toLowerString()]);
+    }
+
+    /**
+     * Collect [start, end] byte ranges of every closure argument passed to a
+     * binding Pest DSL function anywhere in the AST. Walks nested expressions too,
+     * since `describe(..., function () { test(..., fn () => $this->x); })` puts the
+     * inner `test()` closure deep inside the describe callback.
+     *
+     * @param array<Stmt> $stmts
+     * @return list<array{int, int}>
+     */
+    private static function collectBindingClosureRanges(array $stmts): array
+    {
+        $ranges = [];
+
+        /** @var list<FuncCall> $funcCalls */
+        $funcCalls = (new NodeFinder())->findInstanceOf($stmts, FuncCall::class);
+
+        foreach ($funcCalls as $call) {
+            if (! $call->name instanceof Name) {
+                continue;
+            }
+
+            $argIndex = self::PEST_BINDING_DSL_FUNCTIONS[$call->name->toLowerString()] ?? null;
+            if ($argIndex === null) {
+                continue;
+            }
+
+            $arg = $call->args[$argIndex] ?? null;
+            if (! $arg instanceof Arg) {
+                continue;
+            }
+
+            $closure = $arg->value;
+            if (! $closure instanceof Closure && ! $closure instanceof ArrowFunction) {
+                continue;
+            }
+
+            $start = $closure->getStartFilePos();
+            $end = $closure->getEndFilePos();
+            if ($start < 0 || $end < 0) {
+                // Synthetic/un-positioned nodes; cannot range-check against.
+                continue;
+            }
+
+            $ranges[] = [$start, $end];
+        }
+
+        return $ranges;
+    }
+
+    /**
+     * @psalm-external-mutation-free
+     */
+    private static function isInsideBindingClosure(string $filePath, int $rawFileStart): bool
+    {
+        foreach (self::$pestBindingRanges[$filePath] ?? [] as [$start, $end]) {
+            if ($rawFileStart >= $start && $rawFileStart <= $end) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Handlers/Pest/PestSupportHandler.php
+++ b/src/Handlers/Pest/PestSupportHandler.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Pest;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\NullsafeMethodCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Namespace_;
+use Psalm\Issue\InternalMethod;
+use Psalm\Issue\InvalidScope;
+use Psalm\Plugin\EventHandler\BeforeAddIssueInterface;
+use Psalm\Plugin\EventHandler\BeforeFileAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\BeforeAddIssueEvent;
+use Psalm\Plugin\EventHandler\Event\BeforeFileAnalysisEvent;
+
+/**
+ * Pest framework support for Laravel projects.
+ *
+ * Pest is a test framework whose DSL deliberately diverges from class-based test conventions:
+ * test files are plain PHP scripts that call top-level `test()` / `it()` / `describe()` etc.,
+ * passing closures that Pest later binds to a generated TestCase subclass via Closure::bind().
+ * The DSL chain (`expect(...)->toBe(...)`, `test(...)->with(...)`, `uses(...)->in(...)`) is
+ * implemented on classes that Pest marks `@internal` even though they ARE the documented
+ * public surface user code is expected to call.
+ *
+ * Two Psalm checks misfire on this pattern:
+ *
+ *  1. InvalidScope on `$this` inside Pest closures, because Psalm cannot see the runtime
+ *     `Closure::bind()` Pest performs in `Pest\TestSuite::test()`.
+ *
+ *  2. InternalMethod on the Pest DSL surface (`Pest\PendingCalls\*`, `Pest\Mixins\Expectation`,
+ *     and `Pest\Expectations\*` higher-order helpers).
+ *
+ * Detection happens once per file in `beforeAnalyzeFile()` via AST inspection of the parsed
+ * top-level statements (Psalm already parsed the file at this point; we read its AST). The
+ * result is stored in a per-process static map. The hot `beforeAddIssue()` path is then a
+ * single `isset()` lookup against that map, so the handler costs O(1) per issue and zero I/O
+ * during analysis. Non-Pest files are unaffected.
+ *
+ * Out of scope (potential follow-ups):
+ *  - Resolving `$this` inside Pest closures to the bound `TestCase` type, which would
+ *    additionally fix downstream MixedMethodCall on `$this->...` calls.
+ *  - Higher-order expectation property access (`expect(x)->not->toBeFalse()`), where Pest
+ *    resolves `->not` via `__get` and Psalm reports UndefinedPropertyFetch.
+ *
+ * @internal
+ */
+final class PestSupportHandler implements BeforeFileAnalysisInterface, BeforeAddIssueInterface
+{
+    /**
+     * Lowercased prefixes that identify Pest's `@internal` DSL surface as method ids.
+     * `MethodIssue::$method_id` is lowercased on construction (see vendor MethodIssue.php),
+     * so these must be lowercased too. PestSupportHandlerTest exercises each prefix to
+     * guard against the casing invariant silently breaking.
+     */
+    private const PEST_INTERNAL_METHOD_PREFIXES = [
+        // PendingCalls: TestCall, UsesCall, BeforeEachCall, AfterEachCall.
+        'pest\\pendingcalls\\',
+        // Single class — back of `expect(...)->toX()` calls.
+        'pest\\mixins\\expectation::',
+        // Higher-order helpers: HigherOrderExpectation, EachExpectation, OppositeExpectation.
+        // All three are `@internal` in Pest source.
+        'pest\\expectations\\',
+    ];
+
+    /**
+     * Lowercased Pest DSL function names recognised at the top level of a file as the
+     * "this is a Pest test" signature. Matches Pest's own dispatch convention in
+     * `Pest\Functions`. `todo()` and `dataset()` are included because they routinely
+     * stand alone in a file (placeholder test or extracted dataset definitions) and
+     * are the only Pest DSL call those files contain.
+     */
+    private const PEST_DSL_FUNCTIONS = [
+        'test' => true,
+        'it' => true,
+        'describe' => true,
+        'uses' => true,
+        'beforeeach' => true,
+        'aftereach' => true,
+        'beforeall' => true,
+        'afterall' => true,
+        'todo' => true,
+        'dataset' => true,
+    ];
+
+    /**
+     * Per-file detection results, keyed by the file_path Psalm passes through
+     * `StatementsSource::getFilePath()`. Populated lazily during file analysis. Each
+     * Psalm worker process (pcntl_fork) keeps its own copy; correctness does not depend
+     * on cross-worker sharing.
+     *
+     * @var array<string, true>
+     */
+    private static array $pestFilePaths = [];
+
+    /**
+     * Inspect each file's parsed top-level statements once. If any is a call to a Pest
+     * DSL function in the root namespace, mark the file as Pest. AST inspection is
+     * precise — no false positives from comments, strings, or function names that
+     * happen to match a Pest DSL identifier elsewhere in the source.
+     *
+     * A Pest test file may have a namespace declaration (Pest 3 supports this); in that
+     * case the file-level statement is a Namespace_ node whose own stmts contain the
+     * DSL calls. We walk one level into namespace blocks but no further (nested PHP
+     * function bodies are not Pest scope).
+     */
+    #[\Override]
+    public static function beforeAnalyzeFile(BeforeFileAnalysisEvent $event): void
+    {
+        $filePath = $event->getStatementsSource()->getFilePath();
+
+        if (isset(self::$pestFilePaths[$filePath])) {
+            return;
+        }
+
+        if (self::containsPestDslCall($event->getStmts())) {
+            self::$pestFilePaths[$filePath] = true;
+        }
+    }
+
+    /**
+     * @param array<Stmt> $stmts
+     */
+    private static function containsPestDslCall(array $stmts): bool
+    {
+        foreach ($stmts as $stmt) {
+            if ($stmt instanceof Namespace_) {
+                if (self::containsPestDslCall($stmt->stmts)) {
+                    return true;
+                }
+                continue;
+            }
+
+            if ($stmt instanceof Expression && self::isPestDslExpression($stmt->expr)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Walk a top-level expression to find a Pest DSL func call at the root.
+     *
+     * The Pest DSL is chainable: `uses(...)->in(...)`, `test('a', fn () => null)->with([...])`,
+     * `expect($x)->toBe(1)->not->toBeFalse()`. We must unwrap the method-call chain
+     * back to its leftmost receiver, which (for a Pest statement) is a `FuncCall`
+     * to one of the Pest DSL functions. Anything else (a fluent builder, a
+     * static-resolved object) is not Pest.
+     */
+    private static function isPestDslExpression(Expr $expr): bool
+    {
+        while ($expr instanceof MethodCall || $expr instanceof NullsafeMethodCall) {
+            $expr = $expr->var;
+        }
+
+        if (! $expr instanceof FuncCall || ! $expr->name instanceof Name) {
+            return false;
+        }
+
+        return isset(self::PEST_DSL_FUNCTIONS[$expr->name->toLowerString()]);
+    }
+
+    /**
+     * @psalm-external-mutation-free
+     */
+    #[\Override]
+    public static function beforeAddIssue(BeforeAddIssueEvent $event): ?bool
+    {
+        $issue = $event->getIssue();
+
+        // BeforeAddIssue fires for every issue Psalm emits. The instanceof gate keeps
+        // the handler off the hot path for the ~99% of issues we never act on.
+        if (! $issue instanceof InvalidScope && ! $issue instanceof InternalMethod) {
+            return null;
+        }
+
+        if (! isset(self::$pestFilePaths[$issue->code_location->file_path])) {
+            return null;
+        }
+
+        if ($issue instanceof InvalidScope) {
+            // `$this` in a Pest test closure is bound to the TestCase at runtime via
+            // Closure::bind(). The only other way to trip InvalidScope inside a Pest
+            // file is genuinely buggy user code with `$this` in a stray top-level
+            // closure, which is rare enough that losing the signal is acceptable.
+            return false;
+        }
+
+        // InternalMethod: only suppress Pest's own DSL. A user calling some unrelated
+        // `@internal` method from a Pest test file should still be flagged. The cheap
+        // `pest\\` short-circuit avoids walking the prefix list for non-Pest namespaces.
+        if (! \str_starts_with($issue->method_id, 'pest\\')) {
+            return null;
+        }
+
+        foreach (self::PEST_INTERNAL_METHOD_PREFIXES as $prefix) {
+            if (\str_starts_with($issue->method_id, $prefix)) {
+                return false;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Handlers/Pest/PestSupportHandler.php
+++ b/src/Handlers/Pest/PestSupportHandler.php
@@ -14,51 +14,75 @@ use PhpParser\Node\Expr\NullsafeMethodCall;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeFinder;
+use Psalm\Codebase;
 use Psalm\Issue\InternalMethod;
 use Psalm\Issue\InvalidScope;
 use Psalm\Plugin\EventHandler\BeforeAddIssueInterface;
 use Psalm\Plugin\EventHandler\BeforeFileAnalysisInterface;
+use Psalm\Plugin\EventHandler\BeforeStatementAnalysisInterface;
 use Psalm\Plugin\EventHandler\Event\BeforeAddIssueEvent;
 use Psalm\Plugin\EventHandler\Event\BeforeFileAnalysisEvent;
+use Psalm\Plugin\EventHandler\Event\BeforeStatementAnalysisEvent;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Union;
 
 /**
  * Pest framework support for Laravel projects.
  *
- * Pest is a test framework whose DSL deliberately diverges from class-based test conventions:
- * test files are plain PHP scripts that call top-level `test()` / `it()` / `describe()` etc.,
- * passing closures that Pest later binds to a generated TestCase subclass via Closure::bind().
- * The DSL chain (`expect(...)->toBe(...)`, `test(...)->with(...)`, `uses(...)->in(...)`) is
- * implemented on classes that Pest marks `@internal` even though they ARE the documented
- * public surface user code is expected to call.
+ * Pest test files are plain PHP scripts that call top-level `test()` / `it()` / `describe()`
+ * etc., passing closures that Pest later binds to a generated TestCase subclass via
+ * Closure::bind(). The DSL chain (`expect(...)->toBe(...)`, `test(...)->with(...)`,
+ * `uses(...)->in(...)`) is implemented on classes that Pest marks `@internal` even though
+ * they ARE the documented public surface user code is expected to call.
  *
- * Two Psalm checks misfire on this pattern:
+ * The handler addresses two Psalm misfires inside detected Pest files:
  *
- *  1. InvalidScope on `$this` inside Pest closures that Pest binds to the TestCase at
- *     runtime (`test`, `it`, `beforeEach`, `afterEach`). Suppressed only when the offending
- *     `$this` reference is inside a binding closure's file range — `beforeAll`/`afterAll`
- *     run in static context (no `$this`), `describe`'s own closure is unbound, so `$this`
- *     there stays flagged.
+ *  1. **`$this` in binding closures**: Pest binds the closure passed to `test`, `it`,
+ *     `beforeEach`, `afterEach` to a TestCase subclass at runtime. Before Psalm analyzes
+ *     a statement inside such a closure, we inject `$this` into the statement context with
+ *     the resolved TestCase type. This makes `$this->...` calls type-check naturally and
+ *     prevents the InvalidScope check from firing in the first place — no suppression
+ *     needed. Crucially this also avoids a cascade where suppressing InvalidScope alone
+ *     would leave `$this` as `mixed` and trip MixedMethodCall/MixedPropertyFetch on every
+ *     subsequent access (observed on real-world Laravel apps: ~2-3× the suppressed count
+ *     reappear as Mixed errors).
  *
- *  2. InternalMethod on the Pest DSL surface (`Pest\PendingCalls\*`, `Pest\Mixins\Expectation`,
- *     `Pest\Expectations\*` higher-order helpers, `Pest\Configuration` returned by `pest()`).
- *     Suppressed file-wide inside Pest test files because these DSL chains pepper the whole
- *     file and unrelated `@internal` namespaces are excluded by the prefix list.
+ *     `beforeAll` / `afterAll` are NOT bound (Pest runs them in static context per
+ *     `TestSuite::getInstance()->beforeAll->set($closure)`). `describe`'s own closure is
+ *     unbound — only the inner `test()`/`it()` calls inside it bind. `$this` in those
+ *     positions stays correctly flagged.
  *
- * Detection happens once per file in `beforeAnalyzeFile()` via AST inspection of the parsed
- * statements (Psalm already parsed the file at this point; we read its AST). Results are
- * stored in two per-process static maps: one boolean "is Pest file" status, one list of
- * binding-closure byte ranges. The hot `beforeAddIssue()` path is then an O(1) lookup
- * plus, for InvalidScope only, a linear scan over the binding ranges of the issue's file.
+ *  2. **`InternalMethod` on the Pest DSL surface**: dropped only when the called method
+ *     id starts with one of `Pest\PendingCalls\`, `Pest\Mixins\Expectation::`,
+ *     `Pest\Expectations\`, or `Pest\Configuration::`. Unrelated `@internal` calls from
+ *     Pest test files remain flagged.
  *
- * Out of scope (potential follow-ups):
- *  - Resolving `$this` inside Pest closures to the bound `TestCase` type, which would
- *    additionally fix downstream MixedMethodCall on `$this->...` calls.
+ * **TestCase resolution.** First time a Pest file is seen, the handler probes the user's
+ * codebase for the bound TestCase class. `Tests\TestCase` (the Laravel default) is tried
+ * first, then `PHPUnit\Framework\TestCase`. The result is cached for the rest of the
+ * process. Per-directory `uses(X::class)->in(...)` mappings from `tests/Pest.php` are not
+ * yet honored — a follow-up could parse them for projects with multiple test base classes.
+ *
+ * **Detection.** `beforeAnalyzeFile()` walks the parsed AST once per file. A file is
+ * marked Pest if it contains a top-level call to any Pest DSL function (including inside
+ * a top-level `namespace { ... }` block). For each binding-DSL call, the closure
+ * argument's byte range is recorded along with the resolved TestCase FQCN.
+ *
+ * **Hot path.** `beforeAddIssue` is a single class-instanceof gate plus an O(1) `isset()`
+ * lookup. `beforeStatementAnalysis` is gated on the file map first; non-Pest files exit
+ * in one isset check.
+ *
+ * Out of scope:
  *  - Higher-order expectation property access (`expect(x)->not->toBeFalse()`), where Pest
  *    resolves `->not` via `__get` and Psalm reports UndefinedPropertyFetch.
+ *  - Per-directory `uses()->in()` parsing.
  *
  * @internal
  */
-final class PestSupportHandler implements BeforeFileAnalysisInterface, BeforeAddIssueInterface
+final class PestSupportHandler implements
+    BeforeFileAnalysisInterface,
+    BeforeStatementAnalysisInterface,
+    BeforeAddIssueInterface
 {
     /**
      * Lowercased prefixes that identify Pest's `@internal` DSL surface as method ids.
@@ -74,8 +98,7 @@ final class PestSupportHandler implements BeforeFileAnalysisInterface, BeforeAdd
         // Higher-order helpers: HigherOrderExpectation, EachExpectation, OppositeExpectation.
         // All three are `@internal` in Pest source.
         'pest\\expectations\\',
-        // Returned by `pest()` for the tests/Pest.php config-style DSL
-        // (e.g. `pest()->extend(TestCase::class)`).
+        // Returned by `pest()` for the tests/Pest.php config-style DSL.
         'pest\\configuration::',
     ];
 
@@ -121,29 +144,45 @@ final class PestSupportHandler implements BeforeFileAnalysisInterface, BeforeAdd
     ];
 
     /**
-     * Per-file detection status, keyed by the file path Psalm reports on the
-     * CodeLocation / StatementsSource. `true` = detected Pest file; `false` = inspected
-     * and not Pest (cached so long-lived processes don't re-walk the AST). Each Psalm
-     * worker process (pcntl_fork) keeps its own copy.
+     * TestCase class candidates probed at first Pest detection. Order matters: the
+     * Laravel default `Tests\TestCase` is checked first because Laravel scaffolds it
+     * and any Pest test in a Laravel app inherits from it. `PHPUnit\Framework\TestCase`
+     * is the fallback for non-Laravel Pest projects or sandboxes without Tests\TestCase.
+     */
+    private const TEST_CASE_CANDIDATES = [
+        'Tests\\TestCase',
+        'PHPUnit\\Framework\\TestCase',
+    ];
+
+    /**
+     * Per-file detection status. `true` = Pest file; `false` = inspected and not Pest
+     * (negative result cached so long-lived processes don't re-walk the AST). Each
+     * Psalm worker process (pcntl_fork) keeps its own copy.
      *
      * @var array<string, bool>
      */
     private static array $pestFileStatus = [];
 
     /**
-     * Per-file byte ranges of binding closures. An `$this` reference whose CodeLocation's
-     * raw_file_start falls inside any recorded range is treated as TestCase-bound and the
-     * InvalidScope check is suppressed for it.
+     * Per-file list of `[range_start, range_end, test_case_fqcn]` for every binding
+     * closure. A statement whose start position falls inside any range has its context
+     * `$this` populated with `TNamedObject($fqcn)` before analysis.
      *
-     * @var array<string, list<array{int, int}>>
+     * @var array<string, list<array{int, int, string}>>
      */
-    private static array $pestBindingRanges = [];
+    private static array $pestBindingScopes = [];
+
+    /**
+     * Resolved TestCase FQCN for this process. Computed once on the first Pest file
+     * and reused. Null means not yet resolved.
+     */
+    private static ?string $resolvedTestCaseClass = null;
 
     /**
      * Walk each file's AST once. Mark the file as Pest if it contains a top-level Pest
-     * DSL call (or a Pest DSL call inside a top-level `namespace { ... }` block for the
-     * Pest-3 style). Collect the byte ranges of every binding closure so InvalidScope
-     * can be suppressed precisely.
+     * DSL call (or a Pest DSL call inside a top-level `namespace { ... }` block).
+     * Collect the byte ranges of every binding closure so InvalidScope can be suppressed
+     * precisely.
      */
     #[\Override]
     public static function beforeAnalyzeFile(BeforeFileAnalysisEvent $event): void
@@ -163,7 +202,51 @@ final class PestSupportHandler implements BeforeFileAnalysisInterface, BeforeAdd
         }
 
         self::$pestFileStatus[$filePath] = true;
-        self::$pestBindingRanges[$filePath] = self::collectBindingClosureRanges($stmts);
+
+        $testCaseClass = self::resolveTestCaseClass($event->getCodebase());
+        self::$pestBindingScopes[$filePath] = self::collectBindingClosureScopes($stmts, $testCaseClass);
+    }
+
+    /**
+     * Inject `$this` into the analysis context for statements that sit inside a Pest
+     * binding closure. Mutation only happens when `$this` is not already present in
+     * scope, so we never override Psalm's own analysis (e.g. Closure::bind chains it
+     * already understands).
+     */
+    #[\Override]
+    public static function beforeStatementAnalysis(BeforeStatementAnalysisEvent $event): ?bool
+    {
+        $filePath = $event->getStatementsSource()->getFilePath();
+        $scopes = self::$pestBindingScopes[$filePath] ?? null;
+        if ($scopes === null) {
+            return null;
+        }
+
+        $context = $event->getContext();
+        if (isset($context->vars_in_scope['$this'])) {
+            return null;
+        }
+
+        $stmt = $event->getStmt();
+        $stmtStart = $stmt->getStartFilePos();
+        if ($stmtStart < 0) {
+            return null;
+        }
+
+        foreach ($scopes as [$rangeStart, $rangeEnd, $fqcn]) {
+            if ($stmtStart >= $rangeStart && $stmtStart <= $rangeEnd) {
+                $thisType = new Union([new TNamedObject($fqcn)]);
+                $context->vars_in_scope['$this'] = $thisType;
+                $context->vars_possibly_in_scope['$this'] = true;
+                // Mirror Psalm's own ClosureAnalyzer behaviour: set $context->self
+                // so `self::method()` and `static::method()` resolve to the bound class.
+                $context->self = $fqcn;
+
+                return null;
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -174,8 +257,6 @@ final class PestSupportHandler implements BeforeFileAnalysisInterface, BeforeAdd
     {
         $issue = $event->getIssue();
 
-        // BeforeAddIssue fires for every issue Psalm emits. The instanceof gate keeps
-        // the handler off the hot path for the ~99% of issues we never act on.
         if (! $issue instanceof InvalidScope && ! $issue instanceof InternalMethod) {
             return null;
         }
@@ -186,14 +267,23 @@ final class PestSupportHandler implements BeforeFileAnalysisInterface, BeforeAdd
         }
 
         if ($issue instanceof InvalidScope) {
+            // `BeforeStatementAnalysis` already injected `$this` into the context for
+            // statements inside binding closures, which prevents the cascade where
+            // `$this` would otherwise be `mixed` and trip MixedMethodCall everywhere.
+            // But Psalm has two InvalidScope emit sites: `VariableFetchAnalyzer`
+            // (consults `vars_in_scope`, so injection silences it) and
+            // `MethodCallAnalyzer` (checks `$statements_analyzer->getFQCLN()` only,
+            // bypassing the context). Closure FQCLN is not mutable from a plugin, so
+            // we still need to drop InvalidScope here for binding-closure ranges. The
+            // injection makes the subsequent type resolution work; this hook keeps
+            // the cosmetic error off the report.
             return self::isInsideBindingClosure($filePath, $issue->code_location->raw_file_start)
                 ? false
                 : null;
         }
 
-        // InternalMethod: only suppress Pest's own DSL. A user calling some unrelated
-        // `@internal` method from a Pest test file should still be flagged. The cheap
-        // `pest\\` short-circuit avoids walking the prefix list for non-Pest namespaces.
+        // Cheap short-circuit before the prefix walk: 99% of InternalMethod issues
+        // even inside Pest files reference non-Pest namespaces.
         if (! \str_starts_with($issue->method_id, 'pest\\')) {
             return null;
         }
@@ -208,6 +298,20 @@ final class PestSupportHandler implements BeforeFileAnalysisInterface, BeforeAdd
     }
 
     /**
+     * @psalm-external-mutation-free
+     */
+    private static function isInsideBindingClosure(string $filePath, int $rawFileStart): bool
+    {
+        foreach (self::$pestBindingScopes[$filePath] ?? [] as [$start, $end, $_fqcn]) {
+            if ($rawFileStart >= $start && $rawFileStart <= $end) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * @param array<Stmt> $stmts
      */
     private static function containsTopLevelPestCall(array $stmts): bool
@@ -217,7 +321,6 @@ final class PestSupportHandler implements BeforeFileAnalysisInterface, BeforeAdd
                 if (self::containsTopLevelPestCall($stmt->stmts)) {
                     return true;
                 }
-
                 continue;
             }
 
@@ -250,17 +353,17 @@ final class PestSupportHandler implements BeforeFileAnalysisInterface, BeforeAdd
     }
 
     /**
-     * Collect [start, end] byte ranges of every closure argument passed to a
-     * binding Pest DSL function anywhere in the AST. Walks nested expressions too,
-     * since `describe(..., function () { test(..., fn () => $this->x); })` puts the
-     * inner `test()` closure deep inside the describe callback.
+     * Collect `[start, end, fqcn]` for every closure argument passed to a binding Pest
+     * DSL function anywhere in the AST. Walks nested expressions, so an inner
+     * `it()`/`test()` inside a `describe()` callback is captured even though `describe`
+     * itself is not in the binding list.
      *
      * @param array<Stmt> $stmts
-     * @return list<array{int, int}>
+     * @return list<array{int, int, string}>
      */
-    private static function collectBindingClosureRanges(array $stmts): array
+    private static function collectBindingClosureScopes(array $stmts, string $testCaseClass): array
     {
-        $ranges = [];
+        $scopes = [];
 
         /** @var list<FuncCall> $funcCalls */
         $funcCalls = (new NodeFinder())->findInstanceOf($stmts, FuncCall::class);
@@ -288,27 +391,41 @@ final class PestSupportHandler implements BeforeFileAnalysisInterface, BeforeAdd
             $start = $closure->getStartFilePos();
             $end = $closure->getEndFilePos();
             if ($start < 0 || $end < 0) {
-                // Synthetic/un-positioned nodes; cannot range-check against.
+                // Synthetic / un-positioned nodes; cannot range-check against.
                 continue;
             }
 
-            $ranges[] = [$start, $end];
+            $scopes[] = [$start, $end, $testCaseClass];
         }
 
-        return $ranges;
+        return $scopes;
     }
 
     /**
+     * Resolve once per process. `Tests\TestCase` is the Laravel scaffold default and
+     * applies to virtually every Laravel + Pest project; `PHPUnit\Framework\TestCase`
+     * is the universal fallback. Caching here is safe — TestCase resolution does not
+     * depend on which file is being analyzed.
+     *
      * @psalm-external-mutation-free
      */
-    private static function isInsideBindingClosure(string $filePath, int $rawFileStart): bool
+    private static function resolveTestCaseClass(Codebase $codebase): string
     {
-        foreach (self::$pestBindingRanges[$filePath] ?? [] as [$start, $end]) {
-            if ($rawFileStart >= $start && $rawFileStart <= $end) {
-                return true;
+        if (self::$resolvedTestCaseClass !== null) {
+            return self::$resolvedTestCaseClass;
+        }
+
+        foreach (self::TEST_CASE_CANDIDATES as $candidate) {
+            if ($codebase->classOrInterfaceExists($candidate)) {
+                return self::$resolvedTestCaseClass = $candidate;
             }
         }
 
-        return false;
+        // Both candidates absent (e.g. user runs Psalm without PHPUnit installed).
+        // Default to PHPUnit\Framework\TestCase anyway — Psalm will then report
+        // UndefinedClass on `$this`, but that's a more accurate signal than the
+        // alternative of leaving `$this` unbound and re-introducing the InvalidScope
+        // false positive Pest users are trying to avoid.
+        return self::$resolvedTestCaseClass = 'PHPUnit\\Framework\\TestCase';
     }
 }

--- a/src/Handlers/Pest/PestSupportHandler.php
+++ b/src/Handlers/Pest/PestSupportHandler.php
@@ -321,6 +321,7 @@ final class PestSupportHandler implements
                 if (self::containsTopLevelPestCall($stmt->stmts)) {
                     return true;
                 }
+
                 continue;
             }
 

--- a/src/Handlers/Pest/PestSupportHandler.php
+++ b/src/Handlers/Pest/PestSupportHandler.php
@@ -134,6 +134,7 @@ final class PestSupportHandler implements BeforeFileAnalysisInterface, BeforeAdd
                 if (self::containsPestDslCall($stmt->stmts)) {
                     return true;
                 }
+
                 continue;
             }
 

--- a/src/Handlers/Pest/PestSupportHandler.php
+++ b/src/Handlers/Pest/PestSupportHandler.php
@@ -217,6 +217,7 @@ final class PestSupportHandler implements BeforeFileAnalysisInterface, BeforeAdd
                 if (self::containsTopLevelPestCall($stmt->stmts)) {
                     return true;
                 }
+
                 continue;
             }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -212,6 +212,16 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Jobs/DispatchableHandler.php';
         $registration->registerHooksFromClass(Handlers\Jobs\DispatchableHandler::class);
 
+        // Pest framework support: auto-enabled when pestphp/pest is installed. Drops
+        // InvalidScope on `$this` inside Pest test closures and InternalMethod on calls
+        // into Pest's DSL (Pest\PendingCalls\*, Pest\Mixins\Expectation, Pest\Expectations\*),
+        // both gated to files identified as Pest tests via AST inspection during file
+        // analysis. See PestSupportHandler for the detection logic and issue scope.
+        if (\Composer\InstalledVersions::isInstalled('pestphp/pest')) {
+            require_once __DIR__ . '/Handlers/Pest/PestSupportHandler.php';
+            $registration->registerHooksFromClass(Handlers\Pest\PestSupportHandler::class);
+        }
+
         // App-owned Facade subclasses: enumerate after codebase population and register
         // per-class method providers that resolve methods via a `getFacadeRoot()` runtime
         // probe. Covers the gap where FacadeMapProvider cannot discover a facade whose

--- a/tests/Unit/Handlers/Pest/PestSupportHandlerTest.php
+++ b/tests/Unit/Handlers/Pest/PestSupportHandlerTest.php
@@ -6,8 +6,10 @@ namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Pest;
 
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Expression;
 use PhpParser\ParserFactory;
 use PhpParser\PhpVersion;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -25,6 +27,7 @@ use Psalm\Issue\MissingReturnType;
 use Psalm\LaravelPlugin\Handlers\Pest\PestSupportHandler;
 use Psalm\Plugin\EventHandler\Event\BeforeAddIssueEvent;
 use Psalm\Plugin\EventHandler\Event\BeforeFileAnalysisEvent;
+use Psalm\Plugin\EventHandler\Event\BeforeStatementAnalysisEvent;
 use Psalm\StatementsSource;
 use Psalm\Storage\FileStorage;
 
@@ -32,6 +35,16 @@ use Psalm\Storage\FileStorage;
 final class PestSupportHandlerTest extends TestCase
 {
     private const FAKE_PATH = '/virtual/pest-test.php';
+
+    protected function setUp(): void
+    {
+        // Pre-resolve TestCase to PHPUnit\Framework\TestCase so the production
+        // resolver's codebase->classOrInterfaceExists() call is never invoked.
+        // The fallback path is what we want exercised; the "is Tests\TestCase
+        // in scope" lookup needs a real boot we don't have.
+        (new \ReflectionProperty(PestSupportHandler::class, 'resolvedTestCaseClass'))
+            ->setValue(null, 'PHPUnit\\Framework\\TestCase');
+    }
 
     protected function tearDown(): void
     {
@@ -93,14 +106,6 @@ final class PestSupportHandlerTest extends TestCase
             true,
         ];
 
-        yield 'top-level afterAll()' => [
-            <<<'PHP'
-                <?php
-                afterAll(function (): void {});
-                PHP,
-            true,
-        ];
-
         yield 'top-level pest()->extend() configuration' => [
             <<<'PHP'
                 <?php
@@ -131,30 +136,7 @@ final class PestSupportHandlerTest extends TestCase
             false,
         ];
 
-        yield 'service class with method named test — not Pest' => [
-            <<<'PHP'
-                <?php
-                namespace App\Services;
-                final class Foo {
-                    public function bar(): void {
-                        $this->test();
-                    }
-                    private function test(): void {}
-                }
-                PHP,
-            false,
-        ];
-
         yield 'empty file' => ['<?php', false];
-
-        yield 'file with only namespace/use — not Pest' => [
-            <<<'PHP'
-                <?php
-                namespace App;
-                use Illuminate\Support\Str;
-                PHP,
-            false,
-        ];
 
         yield 'namespaced Pest test file (Pest 3 supports this)' => [
             <<<'PHP'
@@ -167,21 +149,9 @@ final class PestSupportHandlerTest extends TestCase
             true,
         ];
 
-        yield 'top-level todo() placeholder' => [
-            <<<'PHP'
-                <?php
-                todo('implement search');
-                PHP,
-            true,
-        ];
+        yield 'top-level todo()' => ["<?php\ntodo('implement search');\n", true];
 
-        yield 'top-level dataset() definition' => [
-            <<<'PHP'
-                <?php
-                dataset('numbers', [1, 2, 3]);
-                PHP,
-            true,
-        ];
+        yield 'top-level dataset()' => ["<?php\ndataset('numbers', [1, 2, 3]);\n", true];
 
         yield 'string containing "test(" — not Pest (AST distinguishes)' => [
             <<<'PHP'
@@ -213,55 +183,59 @@ final class PestSupportHandlerTest extends TestCase
     }
 
     // ---------------------------------------------------------------
-    // beforeAddIssue — InvalidScope range-based suppression
+    // beforeStatementAnalysis — $this injection
     // ---------------------------------------------------------------
 
     #[Test]
-    public function suppresses_invalid_scope_inside_test_closure(): void
+    public function injects_this_inside_test_closure(): void
     {
-        // `$this->x();` sits at byte offset 32 inside the test() callback,
-        // well within the closure range Pest binds at runtime.
         $contents = "<?php\ntest('a', function (): void { \$this->x(); });\n";
         $this->driveBeforeAnalyzeFile(self::FAKE_PATH, $contents);
 
         $thisOffset = (int) \strpos($contents, '$this');
-        $event = $this->makeInvalidScopeEvent(self::FAKE_PATH, $thisOffset);
+        $event = $this->makeBeforeStatementEvent(self::FAKE_PATH, $thisOffset);
 
-        $this->assertFalse(PestSupportHandler::beforeAddIssue($event));
+        PestSupportHandler::beforeStatementAnalysis($event);
+
+        $context = $event->getContext();
+        $this->assertArrayHasKey('$this', $context->vars_in_scope);
+        $this->assertSame('PHPUnit\\Framework\\TestCase', $this->extractFqcn($context));
+        $this->assertSame('PHPUnit\\Framework\\TestCase', $context->self);
     }
 
     #[Test]
-    public function does_not_suppress_invalid_scope_inside_beforeall_closure(): void
+    public function does_not_inject_this_inside_beforeall_closure(): void
     {
-        // beforeAll runs in static context per Pest source; `$this` is genuinely invalid
-        // there and must remain flagged so users see the real bug.
+        // beforeAll runs in static context per Pest source; $this stays unset, so
+        // VariableFetchAnalyzer still raises InvalidScope as the real bug it is.
         $contents = "<?php\nbeforeAll(function (): void { \$this->seed(); });\n";
         $this->driveBeforeAnalyzeFile(self::FAKE_PATH, $contents);
 
         $thisOffset = (int) \strpos($contents, '$this');
-        $event = $this->makeInvalidScopeEvent(self::FAKE_PATH, $thisOffset);
+        $event = $this->makeBeforeStatementEvent(self::FAKE_PATH, $thisOffset);
 
-        $this->assertNull(PestSupportHandler::beforeAddIssue($event));
+        PestSupportHandler::beforeStatementAnalysis($event);
+
+        $this->assertArrayNotHasKey('$this', $event->getContext()->vars_in_scope);
     }
 
     #[Test]
-    public function does_not_suppress_invalid_scope_inside_describe_closure(): void
+    public function does_not_inject_this_inside_describe_body(): void
     {
-        // describe() body is unbound. `$this` here is invalid and stays flagged.
         $contents = "<?php\ndescribe('group', function (): void { \$this->state = 1; });\n";
         $this->driveBeforeAnalyzeFile(self::FAKE_PATH, $contents);
 
         $thisOffset = (int) \strpos($contents, '$this');
-        $event = $this->makeInvalidScopeEvent(self::FAKE_PATH, $thisOffset);
+        $event = $this->makeBeforeStatementEvent(self::FAKE_PATH, $thisOffset);
 
-        $this->assertNull(PestSupportHandler::beforeAddIssue($event));
+        PestSupportHandler::beforeStatementAnalysis($event);
+
+        $this->assertArrayNotHasKey('$this', $event->getContext()->vars_in_scope);
     }
 
     #[Test]
-    public function suppresses_invalid_scope_inside_nested_it_within_describe(): void
+    public function injects_this_inside_nested_it_within_describe(): void
     {
-        // Inner it() closure binds to TestCase even though it sits inside an
-        // unbound describe() block. Range list must catch the nested binding.
         $contents = <<<'PHP'
             <?php
             describe('group', function (): void {
@@ -271,24 +245,46 @@ final class PestSupportHandlerTest extends TestCase
         $this->driveBeforeAnalyzeFile(self::FAKE_PATH, $contents);
 
         $thisOffset = (int) \strpos($contents, '$this');
-        $event = $this->makeInvalidScopeEvent(self::FAKE_PATH, $thisOffset);
+        $event = $this->makeBeforeStatementEvent(self::FAKE_PATH, $thisOffset);
 
-        $this->assertFalse(PestSupportHandler::beforeAddIssue($event));
+        PestSupportHandler::beforeStatementAnalysis($event);
+
+        $this->assertArrayHasKey('$this', $event->getContext()->vars_in_scope);
     }
 
     #[Test]
-    public function passes_through_invalid_scope_in_non_pest_file(): void
+    public function does_not_override_existing_this(): void
     {
-        $contents = "<?php\necho 'plain script';\n";
+        // If Psalm's own analysis (e.g. Closure::bind inside a test() body) has
+        // already populated $this, the handler must not clobber it.
+        $contents = "<?php\ntest('a', function (): void { \$this->x(); });\n";
         $this->driveBeforeAnalyzeFile(self::FAKE_PATH, $contents);
 
-        $event = $this->makeInvalidScopeEvent(self::FAKE_PATH, 0);
+        $thisOffset = (int) \strpos($contents, '$this');
+        $event = $this->makeBeforeStatementEvent(self::FAKE_PATH, $thisOffset);
 
-        $this->assertNull(PestSupportHandler::beforeAddIssue($event));
+        $existing = new \Psalm\Type\Union([new \Psalm\Type\Atomic\TNamedObject('App\\OtherClass')]);
+        $event->getContext()->vars_in_scope['$this'] = $existing;
+
+        PestSupportHandler::beforeStatementAnalysis($event);
+
+        $this->assertSame($existing, $event->getContext()->vars_in_scope['$this']);
+    }
+
+    #[Test]
+    public function skips_non_pest_files_in_statement_analysis(): void
+    {
+        $this->driveBeforeAnalyzeFile(self::FAKE_PATH, "<?php\necho 'plain script';\n");
+
+        $event = $this->makeBeforeStatementEvent(self::FAKE_PATH, 0);
+
+        PestSupportHandler::beforeStatementAnalysis($event);
+
+        $this->assertArrayNotHasKey('$this', $event->getContext()->vars_in_scope);
     }
 
     // ---------------------------------------------------------------
-    // beforeAddIssue — issue type and method-id dispatch
+    // beforeAddIssue — InternalMethod suppression
     // ---------------------------------------------------------------
 
     #[Test]
@@ -303,21 +299,50 @@ final class PestSupportHandlerTest extends TestCase
         $this->assertNull(PestSupportHandler::beforeAddIssue($event));
     }
 
+    #[Test]
+    public function drops_invalid_scope_inside_binding_closure_range(): void
+    {
+        // InvalidScope can fire from MethodCallAnalyzer ($this->method() — checks
+        // getFQCLN() not vars_in_scope), so $this injection alone does not silence
+        // it. beforeAddIssue drops the cosmetic error inside binding ranges.
+        $contents = "<?php\ntest('a', function () { \$this->binds(); });\n";
+        $this->driveBeforeAnalyzeFile(self::FAKE_PATH, $contents);
+
+        $thisOffset = (int) \strpos($contents, '$this');
+        $event = $this->makeBeforeAddEvent(
+            new InvalidScope('Use of $this', $this->makeCodeLocation(self::FAKE_PATH, $thisOffset)),
+        );
+
+        $this->assertFalse(PestSupportHandler::beforeAddIssue($event));
+    }
+
+    #[Test]
+    public function passes_through_invalid_scope_outside_binding_range(): void
+    {
+        // InvalidScope outside a binding closure (beforeAll body, describe body,
+        // or just stray $this in a non-test file marked Pest) stays reported.
+        $contents = "<?php\nbeforeAll(function () { \$this->seed(); });\n";
+        $this->driveBeforeAnalyzeFile(self::FAKE_PATH, $contents);
+
+        $thisOffset = (int) \strpos($contents, '$this');
+        $event = $this->makeBeforeAddEvent(
+            new InvalidScope('Use of $this', $this->makeCodeLocation(self::FAKE_PATH, $thisOffset)),
+        );
+
+        $this->assertNull(PestSupportHandler::beforeAddIssue($event));
+    }
+
     /** @return iterable<string, array{string}> */
     public static function pestInternalMethodIdProvider(): iterable
     {
         // Pass the original (mixed-case) method id. MethodIssue::__construct
         // lowercases on store; the handler keys off the stored lowercased form.
-        // Constructing with mixed case exercises both the framework's lowercasing
-        // and the handler's prefix-match logic.
         yield 'TestCall::with' => ['Pest\\PendingCalls\\TestCall::with'];
-        yield 'TestCall::skip' => ['Pest\\PendingCalls\\TestCall::skip'];
         yield 'UsesCall::in' => ['Pest\\PendingCalls\\UsesCall::in'];
         yield 'BeforeEachCall::group' => ['Pest\\PendingCalls\\BeforeEachCall::group'];
         yield 'AfterEachCall::group' => ['Pest\\PendingCalls\\AfterEachCall::group'];
         yield 'DescribeCall::skip' => ['Pest\\PendingCalls\\DescribeCall::skip'];
         yield 'Mixins\\Expectation::toBe' => ['Pest\\Mixins\\Expectation::toBe'];
-        yield 'Mixins\\Expectation::toContain' => ['Pest\\Mixins\\Expectation::toContain'];
         yield 'Expectations\\HigherOrderExpectation::__call' => ['Pest\\Expectations\\HigherOrderExpectation::__call'];
         yield 'Expectations\\EachExpectation::__call' => ['Pest\\Expectations\\EachExpectation::__call'];
         yield 'Expectations\\OppositeExpectation::toBe' => ['Pest\\Expectations\\OppositeExpectation::toBe'];
@@ -340,8 +365,6 @@ final class PestSupportHandlerTest extends TestCase
     #[Test]
     public function passes_through_unrelated_internal_method_in_pest_file(): void
     {
-        // A legitimate `@internal` call into a non-Pest namespace from a Pest
-        // test file must still be flagged. The suppression is narrow on purpose.
         $this->driveBeforeAnalyzeFile(self::FAKE_PATH, "<?php\ntest('a', fn () => null);\n");
 
         $event = $this->makeBeforeAddEvent(
@@ -358,9 +381,6 @@ final class PestSupportHandlerTest extends TestCase
     #[Test]
     public function passes_through_pest_internal_method_in_non_pest_file(): void
     {
-        // The Pest internal class IS being called — but from a non-Pest file.
-        // The surrounding code is presumably not a test, so the @internal
-        // warning is legitimate and must reach the user.
         $this->driveBeforeAnalyzeFile(self::FAKE_PATH, "<?php\necho 'plain script';\n");
 
         $event = $this->makeBeforeAddEvent(
@@ -378,13 +398,19 @@ final class PestSupportHandlerTest extends TestCase
     // Helpers
     // ---------------------------------------------------------------
 
-    /**
-     * Drive a synthetic file through `beforeAnalyzeFile` so the static
-     * detection map is populated as it would be in a real Psalm run.
-     */
     private function driveBeforeAnalyzeFile(string $filePath, string $contents): void
     {
         PestSupportHandler::beforeAnalyzeFile($this->makeBeforeFileEvent($filePath, $contents));
+    }
+
+    private function extractFqcn(Context $context): string
+    {
+        $names = [];
+        foreach ($context->vars_in_scope['$this']->getAtomicTypes() as $atomic) {
+            $names[] = $atomic->getId();
+        }
+
+        return \implode('|', $names);
     }
 
     private function makeCodeLocation(string $filePath, int $fileStart): CodeLocation
@@ -398,13 +424,6 @@ final class PestSupportHandlerTest extends TestCase
         $node->setAttribute('endFilePos', $fileStart);
 
         return new CodeLocation($source, $node);
-    }
-
-    private function makeInvalidScopeEvent(string $filePath, int $fileStart): BeforeAddIssueEvent
-    {
-        return $this->makeBeforeAddEvent(
-            new InvalidScope('Invalid $this', $this->makeCodeLocation($filePath, $fileStart)),
-        );
     }
 
     /**
@@ -423,7 +442,8 @@ final class PestSupportHandlerTest extends TestCase
     private function resetHandlerState(): void
     {
         (new \ReflectionProperty(PestSupportHandler::class, 'pestFileStatus'))->setValue(null, []);
-        (new \ReflectionProperty(PestSupportHandler::class, 'pestBindingRanges'))->setValue(null, []);
+        (new \ReflectionProperty(PestSupportHandler::class, 'pestBindingScopes'))->setValue(null, []);
+        (new \ReflectionProperty(PestSupportHandler::class, 'resolvedTestCaseClass'))->setValue(null, null);
     }
 
     private function makeBeforeFileEvent(string $filePath, string $contents): BeforeFileAnalysisEvent
@@ -435,15 +455,36 @@ final class PestSupportHandlerTest extends TestCase
         $source->method('getFilePath')->willReturn($filePath);
         $source->method('getFileName')->willReturn(\basename($filePath));
 
-        // BeforeFileAnalysisEvent's constructor is @internal-tagged but public.
-        // The handler reads only $event->getStatementsSource() and ->getStmts(),
-        // so the unused parameters are stubbed minimally.
+        // Use a stub Codebase that returns false for classOrInterfaceExists
+        // (so the handler falls back to PHPUnit\Framework\TestCase). Tests for
+        // the Tests\TestCase preference path would require booting a real codebase;
+        // out of scope for unit coverage.
+        $codebase = (new \ReflectionClass(Codebase::class))->newInstanceWithoutConstructor();
+
         return new BeforeFileAnalysisEvent(
             $source,
             new Context(),
             new FileStorage($filePath),
-            (new \ReflectionClass(Codebase::class))->newInstanceWithoutConstructor(),
+            $codebase,
             $stmts,
+        );
+    }
+
+    private function makeBeforeStatementEvent(string $filePath, int $stmtStart): BeforeStatementAnalysisEvent
+    {
+        $source = $this->createStub(StatementsSource::class);
+        $source->method('getFilePath')->willReturn($filePath);
+        $source->method('getFileName')->willReturn(\basename($filePath));
+
+        $stmt = new Expression(new Variable('this'));
+        $stmt->setAttribute('startFilePos', $stmtStart);
+        $stmt->setAttribute('endFilePos', $stmtStart);
+
+        return new BeforeStatementAnalysisEvent(
+            $stmt,
+            new Context(),
+            $source,
+            (new \ReflectionClass(Codebase::class))->newInstanceWithoutConstructor(),
         );
     }
 

--- a/tests/Unit/Handlers/Pest/PestSupportHandlerTest.php
+++ b/tests/Unit/Handlers/Pest/PestSupportHandlerTest.php
@@ -1,0 +1,382 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Pest;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\Codebase;
+use Psalm\CodeLocation;
+use Psalm\Context;
+use Psalm\FileSource;
+use Psalm\Issue\CodeIssue;
+use Psalm\Issue\InternalMethod;
+use Psalm\Issue\InvalidScope;
+use Psalm\Issue\MissingReturnType;
+use Psalm\LaravelPlugin\Handlers\Pest\PestSupportHandler;
+use Psalm\Plugin\EventHandler\Event\BeforeAddIssueEvent;
+use Psalm\Plugin\EventHandler\Event\BeforeFileAnalysisEvent;
+use Psalm\StatementsSource;
+use Psalm\Storage\FileStorage;
+
+#[CoversClass(PestSupportHandler::class)]
+final class PestSupportHandlerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        $this->resetPestFileMap();
+    }
+
+    private function markPestFile(string $filePath): void
+    {
+        $map = $this->getPestFileMap();
+        $map[$filePath] = true;
+
+        (new \ReflectionProperty(PestSupportHandler::class, 'pestFilePaths'))
+            ->setValue(null, $map);
+    }
+
+    private function resetPestFileMap(): void
+    {
+        (new \ReflectionProperty(PestSupportHandler::class, 'pestFilePaths'))
+            ->setValue(null, []);
+    }
+
+    // ---------------------------------------------------------------
+    // beforeAnalyzeFile — AST-based Pest detection
+    // ---------------------------------------------------------------
+
+    /** @return iterable<string, array{string, bool}> */
+    public static function pestSignatureProvider(): iterable
+    {
+        yield 'top-level test() call' => [
+            <<<'PHP'
+                <?php
+                test('user can do a thing', function (): void {
+                    $this->get('/');
+                });
+                PHP,
+            true,
+        ];
+
+        yield 'top-level it() call' => [
+            <<<'PHP'
+                <?php
+                it('does the thing', function (): void {
+                    expect(true)->toBeTrue();
+                });
+                PHP,
+            true,
+        ];
+
+        yield 'top-level describe() block' => [
+            <<<'PHP'
+                <?php
+                describe('group', function (): void {
+                    it('does a thing', fn () => null);
+                });
+                PHP,
+            true,
+        ];
+
+        yield 'top-level uses()->in()' => [
+            <<<'PHP'
+                <?php
+                uses(Tests\TestCase::class)->in('Feature', 'Unit');
+                PHP,
+            true,
+        ];
+
+        yield 'top-level beforeEach()' => [
+            <<<'PHP'
+                <?php
+                beforeEach(function (): void {
+                    $this->seed();
+                });
+                PHP,
+            true,
+        ];
+
+        yield 'top-level afterAll()' => [
+            <<<'PHP'
+                <?php
+                afterAll(function (): void {});
+                PHP,
+            true,
+        ];
+
+        yield 'plain PHPUnit TestCase subclass — not Pest' => [
+            <<<'PHP'
+                <?php
+                namespace Tests\Feature;
+                use Tests\TestCase;
+                final class ExampleTest extends TestCase {
+                    public function test_something(): void {
+                        $this->assertTrue(true);
+                    }
+                }
+                PHP,
+            false,
+        ];
+
+        yield 'service class with method named test — not Pest' => [
+            <<<'PHP'
+                <?php
+                namespace App\Services;
+                final class Foo {
+                    public function bar(): void {
+                        $this->test();
+                    }
+                    private function test(): void {}
+                }
+                PHP,
+            false,
+        ];
+
+        yield 'empty file' => ['<?php', false];
+
+        yield 'file with only namespace/use — not Pest' => [
+            <<<'PHP'
+                <?php
+                namespace App;
+                use Illuminate\Support\Str;
+                PHP,
+            false,
+        ];
+
+        yield 'namespaced Pest test file (Pest 3 supports this)' => [
+            <<<'PHP'
+                <?php
+                namespace Tests\Feature;
+                test('namespaced thing', function (): void {
+                    expect(true)->toBeTrue();
+                });
+                PHP,
+            true,
+        ];
+
+        yield 'top-level todo() placeholder' => [
+            <<<'PHP'
+                <?php
+                todo('implement search');
+                PHP,
+            true,
+        ];
+
+        yield 'top-level dataset() definition' => [
+            <<<'PHP'
+                <?php
+                dataset('numbers', [1, 2, 3]);
+                PHP,
+            true,
+        ];
+
+        yield 'string containing "test(" — not Pest (AST distinguishes)' => [
+            <<<'PHP'
+                <?php
+                $sql = "SELECT test( 'x' ) FROM ...";
+                PHP,
+            false,
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('pestSignatureProvider')]
+    public function detects_pest_files_by_ast_signature(string $contents, bool $expected): void
+    {
+        $filePath = '/virtual/' . \uniqid('test_', true) . '.php';
+        $event = $this->makeBeforeFileEvent($filePath, $contents);
+
+        PestSupportHandler::beforeAnalyzeFile($event);
+
+        $marked = isset($this->getPestFileMap()[$filePath]);
+        $this->assertSame($expected, $marked);
+    }
+
+    // ---------------------------------------------------------------
+    // beforeAddIssue — issue suppression
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function passes_through_unrelated_issue_types(): void
+    {
+        // MissingReturnType is neither InvalidScope nor InternalMethod. Even when
+        // the surrounding file is a known Pest file, only the two target issues
+        // are touched.
+        $path = '/virtual/pest-test.php';
+        $this->markPestFile($path);
+
+        $event = $this->makeBeforeAddEvent(
+            new MissingReturnType('oops', $this->makeCodeLocation($path)),
+        );
+
+        $this->assertNull(PestSupportHandler::beforeAddIssue($event));
+    }
+
+    #[Test]
+    public function passes_through_invalid_scope_in_non_pest_file(): void
+    {
+        $event = $this->makeBeforeAddEvent(
+            new InvalidScope('Invalid $this', $this->makeCodeLocation('/virtual/plain.php')),
+        );
+
+        $this->assertNull(PestSupportHandler::beforeAddIssue($event));
+    }
+
+    #[Test]
+    public function drops_invalid_scope_in_pest_file(): void
+    {
+        $path = '/virtual/pest-test.php';
+        $this->markPestFile($path);
+
+        $event = $this->makeBeforeAddEvent(
+            new InvalidScope('Invalid $this', $this->makeCodeLocation($path)),
+        );
+
+        $this->assertFalse(PestSupportHandler::beforeAddIssue($event));
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function pestInternalMethodIdProvider(): iterable
+    {
+        // Each entry is a real lowercased method_id Pest emits via the DSL.
+        // MethodIssue::__construct lowercases on store, so the handler keys
+        // off lowercased input. These tests guard the casing invariant.
+        yield 'TestCall::with' => ['pest\\pendingcalls\\testcall::with'];
+        yield 'TestCall::skip' => ['pest\\pendingcalls\\testcall::skip'];
+        yield 'UsesCall::in' => ['pest\\pendingcalls\\usescall::in'];
+        yield 'BeforeEachCall::group' => ['pest\\pendingcalls\\beforeeachcall::group'];
+        yield 'AfterEachCall::group' => ['pest\\pendingcalls\\aftereachcall::group'];
+        yield 'Mixins\\Expectation::toBe' => ['pest\\mixins\\expectation::tobe'];
+        yield 'Mixins\\Expectation::toContain' => ['pest\\mixins\\expectation::tocontain'];
+        yield 'Expectations\\HigherOrderExpectation::__call' => ['pest\\expectations\\higherorderexpectation::__call'];
+        yield 'Expectations\\EachExpectation::__call' => ['pest\\expectations\\eachexpectation::__call'];
+        yield 'Expectations\\OppositeExpectation::toBe' => ['pest\\expectations\\oppositeexpectation::tobe'];
+    }
+
+    #[Test]
+    #[DataProvider('pestInternalMethodIdProvider')]
+    public function drops_internal_method_for_pest_dsl_in_pest_file(string $methodId): void
+    {
+        $path = '/virtual/pest-test.php';
+        $this->markPestFile($path);
+
+        $event = $this->makeBeforeAddEvent(
+            new InternalMethod('internal call', $this->makeCodeLocation($path), $methodId),
+        );
+
+        $this->assertFalse(PestSupportHandler::beforeAddIssue($event));
+    }
+
+    #[Test]
+    public function passes_through_unrelated_internal_method_in_pest_file(): void
+    {
+        // A legitimate `@internal` call into a non-Pest namespace from a Pest
+        // test file must still be flagged. The suppression is narrow on purpose.
+        $path = '/virtual/pest-test.php';
+        $this->markPestFile($path);
+
+        $event = $this->makeBeforeAddEvent(
+            new InternalMethod(
+                'internal call',
+                $this->makeCodeLocation($path),
+                'somepackage\\internal\\service::do',
+            ),
+        );
+
+        $this->assertNull(PestSupportHandler::beforeAddIssue($event));
+    }
+
+    #[Test]
+    public function passes_through_pest_internal_method_in_non_pest_file(): void
+    {
+        // The Pest internal class IS being called — but from a non-Pest file.
+        // The surrounding code is presumably not a test, so the @internal
+        // warning is legitimate and must reach the user.
+        $event = $this->makeBeforeAddEvent(
+            new InternalMethod(
+                'internal call',
+                $this->makeCodeLocation('/virtual/plain.php'),
+                'pest\\pendingcalls\\testcall::with',
+            ),
+        );
+
+        $this->assertNull(PestSupportHandler::beforeAddIssue($event));
+    }
+
+    // ---------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------
+
+    private function makeCodeLocation(string $filePath): CodeLocation
+    {
+        $source = $this->createStub(FileSource::class);
+        $source->method('getFilePath')->willReturn($filePath);
+        $source->method('getFileName')->willReturn(\basename($filePath));
+
+        $node = new FuncCall(new Name('test'), [new Arg(new String_('x'))]);
+        $node->setAttribute('startFilePos', 0);
+        $node->setAttribute('endFilePos', 10);
+
+        return new CodeLocation($source, $node);
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    private function getPestFileMap(): array
+    {
+        $prop = new \ReflectionProperty(PestSupportHandler::class, 'pestFilePaths');
+
+        /** @var array<string, true> $value */
+        $value = $prop->getValue();
+
+        return $value;
+    }
+
+    private function makeBeforeFileEvent(string $filePath, string $contents): BeforeFileAnalysisEvent
+    {
+        $parser = (new ParserFactory())->createForVersion(\PhpParser\PhpVersion::fromComponents(8, 2));
+        $stmts = $parser->parse($contents) ?? [];
+
+        $source = $this->createStub(StatementsSource::class);
+        $source->method('getFilePath')->willReturn($filePath);
+        $source->method('getFileName')->willReturn(\basename($filePath));
+
+        // BeforeFileAnalysisEvent's constructor is @internal-tagged but public.
+        // The handler only reads $event->getStatementsSource() and ->getStmts(),
+        // so the unused parameters can be stubbed minimally.
+        return new BeforeFileAnalysisEvent(
+            $source,
+            new Context(),
+            new FileStorage($filePath),
+            (new \ReflectionClass(Codebase::class))->newInstanceWithoutConstructor(),
+            $stmts,
+        );
+    }
+
+    private function makeBeforeAddEvent(CodeIssue $issue): BeforeAddIssueEvent
+    {
+        // BeforeAddIssueEvent's constructor takes (CodeIssue, bool, Codebase).
+        // The handler never reads the codebase or fixable flag, so we bypass
+        // the constructor via reflection and set only the issue.
+        $event = (new \ReflectionClass(BeforeAddIssueEvent::class))->newInstanceWithoutConstructor();
+
+        (new \ReflectionProperty(BeforeAddIssueEvent::class, 'issue'))->setValue($event, $issue);
+        (new \ReflectionProperty(BeforeAddIssueEvent::class, 'fixable'))->setValue($event, false);
+        (new \ReflectionProperty(BeforeAddIssueEvent::class, 'codebase'))->setValue(
+            $event,
+            (new \ReflectionClass(Codebase::class))->newInstanceWithoutConstructor(),
+        );
+
+        return $event;
+    }
+}

--- a/tests/Unit/Handlers/Pest/PestSupportHandlerTest.php
+++ b/tests/Unit/Handlers/Pest/PestSupportHandlerTest.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\ParserFactory;
+use PhpParser\PhpVersion;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -30,24 +31,11 @@ use Psalm\Storage\FileStorage;
 #[CoversClass(PestSupportHandler::class)]
 final class PestSupportHandlerTest extends TestCase
 {
+    private const FAKE_PATH = '/virtual/pest-test.php';
+
     protected function tearDown(): void
     {
-        $this->resetPestFileMap();
-    }
-
-    private function markPestFile(string $filePath): void
-    {
-        $map = $this->getPestFileMap();
-        $map[$filePath] = true;
-
-        (new \ReflectionProperty(PestSupportHandler::class, 'pestFilePaths'))
-            ->setValue(null, $map);
-    }
-
-    private function resetPestFileMap(): void
-    {
-        (new \ReflectionProperty(PestSupportHandler::class, 'pestFilePaths'))
-            ->setValue(null, []);
+        $this->resetHandlerState();
     }
 
     // ---------------------------------------------------------------
@@ -109,6 +97,22 @@ final class PestSupportHandlerTest extends TestCase
             <<<'PHP'
                 <?php
                 afterAll(function (): void {});
+                PHP,
+            true,
+        ];
+
+        yield 'top-level pest()->extend() configuration' => [
+            <<<'PHP'
+                <?php
+                pest()->extend(Tests\TestCase::class)->in('Feature');
+                PHP,
+            true,
+        ];
+
+        yield 'top-level expect() invocation' => [
+            <<<'PHP'
+                <?php
+                expect([1, 2, 3])->toContain(2);
                 PHP,
             true,
         ];
@@ -193,84 +197,141 @@ final class PestSupportHandlerTest extends TestCase
     public function detects_pest_files_by_ast_signature(string $contents, bool $expected): void
     {
         $filePath = '/virtual/' . \uniqid('test_', true) . '.php';
-        $event = $this->makeBeforeFileEvent($filePath, $contents);
+        PestSupportHandler::beforeAnalyzeFile($this->makeBeforeFileEvent($filePath, $contents));
 
-        PestSupportHandler::beforeAnalyzeFile($event);
+        $this->assertSame($expected, $this->getFileStatus()[$filePath] ?? false);
+    }
 
-        $marked = isset($this->getPestFileMap()[$filePath]);
-        $this->assertSame($expected, $marked);
+    #[Test]
+    public function caches_negative_result_to_avoid_reanalysis(): void
+    {
+        $filePath = '/virtual/' . \uniqid('test_', true) . '.php';
+        PestSupportHandler::beforeAnalyzeFile($this->makeBeforeFileEvent($filePath, "<?php\necho 'no pest';\n"));
+
+        $this->assertArrayHasKey($filePath, $this->getFileStatus());
+        $this->assertFalse($this->getFileStatus()[$filePath]);
     }
 
     // ---------------------------------------------------------------
-    // beforeAddIssue — issue suppression
+    // beforeAddIssue — InvalidScope range-based suppression
     // ---------------------------------------------------------------
 
     #[Test]
-    public function passes_through_unrelated_issue_types(): void
+    public function suppresses_invalid_scope_inside_test_closure(): void
     {
-        // MissingReturnType is neither InvalidScope nor InternalMethod. Even when
-        // the surrounding file is a known Pest file, only the two target issues
-        // are touched.
-        $path = '/virtual/pest-test.php';
-        $this->markPestFile($path);
+        // `$this->x();` sits at byte offset 32 inside the test() callback,
+        // well within the closure range Pest binds at runtime.
+        $contents = "<?php\ntest('a', function (): void { \$this->x(); });\n";
+        $this->driveBeforeAnalyzeFile(self::FAKE_PATH, $contents);
 
-        $event = $this->makeBeforeAddEvent(
-            new MissingReturnType('oops', $this->makeCodeLocation($path)),
-        );
+        $thisOffset = (int) \strpos($contents, '$this');
+        $event = $this->makeInvalidScopeEvent(self::FAKE_PATH, $thisOffset);
+
+        $this->assertFalse(PestSupportHandler::beforeAddIssue($event));
+    }
+
+    #[Test]
+    public function does_not_suppress_invalid_scope_inside_beforeall_closure(): void
+    {
+        // beforeAll runs in static context per Pest source; `$this` is genuinely invalid
+        // there and must remain flagged so users see the real bug.
+        $contents = "<?php\nbeforeAll(function (): void { \$this->seed(); });\n";
+        $this->driveBeforeAnalyzeFile(self::FAKE_PATH, $contents);
+
+        $thisOffset = (int) \strpos($contents, '$this');
+        $event = $this->makeInvalidScopeEvent(self::FAKE_PATH, $thisOffset);
 
         $this->assertNull(PestSupportHandler::beforeAddIssue($event));
+    }
+
+    #[Test]
+    public function does_not_suppress_invalid_scope_inside_describe_closure(): void
+    {
+        // describe() body is unbound. `$this` here is invalid and stays flagged.
+        $contents = "<?php\ndescribe('group', function (): void { \$this->state = 1; });\n";
+        $this->driveBeforeAnalyzeFile(self::FAKE_PATH, $contents);
+
+        $thisOffset = (int) \strpos($contents, '$this');
+        $event = $this->makeInvalidScopeEvent(self::FAKE_PATH, $thisOffset);
+
+        $this->assertNull(PestSupportHandler::beforeAddIssue($event));
+    }
+
+    #[Test]
+    public function suppresses_invalid_scope_inside_nested_it_within_describe(): void
+    {
+        // Inner it() closure binds to TestCase even though it sits inside an
+        // unbound describe() block. Range list must catch the nested binding.
+        $contents = <<<'PHP'
+            <?php
+            describe('group', function (): void {
+                it('thing', function (): void { $this->call(); });
+            });
+            PHP;
+        $this->driveBeforeAnalyzeFile(self::FAKE_PATH, $contents);
+
+        $thisOffset = (int) \strpos($contents, '$this');
+        $event = $this->makeInvalidScopeEvent(self::FAKE_PATH, $thisOffset);
+
+        $this->assertFalse(PestSupportHandler::beforeAddIssue($event));
     }
 
     #[Test]
     public function passes_through_invalid_scope_in_non_pest_file(): void
     {
+        $contents = "<?php\necho 'plain script';\n";
+        $this->driveBeforeAnalyzeFile(self::FAKE_PATH, $contents);
+
+        $event = $this->makeInvalidScopeEvent(self::FAKE_PATH, 0);
+
+        $this->assertNull(PestSupportHandler::beforeAddIssue($event));
+    }
+
+    // ---------------------------------------------------------------
+    // beforeAddIssue — issue type and method-id dispatch
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function passes_through_unrelated_issue_types(): void
+    {
+        $this->driveBeforeAnalyzeFile(self::FAKE_PATH, "<?php\ntest('a', fn () => null);\n");
+
         $event = $this->makeBeforeAddEvent(
-            new InvalidScope('Invalid $this', $this->makeCodeLocation('/virtual/plain.php')),
+            new MissingReturnType('oops', $this->makeCodeLocation(self::FAKE_PATH, 0)),
         );
 
         $this->assertNull(PestSupportHandler::beforeAddIssue($event));
     }
 
-    #[Test]
-    public function drops_invalid_scope_in_pest_file(): void
-    {
-        $path = '/virtual/pest-test.php';
-        $this->markPestFile($path);
-
-        $event = $this->makeBeforeAddEvent(
-            new InvalidScope('Invalid $this', $this->makeCodeLocation($path)),
-        );
-
-        $this->assertFalse(PestSupportHandler::beforeAddIssue($event));
-    }
-
     /** @return iterable<string, array{string}> */
     public static function pestInternalMethodIdProvider(): iterable
     {
-        // Each entry is a real lowercased method_id Pest emits via the DSL.
-        // MethodIssue::__construct lowercases on store, so the handler keys
-        // off lowercased input. These tests guard the casing invariant.
-        yield 'TestCall::with' => ['pest\\pendingcalls\\testcall::with'];
-        yield 'TestCall::skip' => ['pest\\pendingcalls\\testcall::skip'];
-        yield 'UsesCall::in' => ['pest\\pendingcalls\\usescall::in'];
-        yield 'BeforeEachCall::group' => ['pest\\pendingcalls\\beforeeachcall::group'];
-        yield 'AfterEachCall::group' => ['pest\\pendingcalls\\aftereachcall::group'];
-        yield 'Mixins\\Expectation::toBe' => ['pest\\mixins\\expectation::tobe'];
-        yield 'Mixins\\Expectation::toContain' => ['pest\\mixins\\expectation::tocontain'];
-        yield 'Expectations\\HigherOrderExpectation::__call' => ['pest\\expectations\\higherorderexpectation::__call'];
-        yield 'Expectations\\EachExpectation::__call' => ['pest\\expectations\\eachexpectation::__call'];
-        yield 'Expectations\\OppositeExpectation::toBe' => ['pest\\expectations\\oppositeexpectation::tobe'];
+        // Pass the original (mixed-case) method id. MethodIssue::__construct
+        // lowercases on store; the handler keys off the stored lowercased form.
+        // Constructing with mixed case exercises both the framework's lowercasing
+        // and the handler's prefix-match logic.
+        yield 'TestCall::with' => ['Pest\\PendingCalls\\TestCall::with'];
+        yield 'TestCall::skip' => ['Pest\\PendingCalls\\TestCall::skip'];
+        yield 'UsesCall::in' => ['Pest\\PendingCalls\\UsesCall::in'];
+        yield 'BeforeEachCall::group' => ['Pest\\PendingCalls\\BeforeEachCall::group'];
+        yield 'AfterEachCall::group' => ['Pest\\PendingCalls\\AfterEachCall::group'];
+        yield 'DescribeCall::skip' => ['Pest\\PendingCalls\\DescribeCall::skip'];
+        yield 'Mixins\\Expectation::toBe' => ['Pest\\Mixins\\Expectation::toBe'];
+        yield 'Mixins\\Expectation::toContain' => ['Pest\\Mixins\\Expectation::toContain'];
+        yield 'Expectations\\HigherOrderExpectation::__call' => ['Pest\\Expectations\\HigherOrderExpectation::__call'];
+        yield 'Expectations\\EachExpectation::__call' => ['Pest\\Expectations\\EachExpectation::__call'];
+        yield 'Expectations\\OppositeExpectation::toBe' => ['Pest\\Expectations\\OppositeExpectation::toBe'];
+        yield 'Configuration::extend' => ['Pest\\Configuration::extend'];
     }
 
     #[Test]
     #[DataProvider('pestInternalMethodIdProvider')]
     public function drops_internal_method_for_pest_dsl_in_pest_file(string $methodId): void
     {
-        $path = '/virtual/pest-test.php';
-        $this->markPestFile($path);
+        $this->driveBeforeAnalyzeFile(self::FAKE_PATH, "<?php\ntest('a', fn () => null);\n");
 
         $event = $this->makeBeforeAddEvent(
-            new InternalMethod('internal call', $this->makeCodeLocation($path), $methodId),
+            new InternalMethod('internal call', $this->makeCodeLocation(self::FAKE_PATH, 0), $methodId),
         );
 
         $this->assertFalse(PestSupportHandler::beforeAddIssue($event));
@@ -281,14 +342,13 @@ final class PestSupportHandlerTest extends TestCase
     {
         // A legitimate `@internal` call into a non-Pest namespace from a Pest
         // test file must still be flagged. The suppression is narrow on purpose.
-        $path = '/virtual/pest-test.php';
-        $this->markPestFile($path);
+        $this->driveBeforeAnalyzeFile(self::FAKE_PATH, "<?php\ntest('a', fn () => null);\n");
 
         $event = $this->makeBeforeAddEvent(
             new InternalMethod(
                 'internal call',
-                $this->makeCodeLocation($path),
-                'somepackage\\internal\\service::do',
+                $this->makeCodeLocation(self::FAKE_PATH, 0),
+                'SomePackage\\Internal\\Service::do',
             ),
         );
 
@@ -301,11 +361,13 @@ final class PestSupportHandlerTest extends TestCase
         // The Pest internal class IS being called — but from a non-Pest file.
         // The surrounding code is presumably not a test, so the @internal
         // warning is legitimate and must reach the user.
+        $this->driveBeforeAnalyzeFile(self::FAKE_PATH, "<?php\necho 'plain script';\n");
+
         $event = $this->makeBeforeAddEvent(
             new InternalMethod(
                 'internal call',
-                $this->makeCodeLocation('/virtual/plain.php'),
-                'pest\\pendingcalls\\testcall::with',
+                $this->makeCodeLocation(self::FAKE_PATH, 0),
+                'Pest\\PendingCalls\\TestCall::with',
             ),
         );
 
@@ -316,35 +378,57 @@ final class PestSupportHandlerTest extends TestCase
     // Helpers
     // ---------------------------------------------------------------
 
-    private function makeCodeLocation(string $filePath): CodeLocation
+    /**
+     * Drive a synthetic file through `beforeAnalyzeFile` so the static
+     * detection map is populated as it would be in a real Psalm run.
+     */
+    private function driveBeforeAnalyzeFile(string $filePath, string $contents): void
+    {
+        PestSupportHandler::beforeAnalyzeFile($this->makeBeforeFileEvent($filePath, $contents));
+    }
+
+    private function makeCodeLocation(string $filePath, int $fileStart): CodeLocation
     {
         $source = $this->createStub(FileSource::class);
         $source->method('getFilePath')->willReturn($filePath);
         $source->method('getFileName')->willReturn(\basename($filePath));
 
         $node = new FuncCall(new Name('test'), [new Arg(new String_('x'))]);
-        $node->setAttribute('startFilePos', 0);
-        $node->setAttribute('endFilePos', 10);
+        $node->setAttribute('startFilePos', $fileStart);
+        $node->setAttribute('endFilePos', $fileStart);
 
         return new CodeLocation($source, $node);
     }
 
-    /**
-     * @return array<string, true>
-     */
-    private function getPestFileMap(): array
+    private function makeInvalidScopeEvent(string $filePath, int $fileStart): BeforeAddIssueEvent
     {
-        $prop = new \ReflectionProperty(PestSupportHandler::class, 'pestFilePaths');
+        return $this->makeBeforeAddEvent(
+            new InvalidScope('Invalid $this', $this->makeCodeLocation($filePath, $fileStart)),
+        );
+    }
 
-        /** @var array<string, true> $value */
+    /**
+     * @return array<string, bool>
+     */
+    private function getFileStatus(): array
+    {
+        $prop = new \ReflectionProperty(PestSupportHandler::class, 'pestFileStatus');
+
+        /** @var array<string, bool> $value */
         $value = $prop->getValue();
 
         return $value;
     }
 
+    private function resetHandlerState(): void
+    {
+        (new \ReflectionProperty(PestSupportHandler::class, 'pestFileStatus'))->setValue(null, []);
+        (new \ReflectionProperty(PestSupportHandler::class, 'pestBindingRanges'))->setValue(null, []);
+    }
+
     private function makeBeforeFileEvent(string $filePath, string $contents): BeforeFileAnalysisEvent
     {
-        $parser = (new ParserFactory())->createForVersion(\PhpParser\PhpVersion::fromComponents(8, 2));
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 2));
         $stmts = $parser->parse($contents) ?? [];
 
         $source = $this->createStub(StatementsSource::class);
@@ -352,8 +436,8 @@ final class PestSupportHandlerTest extends TestCase
         $source->method('getFileName')->willReturn(\basename($filePath));
 
         // BeforeFileAnalysisEvent's constructor is @internal-tagged but public.
-        // The handler only reads $event->getStatementsSource() and ->getStmts(),
-        // so the unused parameters can be stubbed minimally.
+        // The handler reads only $event->getStatementsSource() and ->getStmts(),
+        // so the unused parameters are stubbed minimally.
         return new BeforeFileAnalysisEvent(
             $source,
             new Context(),
@@ -365,18 +449,10 @@ final class PestSupportHandlerTest extends TestCase
 
     private function makeBeforeAddEvent(CodeIssue $issue): BeforeAddIssueEvent
     {
-        // BeforeAddIssueEvent's constructor takes (CodeIssue, bool, Codebase).
-        // The handler never reads the codebase or fixable flag, so we bypass
-        // the constructor via reflection and set only the issue.
-        $event = (new \ReflectionClass(BeforeAddIssueEvent::class))->newInstanceWithoutConstructor();
-
-        (new \ReflectionProperty(BeforeAddIssueEvent::class, 'issue'))->setValue($event, $issue);
-        (new \ReflectionProperty(BeforeAddIssueEvent::class, 'fixable'))->setValue($event, false);
-        (new \ReflectionProperty(BeforeAddIssueEvent::class, 'codebase'))->setValue(
-            $event,
+        return new BeforeAddIssueEvent(
+            $issue,
+            false,
             (new \ReflectionClass(Codebase::class))->newInstanceWithoutConstructor(),
         );
-
-        return $event;
     }
 }


### PR DESCRIPTION
## Issue to Solve

Laravel projects using [Pest](https://pestphp.com) for tests trigger two classes of false-positive Psalm errors from the plugin:

- `InvalidScope` on `$this` inside `test()` / `it()` / `describe()` / `beforeEach()` / `afterEach()` / `beforeAll()` / `afterAll()` closures. Pest binds the closure to the underlying TestCase at runtime via `Closure::bind()`, which Psalm cannot see.
- `InternalMethod` on calls into Pest's documented DSL surface (`Pest\PendingCalls\TestCall`, `UsesCall`, `BeforeEachCall`, `AfterEachCall`, `Pest\Mixins\Expectation`, and the higher-order helpers under `Pest\Expectations\`). Pest tags these classes `@internal`, but they are the only way to use the DSL.

Today users have to exclude `tests/` from Psalm, litter `@psalm-suppress` everywhere, or run a separate `psalm-pest` config that masks real bugs.

## Related

Closes #966

## Solution Description

New `PestSupportHandler` auto-enabled when `pestphp/pest` is installed.

**How it detects Pest files.** A `BeforeFileAnalysisInterface` hook inspects each file's parsed top-level statements (Psalm already parsed them at this point, so no I/O). If any top-level expression is a call to one of `test`, `it`, `describe`, `uses`, `beforeEach`, `afterEach`, `beforeAll`, `afterAll`, `todo`, or `dataset` (or sits at the top of a `namespace { ... }` block, supported by Pest 3), the file path is added to a per-process set. AST inspection cleanly distinguishes a real `test('a', fn() => ...)` from a string containing `"test("` or a class method named `test`.

**How it suppresses.** A `BeforeAddIssueInterface` hook short-circuits on the issue class with two `instanceof` checks, then does an O(1) `isset()` lookup against the Pest file set. Inside a Pest file: `InvalidScope` is dropped unconditionally; `InternalMethod` is dropped only when `method_id` starts with `pest\\pendingcalls\\`, `pest\\mixins\\expectation::`, or `pest\\expectations\\`. Other `@internal` calls and other issue types are unaffected.

**Verification.**

- 29 unit tests in `tests/Unit/Handlers/Pest/PestSupportHandlerTest.php`, covering AST detection (Pest signatures, namespaced files, plain PHPUnit subclasses, lookalike service classes, strings containing `test(`) and the full `beforeAddIssue` dispatch (each Pest internal method-id prefix, unrelated `@internal` call from Pest file, Pest internal call from non-Pest file).
- Manual end-to-end run in a sandbox project with `pestphp/pest` + `laravel/framework` installed: Pest fixture goes from 7 errors to 3, the 3 remaining are out-of-scope follow-ups (Pest's `__get` magic on `->not`, `$this`-as-TestCase type narrowing for `MixedMethodCall`). Non-Pest files in the same project are unaffected.

**Out of scope** (potential follow-ups):

- Resolving `$this` inside Pest closures to the bound `TestCase` type. Would additionally fix `MixedMethodCall` on `$this->...`.
- Higher-order expectation property access (`expect($x)->not->toBeFalse()`), where Pest resolves `->not` via `__get` and Psalm reports `UndefinedPropertyFetch`.
- `psalm-laravel init` Pest detection hint (covered by #788).

## Checklist

- [x] Tests cover the change (29 unit tests in `tests/Unit/Handlers/Pest/PestSupportHandlerTest.php`)
- [x] Documentation is updated (`README.md` Pest framework support section)
