### PR TITLE
Narrow `Storage::disk()` return to `Cloud` for cloud-driver disks

### DIFF
--- a/src/Handlers/Filesystem/FilesystemConfigAnalyzer.php
+++ b/src/Handlers/Filesystem/FilesystemConfigAnalyzer.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Filesystem;
+
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Psalm\LaravelPlugin\Providers\ConfigRepositoryProvider;
+
+/**
+ * Reads `config/filesystems.php` to determine which disk maps to which driver.
+ * The driver name is then matched against Laravel's built-in `createXDriver()`
+ * methods to decide whether the disk returns a {@see \Illuminate\Contracts\Filesystem\Cloud}
+ * (ships `url()`) or the base {@see \Illuminate\Contracts\Filesystem\Filesystem}
+ * (file-only, does NOT declare `url()`).
+ *
+ * Custom drivers registered via `Storage::extend('foo', ...)` may also return
+ * `Cloud`, but static analysis cannot peek inside the registered closure to
+ * tell. We only narrow for built-ins (currently `'s3'`), which keeps us sound:
+ * a custom cloud driver loses the narrowing but no file-only driver is ever
+ * mis-narrowed to Cloud (which would silence a real `url()` runtime error).
+ *
+ * Mirrors the pattern of {@see \Psalm\LaravelPlugin\Handlers\Auth\AuthConfigAnalyzer}:
+ * single per-process instance, lazy singleton, immutable wrap of the booted
+ * Laravel app's config repository.
+ *
+ * @internal
+ */
+final class FilesystemConfigAnalyzer
+{
+    private static ?FilesystemConfigAnalyzer $instance = null;
+
+    private ?string $default_disk_cache = null;
+
+    private bool $default_disk_loaded = false;
+
+    /** @var array<string, string|null> */
+    private array $driver_cache = [];
+
+    /** @psalm-mutation-free */
+    private function __construct(private readonly ConfigRepository $config) {}
+
+    public static function instance(): self
+    {
+        if (!self::$instance instanceof self) {
+            self::$instance = new self(ConfigRepositoryProvider::get());
+        }
+
+        return self::$instance;
+    }
+
+    public function getDefaultDisk(): ?string
+    {
+        if (!$this->default_disk_loaded) {
+            /** @var mixed $disk */
+            $disk = $this->config->get('filesystems.default');
+            $this->default_disk_cache = \is_string($disk) ? $disk : null;
+            $this->default_disk_loaded = true;
+        }
+
+        return $this->default_disk_cache;
+    }
+
+    /**
+     * Return the configured driver name for a disk, or null if the disk is not
+     * declared (or its `driver` key is missing/non-string). Memoised — repeat
+     * calls for the same disk skip the dotted-path config walk.
+     */
+    public function getDriverForDisk(string $disk): ?string
+    {
+        if (\array_key_exists($disk, $this->driver_cache)) {
+            return $this->driver_cache[$disk];
+        }
+
+        /** @var mixed $driver */
+        $driver = $this->config->get("filesystems.disks.{$disk}.driver");
+
+        return $this->driver_cache[$disk] = \is_string($driver) ? $driver : null;
+    }
+}

--- a/src/Handlers/Filesystem/FilesystemConfigAnalyzer.php
+++ b/src/Handlers/Filesystem/FilesystemConfigAnalyzer.php
@@ -52,7 +52,6 @@ final class FilesystemConfigAnalyzer
     public function getDefaultDisk(): ?string
     {
         if (!$this->default_disk_loaded) {
-            /** @var mixed $disk */
             $disk = $this->config->get('filesystems.default');
             $this->default_disk_cache = \is_string($disk) ? $disk : null;
             $this->default_disk_loaded = true;
@@ -72,7 +71,6 @@ final class FilesystemConfigAnalyzer
             return $this->driver_cache[$disk];
         }
 
-        /** @var mixed $driver */
         $driver = $this->config->get("filesystems.disks.{$disk}.driver");
 
         return $this->driver_cache[$disk] = \is_string($driver) ? $driver : null;

--- a/src/Handlers/Filesystem/StorageHandler.php
+++ b/src/Handlers/Filesystem/StorageHandler.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Filesystem;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Scalar\String_;
+use Psalm\Plugin\EventHandler\Event\MethodParamsProviderEvent;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\MethodParamsProviderInterface;
+use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\Storage\FunctionLikeParameter as Param;
+use Psalm\Type;
+
+/**
+ * Narrows `Storage::disk($name)` / `Storage::drive($name)` (and the same calls on a
+ * DI-injected `FilesystemManager` / `Factory` contract) to
+ * {@see \Illuminate\Contracts\Filesystem\Cloud} when the disk's configured driver
+ * is a built-in Laravel cloud driver. Otherwise returns null to fall through to
+ * the declared `Filesystem` return type from Laravel's `@method` catalogue on
+ * the {@see \Illuminate\Support\Facades\Storage} facade.
+ *
+ * Why a handler instead of a stub
+ * --------------------------------
+ * Larastan's fix vector (and the one suggested in issue #973) is to stub
+ * `Storage::disk()` to return the concrete `\Illuminate\Filesystem\FilesystemAdapter`
+ * for every call. That conflates the Cloud and Filesystem contracts: it makes
+ * `Storage::disk('local')->url('foo.png')` type-check even though the `local`
+ * driver does not provide `url()` on the Filesystem contract (Laravel only
+ * declares `url()` on `Cloud extends Filesystem`). At runtime `LocalFilesystemAdapter`
+ * happens to support `url()` because every shipped adapter extends
+ * `FilesystemAdapter`, but the contract distinction is intentional — projects
+ * that swap a `local` disk for a custom file-only adapter would silently break.
+ *
+ * The correct layer is here: read `filesystems.disks.<name>.driver` from the
+ * user's config and narrow to `Cloud` only for the cloud drivers Laravel ships
+ * (currently just `'s3'`, the only built-in `createXDriver()` typed `@return Cloud`).
+ * Disks backed by `local`/`ftp`/`sftp`/`scoped` keep the contract-correct
+ * `Filesystem` return type, and `disk('local')->url(...)` remains a (correctly
+ * reported) `UndefinedInterfaceMethod`.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/973
+ */
+final class StorageHandler implements MethodReturnTypeProviderInterface, MethodParamsProviderInterface
+{
+    /** `drive()` is the long-standing `FilesystemManager` alias for `disk()` — same forwarding, same return contract. */
+    private const DISK_METHODS = ['disk' => true, 'drive' => true];
+
+    /**
+     * Built-in Laravel driver names whose `createXDriver()` returns
+     * {@see \Illuminate\Contracts\Filesystem\Cloud}. Per
+     * `Illuminate\Filesystem\FilesystemManager`, only `createS3Driver` declares a
+     * Cloud return type; `local`, `ftp`, `sftp`, and `scoped` all return the base
+     * `Filesystem` contract. Custom drivers registered via `Storage::extend(...)`
+     * are opaque to static analysis and never narrowed.
+     */
+    private const CLOUD_DRIVERS = ['s3' => true];
+
+    /**
+     * Cached `Cloud` return type. The narrowed type has no per-call variation, so
+     * a single immutable Union is reused for every successful narrow. Avoids
+     * allocating a fresh Union+Atomic pair on every `Storage::disk('s3')` call
+     * site (an app with hundreds of S3 references would otherwise pay that cost
+     * inside the worker fork).
+     */
+    private static ?Type\Union $cloud_return_type = null;
+
+    /**
+     * Cached parameter list for the facade-only params override (see
+     * {@see self::getMethodParams()}). Same allocation-avoidance rationale as
+     * `$cloud_return_type`.
+     *
+     * @var list<Param>|null
+     */
+    private static ?array $facade_disk_params = null;
+
+    /**
+     * Register for every surface that exposes `disk()` / `drive()`:
+     * - the `Storage` facade (calls go through `__callStatic` → forwarded by Laravel's `@method`),
+     * - the concrete `FilesystemManager` (common DI target),
+     * - the `Factory` contract (DI by interface — `disk()` is its only method).
+     *
+     * @return list<string>
+     * @psalm-pure
+     */
+    #[\Override]
+    public static function getClassLikeNames(): array
+    {
+        return [
+            \Illuminate\Support\Facades\Storage::class,
+            \Illuminate\Filesystem\FilesystemManager::class,
+            \Illuminate\Contracts\Filesystem\Factory::class,
+        ];
+    }
+
+    /** @inheritDoc */
+    #[\Override]
+    public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Type\Union
+    {
+        if (!isset(self::DISK_METHODS[$event->getMethodNameLowercase()])) {
+            return null;
+        }
+
+        $analyzer = FilesystemConfigAnalyzer::instance();
+
+        $disk_name = self::resolveDiskName($event->getCallArgs(), $analyzer);
+        if ($disk_name === null) {
+            return null;
+        }
+
+        $driver = $analyzer->getDriverForDisk($disk_name);
+        if ($driver === null || !isset(self::CLOUD_DRIVERS[$driver])) {
+            return null;
+        }
+
+        return self::$cloud_return_type ??= new Type\Union([
+            new Type\Atomic\TNamedObject(\Illuminate\Contracts\Filesystem\Cloud::class),
+        ]);
+    }
+
+    /**
+     * Extract the disk name argument as a literal string. Returns null when the
+     * call has a dynamic argument we cannot resolve at analysis time.
+     *
+     * `disk()` with no argument or `disk(null)` both fall back to the configured
+     * default disk (`filesystems.default`), mirroring `FilesystemManager::disk()`'s
+     * `$name = enum_value($name) ?: $this->getDefaultDriver()`.
+     *
+     * `UnitEnum` literal cases (`Storage::disk(MyDisk::S3)`) are intentionally not
+     * resolved today — Psalm would need a `ClassConstFetch` walk against the
+     * scanner's enum case storage. Falls through to `null` (no narrowing), which
+     * stays sound at the cost of a missed opportunity.
+     *
+     * @param list<Arg> $args
+     */
+    private static function resolveDiskName(array $args, FilesystemConfigAnalyzer $analyzer): ?string
+    {
+        if ($args === []) {
+            return $analyzer->getDefaultDisk();
+        }
+
+        $first = $args[0]->value;
+
+        if ($first instanceof String_) {
+            return $first->value;
+        }
+
+        if ($first instanceof ConstFetch && $first->name->toLowerString() === 'null') {
+            return $analyzer->getDefaultDisk();
+        }
+
+        return null;
+    }
+
+    /**
+     * Provide explicit params for `disk()` / `drive()` when reached through the
+     * `Storage` facade. The facade only declares these as `@method` (no real
+     * method on the Facade class), and registering a return type provider on a
+     * class without a matching params provider crashes Psalm 7's
+     * `Methods::getMethodParams()` with "Cannot get method params for ..." — the
+     * same failure mode documented on {@see \Psalm\LaravelPlugin\Handlers\Auth\AuthHandler::getMethodParams()}.
+     *
+     * For non-facade receivers (`FilesystemManager`, `Factory` contract) `disk()`
+     * is a real method, so Psalm can derive params itself — we return null and
+     * let Laravel's signature drift through.
+     *
+     * @psalm-external-mutation-free
+     */
+    #[\Override]
+    public static function getMethodParams(MethodParamsProviderEvent $event): ?array
+    {
+        if ($event->getFqClasslikeName() !== \Illuminate\Support\Facades\Storage::class) {
+            return null;
+        }
+
+        if (!isset(self::DISK_METHODS[$event->getMethodNameLowercase()])) {
+            return null;
+        }
+
+        return self::$facade_disk_params ??= self::buildFacadeDiskParams();
+    }
+
+    /**
+     * @return list<Param>
+     * @psalm-pure
+     */
+    private static function buildFacadeDiskParams(): array
+    {
+        // `disk(\UnitEnum|string|null $name = null)` — mirror the facade @method declaration.
+        $name_type = new Type\Union([
+            new Type\Atomic\TString(),
+            new Type\Atomic\TNamedObject(\UnitEnum::class),
+            new Type\Atomic\TNull(),
+        ]);
+
+        $name_param = new Param(
+            'name',
+            false,
+            $name_type,
+            $name_type,
+            is_optional: true,
+            default_type: Type::getNull(),
+        );
+
+        return [$name_param];
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -90,6 +90,10 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Auth/RequestHandler.php';
         $registration->registerHooksFromClass(Handlers\Auth\RequestHandler::class);
 
+        // FilesystemConfigAnalyzer is loaded via PSR-4 from StorageHandler.
+        require_once __DIR__ . '/Handlers/Filesystem/StorageHandler.php';
+        $registration->registerHooksFromClass(Handlers\Filesystem\StorageHandler::class);
+
         // Model property handlers are registered dynamically by ModelRegistrationHandler
         // after Psalm populates its codebase (AfterCodebasePopulated event).
         require_once __DIR__ . '/Handlers/Eloquent/ModelRegistrationHandler.php';

--- a/tests/Type/tests/Facades/StorageDiskUrlTest.phpt
+++ b/tests/Type/tests/Facades/StorageDiskUrlTest.phpt
@@ -1,33 +1,144 @@
 --FILE--
 <?php declare(strict_types=1);
 
+use Illuminate\Contracts\Filesystem\Cloud;
+use Illuminate\Contracts\Filesystem\Factory;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemManager;
 use Illuminate\Support\Facades\Storage;
 
 /**
- * Reproducer (documented broken behavior): `Storage::disk($name)->url($path)`.
+ * Issue #973: `Storage::disk('s3')->url('x')` triggered `UndefinedInterfaceMethod`
+ * because Laravel declares `disk()` as returning `Filesystem`, but `url()`
+ * lives on the `Cloud extends Filesystem` sub-contract.
  *
- * From invoiceninja's app/Console/Commands/BackupUpdate.php — three occurrences
- * across that file alone:
+ * Larastan's fix narrows every `disk()` call to `\Illuminate\Filesystem\FilesystemAdapter`,
+ * which silently allows `disk('local')->url(...)` even though the file-only
+ * `Filesystem` contract does NOT declare `url()`. We instead read
+ * `config/filesystems.php`: cloud-driver disks (currently `'s3'`) narrow to
+ * `Cloud`, file-only disks (`local`, `ftp`, `sftp`, `scoped`) keep the
+ * contract-correct `Filesystem` return type.
  *
- *   $url = Storage::disk($this->option('disk'))->url($path);
- *
- * The `Storage` facade's `@method static disk(...)` is declared by Laravel to
- * return `\Illuminate\Contracts\Filesystem\Filesystem`. The `url($path)` method
- * lives on the `Cloud` sub-contract (and on the concrete `FilesystemAdapter`),
- * not on `Filesystem`. So Psalm correctly reports `UndefinedInterfaceMethod`
- * even though every disk driver Laravel ships extends `FilesystemAdapter` and
- * therefore implements `url()` at runtime.
- *
- * Fix vector: override the `Storage::disk` return type to `FilesystemAdapter`
- * in a plugin stub (mirroring Larastan's approach), or add `url()` to the
- * `Filesystem` contract stub. Either is a small, focused change but kept out of
- * this PR to scope it to test additions.
+ * The Testbench skeleton's `config/filesystems.php` ships `local` (default),
+ * `public` (driver=local), and `s3` (driver=s3) — those three drive the
+ * assertions below.
  */
-function test_storage_disk_url_undefined_on_filesystem_contract(): void
+function test_storage_disk_s3_returns_cloud_contract(): string
 {
-    Storage::disk('local')->url('foo.png');
+    /** @psalm-check-type-exact $disk = Cloud */
+    $disk = Storage::disk('s3');
+
+    return $disk->url('foo.png');
+}
+
+function test_storage_drive_alias_also_narrows(): string
+{
+    /** @psalm-check-type-exact $disk = Cloud */
+    $disk = Storage::drive('s3');
+
+    return $disk->url('foo.png');
+}
+
+/**
+ * File-only drivers stay on the base `Filesystem` contract. `url()` is then
+ * correctly reported as undefined — this matches the Laravel contract design
+ * (only `Cloud` declares `url()`). Users who want `url()` on a `local` disk
+ * should call it on `Storage::cloud()` or against a `Cloud`-typed binding.
+ */
+function test_storage_disk_local_stays_file_only(): void
+{
+    /** @psalm-check-type-exact $disk = Filesystem */
+    $disk = Storage::disk('local');
+
+    $disk->url('foo.png');
+}
+
+/**
+ * No-arg `disk()` and literal `disk(null)` both resolve to the configured
+ * default disk (`filesystems.default`), which is `'local'` in the Testbench
+ * skeleton — mirrors `FilesystemManager::disk()`'s `enum_value($name) ?: $this->getDefaultDriver()`.
+ */
+function test_storage_disk_default_resolves_via_config(): void
+{
+    /** @psalm-check-type-exact $disk = Filesystem */
+    $disk = Storage::disk();
+
+    $disk->url('foo.png');
+}
+
+function test_storage_disk_literal_null_resolves_via_config(): void
+{
+    /** @psalm-check-type-exact $disk = Filesystem */
+    $disk = Storage::disk(null);
+
+    $disk->url('foo.png');
+}
+
+/**
+ * Dynamic disk names are opaque at analysis time — narrowing must NOT apply.
+ * The receiver stays on the declared `Filesystem` contract so that latent
+ * runtime errors (`url()` on a `local` disk) are still surfaced statically.
+ */
+function test_storage_disk_dynamic_name_does_not_narrow(string $name): Filesystem
+{
+    /** @psalm-check-type-exact $disk = Filesystem */
+    $disk = Storage::disk($name);
+
+    return $disk;
+}
+
+/**
+ * Disks not declared in `filesystems.disks` fall through with no narrowing —
+ * the declared `Filesystem` contract from Laravel's `@method` catalogue stands.
+ * Pins the `getDriverForDisk(...) === null` branch in `StorageHandler` so a
+ * future change to "default unknown disks to Cloud" would fail this test.
+ */
+function test_storage_disk_unknown_name_falls_through(): void
+{
+    /** @psalm-check-type-exact $disk = Filesystem */
+    $disk = Storage::disk('disk-that-is-not-in-filesystems-config');
+
+    $disk->url('foo.png');
+}
+
+/**
+ * The facade-only `getMethodParams()` override pins `disk()`'s parameter
+ * signature to `\UnitEnum|string|null`. An incompatible literal must surface
+ * as `InvalidArgument`; if the override silently regressed (e.g. dropped the
+ * params provider entirely), the call below would type-check silently.
+ */
+function test_storage_disk_rejects_non_string_non_enum_non_null_argument(): void
+{
+    Storage::disk(42);
+}
+
+/**
+ * Non-facade receivers: DI-injected `FilesystemManager` (the concrete) and
+ * `Factory` (the contract). The handler registers for both via
+ * `getClassLikeNames()`, so the same narrowing must apply through DI without
+ * regressing Psalm's native resolution of `disk()`'s params (`disk()` is a real
+ * method on both classes — see `getMethodParams()`'s facade-only carve-out).
+ */
+function test_filesystem_manager_disk_narrows(FilesystemManager $mgr): string
+{
+    /** @psalm-check-type-exact $disk = Cloud */
+    $disk = $mgr->disk('s3');
+
+    return $disk->url('foo.png');
+}
+
+function test_factory_contract_disk_narrows(Factory $factory): string
+{
+    /** @psalm-check-type-exact $disk = Cloud */
+    $disk = $factory->disk('s3');
+
+    return $disk->url('foo.png');
 }
 
 ?>
 --EXPECTF--
 UndefinedInterfaceMethod on line %d: Method Illuminate\Contracts\Filesystem\Filesystem::url does not exist
+UndefinedInterfaceMethod on line %d: Method Illuminate\Contracts\Filesystem\Filesystem::url does not exist
+UndefinedInterfaceMethod on line %d: Method Illuminate\Contracts\Filesystem\Filesystem::url does not exist
+UndefinedInterfaceMethod on line %d: Method Illuminate\Contracts\Filesystem\Filesystem::url does not exist
+InvalidArgument on line %d: Argument 1 of Illuminate\Support\Facades\Storage::disk expects UnitEnum|null|string, but 42 provided


### PR DESCRIPTION
## Issue to Solve

`Storage::disk('s3')->url($path)` raised `UndefinedInterfaceMethod` even though the call works at runtime. Laravel declares `Storage::disk()` (and `drive()`) as returning `\Illuminate\Contracts\Filesystem\Filesystem`, but `url()` lives on the `\Illuminate\Contracts\Filesystem\Cloud extends Filesystem` sub-contract. Every disk type returns a `FilesystemAdapter` at runtime, so the contract-level error is statically valid yet practically a nuisance for projects on S3.

## Related

Closes #973.

Partially mitigates #977 (only the `url()` case; `download()`, `directoryExists()`, `temporaryUrl()`, `temporaryUploadUrl()` live exclusively on the concrete `FilesystemAdapter`, not on `Cloud`, so cannot be addressed at the contract layer without lying about Laravel's contract design).

## Solution Description

**Layer choice.** Larastan's fix vector blanket-narrows `disk()` to `\Illuminate\Filesystem\FilesystemAdapter`. That silently permits `Storage::disk('local')->url(...)` even though the file-only `Filesystem` contract does not declare `url()` — conflating Laravel's intentional Cloud/Filesystem split. Projects that swap a `local` disk for a custom file-only adapter would silently break.

**This PR narrows at the correct layer:** a new `StorageHandler` reads `filesystems.disks.<name>.driver` from the booted app's config and only emits `Cloud` when the driver is `'s3'` (the sole built-in `createXDriver()` typed `@return Cloud` in `FilesystemManager`). `local` / `ftp` / `sftp` / `scoped` keep the contract-correct `Filesystem` return type, and `Storage::disk('local')->url(...)` remains a correctly reported `UndefinedInterfaceMethod`.

**Surface coverage.** The handler registers for three receivers via `getClassLikeNames()`:
- `\Illuminate\Support\Facades\Storage` (facade `__callStatic` path)
- `\Illuminate\Filesystem\FilesystemManager` (DI target)
- `\Illuminate\Contracts\Filesystem\Factory` (DI by interface)

**Why a paired `MethodParamsProviderInterface`.** Registering only `MethodReturnTypeProviderInterface` on the `Storage` facade crashes Psalm 7 with `UnexpectedValueException: Cannot get method params for Illuminate\Support\Facades\Storage::disk` because `disk()` exists only as `@method` on the facade — same failure mode documented on `AuthHandler::getMethodParams()`. The override applies only to the facade FQCN; non-facade receivers fall through to Psalm's native param derivation.

**Pattern conformance.** Mirrors `src/Handlers/Auth/` faithfully: singleton config analyzer, paired return-type/params provider, `require_once` + `registerHooksFromClass()` in `Plugin::registerHandlers()`.

**Performance.** All hot-path allocations cached as static singletons:
- The `Cloud` return `Union` is built once per worker and reused.
- The facade params override builds the `\UnitEnum|string|null` `Union` + `FunctionLikeParameter` once.
- `FilesystemConfigAnalyzer` memoises `getDriverForDisk()` and `getDefaultDisk()` lookups so the dotted-path config walk runs at most once per disk name.

Method-name filter (`isset(self::DISK_METHODS[$lowercase_name])`) is the cheapest possible reject for the dominant non-`disk` call path.

**Soundness.** Conservative narrow only: `'s3'` literal-equals to `Cloud`, everything else falls through to no-narrow. Custom drivers registered via `Storage::extend('foo', ...)` that return Cloud lose the narrowing (closure return type is opaque to static analysis), but no file-only driver is ever mis-narrowed to Cloud — which would silence a real runtime `url()` error.

**Out of scope (deliberate gaps).**
- `UnitEnum` literal disk-name arguments (`Storage::disk(Disks::S3)`) fall through with no narrowing — sound, but a missed opportunity. Could be addressed with a `ClassConstFetch` walk against the scanner's enum case storage.
- `Storage::build(['driver' => 's3', ...])` array-literal narrowing — runtime returns `Cloud`, but rare enough in practice to defer.
- `scoped` driver pointing at an s3 parent stays `Filesystem` per Laravel's own `@return` annotation on `createScopedDriver()` — mirroring Laravel's source-level imprecision.

**Verification (10 type-test scenarios):**
- `Storage::disk('s3')->url(...)` → narrowed to `Cloud`, no error.
- `Storage::drive('s3')->url(...)` → same via alias.
- `Storage::disk('local')->url(...)` → stays `Filesystem`, correctly errors.
- `Storage::disk()` no-arg → resolves default disk via config.
- `Storage::disk(null)` literal-null → resolves default disk via config.
- `Storage::disk($dynamic)` → opaque, stays `Filesystem` (no over-narrowing).
- `Storage::disk('disk-not-in-config')` → unknown disk, stays `Filesystem`.
- `Storage::disk(42)` → emits `InvalidArgument` (pins the facade params override).
- DI `FilesystemManager $mgr; $mgr->disk('s3')->url(...)` → narrowed to `Cloud`.
- DI `Factory $f; $f->disk('s3')->url(...)` → narrowed to `Cloud`.

Two `/psalm-review` rounds across 8 specialised agents (code, psalm-expert, architecture, performance, laravel-expert, simplify, tests, types) closed all Critical/Important findings before this PR.

Suites: type 408/408, unit 632/632 (1 skipped, pre-existing), `composer psalm` exit 0, `composer cs` exit 0.

## Checklist

- [x] Tests cover the change (10-scenario type test at `tests/Type/tests/Facades/StorageDiskUrlTest.phpt`)
