### PR TITLE
refactor(blade): extract `ReceiverViewNameResolver` #581

### DIFF
--- a/docs/issues/581-blade-taint-exploration.md
+++ b/docs/issues/581-blade-taint-exploration.md
@@ -15,7 +15,7 @@ The work lands in incremental sub-PRs that all target the umbrella branch
 not `master`. Merging the scanner epic piecewise into `master` would expose
 half-implementations (e.g. a scanner that classifies templates but no handler
 that consumes the classification), so each sub-PR stacks on the umbrella
-branch and is reviewed against it. Once every sub-PR (PR-1 through PR-5)
+branch and is reviewed against it. Once every sub-PR (PR-1 through PR-6)
 is merged into the umbrella branch, the umbrella PR ships into `master` as
 a single reviewable unit.
 
@@ -26,8 +26,9 @@ Status of the epic at the time of writing:
 | PR-1 [#920](https://github.com/psalm/psalm-plugin-laravel/pull/920) | Tri-state scanner via `BladeCompiler` + php-parser. `BladeViewSafetyKind`, `BladeUncertaintyReason`, `BladeSafetyMap`. | merged into umbrella |
 | PR-2 (TBD) | First-pass scanner precision: scope frame push/pop, source-mapped line numbers. (Literal `@include` resolution shipped in PR-4.) | not started |
 | PR-3 [#926](https://github.com/psalm/psalm-plugin-laravel/pull/926) | `BladeAwareViewTaintHandler`. Wires `BladeSafetyMap` into Psalm's taint flow for `view()` / `Factory::make()` / facade `View::make()`. Per-key sinks for `UNSAFE_KEYS`, whole-data fallback for `UNKNOWN` and dynamic view names. | merged into umbrella |
-| PR-4 (this PR) | Extended dispatch to `Factory::first()` (multi-template union), `Factory::renderEach()` (per-iterator key shape), `Routing\ResponseFactory::view()` (concrete + contract), `View::with()` / `View::nest()` (receiver-resolved view name), and the Mailable / MailMessage / Content view-binding methods. Scanner records literal `@include('child', [...])` edges; `BladeSafetyMap::build()` folds child unsafe keys into the parent via a fixed-point pass that accounts for Laravel's `compileInclude()` mergeData pass-through. Cycles in the include graph bail to `UNKNOWN(IncludeCycle)`. | shipping |
-| PR-5 (TBD) | Component data flow (`<x-foo :bar="$data" />`), section graph, scanner result caching across analysis runs, variable-bound view-builder chains (`$v = view('home'); $v->with(...)`). | not started |
+| PR-4 [#934](https://github.com/psalm/psalm-plugin-laravel/pull/934) | Extended dispatch to `Factory::first()` (multi-template union), `Factory::renderEach()` (per-iterator key shape), `Routing\ResponseFactory::view()` (concrete + contract), `View::with()` / `View::nest()` (receiver-resolved view name), and the Mailable / MailMessage / Content view-binding methods. Scanner records literal `@include('child', [...])` edges; `BladeSafetyMap::build()` folds child unsafe keys into the parent via a fixed-point pass that accounts for Laravel's `compileInclude()` mergeData pass-through. Cycles in the include graph bail to `UNKNOWN(IncludeCycle)`. | merged into umbrella |
+| PR-5 (this PR) | Refactor only: extracts the view-chain receiver-walk out of `BladeAwareViewTaintHandler` into a dedicated `ReceiverViewNameResolver` pure-AST utility. No behaviour change. Adds 26 direct AST-level unit tests covering the resolution table. Decouples the receiver-walk from the dispatcher so PR-6 can extend the chain-preserving allowlist (Mailable view/markdown/text chains) without touching taint sink construction. | shipping |
+| PR-6 (TBD) | Component data flow (`<x-foo :bar="$data" />`), section graph (`@extends`/`@section`/`@yield`), Mailable `view()`/`markdown()`/`text()` -> `with()` chain via receiver-walk extension, `View::share()` global data, scanner result caching across analysis runs. Variable-bound view-builder chains (`$v = view('home'); $v->with(...)`) remain deferred — see "Key decisions" below. | not started |
 
 Neither PR-3 nor PR-4 includes integration tests under `tests/Application/`.
 The Application test harness (`tests/Application/laravel-test.sh`) runs Psalm
@@ -36,6 +37,69 @@ a new harness flow or a refactor of the existing one. The handler is covered
 end-to-end by `tests/Type/tests/Blade/` (PHPT) and unit tests; the Application
 test layer still exercises Plugin.php's boot path through `initBladeAwareViewTaintHandler`,
 so a boot crash would still surface there.
+
+## Key decisions during PR-5
+
+PR-5 originally proposed wider scope (component data flow, scanner caching,
+variable-bound view-builder chains via a NodeTypeProvider tracker). During
+implementation the scope collapsed to a pure extraction after the following
+decisions:
+
+1. **NodeTypeProvider-based tracker rejected.** The intent was to attach a
+   marker to the `\Psalm\Type\Union` returned by `view()` / `Factory::make()`
+   so that variable-bound chains (`$v = view('home'); $v->with(...)`) would
+   resolve the same way as inline chains. Two encodings were evaluated and
+   both rejected:
+    - **Custom `\Psalm\Type\Atomic` subclass.** No third-party plugin in
+      `vendor/` extends `Atomic`. Psalm's `TypeCombiner::combine()` has
+      hardcoded match arms on built-in atomic classes; custom atomics fall
+      into the default branch and risk collapsing to `mixed` on union join.
+      Cache round-trip and intersection behaviour are also undocumented
+      plugin surface. Rejected.
+    - **Synthetic `DataFlowNode` in `Union->parent_nodes`.** Psalm's
+      existing taint machinery uses this channel, so cache and combine
+      behaviour are known-good. The blocker is `AssignmentAnalyzer`:
+      assignment typically wraps the right-hand side in a `variable-use:$v:N`
+      `DataFlowNode`, so at the chained `with()` site, the receiver's
+      `parent_nodes` only carries the wrapping node — the original marker
+      is reachable solely by walking `taint_flow_graph->forward_edges`
+      transitively, which is O(graph) on every method call. Too expensive
+      for the hot path. Rejected.
+
+   The variable-bound chain gap therefore stays open until a cheaper
+   resolution mechanism surfaces (or until real-world apps prove the gap
+   matters enough to absorb the cost). The `MissingViewHandler`-style
+   "view not in map -> no sink" policy is the conservative default.
+
+2. **PR-5 reduced to receiver-walk extraction only.** With the tracker
+   dropped, the remaining PR-5 deliverable was the prerequisite refactor
+   that PR-6 needs: lifting the receiver-walk into a standalone class
+   (`ReceiverViewNameResolver`) so the chain-preserving allowlist can be
+   extended (Mailable receiver gating) without touching the dispatcher.
+   No behaviour change in PR-5; 26 unit tests pin the resolution table
+   head-on for regression protection.
+
+3. **Mailable `view()`/`markdown()`/`text()` -> `with()` chain deferred to
+   PR-6.** The Mailable chain is reachable through receiver-walk alone
+   without a tracker, but the registration carries its own scope (class
+   gating, multi-view Content dispatch, the "last view() wins" semantic
+   when a chain calls more than one view-binding method). Split out so
+   PR-5 stays a pure refactor.
+
+4. **Components, sections, share, and scanner cache deferred to PR-6.**
+   PR-5's original brief grouped these with the tracker work; once the
+   tracker was dropped they no longer made sense in the same PR. PR-6
+   picks them up as four independent sub-PRs.
+
+5. **`x-tag` component compilation: don't reuse Laravel's
+   `ComponentTagCompiler` directly.** Reuse was prototyped: in the
+   plugin's bare Testbench-booted container, `componentClass()` throws
+   `InvalidArgumentException` for any unresolvable component, and the
+   compiler processes the whole template at once so one bad tag kills
+   compilation for all tags. Per-tag try/catch isolation would essentially
+   re-implement the tag loop. A local x-tag scanner that records
+   component edges into `BladeSafetyMap` (mirroring PR-4's include-edge
+   propagation) is the planned approach for PR-6's component sub-PR.
 
 ## Current state (baseline)
 

--- a/src/Handlers/Views/BladeAwareViewTaintHandler.php
+++ b/src/Handlers/Views/BladeAwareViewTaintHandler.php
@@ -59,13 +59,19 @@ use Psalm\Type\Union;
  * same `extract()` call as `$data`, so it is subjected to identical rules:
  * the keys observed by the scanner apply to either source.
  *
- * Out of scope (tracked under issue #581 for PR-5+):
+ * Out of scope (tracked under issue #581 for PR-6+):
  *  - Component data flow (`<x-foo :bar="$data" />`).
  *  - Variable-bound view-builder chains (`$v = view('home'); $v->with(...)`)
- *    where the receiver-walk in {@see self::resolveReceiverViewName()} cannot
- *    recover the literal view name through the intermediate variable binding.
- *    PR-5 may attach view-name metadata to the {@see Union} returned by
- *    `view()` / `Factory::make()` so the chain resolves through the variable.
+ *    where the receiver-walk in
+ *    {@see ReceiverViewNameResolver::resolve()} cannot recover the literal
+ *    view name through the intermediate variable binding. PR-5 evaluated a
+ *    NodeTypeProvider-based tracker that would attach a marker to the
+ *    {@see Union} returned by `view()` / `Factory::make()`, but Psalm's
+ *    `AssignmentAnalyzer` typically wraps the right-hand side in a
+ *    `variable-use:$v:N` `DataFlowNode` on assignment, so the marker is
+ *    reachable from the receiver Union only by walking
+ *    `taint_flow_graph->forward_edges` on every method call — too expensive
+ *    for the hot path. Deferred until real-world apps surface the gap.
  *  - `Mailable::with($key, $value)` chained onto `Mailable::view(...)` /
  *    `Mailable::markdown(...)` / `Mailable::text(...)`. `Mailable::view`,
  *    `markdown`, `text` ARE registered as direct sink sites, but the
@@ -74,7 +80,10 @@ use Psalm\Type\Union;
  *    receiver-walk support would be a no-op). Users who write
  *    `(new InvoiceMail)->view('mail.invoice')->with('bio', $tainted)` will
  *    have the `view()` call analysed (no data array there) but `with()`
- *    silently miss. Same scope as variable-bound chains; same PR-5 fix.
+ *    silently miss. PR-6 ships this via a class-gated extension to
+ *    `ReceiverViewNameResolver`'s chain-preserving allowlist; the underlying
+ *    receiver-walk already handles the `MethodCall` chain shape without a
+ *    tracker.
  *  - `View::share()` global view data — runtime-injected across every
  *    subsequent `view()` call, with no per-call site for the dispatcher to
  *    hook.
@@ -673,7 +682,7 @@ final class BladeAwareViewTaintHandler implements
             return;
         }
 
-        $viewName = self::resolveReceiverViewName($callExpr->var);
+        $viewName = ReceiverViewNameResolver::resolve($callExpr->var);
 
         if ($viewName === null) {
             // Receiver does not name a literal view. Consistent with PR-3's
@@ -793,185 +802,6 @@ final class BladeAwareViewTaintHandler implements
         }
 
         return $value->name->toLowerString() === 'null';
-    }
-
-    /**
-     * Walk a `View::with()` receiver expression to recover the bound view
-     * name. Returns null when the receiver shape cannot be resolved (variable
-     * receiver, dynamic view name, chained call with no statically known
-     * source).
-     *
-     * Resolvable shapes:
-     *  - `view('home')->with(...)`
-     *    – `FuncCall(name='view', args=[String('home'), ...])`
-     *  - `View::make('home')->with(...)` or `app('view')->make('home')->with(...)`
-     *    – `MethodCall(name='make', args=[String('home'), ...])` /
-     *      `StaticCall(name='make', args=[String('home'), ...])`
-     *  - `view('home')->with('a', 1)->with(...)` — recurse into receiver's
-     *    receiver for any chain of `with()` calls.
-     *  - `View::first(['a', 'b'])->with(...)` — first literal in the array.
-     *
-     * PR-4 does not propagate view names through variable bindings; a future
-     * PR may attach metadata to {@see \Psalm\Type\Union} via NodeTypeProvider
-     * to cover the `$v = view('home'); $v->with(...)` pattern.
-     */
-    private static function resolveReceiverViewName(\PhpParser\Node\Expr $receiver): ?string
-    {
-        // Treat nullsafe and regular method calls uniformly. We re-dispatch
-        // by drilling into the same shape rather than constructing a fresh
-        // MethodCall node (which would trigger Psalm's purity guards on the
-        // node constructor).
-        if ($receiver instanceof \PhpParser\Node\Expr\NullsafeMethodCall) {
-            return self::resolveMethodCallReceiver($receiver->var, $receiver->name, $receiver->args);
-        }
-
-        if ($receiver instanceof \PhpParser\Node\Expr\FuncCall) {
-            return self::viewNameFromFuncCall($receiver);
-        }
-
-        if ($receiver instanceof \PhpParser\Node\Expr\MethodCall) {
-            return self::resolveMethodCallReceiver($receiver->var, $receiver->name, $receiver->args);
-        }
-
-        if ($receiver instanceof \PhpParser\Node\Expr\StaticCall) {
-            if (!$receiver->name instanceof \PhpParser\Node\Identifier) {
-                return null;
-            }
-
-            $methodName = $receiver->name->toLowerString();
-
-            if ($methodName === 'make') {
-                return self::viewNameFromArg($receiver->args[0] ?? null);
-            }
-
-            if ($methodName === 'first') {
-                return self::firstLiteralFromArrayArg($receiver->args[0] ?? null);
-            }
-
-            return null;
-        }
-
-        return null;
-    }
-
-    /**
-     * Shared resolution for `MethodCall` / `NullsafeMethodCall` receivers.
-     * Both shapes carry the same `(receiver, method-name, args)` triple; the
-     * caller pre-extracts them so this helper can run on either node type
-     * without constructing intermediate AST nodes (which would breach Psalm
-     * purity guards on the php-parser constructors).
-     *
-     * @param array<array-key, \PhpParser\Node\VariadicPlaceholder|\PhpParser\Node\Arg> $args
-     */
-    private static function resolveMethodCallReceiver(
-        \PhpParser\Node\Expr $methodReceiver,
-        \PhpParser\Node\Identifier|\PhpParser\Node\Expr $methodName,
-        array $args,
-    ): ?string {
-        if (!$methodName instanceof \PhpParser\Node\Identifier) {
-            return null;
-        }
-
-        $methodNameLc = $methodName->toLowerString();
-
-        // Chained `with()` / `withErrors()` (and similar) preserve the
-        // view-builder identity. Recurse into the receiver's receiver to
-        // recover the underlying view name.
-        if ($methodNameLc === 'with' || $methodNameLc === 'witherrors') {
-            return self::resolveReceiverViewName($methodReceiver);
-        }
-
-        if ($methodNameLc === 'make') {
-            return self::viewNameFromArg($args[0] ?? null);
-        }
-
-        if ($methodNameLc === 'first') {
-            return self::firstLiteralFromArrayArg($args[0] ?? null);
-        }
-
-        return null;
-    }
-
-    private static function viewNameFromFuncCall(\PhpParser\Node\Expr\FuncCall $call): ?string
-    {
-        if (!$call->name instanceof \PhpParser\Node\Name) {
-            return null;
-        }
-
-        if ($call->name->toLowerString() !== self::FUNCTION_VIEW) {
-            return null;
-        }
-
-        return self::viewNameFromArg($call->args[0] ?? null);
-    }
-
-    /** @psalm-mutation-free */
-    private static function viewNameFromArg(\PhpParser\Node\VariadicPlaceholder|\PhpParser\Node\Arg|null $arg): ?string
-    {
-        if (!$arg instanceof Arg) {
-            return null;
-        }
-
-        return self::literalString($arg);
-    }
-
-    /**
-     * Return the sole literal-string element of an array literal argument, or
-     * null if the argument is not an array literal, contains no literal
-     * strings, or contains MORE THAN ONE literal string.
-     *
-     * Used for `View::first(['a', 'b'])->with(...)` chains. Laravel's runtime
-     * semantics for `first()` are "render the first existing view"; at
-     * analysis time we cannot know which candidate exists, so picking ANY one
-     * literal would be unsound for the receiver-walk's single-view lookup.
-     * Consider:
-     *
-     *     view::first(['safe_layout', 'unsafe_show'])->with('html_body', $tainted);
-     *
-     * If `safe_layout` ships and `unsafe_show` doesn't, no XSS. If
-     * `safe_layout` is later renamed and Laravel falls back to `unsafe_show`,
-     * `$tainted` reaches a raw echo. Picking `safe_layout` for the with-
-     * dispatcher's safety lookup would silently miss this regression.
-     *
-     * The conservative fix is to refuse resolution entirely for multi-
-     * candidate arrays. `dispatchFirstLike` already takes the union across
-     * all literals at the direct `Factory::first(...)` call site; the
-     * receiver-walk path (chained `with()` off a `first()` receiver) does
-     * not have an equivalent union mechanism wired here yet. Treating the
-     * receiver as unresolvable is consistent with PR-3's "view not in map
-     * → no sink" policy.
-     *
-     * @psalm-mutation-free
-     */
-    private static function firstLiteralFromArrayArg(\PhpParser\Node\VariadicPlaceholder|\PhpParser\Node\Arg|null $arg): ?string
-    {
-        if (!$arg instanceof Arg || $arg->unpack || !$arg->value instanceof Array_) {
-            return null;
-        }
-
-        $resolved = null;
-
-        foreach ($arg->value->items as $item) {
-            if (!$item instanceof ArrayItem) {
-                continue;
-            }
-
-            if (!$item->value instanceof String_) {
-                // Non-literal candidate: the runtime view name is opaque, so
-                // any earlier match we picked would be unsound. Bail.
-                return null;
-            }
-
-            if ($resolved !== null) {
-                // Second literal observed: cannot tell which Laravel will
-                // pick. Conservatively refuse resolution.
-                return null;
-            }
-
-            $resolved = $item->value->value;
-        }
-
-        return $resolved;
     }
 
     /**
@@ -1580,17 +1410,26 @@ final class BladeAwareViewTaintHandler implements
         // slot, dispatched as a single multi-view spec.
         $specs[\strtolower(\Illuminate\Mail\Mailables\Content::class) . '::__construct'] = $contentConstructorSpec;
 
-        // Known coverage gaps left for PR-5+:
-        //  - Component data flow `<x-foo :bar="$data" />` (PR-5 scope).
+        // Known coverage gaps left for PR-6+:
+        //  - Component data flow `<x-foo :bar="$data" />`.
+        //  - `Mailable::with(...)` chained onto `Mailable::view(...)` /
+        //    `markdown(...)` / `text(...)`. Reachable through receiver-walk
+        //    alone once the chain-preserving allowlist in
+        //    {@see ReceiverViewNameResolver} is extended for the Mailable
+        //    receiver class. See `.alies/docs/blade.md` (PR-6 plan).
         //  - `View::share()` global view data — the binding is replayed at
         //    render-time across every subsequent `view()` call from any
         //    caller, so the scanner's per-call dispatch model does not fit.
         //  - Variable-bound view-builder chains
-        //    (`$v = view('home'); $v->with(...)`) — PR-5 may attach view
-        //    names to {@see \Psalm\Type\Union} via NodeTypeProvider metadata
-        //    to recover the view name through indirections.
+        //    (`$v = view('home'); $v->with(...)`) — PR-5 evaluated a
+        //    NodeTypeProvider-based tracker and rejected it: Psalm's
+        //    `AssignmentAnalyzer` wraps the right-hand side in a
+        //    `variable-use:$v:N` `DataFlowNode`, so any marker attached to
+        //    the {@see \Psalm\Type\Union} returned by `view()` is reachable
+        //    only by walking `taint_flow_graph->forward_edges` on every
+        //    method call — too expensive for the hot path. Deferred.
         //  - Caching the safety map across analysis runs — handled in a
-        //    follow-up after PR-5 stabilises the map shape.
+        //    follow-up after PR-6 stabilises the map shape.
 
         return $specs;
     }

--- a/src/Handlers/Views/ReceiverViewNameResolver.php
+++ b/src/Handlers/Views/ReceiverViewNameResolver.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Views;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\ArrayItem;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Scalar\String_;
+
+/**
+ * Pure AST walker that recovers the literal view name from a chained
+ * view-builder receiver. Extracted from {@see BladeAwareViewTaintHandler} so
+ * the tracker handler (PR-5+) can share the same lookup without duplicating
+ * the receiver-shape table.
+ *
+ * Resolvable shapes:
+ *  - `view('home')->with(...)`
+ *    – `FuncCall(name='view', args=[String('home'), ...])`
+ *  - `View::make('home')->with(...)` or `app('view')->make('home')->with(...)`
+ *    – `MethodCall(name='make', args=[String('home'), ...])` /
+ *      `StaticCall(name='make', args=[String('home'), ...])`
+ *  - `view('home')->with('a', 1)->with(...)` — recurse into the receiver's
+ *    receiver for any chain of `with()` / `withErrors()` calls.
+ *  - `View::first(['a', 'b'])->with(...)` — the sole literal in the array, or
+ *    null when the array has multiple literals (see
+ *    {@see self::firstLiteralFromArrayArg()}).
+ *
+ * PR-5 introduces {@see BladeViewBindingTracker} which attaches a synthetic
+ * `parent_nodes` marker to the {@see \Psalm\Type\Union} returned by
+ * `view()` / `Factory::make()` etc. The tracker is preferred at the dispatch
+ * call site because it covers variable-bound chains
+ * (`$v = view('home'); $v->with(...)`); this AST walker remains the literal
+ * fallback when the tracker has no marker (e.g. before any handler runs).
+ *
+ * Soundness invariants:
+ *  - never picks one literal when multiple are present in a `first()` array —
+ *    Laravel's runtime semantics pick the first existing view, which is
+ *    opaque at analysis time. Refusing resolution avoids a silent miss when
+ *    the runtime falls back to a later, unsafe view.
+ *  - never resolves through variables (covered by the tracker, not here).
+ *  - returns null for unsupported `StaticCall` method names so callers know
+ *    to fall through to the whole-data sink path.
+ *
+ * @internal
+ */
+final class ReceiverViewNameResolver
+{
+    /**
+     * The `view()` helper as registered in Laravel's global function table.
+     * Compared against the lowercased function name on a `FuncCall` receiver.
+     */
+    private const FUNCTION_VIEW = 'view';
+
+    /**
+     * Seal the static-only contract. The class holds no instance state and
+     * exposes only static methods; instantiation would be a programmer
+     * error. {@see self::resolve()} is the single public entry point.
+     *
+     * @psalm-api
+     *
+     * @psalm-mutation-free
+     */
+    private function __construct() {}
+
+    public static function resolve(Expr $receiver): ?string
+    {
+        // Treat nullsafe and regular method calls uniformly. We re-dispatch
+        // by drilling into the same shape rather than constructing a fresh
+        // MethodCall node (which would trigger Psalm's purity guards on the
+        // node constructor).
+        if ($receiver instanceof Expr\NullsafeMethodCall) {
+            return self::resolveMethodCallReceiver($receiver->var, $receiver->name, $receiver->args);
+        }
+
+        if ($receiver instanceof Expr\FuncCall) {
+            return self::viewNameFromFuncCall($receiver);
+        }
+
+        if ($receiver instanceof Expr\MethodCall) {
+            return self::resolveMethodCallReceiver($receiver->var, $receiver->name, $receiver->args);
+        }
+
+        if ($receiver instanceof Expr\StaticCall) {
+            if (!$receiver->name instanceof \PhpParser\Node\Identifier) {
+                return null;
+            }
+
+            $methodName = $receiver->name->toLowerString();
+
+            if ($methodName === 'make') {
+                return self::viewNameFromArg($receiver->args[0] ?? null);
+            }
+
+            if ($methodName === 'first') {
+                return self::firstLiteralFromArrayArg($receiver->args[0] ?? null);
+            }
+
+            return null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Shared resolution for `MethodCall` / `NullsafeMethodCall` receivers.
+     * Both shapes carry the same `(receiver, method-name, args)` triple; the
+     * caller pre-extracts them so this helper can run on either node type
+     * without constructing intermediate AST nodes (which would breach Psalm
+     * purity guards on the php-parser constructors).
+     *
+     * @param array<array-key, \PhpParser\Node\VariadicPlaceholder|Arg> $args
+     */
+    private static function resolveMethodCallReceiver(
+        Expr $methodReceiver,
+        \PhpParser\Node\Identifier|Expr $methodName,
+        array $args,
+    ): ?string {
+        if (!$methodName instanceof \PhpParser\Node\Identifier) {
+            return null;
+        }
+
+        $methodNameLc = $methodName->toLowerString();
+
+        // Chained `with()` / `withErrors()` (and similar) preserve the
+        // view-builder identity. Recurse into the receiver's receiver to
+        // recover the underlying view name.
+        if ($methodNameLc === 'with' || $methodNameLc === 'witherrors') {
+            return self::resolve($methodReceiver);
+        }
+
+        if ($methodNameLc === 'make') {
+            return self::viewNameFromArg($args[0] ?? null);
+        }
+
+        if ($methodNameLc === 'first') {
+            return self::firstLiteralFromArrayArg($args[0] ?? null);
+        }
+
+        return null;
+    }
+
+    private static function viewNameFromFuncCall(Expr\FuncCall $call): ?string
+    {
+        if (!$call->name instanceof \PhpParser\Node\Name) {
+            return null;
+        }
+
+        if ($call->name->toLowerString() !== self::FUNCTION_VIEW) {
+            return null;
+        }
+
+        return self::viewNameFromArg($call->args[0] ?? null);
+    }
+
+    /** @psalm-mutation-free */
+    private static function viewNameFromArg(\PhpParser\Node\VariadicPlaceholder|Arg|null $arg): ?string
+    {
+        if (!$arg instanceof Arg) {
+            return null;
+        }
+
+        return self::literalString($arg);
+    }
+
+    /**
+     * Return the sole literal-string element of an array literal argument, or
+     * null if the argument is not an array literal, contains no literal
+     * strings, or contains MORE THAN ONE literal string.
+     *
+     * Used for `View::first(['a', 'b'])->with(...)` chains. Laravel's runtime
+     * semantics for `first()` are "render the first existing view"; at
+     * analysis time we cannot know which candidate exists, so picking ANY one
+     * literal would be unsound for the receiver-walk's single-view lookup.
+     * Consider:
+     *
+     *     view::first(['safe_layout', 'unsafe_show'])->with('html_body', $tainted);
+     *
+     * If `safe_layout` ships and `unsafe_show` doesn't, no XSS. If
+     * `safe_layout` is later renamed and Laravel falls back to `unsafe_show`,
+     * `$tainted` reaches a raw echo. Picking `safe_layout` for the with-
+     * dispatcher's safety lookup would silently miss this regression.
+     *
+     * The conservative fix is to refuse resolution entirely for multi-
+     * candidate arrays. `BladeAwareViewTaintHandler::dispatchFirstLike` takes
+     * the union across all literals at the direct `Factory::first(...)` call
+     * site; the receiver-walk path (chained `with()` off a `first()`
+     * receiver) does not have an equivalent union mechanism wired here yet.
+     * Treating the receiver as unresolvable is consistent with PR-3's "view
+     * not in map → no sink" policy.
+     *
+     * @psalm-mutation-free
+     */
+    private static function firstLiteralFromArrayArg(\PhpParser\Node\VariadicPlaceholder|Arg|null $arg): ?string
+    {
+        if (!$arg instanceof Arg || $arg->unpack || !$arg->value instanceof Array_) {
+            return null;
+        }
+
+        $resolved = null;
+
+        foreach ($arg->value->items as $item) {
+            if (!$item instanceof ArrayItem) {
+                continue;
+            }
+
+            if (!$item->value instanceof String_) {
+                // Non-literal candidate: the runtime view name is opaque, so
+                // any earlier match we picked would be unsound. Bail.
+                return null;
+            }
+
+            if ($resolved !== null) {
+                // Second literal observed: cannot tell which Laravel will
+                // pick. Conservatively refuse resolution.
+                return null;
+            }
+
+            $resolved = $item->value->value;
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * Literal-string extractor scoped to {@see Arg}. Duplicated from the
+     * handler so this resolver has no inbound dependency on
+     * {@see BladeAwareViewTaintHandler}. Kept private — callers reach the
+     * literal-name surface via {@see self::resolve()}.
+     *
+     * @psalm-mutation-free
+     */
+    private static function literalString(Arg $arg): ?string
+    {
+        if ($arg->value instanceof String_) {
+            return $arg->value->value;
+        }
+
+        return null;
+    }
+}

--- a/tests/Unit/Handlers/Views/ReceiverViewNameResolverTest.php
+++ b/tests/Unit/Handlers/Views/ReceiverViewNameResolverTest.php
@@ -1,0 +1,338 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Views;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\ArrayItem;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\NullsafeMethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Handlers\Views\ReceiverViewNameResolver;
+
+/**
+ * Direct AST-level coverage for the receiver-walk extracted from
+ * {@see \Psalm\LaravelPlugin\Handlers\Views\BladeAwareViewTaintHandler}. The
+ * handler tests in {@see BladeAwareViewTaintHandlerTest} exercise the same
+ * resolver indirectly through dispatch; these tests pin the resolution table
+ * head-on, so a regression in shape-matching surfaces here before the
+ * handler-level taint tests start drifting.
+ *
+ * Every case constructs a synthetic AST node and asserts on the resolver's
+ * single-string return. No Psalm process is spawned.
+ */
+#[CoversClass(ReceiverViewNameResolver::class)]
+final class ReceiverViewNameResolverTest extends TestCase
+{
+    #[Test]
+    public function resolves_view_helper_literal(): void
+    {
+        $node = $this->funcCall('view', [$this->string('home')]);
+
+        $this->assertSame('home', ReceiverViewNameResolver::resolve($node));
+    }
+
+    #[Test]
+    public function refuses_view_helper_with_variable_argument(): void
+    {
+        $node = $this->funcCall('view', [new Arg(new Variable('dynamic'))]);
+
+        $this->assertNull(ReceiverViewNameResolver::resolve($node));
+    }
+
+    #[Test]
+    public function refuses_other_function_helpers(): void
+    {
+        $node = $this->funcCall('notview', [$this->string('home')]);
+
+        $this->assertNull(ReceiverViewNameResolver::resolve($node));
+    }
+
+    #[Test]
+    public function resolves_view_helper_via_chained_with(): void
+    {
+        $inner = $this->funcCall('view', [$this->string('profile')]);
+        $chain = new MethodCall($inner, new Identifier('with'), [$this->string('a'), $this->int(1)]);
+
+        $this->assertSame('profile', ReceiverViewNameResolver::resolve($chain));
+    }
+
+    #[Test]
+    public function resolves_view_helper_via_double_chained_with(): void
+    {
+        // view('home')->with('a', 1)->with('b', 2) — recursion depth > 1.
+        $inner = $this->funcCall('view', [$this->string('home')]);
+        $mid = new MethodCall($inner, new Identifier('with'), [$this->string('a'), $this->int(1)]);
+        $outer = new MethodCall($mid, new Identifier('with'), [$this->string('b'), $this->int(2)]);
+
+        $this->assertSame('home', ReceiverViewNameResolver::resolve($outer));
+    }
+
+    #[Test]
+    public function resolves_chained_witherrors(): void
+    {
+        // Chain-preserving allowlist also covers `withErrors()` (and similar
+        // builder identity-preserving methods).
+        $inner = $this->funcCall('view', [$this->string('login')]);
+        $chain = new MethodCall($inner, new Identifier('withErrors'), [$this->string('a')]);
+
+        $this->assertSame('login', ReceiverViewNameResolver::resolve($chain));
+    }
+
+    #[Test]
+    public function resolves_method_call_make_literal(): void
+    {
+        // $factory->make('home')
+        $node = new MethodCall(new Variable('factory'), new Identifier('make'), [$this->string('home')]);
+
+        $this->assertSame('home', ReceiverViewNameResolver::resolve($node));
+    }
+
+    #[Test]
+    public function refuses_method_call_make_with_variable_argument(): void
+    {
+        $node = new MethodCall(
+            new Variable('factory'),
+            new Identifier('make'),
+            [new Arg(new Variable('dynamic'))],
+        );
+
+        $this->assertNull(ReceiverViewNameResolver::resolve($node));
+    }
+
+    #[Test]
+    public function refuses_method_call_unsupported_name(): void
+    {
+        // Method names outside the allowlist do not recurse — `share()`
+        // returns null so the dispatcher falls back to the whole-data sink.
+        $node = new MethodCall(new Variable('factory'), new Identifier('share'), [$this->string('a')]);
+
+        $this->assertNull(ReceiverViewNameResolver::resolve($node));
+    }
+
+    #[Test]
+    public function resolves_static_call_make(): void
+    {
+        // \View::make('home')
+        $node = new StaticCall(new Name('View'), new Identifier('make'), [$this->string('home')]);
+
+        $this->assertSame('home', ReceiverViewNameResolver::resolve($node));
+    }
+
+    #[Test]
+    public function resolves_static_call_first_single_literal(): void
+    {
+        $node = new StaticCall(new Name('View'), new Identifier('first'), [
+            new Arg(new Array_([new ArrayItem($this->string('home')->value)])),
+        ]);
+
+        $this->assertSame('home', ReceiverViewNameResolver::resolve($node));
+    }
+
+    #[Test]
+    public function refuses_static_call_first_with_multiple_literals(): void
+    {
+        // Laravel's runtime picks the first existing view; analysis-time we
+        // cannot tell, so the resolver refuses both. See class docblock on
+        // ReceiverViewNameResolver::firstLiteralFromArrayArg() for soundness.
+        $node = new StaticCall(new Name('View'), new Identifier('first'), [
+            new Arg(new Array_([
+                new ArrayItem($this->string('safe_layout')->value),
+                new ArrayItem($this->string('unsafe_show')->value),
+            ])),
+        ]);
+
+        $this->assertNull(ReceiverViewNameResolver::resolve($node));
+    }
+
+    #[Test]
+    public function refuses_static_call_first_with_non_literal_element(): void
+    {
+        $node = new StaticCall(new Name('View'), new Identifier('first'), [
+            new Arg(new Array_([
+                new ArrayItem($this->string('home')->value),
+                new ArrayItem(new Variable('dynamic')),
+            ])),
+        ]);
+
+        $this->assertNull(ReceiverViewNameResolver::resolve($node));
+    }
+
+    #[Test]
+    public function refuses_static_call_first_with_non_array_argument(): void
+    {
+        $node = new StaticCall(
+            new Name('View'),
+            new Identifier('first'),
+            [new Arg(new Variable('views'))],
+        );
+
+        $this->assertNull(ReceiverViewNameResolver::resolve($node));
+    }
+
+    #[Test]
+    public function refuses_static_call_unsupported_method(): void
+    {
+        $node = new StaticCall(new Name('View'), new Identifier('share'), [$this->string('a')]);
+
+        $this->assertNull(ReceiverViewNameResolver::resolve($node));
+    }
+
+    #[Test]
+    public function refuses_static_call_dynamic_method_name(): void
+    {
+        // \View::{$method}('home') — method name is an expression, not an
+        // Identifier. Resolver bails out.
+        $node = new StaticCall(new Name('View'), new Variable('method'), [$this->string('home')]);
+
+        $this->assertNull(ReceiverViewNameResolver::resolve($node));
+    }
+
+    #[Test]
+    public function resolves_nullsafe_method_call_make_literal(): void
+    {
+        // $factory?->make('home')
+        $node = new NullsafeMethodCall(
+            new Variable('factory'),
+            new Identifier('make'),
+            [$this->string('home')],
+        );
+
+        $this->assertSame('home', ReceiverViewNameResolver::resolve($node));
+    }
+
+    #[Test]
+    public function refuses_nullsafe_method_call_unsupported_name(): void
+    {
+        $node = new NullsafeMethodCall(
+            new Variable('factory'),
+            new Identifier('share'),
+            [$this->string('a')],
+        );
+
+        $this->assertNull(ReceiverViewNameResolver::resolve($node));
+    }
+
+    #[Test]
+    public function refuses_bare_variable_receiver(): void
+    {
+        // The driving motivation for not supporting variable-bound chains in
+        // PR-5: $v = view('home'); $v->with(...). Resolver hits the Variable
+        // receiver at the bottom of the recursion and returns null.
+        $node = new MethodCall(new Variable('v'), new Identifier('with'), [$this->string('a')]);
+
+        $this->assertNull(ReceiverViewNameResolver::resolve($node));
+    }
+
+    #[Test]
+    public function refuses_view_helper_via_dynamic_function_name(): void
+    {
+        // ${$fn}('home') — function name is an expression, not a Name node.
+        $node = new FuncCall(new Variable('fn'), [$this->string('home')]);
+
+        $this->assertNull(ReceiverViewNameResolver::resolve($node));
+    }
+
+    #[Test]
+    public function resolves_method_call_first_single_literal(): void
+    {
+        // $factory->first(['home']) — the MethodCall counterpart to the
+        // StaticCall coverage. Guards against a regression that drops the
+        // `first` arm in resolveMethodCallReceiver while leaving the
+        // StaticCall arm intact.
+        $node = new MethodCall(new Variable('factory'), new Identifier('first'), [
+            new Arg(new Array_([new ArrayItem($this->string('home')->value)])),
+        ]);
+
+        $this->assertSame('home', ReceiverViewNameResolver::resolve($node));
+    }
+
+    #[Test]
+    public function refuses_method_call_dynamic_method_name(): void
+    {
+        // $factory->{$method}('home') — non-Identifier method name.
+        $node = new MethodCall(new Variable('factory'), new Variable('method'), [$this->string('home')]);
+
+        $this->assertNull(ReceiverViewNameResolver::resolve($node));
+    }
+
+    #[Test]
+    public function refuses_first_with_empty_array(): void
+    {
+        // \View::first([]) — no literal candidates means no view name to
+        // resolve. firstLiteralFromArrayArg never sets $resolved.
+        $node = new StaticCall(new Name('View'), new Identifier('first'), [
+            new Arg(new Array_([])),
+        ]);
+
+        $this->assertNull(ReceiverViewNameResolver::resolve($node));
+    }
+
+    #[Test]
+    public function refuses_first_with_unpacked_argument(): void
+    {
+        // \View::first(...$views) — argument-level spread bypasses the
+        // array-literal contract. firstLiteralFromArrayArg rejects via the
+        // $arg->unpack guard.
+        $arg = new Arg(new Array_([new ArrayItem($this->string('home')->value)]), unpack: true);
+        $node = new StaticCall(new Name('View'), new Identifier('first'), [$arg]);
+
+        $this->assertNull(ReceiverViewNameResolver::resolve($node));
+    }
+
+    #[Test]
+    public function resolves_first_with_keyed_array_literal(): void
+    {
+        // \View::first(['primary' => 'home']) — Laravel accepts arbitrary
+        // array keys in the candidate list; firstLiteralFromArrayArg checks
+        // $item->value (the string), not $item->key. The resolver should
+        // treat keyed and unkeyed single-literal arrays identically.
+        $node = new StaticCall(new Name('View'), new Identifier('first'), [
+            new Arg(new Array_([
+                new ArrayItem($this->string('home')->value, new String_('primary')),
+            ])),
+        ]);
+
+        $this->assertSame('home', ReceiverViewNameResolver::resolve($node));
+    }
+
+    #[Test]
+    public function resolves_nullsafe_method_call_with_chain(): void
+    {
+        // view('home')?->with('a', 1) — confirms the nullsafe branch routes
+        // through the chain-preserving allowlist, not only through the
+        // `make`/`first` view-name arms.
+        $inner = $this->funcCall('view', [$this->string('home')]);
+        $chain = new NullsafeMethodCall($inner, new Identifier('with'), [$this->string('a'), $this->int(1)]);
+
+        $this->assertSame('home', ReceiverViewNameResolver::resolve($chain));
+    }
+
+    /**
+     * @param list<Arg> $args
+     */
+    private function funcCall(string $name, array $args): FuncCall
+    {
+        return new FuncCall(new Name($name), $args);
+    }
+
+    private function string(string $value): Arg
+    {
+        return new Arg(new String_($value));
+    }
+
+    private function int(int $value): Arg
+    {
+        return new Arg(new \PhpParser\Node\Scalar\Int_($value));
+    }
+}


### PR DESCRIPTION
## Issue to Solve

PR-5 of the issue #581 epic. The view-chain receiver-walk (the AST helper that recovers a literal view name from `view('home')->with(...)`, `View::make('home')`, `View::first(['home'])` etc.) was inlined as ~165 LOC of private static methods inside `BladeAwareViewTaintHandler`. PR-6 needs to extend the chain-preserving allowlist (Mailable `view()` / `markdown()` / `text()` -> `with()`) without touching taint sink construction. The current shape couples those two concerns.

## Related

Stacks on top of PR-4 (#934). Targets the umbrella branch `worktree-581-blade-taint-exploration` (PR #872), not `master`.

Tracking issue: #581.

## Solution Description

Pure refactor. No behaviour change.

- Move `resolveReceiverViewName` / `resolveMethodCallReceiver` / `viewNameFromFuncCall` / `viewNameFromArg` / `firstLiteralFromArrayArg` / `literalString` out of `BladeAwareViewTaintHandler` into a new `Psalm\LaravelPlugin\Handlers\Views\ReceiverViewNameResolver` final class.
- Handler delegates to `ReceiverViewNameResolver::resolve($callExpr->var)` at the single call site (no other call sites existed).
- Resolver is pure-AST: no Psalm internals, no handler back-reference. Sealed via `private __construct()` (`@psalm-api` + `@psalm-mutation-free`).
- 26 direct AST-level unit tests added under `tests/Unit/Handlers/Views/ReceiverViewNameResolverTest.php`. Resolution table covered: `view()` helper (literal / dynamic arg / non-`view` function / dynamic function name), `View::with()` / `View::withErrors()` chain recursion (single + double depth), `MethodCall::make` / `first`, `StaticCall::make` / `first` (single literal / multi-literal refusal / non-literal element refusal / non-array arg / empty array / unpacked arg / keyed array), `NullsafeMethodCall` variants (make + with chain + unsupported name), bare-`Variable` receiver bottom-of-chain refusal, dynamic method names on both `MethodCall` and `StaticCall`. Existing handler dispatch tests in `BladeAwareViewTaintHandlerTest` continue to exercise end-to-end behaviour; new tests pin the resolution table head-on so a regression surfaces before the handler-level taint tests start drifting.
- Handler class docblock and the trailing deferred-list comment in `buildMethodSpecs()` updated to reflect PR-5's scope cut and the deferred PR-6 items.

### Key decisions during PR-5 (also captured in `docs/issues/581-blade-taint-exploration.md`)

PR-5's original brief bundled component data flow, scanner caching, and a NodeTypeProvider-based tracker for variable-bound view-builder chains (`$v = view('home'); $v->with(...)`). The scope collapsed to a pure extraction after the following decisions:

1. **NodeTypeProvider-based tracker rejected.** Two encodings were evaluated and both rejected:
    - Custom `\Psalm\Type\Atomic` subclass — no third-party plugin in `vendor/` precedent, `TypeCombiner::combine()` falls custom atomics into a default branch that risks collapsing to `mixed` on union join, and cache round-trip / intersection behaviour is undocumented plugin surface.
    - Synthetic `DataFlowNode` in `Union->parent_nodes` — Psalm's `AssignmentAnalyzer` typically wraps the right-hand side of an assignment in a `variable-use:$v:N` `DataFlowNode`, so at the chained `with()` site the receiver's `parent_nodes` only carries the wrapping node. Recovering the original marker requires walking `taint_flow_graph->forward_edges` transitively on every method call — too expensive for the hot path.

   The variable-bound chain gap stays open until a cheaper resolution mechanism surfaces or until real-world apps prove the gap matters enough to absorb the cost. The `MissingViewHandler`-style "view not in map -> no sink" policy is the conservative default.

2. **Mailable `view()` / `markdown()` / `text()` -> `with()` chain deferred to PR-6.** Reachable through receiver-walk alone (no tracker needed), but registration carries its own scope (class gating, multi-view Content dispatch, "last view() wins" semantic). Split out so PR-5 stays a pure refactor.

3. **Components, sections, `View::share()`, scanner cache deferred to PR-6.** Once the tracker was dropped, these no longer made sense in the same PR. PR-6 picks them up as four independent sub-PRs.

4. **For PR-6's component sub-PR: don't reuse Laravel's `ComponentTagCompiler` directly.** Prototyped: in the plugin's bare Testbench-booted container, `componentClass()` throws `InvalidArgumentException` for any unresolvable component, and the compiler processes the whole template at once so one bad tag kills compilation for all tags. Per-tag try/catch isolation would re-implement the tag loop. A local x-tag scanner that records component edges into `BladeSafetyMap` (mirroring PR-4's include-edge propagation) is the planned approach.

## Verification

- `composer cs`: clean.
- `composer rector`: clean.
- `composer psalm`: clean (zero new findings).
- `composer test:unit`: 813 tests pass (1 skipped), 26 new in `ReceiverViewNameResolverTest`.
- `composer test:type`: 397 / 397 pass.
- Two `/psalm-review` rounds, both ending without high-confidence findings remaining.

## Checklist

- [x] Tests cover the change (26 unit tests in `tests/Unit/Handlers/Views/ReceiverViewNameResolverTest.php`)
- [x] Documentation is updated (handler docblock, `docs/issues/581-blade-taint-exploration.md`, `.alies/docs/blade.md`)
