### PR TITLE
Fix `Route::middleware` variadic via facade and `RouteRegistrar`

### DIFF
--- a/stubs/common/Routing/RouteRegistrar.phpstub
+++ b/stubs/common/Routing/RouteRegistrar.phpstub
@@ -1,0 +1,48 @@
+<?php
+
+namespace Illuminate\Routing;
+
+/**
+ * RouteRegistrar's source `@method` annotations declare `middleware` as
+ * single-arg, but `RouteRegistrar::__call` actually collects variadic strings:
+ *
+ *     if ($method === 'middleware') {
+ *         return $this->attribute($method, is_array($parameters[0]) ? $parameters[0] : $parameters);
+ *     }
+ *
+ * The variadic call shape `(new RouteRegistrar(...))->middleware('a', 'b', 'c')`
+ * is valid at runtime but Psalm reports `TooManyArguments` against the
+ * single-arg `@method` tag.
+ *
+ * Override that single tag here as a real method with `@psalm-variadic`. Psalm
+ * preserves the source's other `@method` tags (`prefix`, `name`, `group`, etc.)
+ * because the class-stub merge only resets `class_implements` /
+ * `parent_interfaces`, not `pseudo_static_methods` (see
+ * `Psalm\Internal\PhpVisitor\Reflector\ClassLikeNodeScanner::start()`).
+ *
+ * The companion facade override lives in `stubs/common/Support/Facades/Route.phpstub`
+ * because `Illuminate\Support\Facades\Route` declares its own
+ * `@method static middleware(...)` tag that takes precedence over this class
+ * during static-call resolution.
+ */
+class RouteRegistrar
+{
+    /**
+     * Set the middleware attached to the route group.
+     *
+     * The broad `string[]|string|null` param is intentional. With `@psalm-variadic`
+     * each variadic slot accepts this union, matching the runtime forms
+     * `middleware('a', 'b', 'c')`, `middleware('a')`, `middleware(['a', 'b'])`, and
+     * `middleware(null)`. Tightening the type to `string` would reject the documented
+     * array form; tightening it to drop `null` would reject the no-op `middleware(null)`
+     * call. Mixed forms like `middleware(['a'], 'b')` slip through this typing but
+     * Laravel's `__call` silently drops the second arg at runtime; no useful Psalm
+     * signature can express that asymmetry, so we mirror Laravel's permissive surface.
+     *
+     * @param string[]|string|null $middleware
+     * @return $this
+     *
+     * @psalm-variadic
+     */
+    public function middleware($middleware = null) {}
+}

--- a/stubs/common/Support/Facades/Route.phpstub
+++ b/stubs/common/Support/Facades/Route.phpstub
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Support\Facades;
+
+/**
+ * The `Illuminate\Support\Facades\Route` source declares
+ * `@method static \Illuminate\Routing\RouteRegistrar middleware(array|string|null $middleware)`
+ * as single-arg, but the underlying `RouteRegistrar::__call` collects variadic
+ * strings (see `stubs/common/Routing/RouteRegistrar.phpstub`). Without this
+ * override Psalm reports `TooManyArguments` on the common routes-file shape:
+ *
+ *     Route::middleware('contact_db', 'api_secret_check', 'contact_token_auth')
+ *         ->prefix('api/v1/contact')->name('api.contact.')->group(fn () => ...);
+ *
+ * Re-declaring the facade with a single overriding `@method static` tag is
+ * enough: Psalm's stub/source merge keeps the source's other `@method static`
+ * declarations on `pseudo_static_methods` and overwrites only the `middleware`
+ * key. The plugin's FacadeMethodHandler short-circuits when a `@method` tag
+ * exists, so the variadic pseudo signature is the one Psalm uses for the static
+ * call.
+ */
+
+/**
+ * @method static \Illuminate\Routing\RouteRegistrar middleware(array|string|null ...$middleware)
+ */
+class Route extends Facade
+{
+}

--- a/tests/Type/tests/RouteMiddlewareFacadeStaticVariadicTest.phpt
+++ b/tests/Type/tests/RouteMiddlewareFacadeStaticVariadicTest.phpt
@@ -6,32 +6,35 @@ use Illuminate\Routing\RouteRegistrar;
 use Illuminate\Support\Facades\Route as RouteFacade;
 
 /**
- * Reproducer (documented broken behavior) for the `routes/contact.php` form in
- * invoiceninja:
+ * Regression test for issue #972 — the `routes/contact.php` form in invoiceninja:
  *
  *   Route::middleware('contact_db', 'api_secret_check', 'contact_token_auth')
  *       ->prefix('api/v1/contact')->name('api.contact.')->group(function () { ... });
  *
  * The Laravel framework's `RouteRegistrar::__call` resolves `middleware(...)` by
  * collecting variadic strings (`is_array($parameters[0]) ? $parameters[0] : $parameters`),
- * so this call shape is valid at runtime. The `@method static` annotation on
- * `Illuminate\Support\Facades\Route` and on `Illuminate\Routing\RouteRegistrar`
- * declares it as single-arg (`array|string|null $middleware`), so Psalm reports
- * `TooManyArguments` even though the runtime accepts the call.
+ * so this call shape is valid at runtime. Laravel's source declares
+ * `@method static middleware(array|string|null $middleware)` (single-arg) on both
+ * `Illuminate\Support\Facades\Route` and `Illuminate\Routing\RouteRegistrar`,
+ * which previously caused Psalm to report `TooManyArguments`.
  *
- * The existing RouteMiddlewareTest covers the Route *instance* form via the
- * `@psalm-variadic` stub on `Illuminate\Routing\Route::middleware`. The facade
- * / RouteRegistrar entry point lacks the same override.
- *
- * Once a plugin stub adds `@psalm-variadic` to RouteRegistrar::middleware (or the
- * Route facade @method static is overridden), the EXPECTF below should be cleared
- * and this becomes a positive regression test.
+ * Fix uses two stubs:
+ *   - `stubs/common/Routing/RouteRegistrar.phpstub` declares `middleware` as a
+ *     real method with `@psalm-variadic` (covers the instance form).
+ *   - `stubs/common/Support/Facades/Route.phpstub` overrides the facade's
+ *     `@method static middleware(...)` to use variadic syntax (covers the
+ *     facade form, which Psalm resolves via the facade's own pseudo method
+ *     before any rootClass lookup runs).
  */
 
-// Variadic strings (the exact invoiceninja shape).
+// Variadic strings (the exact invoiceninja shape). Pin the exact type so a future
+// regression that widens to `RouteRegistrar|mixed` can't slip through under the
+// covariant return-type-only signal.
 function test_route_facade_middleware_variadic_strings(): RouteRegistrar
 {
-    return RouteFacade::middleware('contact_db', 'api_secret_check', 'contact_token_auth');
+    $_x = RouteFacade::middleware('contact_db', 'api_secret_check', 'contact_token_auth');
+    /** @psalm-check-type-exact $_x = RouteRegistrar */
+    return $_x;
 }
 
 // Single-string form: still valid, must not regress.
@@ -56,9 +59,15 @@ function test_route_facade_middleware_chain_intermediate(): void
         ->prefix('api/v1/contact')
         ->name('api.contact.');
     /** @psalm-check-type-exact $_chain = RouteRegistrar */
+
+    // Full invoiceninja chain including the terminal ->group(\Closure) call. Once the
+    // intermediate is RouteRegistrar the source's `@method group(\Closure ...)` resolves,
+    // but pin the full shape so a future regression of either link surfaces here.
+    RouteFacade::middleware('contact_db', 'api_secret_check')
+        ->prefix('api/v1/contact')
+        ->name('api.contact.')
+        ->group(static fn () => null);
 }
 
 ?>
---EXPECTF--
-TooManyArguments on line %d: Too many arguments for Illuminate\Support\Facades\Route::middleware - expecting 1 but saw 3
-TooManyArguments on line %d: Too many arguments for Illuminate\Support\Facades\Route::middleware - expecting 1 but saw 2
+--EXPECT--


### PR DESCRIPTION
## Issue to Solve

Calling `Route::middleware('a', 'b', 'c')->prefix(...)->group(...)` (a common shape, e.g. invoiceninja's `routes/contact.php:21`) raised a Psalm false-positive:

```
TooManyArguments: Too many arguments for Illuminate\Support\Facades\Route::middleware - expecting 1 but saw 3
```

At runtime, `Illuminate\Routing\RouteRegistrar::__call` collects variadic strings via `is_array($parameters[0]) ? $parameters[0] : $parameters`. The `@method static middleware(array|string|null $middleware)` declarations on both `Illuminate\Support\Facades\Route` and `Illuminate\Routing\RouteRegistrar` are single-arg, so Psalm rejects the variadic call shape that Laravel actually accepts.

## Related

Fixes #972. Reproducer test landed in #971 as a documented-broken case.

## Solution Description

Two stubs make the variadic signature visible to Psalm:

- `stubs/common/Routing/RouteRegistrar.phpstub` declares `middleware` as a real method with `@psalm-variadic` (covers the instance form, e.g. `(new RouteRegistrar(...))->middleware(...)`).
- `stubs/common/Support/Facades/Route.phpstub` overrides the facade's `@method static middleware(...)` with a variadic signature (covers the facade form). Psalm's stub/source merge preserves the source's other `pseudo_static_methods` (verified in `Psalm\Internal\PhpVisitor\Reflector\ClassLikeNodeScanner::start()`), so only `middleware` is shadowed.

`withoutMiddleware` is intentionally not patched: its `__call` branch falls through to single-arg `array_key_exists(0, $parameters)` and would silently drop extra args at runtime, so the current `TooManyArguments` is the correct signal.

Test changes flip the existing `RouteMiddlewareFacadeStaticVariadicTest.phpt` from documented-broken `--EXPECTF--` to empty `--EXPECT--` and add positive regression assertions covering the variadic, single-string, array, and full chain (`->prefix(...)->name(...)->group(...)`) shapes, plus an `@psalm-check-type-exact $_x = RouteRegistrar` pin on the primary reproducer.

Verified clean:
- `composer test:type` — 415 tests pass
- `composer psalm` — 0 errors
- `composer cs` — 0 errors
- `composer test:unit` — 635 tests pass

## Checklist
- [x] Tests cover the change (positive regression in `tests/Type/tests/RouteMiddlewareFacadeStaticVariadicTest.phpt`)
