### PR TITLE
Lock in fluent macro narrowing on closure `: static` return types

### DIFF
--- a/src/Handlers/Magic/MacroHandler.php
+++ b/src/Handlers/Magic/MacroHandler.php
@@ -104,9 +104,23 @@ use Psalm\Storage\MethodStorage;
  *   redirects through the mixin path before consulting the host's pseudo-methods),
  *   and risks `self`/`static` mis-expansion in the macro signature. Tracked as a
  *   follow-up — needs a Psalm-side change or a different lookup hook.
- * - **Fluent return narrowing**: a macro whose body returns `$this` should narrow
- *   to the calling instance type (`@psalm-this-out` / `self_out_type`). Out of
- *   scope for the foundation.
+ * - **Fluent return narrowing**: a closure registered as a macro with an
+ *   explicit `: static` (or `: $this`) native return type ALREADY narrows to
+ *   the calling instance type. `MacroRegistry` preserves the `static` token in
+ *   the parsed return type for Closure callables (Macroable rebinds the
+ *   closure via `bindTo($this, static::class)` so the binding semantics
+ *   match), and `MissingMethodCallHandler::handleMagicMethod()` runs the
+ *   pseudo-method's `return_type` through `TypeExpander::expandUnion` with the
+ *   lhs caller as `$static_class_type`. Locked in by
+ *   `tests/Type/tests/Macros/MacroFluentStaticTest.phpt`. What is still out of
+ *   scope: closures with NO native return type whose body is structurally
+ *   `return $this;`, and `@return static` / `@psalm-return $this` docblock-only
+ *   annotations. Both require Strategy C (AST scan) to reach inside the
+ *   closure. `MethodStorage::$self_out_type` would be the natural plumbing
+ *   point but is NOT consulted on pseudo-method dispatch in Psalm 7 (read only
+ *   by the real-method dispatch path — `ExistingAtomicMethodCallAnalyzer` and
+ *   `NewAnalyzer`), so it cannot substitute for the `return_type`-driven
+ *   narrowing path here.
  * - **Memory footprint**: each propagated macro materialises two `MethodStorage`
  *   instances on every descendant class (one per `pseudo_methods` array). Scales
  *   roughly as `descendants × macros × 2`. Acceptable for the foundation's typical

--- a/src/Providers/MacroRegistry.php
+++ b/src/Providers/MacroRegistry.php
@@ -283,6 +283,17 @@ final class MacroRegistry
         //   class. The conservative-but-correct approximation is `get_class($obj)`. For
         //   `[Class::class, 'method']` and `'Class::method'` string callables there's no
         //   instance to bind to, so `static` collapses to the declaring class.
+        //
+        // **Why this branch deliberately excludes Closure callables.** Macroable's
+        // `__call` rebinds closure macros via `bindTo($this, static::class)`, so
+        // `static` in a closure body resolves to the call site's class, not the
+        // declaring class. Leaving `$selfHostClass`/`$staticHostClass` null for
+        // closures keeps the literal `static` token in the parsed return type
+        // (`TNamedObject('static')`), which Psalm's pseudo-method dispatch then
+        // expands against the lhs caller via `TypeExpander::expandUnion` —
+        // delivering fluent narrowing on `: static` closure return types. Issue
+        // #899 §C signal 1; locked in by
+        // `tests/Type/tests/Macros/MacroFluentStaticTest.phpt`.
         $selfHostClass = null;
         $staticHostClass = null;
         if ($reflection instanceof \ReflectionMethod) {

--- a/tests/Type/macro-fixtures.php
+++ b/tests/Type/macro-fixtures.php
@@ -29,6 +29,27 @@ use Tests\Psalm\LaravelPlugin\Type\Fixtures\MacroFixtureBag;
 MacroFixtureBag::macro('shoutTest', static fn(): string => 'OK');
 MacroFixtureBag::macro('countCharsTest', static fn(string $needle): int => 0);
 
+// Fluent macro returning `static` — locks in issue #899 §C signal 1
+// (fluent return narrowing). Macroable rebinds the closure to the calling
+// instance via `bindTo($this, static::class)`, so `static` resolves to the
+// caller's runtime class. Psalm's pseudo-method dispatch expands a
+// `TNamedObject('static')` in the return type against the lhs caller, so the
+// registry must preserve the literal `static` token rather than flattening
+// it to the declaring-class FQCN.
+//
+// Use a non-`static` closure so `Macroable::__call` can `bindTo($this, ...)`
+// successfully — a `static fn(): static => $this` closure can't rebind to a
+// non-null `$this` (PHP raises a warning, `bindTo` returns null), forcing the
+// `bindTo(null, static::class)` fallback. The current shape avoids that
+// detour while still exercising the `: static` return-type expansion.
+MacroFixtureBag::macro(
+    'fluentTest',
+    function (): static {
+        /** @var static $this */
+        return $this;
+    },
+);
+
 // Locks in coverage for the issue #648 motivating case: a Builder macro
 // registered at runtime should resolve when reached through the typed
 // `Customer::query()->testBuilderMacro()` path. Builder is a Macroable owner,

--- a/tests/Type/tests/Macros/MacroFluentStaticTest.phpt
+++ b/tests/Type/tests/Macros/MacroFluentStaticTest.phpt
@@ -1,0 +1,96 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Tests\Psalm\LaravelPlugin\Type\Fixtures\MacroFixtureBag;
+use Tests\Psalm\LaravelPlugin\Type\Fixtures\MacroFixtureChild;
+
+/**
+ * Fluent macro narrowing — issue #899 §C signal 1.
+ *
+ * `fluentTest` is registered in `tests/Type/macro-fixtures.php` as a closure
+ * with `: static` return type. Calling it on a subclass instance must narrow
+ * the result to the subclass type, not collapse to the declaring class.
+ *
+ * Mechanism: `MissingMethodCallHandler::handleMagicMethod()` calls
+ * `TypeExpander::expandUnion` with the lhs caller as the `$static_class_type`
+ * argument; if the pseudo-method's `return_type` preserves the literal `static`
+ * token (a `TNamedObject('static')`), the expander rewrites it to the caller.
+ * Psalm renders the result as `Class&static` to signal that further chaining
+ * keeps the late-bound type alive.
+ *
+ * Plugin invariant: `MacroRegistry::reflectionTypeToUnion()` MUST NOT flatten
+ * `static` to a concrete FQCN for Closure callables. Macroable rebinds the
+ * closure via `bindTo($this, static::class)` so `static` resolves to the call
+ * site at runtime — the type must follow that binding. The
+ * `expandSelfStaticParent()` helper that DOES flatten `static` is gated behind
+ * `$reflection instanceof \ReflectionMethod`, which excludes closures by
+ * construction; this test locks that contract in against future refactors.
+ */
+
+function test_fluent_macro_narrows_on_subclass_instance(): MacroFixtureChild
+{
+    $_ = (new MacroFixtureChild())->fluentTest();
+    /** @psalm-check-type-exact $_ = Tests\Psalm\LaravelPlugin\Type\Fixtures\MacroFixtureChild&static */
+    return $_;
+}
+
+function test_fluent_macro_returns_declaring_class_on_root_instance(): MacroFixtureBag
+{
+    $_ = (new MacroFixtureBag())->fluentTest();
+    /** @psalm-check-type-exact $_ = Tests\Psalm\LaravelPlugin\Type\Fixtures\MacroFixtureBag&static */
+    return $_;
+}
+
+function test_fluent_macro_chains_preserve_caller_type(): string
+{
+    // After fluentTest() narrows to MacroFixtureChild&static, the next call in
+    // the chain must still see the macros inherited from the declaring class.
+    $_ = (new MacroFixtureChild())->fluentTest()->shoutTest();
+    /** @psalm-check-type-exact $_ = string */
+    return $_;
+}
+
+function test_fluent_macro_chain_preserves_narrowing_across_two_hops(): string
+{
+    // Two-hop fluent chain — each `__call` dispatch re-runs
+    // `TypeExpander::expandUnion`, so the second hop's lhs caller must still
+    // be a `TNamedObject('static')`-aware type, not the literal expanded
+    // FQCN. A regression where `static` is substituted earlier in the
+    // pipeline would let the first hop pass and silently flatten the
+    // second, so the terminator must be a macro that requires resolution
+    // on the doubly-narrowed type (`shoutTest` is registered on
+    // `MacroFixtureBag`).
+    $_ = (new MacroFixtureChild())->fluentTest()->fluentTest()->shoutTest();
+    /** @psalm-check-type-exact $_ = string */
+    return $_;
+}
+
+/**
+ * Probe class anchored on the Macroable host. Exercises the `$this->macro()`
+ * lhs shape — different from `(new Foo())->macro()` because `$this` carries
+ * a `TThis` flag through the type-expansion pipeline. A regression that
+ * substituted `static` against an `is_static_resolved` receiver too early
+ * would only surface here.
+ */
+final class ProbeFluentMacroUser extends MacroFixtureBag
+{
+    public function callFluent(): static
+    {
+        $_ = $this->fluentTest();
+        /** @psalm-check-type-exact $_ = ProbeFluentMacroUser&static */
+        return $_;
+    }
+}
+
+function test_fluent_macro_static_call_narrows_on_subclass(): MacroFixtureChild
+{
+    // `Macroable` defines `__callStatic`, so the pseudo-method also lands in
+    // `pseudo_static_methods`. The static-call path uses
+    // `AtomicStaticCallAnalyzer`, which threads the receiver class through
+    // `TypeExpander` the same way the instance path does.
+    $_ = MacroFixtureChild::fluentTest();
+    /** @psalm-check-type-exact $_ = Tests\Psalm\LaravelPlugin\Type\Fixtures\MacroFixtureChild&static */
+    return $_;
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

Issue #899 §C signal 1 — closure macros registered with an explicit `: static` (or `: $this`) native return type must narrow on subclass dispatch (`(new ChildBag())->fluentTest()` should resolve to `ChildBag&static`, not collapse to the declaring class), and the same expansion must compose across chained fluent calls.

This already worked in v4.x. The contract was just undocumented and easy to regress.

## Related

Refs #899.

Foundation laid in #894 (issue #758).

## Solution Description

**Not a behavior change.** Verified empirically before writing anything: the closure path was already correct because `MacroRegistry::reflectionTypeToUnion()` only invokes `expandSelfStaticParent()` when `$reflection instanceof \ReflectionMethod`. Closures fall outside that branch, so the literal `static` token survives into the parsed `return_type` as `TNamedObject('static')`. Psalm's `MissingMethodCallHandler::handleMagicMethod()` (and the static-call counterpart in `AtomicStaticCallAnalyzer`) then expands it against the lhs caller via `TypeExpander::expandUnion`.

What the PR does:

1. **Locks the invariant in with a phpt regression test** (`tests/Type/tests/Macros/MacroFluentStaticTest.phpt`). Covers:
   - Instance dispatch on declaring class and subclass — narrows to `MacroFixtureChild&static`.
   - Static dispatch — `MacroFixtureChild::fluentTest()` narrows identically.
   - Chain `->fluentTest()->shoutTest()` — chain still resolves macros inherited from the declaring class.
   - Two-hop chain `->fluentTest()->fluentTest()->shoutTest()` — catches a regression where `static` substitution short-circuits after hop 1.
   - `$this->fluentTest()` from inside a Macroable host's instance method — different lhs shape from `(new X())->fluentTest()` since `$this` carries a `TThis` flag through type expansion.

2. **Clarifies two docblocks** so a future "simplification" doesn't strip the `instanceof \ReflectionMethod` gate:
   - `MacroRegistry` — comment block above `$selfHostClass = null;` explains why Closures are deliberately excluded from `static`/`self`/`parent` expansion (Macroable rebinds via `bindTo($this, static::class)`, so `static` must follow the caller, not the declaring class).
   - `MacroHandler` class-level TODO — narrows the "Fluent return narrowing" entry from "out of scope" to: "supported for closures with native `: static`; still out of scope: body-level `return $this;` inference and docblock-only `@return static`, both of which need Strategy C". Also documents why `MethodStorage::$self_out_type` cannot substitute for the `return_type`-driven path (Psalm 7's pseudo-method dispatch never reads `self_out_type`; only the real-method paths `ExistingAtomicMethodCallAnalyzer` and `NewAnalyzer` do).

3. **Adds the test fixture closure** (`tests/Type/macro-fixtures.php` registers `MacroFixtureBag::macro('fluentTest', function (): static { return $this; })`). A non-static closure is required so Macroable's `bindTo($this, static::class)` rebind succeeds.

### Still out of scope (Strategy C)

These cases remain `mixed` until #899 idea #1 (AST scan) lands:

- Closures with NO native return type whose body is structurally `return $this;`. Common shape in real Laravel apps:
  ```php
  ComponentAttributeBag::macro('color', function (string $c) {
      $this->attributes['class'] .= " text-{$c}";
      return $this;
  });
  ```
- Docblock-only `@return static` / `@psalm-return $this` on closures without a native return type.

Both require reaching inside the closure body via PHP-Parser, which is Strategy C territory.

### Verification

- `composer test:type` — 414 tests, 414 assertions, all OK.
- `composer psalm --no-progress --no-suggestions` — 0 errors, 100% type coverage.
- `composer cs:check` — clean.
- `composer test:unit` — 635 tests, 1672 assertions, 1 skipped (unchanged).

## Checklist

- [x] Tests cover the change (type test in `tests/Type/`)
