### PR TITLE
Validate multi-segment dynamic `where{Column}` method calls

### DIFF
--- a/src/Handlers/Magic/MethodForwardingHandler.php
+++ b/src/Handlers/Magic/MethodForwardingHandler.php
@@ -48,6 +48,13 @@ final class MethodForwardingHandler implements
     MethodReturnTypeProviderInterface,
     MethodParamsProviderInterface
 {
+    /**
+     * Larastan parity: split a where{Column} suffix on And/Or boundaries followed by an
+     * uppercase letter. Mirrors `Illuminate\Database\Query\Builder::dynamicWhere`'s
+     * `(And|Or)(?=[A-Z])`; we use a non-capturing group since we don't need the connector.
+     */
+    private const SEGMENT_SPLIT_PATTERN = '/(?:And|Or)(?=[A-Z])/';
+
     private static ?ForwardingRule $rule = null;
 
     /** @var array<lowercase-string, bool> Indexed source classes for O(1) lookup */
@@ -578,15 +585,7 @@ final class MethodForwardingHandler implements
 
         $stmt = $event->getStmt();
 
-        // The AST preserves the original camel-cased method name; Psalm only lowercases
-        // it before fanning out to providers. For dynamic-method calls (`$x->{$var}()`)
-        // Psalm's MethodCallAnalyzer short-circuits and never invokes return-type providers,
-        // so the Expr branch here is unreachable for MethodCall in practice. Kept as a
-        // defensive fallback for StaticCall (whose $name is also Identifier|Expr) and
-        // future Psalm versions that might resolve literal-string dynamic names.
-        $originalMethodName = $stmt instanceof MethodCall && $stmt->name instanceof \PhpParser\Node\Identifier
-            ? $stmt->name->name
-            : $methodName;
+        $originalMethodName = self::originalMethodName($stmt, $methodName);
 
         $columnType = self::resolveDynamicWhereColumnType($codebase, $modelClass, $originalMethodName);
 
@@ -723,6 +722,28 @@ final class MethodForwardingHandler implements
     }
 
     /**
+     * Pull the original camel-cased method name from the AST, falling back to the
+     * already-lowercased event method name when the call uses a dynamic name
+     * (e.g. `$x->{$var}()`) or is a StaticCall. The camel case matters because
+     * the And/Or segment split requires uppercase boundaries that Psalm strips
+     * from getMethodNameLowercase().
+     *
+     * Psalm's MethodCallAnalyzer short-circuits dynamic-name MethodCalls before
+     * invoking return-type providers, so the fallback branch is effectively dead
+     * for the MethodCall case; kept for StaticCall and future Psalm versions.
+     *
+     * @psalm-mutation-free
+     */
+    private static function originalMethodName(
+        \PhpParser\Node\Expr\MethodCall|\PhpParser\Node\Expr\StaticCall $stmt,
+        string $lowercaseFallback,
+    ): string {
+        return $stmt instanceof MethodCall && $stmt->name instanceof \PhpParser\Node\Identifier
+            ? $stmt->name->name
+            : $lowercaseFallback;
+    }
+
+    /**
      * Validate a dynamic where{Column} method call against the model's declared @property
      * entries and return the column type when (and only when) a single scalar column was
      * matched.
@@ -766,12 +787,10 @@ final class MethodForwardingHandler implements
         // always "where" in some casing. substr is byte-safe for that ASCII prefix.
         $suffix = \substr($originalMethodName, 5);
 
-        // Larastan parity: split on And/Or capitalised boundaries. Non-capturing group so the
-        // delimiters themselves don't appear in the segment list. preg_split returns
-        // non-empty-list<string>|false; false would require a regex compile failure, impossible
-        // for this literal pattern, but we defend against it for completeness.
-        $segments = \preg_split('/(?:And|Or)(?=[A-Z])/', $suffix);
+        $segments = \preg_split(self::SEGMENT_SPLIT_PATTERN, $suffix);
 
+        // preg_split with this literal pattern cannot fail at runtime; the guard is
+        // a Psalm narrowing concession (return type is non-empty-list<string>|false).
         if ($segments === false) {
             return self::$dynamicWhereCache[$key] = false;
         }
@@ -784,37 +803,39 @@ final class MethodForwardingHandler implements
 
         // Build a normalised property map once per (model, method) pair. Cheaper than
         // re-running str_replace+strtolower over every property for every segment.
-        // We deliberately do NOT cache this map across calls: Psalm may populate
-        // pseudo_property_get_types lazily as it parses the class, and a stale snapshot
-        // could miss properties that appear after first invocation.
+        // The map is not memoized across calls: Psalm may populate pseudo_property_get_types
+        // lazily as it parses the class, and a stale snapshot could miss properties added
+        // after first invocation.
         //
-        // Uses pseudo_property_get_types (from @property and @property-read) rather than
-        // pseudo_property_set_types (@property-write). Dynamic WHERE filters on readable
-        // database columns; @property-write only properties are write-only computed fields
-        // (e.g. password hashing) that do not correspond to filterable columns.
+        // pseudo_property_get_types is sourced from @property/@property-read — readable
+        // columns. @property-write entries (password hashing etc.) don't correspond to
+        // filterable columns and are intentionally excluded.
         $normalizedProperties = [];
         foreach ($storage->pseudo_property_get_types as $propName => $propType) {
             $normalizedProperties[\strtolower(\str_replace(['$', '_'], '', $propName))] = $propType;
         }
 
-        // Validate every segment uniformly. An empty segment (e.g. `whereAndFoo` splitting
-        // to ['', 'Foo']) or any unmatched column rejects the whole call. The strlen > 5
-        // guard in isDynamicWhereMethod already filters out a bare `where()` upstream.
+        // Validate every segment and stash the matching column type. An empty segment
+        // (e.g. `whereAndFoo` splitting to ['', 'Foo']) or any unmatched column rejects
+        // the whole call.
+        $matchedColumnTypes = [];
         foreach ($segments as $segment) {
             $segmentKey = \strtolower($segment);
 
             if ($segmentKey === '' || !isset($normalizedProperties[$segmentKey])) {
                 return self::$dynamicWhereCache[$key] = false;
             }
+
+            $matchedColumnTypes[] = $normalizedProperties[$segmentKey];
         }
 
         // Multi-segment calls take one argument per segment with potentially different
         // column types — no single Union can stand in for the typed-param hand-off.
-        if (\count($segments) !== 1) {
+        if (\count($matchedColumnTypes) !== 1) {
             return self::$dynamicWhereCache[$key] = null;
         }
 
-        $columnType = $normalizedProperties[\strtolower($segments[0])];
+        $columnType = $matchedColumnTypes[0];
 
         // Object/array column types (Carbon, BackedEnum, json casts) skip the typed-param
         // hand-off — Laravel coerces strings/ints to these at the query layer, so narrowing

--- a/src/Handlers/Magic/MethodForwardingHandler.php
+++ b/src/Handlers/Magic/MethodForwardingHandler.php
@@ -65,13 +65,24 @@ final class MethodForwardingHandler implements
     private static bool $enableDynamicWhere = false;
 
     /**
-     * Cache: "ModelClass:methodName" → column type (or null when no column matched).
+     * Cache: "ModelClass:originalMethodName" → three-state validation result.
      *
-     * Keyed by model class + method name to avoid repeating the property-name normalisation
-     * loop on subsequent calls with the same (model, method) pair. A null value records a
-     * negative match so we skip the loop on subsequent misses too.
+     * Keyed by model class + ORIGINAL-CASE method name (not lowercase). The original case
+     * is needed because Laravel's runtime `Builder::dynamicWhere` splits the suffix on
+     * `(?:And|Or)(?=[A-Z])`, which only fires on properly camel-cased boundaries. The same
+     * lowercase name can therefore come from a splittable call (`whereFooAndBar`) or a
+     * non-splittable one (`wherefooandbar`), and they validate differently.
      *
-     * @var array<string, ?Union>
+     * Values:
+     *   - `false`: validation failed (one or more segments don't match a declared
+     *     pseudo property). Caller falls through to mixed.
+     *   - `null`: validation passed but no scalar column type can be handed off to the
+     *     typed-parameter checker (multi-segment call, or single-segment whose type is
+     *     object/array — Carbon, BackedEnum, json casts).
+     *   - `Union`: validation passed AND the call is single-segment with a scalar column
+     *     type. The typed-param hand-off path (issue #928) consumes this.
+     *
+     * @var array<string, false|null|Union>
      */
     private static array $dynamicWhereCache = [];
 
@@ -120,13 +131,23 @@ final class MethodForwardingHandler implements
      */
     private static array $pendingDynamicWhereColumnType = [];
 
-    /** @psalm-external-mutation-free */
+    /**
+     * Reset all static state. Called once per Plugin::__construct in production, plus
+     * by test fixtures that re-bootstrap the handler. Every cache MUST be cleared so
+     * leftover entries from a previous run can't leak across boundaries — in particular
+     * $pendingDynamicWhereColumnType, where a stale entry could be consumed by a future
+     * call whose first Arg happens to share an spl_object_id.
+     *
+     * @psalm-external-mutation-free
+     */
     public static function init(ForwardingRule $rule): void
     {
         self::$rule = $rule;
         self::$sourceClassIndex = [];
         self::$searchClassIndex = [];
         self::$scopeParamsCache = [];
+        self::$dynamicWhereCache = [];
+        self::$pendingDynamicWhereColumnType = [];
 
         foreach ($rule->allSourceClasses() as $class) {
             self::$sourceClassIndex[\strtolower($class)] = true;
@@ -511,17 +532,29 @@ final class MethodForwardingHandler implements
     /**
      * Attempt to resolve a dynamic where{Column} method call on a relation.
      *
-     * Returns the relation's generic type (e.g. HasMany<Post, User>) when the method
-     * name matches the where{Column} pattern and the column is declared on the related model
-     * via @property annotations. Returns null otherwise (falling through to Psalm default).
+     * Returns the relation's generic type (e.g. HasMany<Post, User>) when every
+     * segment of the where suffix corresponds to a declared @property on the related
+     * model. Returns null otherwise (falling through to Psalm default).
      *
-     * Column matching normalises both sides to lowercase-without-underscores so that:
-     *   - whereTitle       → matches @property string $title
-     *   - whereEmailAddress → matches @property string $email_address
-     *   - whereFirstName   → matches @property string $first_name
+     * The suffix is split on `(?:And|Or)(?=[A-Z])` (Larastan parity), so multi-segment
+     * forms like `whereFirstNameAndLastName($a, $b)` and `whereTitleOrSlug($x)` are
+     * recognised. Splitting requires the ORIGINAL camel-cased method name from the
+     * AST — Psalm lowercases the method name before invoking providers, which would
+     * erase every `And`/`Or` boundary and collapse all multi-segment calls to a
+     * single unrecognised token (see issue #927).
      *
-     * When a column type is resolved, also queues it in {@see $pendingDynamicWhereColumnType}
-     * so {@see getMethodParams} can return typed params for argument validation. Issue #928.
+     * Each segment is normalised (lowercased, `$` and `_` stripped) and compared
+     * against `pseudo_property_get_types`, so:
+     *   - whereTitle              → ['Title']                        → @property $title
+     *   - whereEmailAddress       → ['EmailAddress']                  → @property $email_address
+     *   - whereFirstNameAndLastName → ['FirstName', 'LastName']        → both @property
+     *   - whereTitleOrSlug        → ['Title', 'Slug']                  → both @property
+     *
+     * For SINGLE-segment scalar-typed columns, the column type is queued in
+     * {@see $pendingDynamicWhereColumnType} so {@see getMethodParams} can return
+     * typed params for argument validation (issue #928). Multi-segment calls have
+     * one argument per segment with different types, which doesn't fit the
+     * single-typed-param hand-off; they get the variadic-mixed fallback.
      *
      * @param non-empty-list<Union>|list<Union>|null $templateParams Relation's template type parameters
      */
@@ -543,39 +576,45 @@ final class MethodForwardingHandler implements
             return null;
         }
 
-        $columnType = self::resolveDynamicWhereColumnType($codebase, $modelClass, $methodName);
+        $stmt = $event->getStmt();
 
-        if (!$columnType instanceof Union) {
+        // The AST preserves the original camel-cased method name; Psalm only lowercases
+        // it before fanning out to providers. For dynamic-method calls (`$x->{$var}()`)
+        // Psalm's MethodCallAnalyzer short-circuits and never invokes return-type providers,
+        // so the Expr branch here is unreachable for MethodCall in practice. Kept as a
+        // defensive fallback for StaticCall (whose $name is also Identifier|Expr) and
+        // future Psalm versions that might resolve literal-string dynamic names.
+        $originalMethodName = $stmt instanceof MethodCall && $stmt->name instanceof \PhpParser\Node\Identifier
+            ? $stmt->name->name
+            : $methodName;
+
+        $columnType = self::resolveDynamicWhereColumnType($codebase, $modelClass, $originalMethodName);
+
+        if ($columnType === false) {
             return null;
         }
 
-        // Hand off the column type to getMethodParams() so it can build a typed parameter
-        // list and let Psalm validate arguments. See $pendingDynamicWhereColumnType for the
-        // lifecycle and rationale. Issue #928.
+        // Hand off the scalar column type to getMethodParams() so it can build a typed
+        // parameter list and let Psalm validate arguments. See $pendingDynamicWhereColumnType
+        // for the lifecycle and rationale. Issue #928.
         //
-        // Two gates on the store:
+        // Gates on the store:
         //   (a) Path 1 (mixin interception) writes are unconsumable — Builder is in
         //       searchClassIndex, not sourceClassIndex, so our MethodParamsProvider
         //       early-returns for it and the entry would leak. Only store when the event
         //       fires for the relation class itself (Path 2 / direct __call).
-        //   (b) Skip non-scalar column types (Carbon, BackedEnum, json-cast arrays).
-        //       Laravel coerces strings/ints to these at the query layer, so narrowing
-        //       to the declared property type would mass-regress real codebases.
+        //   (b) Only single-segment scalar columns produce a Union here; multi-segment
+        //       and non-scalar single-segment results were cached as `null` upstream.
         //   (c) Only enqueue when the call has exactly one argument — the only shape
         //       consumeDynamicWhereTypedParams() actually consumes. Without this gate,
         //       2+ arg calls would deposit entries that the consumer skips, leaking
         //       across the analysis run (and risking a wrong-type lookup later if PHP
         //       reuses the spl_object_id of a freed Arg node).
-        if (\strtolower($event->getFqClasslikeName()) !== \strtolower($relationClass)) {
-            return new Union([new TGenericObject($relationClass, $templateParams)]);
-        }
-
-        if ($columnType->hasObjectType() || $columnType->hasArray()) {
-            return new Union([new TGenericObject($relationClass, $templateParams)]);
-        }
-
-        $stmt = $event->getStmt();
-        if ($stmt instanceof MethodCall) {
+        if (
+            $columnType instanceof Union
+            && \strtolower($event->getFqClasslikeName()) === \strtolower($relationClass)
+            && $stmt instanceof MethodCall
+        ) {
             $args = $stmt->getArgs();
 
             if (\count($args) === 1) {
@@ -583,7 +622,7 @@ final class MethodForwardingHandler implements
             }
         }
 
-        // Column exists on the model → method is fluent, return the full Relation type.
+        // Every segment matched → method is fluent, return the full Relation type.
         return new Union([
             new TGenericObject($relationClass, $templateParams),
         ]);
@@ -684,21 +723,29 @@ final class MethodForwardingHandler implements
     }
 
     /**
-     * Resolve the column type for a dynamic where{Column} method call, or null when no
-     * @property entry matches the suffix.
+     * Validate a dynamic where{Column} method call against the model's declared @property
+     * entries and return the column type when (and only when) a single scalar column was
+     * matched.
      *
-     * The column suffix (method name minus "where") is compared against the model's
-     * pseudo_property_get_types (populated from @property / @property-read annotations).
+     * Mirrors Larastan's `BuilderHelper::dynamicWhere` (split on And/Or capitalised boundaries,
+     * every segment must correspond to a declared column). The suffix after "where" is split
+     * by `(?:And|Or)(?=[A-Z])`, so the ORIGINAL camel-cased method name from the AST is
+     * required — see the caller for why we pull it from $stmt->name rather than the
+     * lowercased event method name.
      *
-     * Psalm lowercases all method names before passing them to providers, so the suffix is
-     * already lowercase (e.g. "wherefirstname" → suffix "firstname"). The @property names
-     * are normalised to the same form by stripping "$" and underscores and lowercasing, so:
-     *   - whereTitle (→ "title") matches @property string $title (→ "title")
-     *   - whereFirstName (→ "firstname") matches @property string $first_name (→ "firstname")
-     *   - whereEmailAddress (→ "emailaddress") matches @property string $email_address (→ "emailaddress")
+     * @property entries are normalised by stripping `$` and underscores and lowercasing
+     * (so `$email_address` collapses to `emailaddress`); each segment goes through the
+     * same normalisation and the call is rejected on the first mismatch.
      *
-     * Note: PHP method names use camelCase, so underscores in the suffix only arise for
-     * non-standard calls that would not match Laravel's dynamicWhere convention anyway.
+     * Return values:
+     *   - `false`: at least one segment doesn't match a declared property. Caller skips
+     *     the dynamic where resolution entirely.
+     *   - `null`: every segment matched but no scalar column type is suitable for the
+     *     typed-parameter hand-off (multi-segment, or single-segment whose type contains
+     *     an object/array — Carbon, BackedEnum, json casts). Caller returns the Relation
+     *     type without populating the hand-off cache.
+     *   - `Union`: every segment matched, the call is single-segment, and the column
+     *     type is scalar. Caller queues this type for {@see getMethodParams} (issue #928).
      *
      * @param class-string<\Illuminate\Database\Eloquent\Model> $modelClass
      * @psalm-external-mutation-free
@@ -706,45 +753,77 @@ final class MethodForwardingHandler implements
     private static function resolveDynamicWhereColumnType(
         Codebase $codebase,
         string $modelClass,
-        string $methodName,
-    ): ?Union {
-        $key = $modelClass . ':' . $methodName;
+        string $originalMethodName,
+    ): false|Union|null {
+        $key = $modelClass . ':' . $originalMethodName;
 
         if (\array_key_exists($key, self::$dynamicWhereCache)) {
             return self::$dynamicWhereCache[$key];
         }
 
-        // Extract the column suffix: "wheretitle" → "title", "wherefirstname" → "firstname"
-        $columnSuffix = \substr($methodName, 5);
+        // Strip "where" / "WHERE" prefix — original-case may be anything from "Where" to "WHERE",
+        // but our isDynamicWhereMethod gate ran on the lowercase form so the first 5 chars are
+        // always "where" in some casing. substr is byte-safe for that ASCII prefix.
+        $suffix = \substr($originalMethodName, 5);
+
+        // Larastan parity: split on And/Or capitalised boundaries. Non-capturing group so the
+        // delimiters themselves don't appear in the segment list. preg_split returns
+        // non-empty-list<string>|false; false would require a regex compile failure, impossible
+        // for this literal pattern, but we defend against it for completeness.
+        $segments = \preg_split('/(?:And|Or)(?=[A-Z])/', $suffix);
+
+        if ($segments === false) {
+            return self::$dynamicWhereCache[$key] = false;
+        }
 
         try {
             $storage = $codebase->classlike_storage_provider->get(\strtolower($modelClass));
         } catch (\InvalidArgumentException) {
-            self::$dynamicWhereCache[$key] = null;
-            return null;
+            return self::$dynamicWhereCache[$key] = false;
         }
 
-        // Use pseudo_property_get_types (from @property and @property-read) rather than
+        // Build a normalised property map once per (model, method) pair. Cheaper than
+        // re-running str_replace+strtolower over every property for every segment.
+        // We deliberately do NOT cache this map across calls: Psalm may populate
+        // pseudo_property_get_types lazily as it parses the class, and a stale snapshot
+        // could miss properties that appear after first invocation.
+        //
+        // Uses pseudo_property_get_types (from @property and @property-read) rather than
         // pseudo_property_set_types (@property-write). Dynamic WHERE filters on readable
         // database columns; @property-write only properties are write-only computed fields
         // (e.g. password hashing) that do not correspond to filterable columns.
-        //
-        // We do NOT cache the per-model normalised property set separately. Psalm may populate
-        // pseudo_property_get_types lazily (adding entries as it parses the class), so a
-        // snapshot taken on the first call could be incomplete for subsequent method checks.
-        // The per-(model, method) $dynamicWhereCache still prevents redundant lookups.
-        // "$first_name" → "firstname", "$title" → "title"
+        $normalizedProperties = [];
         foreach ($storage->pseudo_property_get_types as $propName => $propType) {
-            $normalized = \strtolower(\str_replace(['$', '_'], '', $propName));
+            $normalizedProperties[\strtolower(\str_replace(['$', '_'], '', $propName))] = $propType;
+        }
 
-            if ($normalized === $columnSuffix) {
-                self::$dynamicWhereCache[$key] = $propType;
-                return $propType;
+        // Validate every segment uniformly. An empty segment (e.g. `whereAndFoo` splitting
+        // to ['', 'Foo']) or any unmatched column rejects the whole call. The strlen > 5
+        // guard in isDynamicWhereMethod already filters out a bare `where()` upstream.
+        foreach ($segments as $segment) {
+            $segmentKey = \strtolower($segment);
+
+            if ($segmentKey === '' || !isset($normalizedProperties[$segmentKey])) {
+                return self::$dynamicWhereCache[$key] = false;
             }
         }
 
-        self::$dynamicWhereCache[$key] = null;
-        return null;
+        // Multi-segment calls take one argument per segment with potentially different
+        // column types — no single Union can stand in for the typed-param hand-off.
+        if (\count($segments) !== 1) {
+            return self::$dynamicWhereCache[$key] = null;
+        }
+
+        $columnType = $normalizedProperties[\strtolower($segments[0])];
+
+        // Object/array column types (Carbon, BackedEnum, json casts) skip the typed-param
+        // hand-off — Laravel coerces strings/ints to these at the query layer, so narrowing
+        // to the property type would mass-regress real codebases.
+        if ($columnType->hasObjectType() || $columnType->hasArray()) {
+            return self::$dynamicWhereCache[$key] = null;
+        }
+
+        return self::$dynamicWhereCache[$key] = $columnType;
     }
 
 }

--- a/tests/Type/tests/Relation/DynamicWhereArgumentTypingTest.phpt
+++ b/tests/Type/tests/Relation/DynamicWhereArgumentTypingTest.phpt
@@ -70,6 +70,21 @@ function test_dynamic_where_unknown_column_skips_validation(): void {
     $r->whereNonExistentColumn(123);
 }
 
+function test_dynamic_where_multi_segment_falls_back_to_variadic(): void {
+    // Multi-segment forms (issue #927) take one argument per segment, each with
+    // potentially different column types. The validator caches multi-segment
+    // success as `null` so getMethodParams() does NOT consume a Union and apply
+    // single-typed-param checking — that would otherwise narrow segment 1's
+    // arg to invoice_number's type and reject correct values in segment 2.
+    // Passing the wrong type in either position is therefore silently accepted
+    // (the variadic-mixed fallback governs argument arity only).
+    $r = (new WorkOrder())->invoice();
+    // invoice_number AND status are both strings, but the multi-segment path
+    // intentionally skips the typed-param hand-off; int args don't error.
+    $r->whereInvoiceNumberAndStatus(123, 456);
+    $r->whereInvoiceNumberOrStatus(123, 456);
+}
+
 function test_dynamic_where_multi_arg_form_falls_back_to_variadic(): void {
     // Laravel's Builder::dynamicWhere silently drops the second+ arguments and
     // always uses '=' as the operator (see Query\Builder::addDynamic). The 2-arg

--- a/tests/Type/tests/Relation/DynamicWhereDisabledTest.phpt
+++ b/tests/Type/tests/Relation/DynamicWhereDisabledTest.phpt
@@ -21,5 +21,14 @@ function test_dynamic_where_not_resolved_when_disabled(): void {
     $_ = $r->whereInvoiceNumber('INV-2024-001');
     /** @psalm-check-type-exact $_ = mixed */
 }
+
+// Multi-segment dynamic where (issue #927) must respect the disabled flag too.
+// A regression that wired the segment-split path outside the $enableDynamicWhere
+// gate would still resolve here; verify the call collapses to mixed.
+function test_dynamic_where_multi_segment_not_resolved_when_disabled(): void {
+    $r = (new WorkOrder())->invoice();
+    $_ = $r->whereInvoiceNumberAndStatus('INV-2024-001', 'paid');
+    /** @psalm-check-type-exact $_ = mixed */
+}
 ?>
 --EXPECTF--

--- a/tests/Type/tests/Relation/DynamicWhereMultiSegmentTest.phpt
+++ b/tests/Type/tests/Relation/DynamicWhereMultiSegmentTest.phpt
@@ -1,0 +1,95 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Invoice;
+use App\Models\WorkOrder;
+
+/**
+ * Tests for multi-segment dynamic where{Column} methods on relation chains.
+ *
+ * Laravel's `Builder::dynamicWhere` splits the suffix after "where" on
+ * `(?:And|Or)(?=[A-Z])` and treats each segment as a separate column condition,
+ * so `whereInvoiceNumberAndStatus('INV-X', 'paid')` is equivalent to
+ * `where('invoice_number', 'INV-X')->where('status', 'paid')`. The handler must
+ * recognise these calls as fluent so chaining preserves the Relation generic
+ * type, and must reject calls where any segment doesn't correspond to a
+ * declared @property (falling through to mixed, consistent with single-segment
+ * unknown-column behaviour in DynamicWhereUnknownColumnTest).
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/927
+ */
+
+// Valid AND form: both invoice_number and status are @property on Invoice.
+// The two-segment call returns Invoice|null after ->first(), matching the
+// single-segment behaviour from DynamicWhereMethodTest.
+function test_dynamic_where_and_multi_segment_valid(): void {
+    $r = (new WorkOrder())->invoice();
+    $_ = $r->whereInvoiceNumberAndStatus('INV-2024-001', 'paid')->first();
+    /** @psalm-check-type-exact $_ = App\Models\Invoice|null */
+}
+
+// Valid Or form: both invoice_number and status are @property on Invoice.
+function test_dynamic_where_or_multi_segment_valid(): void {
+    $r = (new WorkOrder())->invoice();
+    $_ = $r->whereInvoiceNumberOrStatus('INV-2024-001')->first();
+    /** @psalm-check-type-exact $_ = App\Models\Invoice|null */
+}
+
+// Mixed three-segment And/Or: every segment must validate.
+function test_dynamic_where_mixed_multi_segment_valid(): void {
+    $r = (new WorkOrder())->invoice();
+    $_ = $r->whereInvoiceNumberAndStatusOrInvoiceNumber('INV-2024-001', 'paid', 'INV-2024-002')->first();
+    /** @psalm-check-type-exact $_ = App\Models\Invoice|null */
+}
+
+// One bad segment → fall through to mixed (consistent with single-segment unknown
+// column behaviour; the plugin doesn't emit a warning here).
+function test_dynamic_where_multi_segment_with_unknown_column_falls_through(): void {
+    $r = (new WorkOrder())->invoice();
+    // 'nope' is not a @property on Invoice; the whole call must not be recognised
+    // as fluent and the return type collapses to mixed via __call.
+    $_ = $r->whereInvoiceNumberAndNope('INV-2024-001', 'x');
+    /** @psalm-check-type-exact $_ = mixed */
+}
+
+// All segments unknown → also falls through.
+function test_dynamic_where_multi_segment_all_unknown_falls_through(): void {
+    $r = (new WorkOrder())->invoice();
+    $_ = $r->whereFooAndBar('a', 'b');
+    /** @psalm-check-type-exact $_ = mixed */
+}
+
+// Cache key includes the ORIGINAL-case method name from the AST, so the same
+// lowercase shape spelled two ways produces two different cache outcomes:
+//   - whereInvoiceNumberAndStatus → splits on `(?:And|Or)(?=[A-Z])` → valid
+//   - whereinvoicenumberandstatus → no capital after `and` → single segment
+//     `invoicenumberandstatus`, no such column → falls through to mixed.
+// PHP method dispatch is case-insensitive, so both reach the same Relation
+// method, but php-parser preserves source casing and our cache key relies on
+// it. A regression that lowercased the cache key would conflate these.
+function test_dynamic_where_cache_key_preserves_original_case(): void {
+    $r = (new WorkOrder())->invoice();
+    // Splittable form: valid two-segment call, returns Relation type.
+    $_a = $r->whereInvoiceNumberAndStatus('INV-2024-001', 'paid')->first();
+    /** @psalm-check-type-exact $_a = App\Models\Invoice|null */
+
+    // Non-splittable form: single segment that isn't a column → mixed.
+    $_b = $r->whereinvoicenumberandstatus('INV-2024-001', 'paid');
+    /** @psalm-check-type-exact $_b = mixed */
+}
+
+// Dynamic-name method call (`$r->{$name}('x')`). Psalm's MethodCallAnalyzer
+// short-circuits dynamic-name dispatch before invoking return-type providers,
+// so the plugin never sees this call regardless of its handler logic. The
+// assertion locks in the Psalm-level behaviour: if a future Psalm version
+// resolves literal-string dynamic names and starts firing providers, this
+// test will flip and force us to revisit the Expr fallback in
+// resolveDynamicWhereOnRelation.
+function test_dynamic_where_skipped_for_dynamic_method_name(): void {
+    $r = (new WorkOrder())->invoice();
+    $name = 'whereInvoiceNumber';
+    $_ = $r->{$name}('INV-2024-001');
+    /** @psalm-check-type-exact $_ = mixed */
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

`MethodForwardingHandler` only validated single-segment dynamic where method calls. Multi-segment forms like `whereFirstNameAndLastName($a, $b)` or `whereTitleOrSlug($x)` were silently accepted via the variadic-mixed fallback regardless of whether each segment matched a declared `@property`. Valid multi-segment calls also lost their fluent `Relation<Model>` return type, collapsing to `mixed` via `__call`, which broke chained `->first()` / `->get()` resolution.

The single-suffix matcher never recognised them because Psalm lowercases method names before invoking providers, which erases the `And`/`Or` capitalised boundaries Laravel's runtime `Builder::dynamicWhere` splits on.

## Related

Closes #927

## Solution Description

Pull the original camel-cased method name from `$stmt->name` (Identifier) and split the suffix with `(?:And|Or)(?=[A-Z])` (Larastan parity, mirrors `BuilderHelper::dynamicWhere`). Every segment must correspond to a declared pseudo-property; otherwise the call falls through to `mixed`, consistent with single-segment unknown-column behaviour.

The validation cache became three-state to preserve the issue #928 typed-param hand-off:

- `false`: validation failed, caller returns null.
- `null`: validated but no scalar column for hand-off (multi-segment, or non-scalar single-segment such as Carbon / BackedEnum / json-cast).
- `Union`: validated single-segment scalar column, hand-off enabled.

The cache key is now the original-case method name (was lowercase) so splittable (`whereFooAndBar`) and non-splittable (`wherefooandbar`) spellings cache independently. `init()` now resets every static cache uniformly, including the producer/consumer hand-off store, to close a leak risk on re-bootstrap.

### Verification

- New `tests/Type/tests/Relation/DynamicWhereMultiSegmentTest.phpt` covers valid AND form, valid OR form, mixed three-segment, partial-unknown fall-through, all-unknown fall-through, cache-key original-case isolation, and dynamic-method-name dispatch.
- Extended `DynamicWhereArgumentTypingTest.phpt` with a regression guard that multi-segment calls never consume the typed-param hand-off (passing wrong-type args is silently accepted).
- Extended `DynamicWhereDisabledTest.phpt` to confirm multi-segment respects `<resolveDynamicWhereClauses value="false" />`.
- `composer test:type` passes (408/408), `composer psalm` exit 0, `composer cs` clean.

## Checklist

- [x] Tests cover the change (type tests in `tests/Type/tests/Relation/`)
