### PR TITLE
Keep canonical `Auth` facade in narrowing handler list

### DIFF
--- a/src/Handlers/Auth/AuthConfigAnalyzer.php
+++ b/src/Handlers/Auth/AuthConfigAnalyzer.php
@@ -11,6 +11,20 @@ final class AuthConfigAnalyzer
 {
     private static ?AuthConfigAnalyzer $instance = null;
 
+    /**
+     * Memoizes `getGuardFQCN()` so the per-call-site Psalm hook avoids
+     * re-walking `auth.guards.<name>.driver` through `Repository::get()`.
+     * The negative result (`null`) is cached too — `array_key_exists` is
+     * used at the call site to distinguish "not yet computed" from "known
+     * unresolvable" (custom driver / unknown guard).
+     *
+     * @var array<string, class-string<\Illuminate\Contracts\Auth\Guard>|null>
+     */
+    private array $guardFqcnCache = [];
+
+    private ?string $defaultGuardCache = null;
+    private bool $defaultGuardResolved = false;
+
     /** @psalm-mutation-free */
     private function __construct(private readonly ConfigRepository $config) {}
 
@@ -54,10 +68,16 @@ final class AuthConfigAnalyzer
 
     public function getDefaultGuard(): ?string
     {
+        if ($this->defaultGuardResolved) {
+            return $this->defaultGuardCache;
+        }
+
         /** @var string|null $guard */
         $guard = $this->config->get('auth.defaults.guard');
+        $this->defaultGuardCache = \is_string($guard) ? $guard : null;
+        $this->defaultGuardResolved = true;
 
-        return \is_string($guard) ? $guard : null;
+        return $this->defaultGuardCache;
     }
 
     /**
@@ -72,13 +92,17 @@ final class AuthConfigAnalyzer
      */
     public function getGuardFQCN(string $guard): ?string
     {
+        if (\array_key_exists($guard, $this->guardFqcnCache)) {
+            return $this->guardFqcnCache[$guard];
+        }
+
         $driver = $this->config->get("auth.guards.{$guard}.driver");
 
         if (! \is_string($driver)) {
-            return null;
+            return $this->guardFqcnCache[$guard] = null;
         }
 
-        return match ($driver) {
+        return $this->guardFqcnCache[$guard] = match ($driver) {
             'session' => \Illuminate\Auth\SessionGuard::class,
             'token' => \Illuminate\Auth\TokenGuard::class,
             default => null, // custom drivers cannot be statically resolved

--- a/src/Handlers/Auth/AuthFunctionHandler.php
+++ b/src/Handlers/Auth/AuthFunctionHandler.php
@@ -71,6 +71,6 @@ final class AuthFunctionHandler implements FunctionReturnTypeProviderInterface
             return null;
         }
 
-        return GuardClassResolver::resolveUnion($first_arg->value);
+        return GuardClassResolver::resolve($first_arg->value);
     }
 }

--- a/src/Handlers/Auth/AuthFunctionHandler.php
+++ b/src/Handlers/Auth/AuthFunctionHandler.php
@@ -9,7 +9,6 @@ use PhpParser\Node\Scalar\String_;
 use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
 use Psalm\Type;
-use Psalm\Type\Atomic\TNamedObject;
 
 /**
  * Narrows the return type of the global `auth($guard)` helper to the concrete guard
@@ -31,11 +30,13 @@ use Psalm\Type\Atomic\TNamedObject;
  * Dynamic guard names (variable, unknown string) and custom drivers fall back to the
  * stub-declared union.
  *
- * @see \Psalm\LaravelPlugin\Handlers\Auth\AuthHandler::resolveGuardReturnType()
+ * @see \Psalm\LaravelPlugin\Handlers\Auth\AuthMethodHandler::resolveGuardReturnType()
  *      for the equivalent narrowing on `Auth::guard()` / `AuthManager::guard()`.
+ * @see \Psalm\LaravelPlugin\Handlers\Auth\GuardClassResolver
+ *      for the shared guard-name → concrete-class mapping.
  * @see https://github.com/psalm/psalm-plugin-laravel/issues/979
  */
-final class AuthHelperHandler implements FunctionReturnTypeProviderInterface
+final class AuthFunctionHandler implements FunctionReturnTypeProviderInterface
 {
     /**
      * @inheritDoc
@@ -70,11 +71,6 @@ final class AuthHelperHandler implements FunctionReturnTypeProviderInterface
             return null;
         }
 
-        $fqcn = AuthConfigAnalyzer::instance()->getGuardFQCN($first_arg->value);
-        if ($fqcn === null) {
-            return null; // unknown guard or custom driver — fall back to stub
-        }
-
-        return new Type\Union([new TNamedObject($fqcn)]);
+        return GuardClassResolver::resolveUnion($first_arg->value);
     }
 }

--- a/src/Handlers/Auth/AuthHelperHandler.php
+++ b/src/Handlers/Auth/AuthHelperHandler.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Auth;
+
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Scalar\String_;
+use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
+use Psalm\Type;
+use Psalm\Type\Atomic\TNamedObject;
+
+/**
+ * Narrows the return type of the global `auth($guard)` helper to the concrete guard
+ * class when the guard name is a known string literal and its driver maps to a standard
+ * Laravel guard class (session/token).
+ *
+ * Without this narrowing, `auth('web')->logout()` fails with `UndefinedInterfaceMethod`
+ * because the stub return type is the union `Guard|StatefulGuard` and `logout()` is
+ * declared only on `StatefulGuard`. Narrowing to `SessionGuard` lets Psalm resolve the
+ * concrete method. For a token-driver guard the narrowed type is `TokenGuard`, which
+ * intentionally lacks `logout()` — that is the correct error, since calling logout on
+ * a stateless guard fails at runtime too.
+ *
+ * The `auth()` / `auth(null)` no-argument case keeps the stub's `AuthManager` return
+ * type. `AuthManager` carries `@mixin StatefulGuard`, so calls like `auth()->logout()`
+ * already resolve correctly. Narrowing those calls here would lose access to manager-
+ * only methods (`extend`, `provider`, `guard`, …) that the stub still exposes.
+ *
+ * Dynamic guard names (variable, unknown string) and custom drivers fall back to the
+ * stub-declared union.
+ *
+ * @see \Psalm\LaravelPlugin\Handlers\Auth\AuthHandler::resolveGuardReturnType()
+ *      for the equivalent narrowing on `Auth::guard()` / `AuthManager::guard()`.
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/979
+ */
+final class AuthHelperHandler implements FunctionReturnTypeProviderInterface
+{
+    /**
+     * @inheritDoc
+     * @psalm-pure
+     */
+    #[\Override]
+    public static function getFunctionIds(): array
+    {
+        return ['auth'];
+    }
+
+    /** @inheritDoc */
+    #[\Override]
+    public static function getFunctionReturnType(FunctionReturnTypeProviderEvent $event): ?Type\Union
+    {
+        $call_args = $event->getCallArgs();
+
+        // No-arg and literal-null cases resolve to AuthManager via the stub.
+        // AuthManager's @mixin StatefulGuard covers logout/onceUsingId/viaRemember,
+        // and narrowing here would shadow the manager-only methods.
+        if ($call_args === []) {
+            return null;
+        }
+
+        $first_arg = $call_args[0]->value;
+        if ($first_arg instanceof ConstFetch && $first_arg->name->toLowerString() === 'null') {
+            return null;
+        }
+
+        // Only narrow when the guard name is a literal string we can resolve.
+        if (! $first_arg instanceof String_) {
+            return null;
+        }
+
+        $fqcn = AuthConfigAnalyzer::instance()->getGuardFQCN($first_arg->value);
+        if ($fqcn === null) {
+            return null; // unknown guard or custom driver — fall back to stub
+        }
+
+        return new Type\Union([new TNamedObject($fqcn)]);
+    }
+}

--- a/src/Handlers/Auth/AuthMethodHandler.php
+++ b/src/Handlers/Auth/AuthMethodHandler.php
@@ -57,7 +57,15 @@ final class AuthMethodHandler implements MethodReturnTypeProviderInterface, Meth
     #[\Override]
     public static function getClassLikeNames(): array
     {
+        // The canonical facade FQCN is hardcoded (not sourced from FacadeMapProvider)
+        // because apps that trim `config/app.php`'s `aliases` array (e.g. IxDF
+        // registering only `Vite`) end up with an empty AliasLoader entry for `Auth`.
+        // FacadeMapProvider iterates AliasLoader, so its lookup returns an empty list
+        // for AuthManager in that setup — relying on it alone would silently drop the
+        // canonical facade from this handler and skip narrowing for every
+        // `Illuminate\Support\Facades\Auth::guard(...)` call site.
         return [
+            \Illuminate\Support\Facades\Auth::class,
             \Illuminate\Auth\AuthManager::class,
             \Illuminate\Contracts\Auth\Factory::class,
             ...FacadeMapProvider::getFacadeClasses(\Illuminate\Auth\AuthManager::class),

--- a/src/Handlers/Auth/AuthMethodHandler.php
+++ b/src/Handlers/Auth/AuthMethodHandler.php
@@ -124,7 +124,7 @@ final class AuthMethodHandler implements MethodReturnTypeProviderInterface, Meth
             return null; // dynamic guard name — cannot narrow statically
         }
 
-        return GuardClassResolver::resolveUnion($guard_name);
+        return GuardClassResolver::resolve($guard_name);
     }
 
     /**

--- a/src/Handlers/Auth/AuthMethodHandler.php
+++ b/src/Handlers/Auth/AuthMethodHandler.php
@@ -167,9 +167,16 @@ final class AuthMethodHandler implements MethodReturnTypeProviderInterface, Meth
     {
         $method_name_lowercase = $event->getMethodNameLowercase();
 
-        // Defer guard()'s params to Laravel source for non-facade receivers — see method docblock.
+        // Defer guard()'s params to Laravel source for the real declaring classes
+        // (AuthManager / Factory), where `guard()` is a concrete method Psalm can resolve.
+        // For facade and root-alias receivers (`Illuminate\Support\Facades\Auth`, `\Auth`, ...)
+        // `guard()` only exists as a parent `@method` annotation, so returning null here
+        // re-triggers the #454/#854 `Cannot get method params for ...::guard` crash.
         if ($method_name_lowercase === 'guard'
-            && $event->getFqClasslikeName() !== \Illuminate\Support\Facades\Auth::class
+            && \in_array($event->getFqClasslikeName(), [
+                \Illuminate\Auth\AuthManager::class,
+                \Illuminate\Contracts\Auth\Factory::class,
+            ], true)
         ) {
             return null;
         }

--- a/src/Handlers/Auth/AuthMethodHandler.php
+++ b/src/Handlers/Auth/AuthMethodHandler.php
@@ -33,7 +33,7 @@ use Psalm\Type;
  * Subsequent calls on the returned Guard instance (e.g. `Auth::guard('web')->user()`) are
  * narrowed by {@see \Psalm\LaravelPlugin\Handlers\Auth\GuardHandler}.
  */
-final class AuthHandler implements MethodReturnTypeProviderInterface, MethodParamsProviderInterface
+final class AuthMethodHandler implements MethodReturnTypeProviderInterface, MethodParamsProviderInterface
 {
     use ExtractsGuardNameFromCallLike;
 
@@ -124,12 +124,7 @@ final class AuthHandler implements MethodReturnTypeProviderInterface, MethodPara
             return null; // dynamic guard name — cannot narrow statically
         }
 
-        $fqcn = AuthConfigAnalyzer::instance()->getGuardFQCN($guard_name);
-        if ($fqcn === null) {
-            return null; // unknown guard or custom driver
-        }
-
-        return new Type\Union([new Type\Atomic\TNamedObject($fqcn)]);
+        return GuardClassResolver::resolveUnion($guard_name);
     }
 
     /**

--- a/src/Handlers/Auth/AuthMethodHandler.php
+++ b/src/Handlers/Auth/AuthMethodHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Psalm\LaravelPlugin\Handlers\Auth;
 
 use Psalm\LaravelPlugin\Handlers\Auth\Concerns\ExtractsGuardNameFromCallLike;
+use Psalm\LaravelPlugin\Providers\FacadeMapProvider;
 use Psalm\Plugin\EventHandler\Event\MethodParamsProviderEvent;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\MethodParamsProviderInterface;
@@ -38,21 +39,28 @@ final class AuthMethodHandler implements MethodReturnTypeProviderInterface, Meth
     use ExtractsGuardNameFromCallLike;
 
     /**
-     * Register for the Auth facade, the concrete AuthManager (common DI target), and the
-     * Factory contract (DI by interface). {@see getMethodReturnType} is class-agnostic and
-     * narrows uniformly across all three surfaces; {@see getMethodParams} has one carve-out
-     * for `guard()` on non-facade receivers (see that method's docblock).
+     * Register for the Auth facade, the concrete AuthManager (common DI target), the
+     * Factory contract (DI by interface), AND any root-namespace alias that proxies
+     * to AuthManager. {@see getMethodReturnType} is class-agnostic and narrows
+     * uniformly across all surfaces; {@see getMethodParams} has one carve-out for
+     * `guard()` on non-facade receivers (see that method's docblock).
+     *
+     * The `FacadeMapProvider::getFacadeClasses()` lookup is critical: Psalm dispatches
+     * `MethodReturnTypeProvider` hooks by exact class name, so a `use Auth;` import
+     * referring to the root-namespace `\Auth` alias (the default Laravel alias
+     * generated into `aliases.phpstub`) would otherwise miss this handler entirely
+     * and surface `Auth::guard('web')->logout()` as `Guard::logout does not exist`.
      *
      * @return list<string>
-     * @psalm-pure
+     * @psalm-external-mutation-free
      */
     #[\Override]
     public static function getClassLikeNames(): array
     {
         return [
-            \Illuminate\Support\Facades\Auth::class,
             \Illuminate\Auth\AuthManager::class,
             \Illuminate\Contracts\Auth\Factory::class,
+            ...FacadeMapProvider::getFacadeClasses(\Illuminate\Auth\AuthManager::class),
         ];
     }
 

--- a/src/Handlers/Auth/GuardClassResolver.php
+++ b/src/Handlers/Auth/GuardClassResolver.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Auth;
+
+use Psalm\Type;
+use Psalm\Type\Atomic\TNamedObject;
+
+/**
+ * Resolves a guard name to the Psalm `Union` for its concrete driver class.
+ *
+ * Single source of truth shared between the auth-domain handlers:
+ *
+ *  - {@see AuthMethodHandler::resolveGuardReturnType()} narrows the return type of
+ *    `Auth::guard($name)` / `AuthManager::guard($name)` / `Factory::guard($name)`.
+ *  - {@see AuthFunctionHandler::getFunctionReturnType()} narrows the return type
+ *    of the global `auth($name)` helper.
+ *
+ * Both surfaces apply the same rule (guard name + `auth.guards.<name>.driver` →
+ * concrete `SessionGuard` / `TokenGuard`), so the rule lives here and the callers
+ * stay focused on dispatch.
+ *
+ * Returns `null` for unknown guards or custom (non-standard) drivers; callers fall
+ * back to the stub-declared union type in that case.
+ */
+final class GuardClassResolver
+{
+    public static function resolveUnion(string $guardName): ?Type\Union
+    {
+        $fqcn = AuthConfigAnalyzer::instance()->getGuardFQCN($guardName);
+        if ($fqcn === null) {
+            return null;
+        }
+
+        return new Type\Union([new TNamedObject($fqcn)]);
+    }
+}

--- a/src/Handlers/Auth/GuardClassResolver.php
+++ b/src/Handlers/Auth/GuardClassResolver.php
@@ -26,13 +26,23 @@ use Psalm\Type\Atomic\TNamedObject;
  */
 final class GuardClassResolver
 {
-    public static function resolveUnion(string $guardName): ?Type\Union
+    /**
+     * Psalm hooks fire once per call site. Typical Laravel apps use 1–3 distinct
+     * guard classes total, so caching by FQCN turns N `auth('web')` / `Auth::guard('web')`
+     * call sites into one allocation. `Type\Union` is `ImmutableNonCloneableTrait`,
+     * so sharing the same instance across call sites is safe.
+     *
+     * @var array<class-string, Type\Union>
+     */
+    private static array $union_cache = [];
+
+    public static function resolve(string $guardName): ?Type\Union
     {
         $fqcn = AuthConfigAnalyzer::instance()->getGuardFQCN($guardName);
         if ($fqcn === null) {
             return null;
         }
 
-        return new Type\Union([new TNamedObject($fqcn)]);
+        return self::$union_cache[$fqcn] ??= new Type\Union([new TNamedObject($fqcn)]);
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -85,6 +85,8 @@ final class Plugin implements PluginEntryPointInterface
 
         require_once __DIR__ . '/Handlers/Auth/AuthHandler.php';
         $registration->registerHooksFromClass(Handlers\Auth\AuthHandler::class);
+        require_once __DIR__ . '/Handlers/Auth/AuthHelperHandler.php';
+        $registration->registerHooksFromClass(Handlers\Auth\AuthHelperHandler::class);
         require_once __DIR__ . '/Handlers/Auth/GuardHandler.php';
         $registration->registerHooksFromClass(Handlers\Auth\GuardHandler::class);
         require_once __DIR__ . '/Handlers/Auth/RequestHandler.php';

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -83,10 +83,10 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Application/OffsetHandler.php';
         $registration->registerHooksFromClass(Handlers\Application\OffsetHandler::class);
 
-        require_once __DIR__ . '/Handlers/Auth/AuthHandler.php';
-        $registration->registerHooksFromClass(Handlers\Auth\AuthHandler::class);
-        require_once __DIR__ . '/Handlers/Auth/AuthHelperHandler.php';
-        $registration->registerHooksFromClass(Handlers\Auth\AuthHelperHandler::class);
+        require_once __DIR__ . '/Handlers/Auth/AuthMethodHandler.php';
+        $registration->registerHooksFromClass(Handlers\Auth\AuthMethodHandler::class);
+        require_once __DIR__ . '/Handlers/Auth/AuthFunctionHandler.php';
+        $registration->registerHooksFromClass(Handlers\Auth\AuthFunctionHandler::class);
         require_once __DIR__ . '/Handlers/Auth/GuardHandler.php';
         $registration->registerHooksFromClass(Handlers\Auth\GuardHandler::class);
         require_once __DIR__ . '/Handlers/Auth/RequestHandler.php';

--- a/tests/Type/tests/Auth/AuthTest.phpt
+++ b/tests/Type/tests/Auth/AuthTest.phpt
@@ -4,7 +4,7 @@
 $_user = \Illuminate\Support\Facades\Auth::user();
 /** @psalm-check-type-exact $_user = \Illuminate\Foundation\Auth\User|null */
 
-// All facade methods handled by AuthHandler must not crash Psalm 7
+// All facade methods handled by AuthMethodHandler must not crash Psalm 7
 // (previously getUser/authenticate/etc. caused UnexpectedValueException
 // because getMethodParams returned null for @method-annotated methods)
 $_getUser = \Illuminate\Support\Facades\Auth::getUser();

--- a/tests/Type/tests/Auth/AuthTest.phpt
+++ b/tests/Type/tests/Auth/AuthTest.phpt
@@ -150,5 +150,37 @@ function _diStatefulGuard(\Illuminate\Contracts\Auth\StatefulGuard $guard): void
     $_stLogin = $guard->loginUsingId(1);
     /** @psalm-check-type-exact $_stLogin = \Illuminate\Foundation\Auth\User|false */
 }
+
+// `auth()` helper narrowing — issue #979.
+// String-literal guard names resolve to the concrete driver class so calls like
+// `auth('web')->logout()` succeed (logout is on StatefulGuard, not the Guard contract).
+$_authWeb = auth('web');
+/** @psalm-check-type-exact $_authWeb = \Illuminate\Auth\SessionGuard */
+
+// Regression assertion for #979: the original failure was UndefinedInterfaceMethod on
+// `auth('web')->logout()`. Once auth('web') narrows to SessionGuard, the call resolves.
+auth('web')->logout();
+
+$_authApi = auth('api');
+/** @psalm-check-type-exact $_authApi = \Illuminate\Auth\TokenGuard */
+
+// No-arg / literal-null preserve the stub's AuthManager return so the manager-only
+// methods (extend, provider, guard, …) stay reachable. AuthManager's @mixin StatefulGuard
+// still covers `auth()->logout()`.
+$_authNoArg = auth();
+/** @psalm-check-type-exact $_authNoArg = \Illuminate\Auth\AuthManager */
+
+$_authNullArg = auth(null);
+/** @psalm-check-type-exact $_authNullArg = \Illuminate\Auth\AuthManager */
+
+/** @var string $dynamicGuardName */
+$dynamicGuardName = 'web';
+$_authDynamic = auth($dynamicGuardName);
+// dynamic guard name — falls back to the stub-declared union
+/** @psalm-check-type-exact $_authDynamic = \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard */
+
+$_authUnknown = auth('nonexistent-guard');
+// unknown guard name — falls back to the stub-declared union
+/** @psalm-check-type-exact $_authUnknown = \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard */
 ?>
 --EXPECT--

--- a/tests/Unit/Handlers/Auth/AuthMethodHandlerTest.php
+++ b/tests/Unit/Handlers/Auth/AuthMethodHandlerTest.php
@@ -7,11 +7,11 @@ namespace Psalm\LaravelPlugin\Tests\Unit\Handlers\Auth;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Psalm\LaravelPlugin\Handlers\Auth\AuthHandler;
+use Psalm\LaravelPlugin\Handlers\Auth\AuthMethodHandler;
 use Psalm\Plugin\EventHandler\Event\MethodParamsProviderEvent;
 
-#[CoversClass(AuthHandler::class)]
-final class AuthHandlerTest extends TestCase
+#[CoversClass(AuthMethodHandler::class)]
+final class AuthMethodHandlerTest extends TestCase
 {
     /**
      * Methods with no parameters should return an empty array.
@@ -34,7 +34,7 @@ final class AuthHandlerTest extends TestCase
             $method,
         );
 
-        $params = AuthHandler::getMethodParams($event);
+        $params = AuthMethodHandler::getMethodParams($event);
 
         $this->assertNotNull($params, "getMethodParams() must not return null for '{$method}' — Psalm 7 crashes on null for @method-annotated facade methods");
         $this->assertEmpty($params);
@@ -47,7 +47,7 @@ final class AuthHandlerTest extends TestCase
             'loginusingid',
         );
 
-        $params = AuthHandler::getMethodParams($event);
+        $params = AuthMethodHandler::getMethodParams($event);
 
         $this->assertNotNull($params);
         $this->assertCount(2, $params);
@@ -64,7 +64,7 @@ final class AuthHandlerTest extends TestCase
             'onceusingid',
         );
 
-        $params = AuthHandler::getMethodParams($event);
+        $params = AuthMethodHandler::getMethodParams($event);
 
         $this->assertNotNull($params);
         $this->assertCount(1, $params);
@@ -79,7 +79,7 @@ final class AuthHandlerTest extends TestCase
             'logoutotherdevices',
         );
 
-        $params = AuthHandler::getMethodParams($event);
+        $params = AuthMethodHandler::getMethodParams($event);
 
         $this->assertNotNull($params);
         $this->assertCount(1, $params);
@@ -94,7 +94,7 @@ final class AuthHandlerTest extends TestCase
             'guard',
         );
 
-        $params = AuthHandler::getMethodParams($event);
+        $params = AuthMethodHandler::getMethodParams($event);
 
         $this->assertNotNull($params, "getMethodParams() must not return null for 'guard' — Psalm 7 crashes on null for @method-annotated facade methods");
         $this->assertCount(1, $params);
@@ -109,7 +109,7 @@ final class AuthHandlerTest extends TestCase
             'unknown',
         );
 
-        $params = AuthHandler::getMethodParams($event);
+        $params = AuthMethodHandler::getMethodParams($event);
 
         $this->assertNull($params);
     }
@@ -143,7 +143,7 @@ final class AuthHandlerTest extends TestCase
         $event = new MethodParamsProviderEvent($fqClassLikeName, $method);
 
         $this->assertNotNull(
-            AuthHandler::getMethodParams($event),
+            AuthMethodHandler::getMethodParams($event),
             "getMethodParams() must not return null for {$fqClassLikeName}::{$method} — Psalm 7 crashes when the method is reached via __call (issue #854)",
         );
     }
@@ -172,7 +172,7 @@ final class AuthHandlerTest extends TestCase
         $event = new MethodParamsProviderEvent($fqClassLikeName, 'guard');
 
         $this->assertNull(
-            AuthHandler::getMethodParams($event),
+            AuthMethodHandler::getMethodParams($event),
             "getMethodParams() must return null for {$fqClassLikeName}::guard so Psalm uses the native signature",
         );
     }


### PR DESCRIPTION
## Issue to Solve

After #981 merged, apps that trim `config/app.php`'s `aliases` array surface false-positive `UndefinedInterfaceMethod` errors on every `Auth::guard($name)->{statefulMethod}()` call. Concretely IxDF (which registers only `Vite` as an alias) sees:

```
ERROR: UndefinedInterfaceMethod
  Auth::guard('member')->login($member);
  Method Illuminate\Contracts\Auth\Guard::login does not exist
```

Plus the same shape for `->logout()`, `->loginUsingId()`, and any other `StatefulGuard`-only method. ~10+ occurrences in IxDF alone.

## Related

Follows #981 (regression fix).

## Solution Description

`AuthMethodHandler::getClassLikeNames()` sourced the canonical facade FQCN (`Illuminate\Support\Facades\Auth`) solely through `FacadeMapProvider::getFacadeClasses(AuthManager::class)`. `FacadeMapProvider` iterates Laravel's `AliasLoader`, so its lookup returns an empty list for `AuthManager` in apps that trim the default aliases (e.g. IxDF registering only `Vite`). The canonical facade then silently disappeared from the handler list, and narrowing was skipped for every `Illuminate\Support\Facades\Auth::guard(...)` call site. The stub `@method` union (`Guard|StatefulGuard`) fell back to the failing `Guard` branch when chained with a `StatefulGuard`-only method.

Hardcode the canonical facade FQCN; keep the `FacadeMapProvider` spread for alias discovery on apps that DO register them (e.g. invoiceninja uses `use Auth;` resolving to the root-namespace alias).

Verification on real apps with this branch applied:

| App | Threads=1 | Default threads |
|---|---:|---:|
| IxDF `Guard::login` errors | 0 | 0 |
| invoiceninja `Guard::logout` errors | 0 | 0 |

`composer test:type` (413/413) and `composer psalm` clean.

## Checklist

- [x] Tests cover the change (existing AuthTest.phpt cases keep passing; the regression is real-world-app-only because Testbench registers the default aliases)
