### PR TITLE
Accept variadic strings on `Route::middleware` facade and `RouteRegistrar`

### DIFF
--- a/stubs/common/Routing/RouteRegistrar.phpstub
+++ b/stubs/common/Routing/RouteRegistrar.phpstub
@@ -20,6 +20,15 @@ namespace Illuminate\Routing;
 class RouteRegistrar
 {
     /**
+     * The broad `string|array<string>|null` param is intentional. With `@psalm-variadic`
+     * each variadic slot accepts this union, matching the runtime forms
+     * `middleware('a', 'b', 'c')`, `middleware('a')`, `middleware(['a', 'b'])`, and
+     * `middleware(null)`. Tightening the type to `string` would reject the documented
+     * array form; tightening it to drop `null` would reject the no-op `middleware(null)`
+     * call. Mixed forms like `middleware(['a'], 'b')` slip through this typing but
+     * Laravel's `__call` silently drops the second arg at runtime; no useful Psalm
+     * signature can express that asymmetry, so we mirror Laravel's permissive surface.
+     *
      * @param string|array<string>|null $middleware
      * @return $this
      *

--- a/stubs/common/Routing/RouteRegistrar.phpstub
+++ b/stubs/common/Routing/RouteRegistrar.phpstub
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Routing;
+
+/**
+ * Laravel declares `middleware` only via class-level `@method` on `RouteRegistrar`
+ * (the runtime resolution lives in `RouteRegistrar::__call`, which collects variadic
+ * strings via `is_array($parameters[0]) ? $parameters[0] : $parameters`). The source
+ * `@method ... middleware(array|string|null $middleware)` is single-arg, so calls like
+ * `$registrar->middleware('a', 'b', 'c')` raise `TooManyArguments`.
+ *
+ * We expose a concrete `middleware()` method here with `@psalm-variadic` so chained
+ * calls on the registrar accept the runtime-valid variadic form. The matching facade
+ * fix lives in {@see stubs/common/Support/Facades/Route.phpstub}; the registrar form
+ * is patched here because chains like `Route::prefix('foo')->middleware('a', 'b')`
+ * dispatch through the RouteRegistrar pseudo-method table.
+ *
+ * @method \Illuminate\Routing\RouteRegistrar middleware(string|array|null ...$middleware)
+ */
+class RouteRegistrar
+{
+    /**
+     * @param string|array<string>|null $middleware
+     * @return $this
+     *
+     * @psalm-variadic
+     */
+    public function middleware($middleware = null) {}
+}

--- a/stubs/common/Support/Facades/Route.phpstub
+++ b/stubs/common/Support/Facades/Route.phpstub
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Support\Facades;
+
+/**
+ * `Illuminate\Support\Facades\Route` declares
+ *   `@method static \Illuminate\Routing\RouteRegistrar middleware(array|string|null $middleware)`
+ * at class level. The runtime resolution (Router::__call → RouteRegistrar) treats the
+ * argument list as variadic strings — `Route::middleware('a', 'b', 'c')` is a valid
+ * Laravel idiom (e.g. invoiceninja `routes/contact.php`).
+ *
+ * Following the Schema facade pattern, we override the narrower vendor `@method static`
+ * with a variadic pseudo-method and pair it with a concrete static method. The pseudo
+ * entry is what Psalm consults during `__callStatic` resolution; the concrete method
+ * keeps the stub self-consistent if Psalm ever switches to native lookup.
+ *
+ * @method static \Illuminate\Routing\RouteRegistrar middleware(string|array|null ...$middleware)
+ */
+class Route extends Facade
+{
+    /**
+     * @param string|array<string>|null $middleware
+     * @return \Illuminate\Routing\RouteRegistrar
+     *
+     * @psalm-variadic
+     */
+    public static function middleware($middleware = null) {}
+}

--- a/tests/Type/tests/RouteMiddlewareFacadeStaticVariadicTest.phpt
+++ b/tests/Type/tests/RouteMiddlewareFacadeStaticVariadicTest.phpt
@@ -6,26 +6,24 @@ use Illuminate\Routing\RouteRegistrar;
 use Illuminate\Support\Facades\Route as RouteFacade;
 
 /**
- * Reproducer (documented broken behavior) for the `routes/contact.php` form in
- * invoiceninja:
+ * Regression test for the `routes/contact.php` form in invoiceninja:
  *
  *   Route::middleware('contact_db', 'api_secret_check', 'contact_token_auth')
  *       ->prefix('api/v1/contact')->name('api.contact.')->group(function () { ... });
  *
  * The Laravel framework's `RouteRegistrar::__call` resolves `middleware(...)` by
  * collecting variadic strings (`is_array($parameters[0]) ? $parameters[0] : $parameters`),
- * so this call shape is valid at runtime. The `@method static` annotation on
+ * so this call shape is valid at runtime. The vendor `@method static` annotation on
  * `Illuminate\Support\Facades\Route` and on `Illuminate\Routing\RouteRegistrar`
- * declares it as single-arg (`array|string|null $middleware`), so Psalm reports
- * `TooManyArguments` even though the runtime accepts the call.
+ * declares it as single-arg (`array|string|null $middleware`), so without overrides
+ * Psalm reports `TooManyArguments`.
  *
- * The existing RouteMiddlewareTest covers the Route *instance* form via the
- * `@psalm-variadic` stub on `Illuminate\Routing\Route::middleware`. The facade
- * / RouteRegistrar entry point lacks the same override.
- *
- * Once a plugin stub adds `@psalm-variadic` to RouteRegistrar::middleware (or the
- * Route facade @method static is overridden), the EXPECTF below should be cleared
- * and this becomes a positive regression test.
+ * Coverage:
+ *   - The Route *instance* form is covered by RouteMiddlewareTest (via the
+ *     `@psalm-variadic` stub on `Illuminate\Routing\Route::middleware`).
+ *   - The facade / RouteRegistrar entry points are patched by the
+ *     `stubs/common/Support/Facades/Route.phpstub` and
+ *     `stubs/common/Routing/RouteRegistrar.phpstub` overrides.
  */
 
 // Variadic strings (the exact invoiceninja shape).
@@ -58,7 +56,15 @@ function test_route_facade_middleware_chain_intermediate(): void
     /** @psalm-check-type-exact $_chain = RouteRegistrar */
 }
 
+// Reverse-chain: registrar produced by ->prefix(), then ->middleware(...) with
+// variadic strings. Pins the concrete RouteRegistrar::middleware() override
+// directly (rather than the facade __callStatic path), guarding the second
+// half of the stub fix from regression independent of the facade entry point.
+function test_route_registrar_middleware_variadic_from_prefix(): RouteRegistrar
+{
+    return RouteFacade::prefix('api/v1/contact')
+        ->middleware('contact_db', 'api_secret_check', 'contact_token_auth');
+}
+
 ?>
 --EXPECTF--
-TooManyArguments on line %d: Too many arguments for Illuminate\Support\Facades\Route::middleware - expecting 1 but saw 3
-TooManyArguments on line %d: Too many arguments for Illuminate\Support\Facades\Route::middleware - expecting 1 but saw 2

--- a/tests/Type/tests/RouteMiddlewareFacadeStaticVariadicTest.phpt
+++ b/tests/Type/tests/RouteMiddlewareFacadeStaticVariadicTest.phpt
@@ -26,10 +26,14 @@ use Illuminate\Support\Facades\Route as RouteFacade;
  *     `stubs/common/Routing/RouteRegistrar.phpstub` overrides.
  */
 
-// Variadic strings (the exact invoiceninja shape).
+// Variadic strings (the exact invoiceninja shape). Pin the exact type so a future
+// regression that widens to `RouteRegistrar|mixed` can't slip through under the
+// covariant return-type-only signal.
 function test_route_facade_middleware_variadic_strings(): RouteRegistrar
 {
-    return RouteFacade::middleware('contact_db', 'api_secret_check', 'contact_token_auth');
+    $_x = RouteFacade::middleware('contact_db', 'api_secret_check', 'contact_token_auth');
+    /** @psalm-check-type-exact $_x = RouteRegistrar */
+    return $_x;
 }
 
 // Single-string form: still valid, must not regress.
@@ -54,6 +58,14 @@ function test_route_facade_middleware_chain_intermediate(): void
         ->prefix('api/v1/contact')
         ->name('api.contact.');
     /** @psalm-check-type-exact $_chain = RouteRegistrar */
+
+    // Full invoiceninja chain including the terminal ->group(\Closure) call. Once the
+    // intermediate is RouteRegistrar the source's `@method group(\Closure ...)` resolves,
+    // but pin the full shape so a future regression of either link surfaces here.
+    RouteFacade::middleware('contact_db', 'api_secret_check')
+        ->prefix('api/v1/contact')
+        ->name('api.contact.')
+        ->group(static fn () => null);
 }
 
 // Reverse-chain: registrar produced by ->prefix(), then ->middleware(...) with


### PR DESCRIPTION
## Issue to Solve

`Route::middleware('a', 'b', 'c')->prefix(...)->group(...)` (e.g. invoiceninja `routes/contact.php`) raised `TooManyArguments - expecting 1 but saw 3`. Laravel declares `middleware(array|string|null $middleware)` as single-arg via class-level `@method` on `Illuminate\Routing\RouteRegistrar` and `@method static` on `Illuminate\Support\Facades\Route`, but the runtime `__call` actually accepts variadic strings:

```php
// Illuminate/Routing/RouteRegistrar.php (and Router.php)
if ($method === 'middleware') {
    return $this->attribute($method, is_array($parameters[0]) ? $parameters[0] : $parameters);
}
```

## Related

Fixes #972
Reproducer test landed via #971.

## Solution Description

Two new stubs patch the two entry points with the same dual-mechanism pattern used by `stubs/common/Support/Facades/Schema.phpstub`:

- `stubs/common/Routing/RouteRegistrar.phpstub` — `@method ... middleware(string|array|null ...$middleware)` overrides the narrower vendor `@method`; paired with a concrete `middleware()` method carrying `@psalm-variadic`. Covers the `$registrar->middleware(...)` instance call form.
- `stubs/common/Support/Facades/Route.phpstub` — same shape for the `@method static`. Covers `Route::middleware(...)` facade form.

The `@method` declaration is load-bearing: it carries the per-argument type check on the static path. The concrete method carries `@psalm-variadic` for the registrar instance path and keeps the stub self-consistent. The dual-mechanism comment block in each stub documents the rationale to protect the asymmetry from accidental simplification.

`withoutMiddleware` is intentionally **not** patched: its `__call` branch falls through to `array_key_exists(0, $parameters) ? $parameters[0] : true` and would silently drop extra args at runtime, so widening it would create a wrong signal.

Verified against Laravel source on both Laravel 12.59.0 and 13.8.0 (identical semantics). The reproducer test `RouteMiddlewareFacadeStaticVariadicTest.phpt` flips from a documented-broken-behavior EXPECTF to a positive regression test. A reverse-chain case (`Route::prefix(...)->middleware('a', 'b', 'c')`) was added to pin the `RouteRegistrar` stub override independently of the facade entry point.

## Checklist

- [x] Tests cover the change (type test in `tests/Type/`)
