### PR TITLE
Keep canonical `Auth` facade in narrowing handler list

### DIFF
--- a/src/Handlers/Auth/AuthMethodHandler.php
+++ b/src/Handlers/Auth/AuthMethodHandler.php
@@ -57,7 +57,16 @@ final class AuthMethodHandler implements MethodReturnTypeProviderInterface, Meth
     #[\Override]
     public static function getClassLikeNames(): array
     {
+        // The canonical facade FQCN is hardcoded (not sourced from FacadeMapProvider)
+        // because apps that trim `config/app.php`'s `aliases` array (e.g. registering
+        // only a single project-specific alias and dropping `Facade::defaultAliases()`)
+        // end up with an empty AliasLoader entry for `Auth`. FacadeMapProvider iterates
+        // AliasLoader, so its lookup returns an empty list for AuthManager in that
+        // setup — relying on it alone would silently drop the canonical facade from
+        // this handler and skip narrowing for every
+        // `Illuminate\Support\Facades\Auth::guard(...)` call site.
         return [
+            \Illuminate\Support\Facades\Auth::class,
             \Illuminate\Auth\AuthManager::class,
             \Illuminate\Contracts\Auth\Factory::class,
             ...FacadeMapProvider::getFacadeClasses(\Illuminate\Auth\AuthManager::class),


### PR DESCRIPTION
## Issue to Solve

After #981 merged, apps that trim `config/app.php`'s `aliases` array (dropping `Facade::defaultAliases()` and registering only a single project-specific alias) surface false-positive `UndefinedInterfaceMethod` errors on every `Auth::guard($name)->{statefulMethod}()` call. Example:

```
ERROR: UndefinedInterfaceMethod
  Auth::guard('member')->login($member);
  Method Illuminate\Contracts\Auth\Guard::login does not exist
```

Same shape for `->logout()`, `->loginUsingId()`, and any other `StatefulGuard`-only method.

## Related

Follows #981 (regression fix).

## Solution Description

`AuthMethodHandler::getClassLikeNames()` sourced the canonical facade FQCN (`Illuminate\Support\Facades\Auth`) solely through `FacadeMapProvider::getFacadeClasses(AuthManager::class)`. `FacadeMapProvider` iterates Laravel's `AliasLoader`, so its lookup returns an empty list for `AuthManager` in apps that trim the default aliases. The canonical facade then silently disappeared from the handler list, and narrowing was skipped for every `Illuminate\Support\Facades\Auth::guard(...)` call site. The stub `@method` union (`Guard|StatefulGuard`) fell back to the failing `Guard` branch when chained with a `StatefulGuard`-only method.

Hardcode the canonical facade FQCN; keep the `FacadeMapProvider` spread for alias discovery on apps that DO register them (e.g. invoiceninja uses `use Auth;` resolving to the root-namespace alias).

`composer test:type` (413/413) and `composer psalm` clean.

## Checklist

- [x] Tests cover the change (existing AuthTest.phpt cases keep passing; the regression is real-world-app-only because Testbench registers the default aliases)
