### PR TITLE
Use `Macroable` return type info from docblock Psalm storage

### DIFF
--- a/src/Handlers/Magic/MacroHandler.php
+++ b/src/Handlers/Magic/MacroHandler.php
@@ -88,6 +88,16 @@ use Psalm\Storage\MethodStorage;
  * because `Builder<User>` is the direct dispatch target.
  *
  * TODO Strategy C / follow-up:
+ * - **Docblock-aware closure types** (issue #899 idea #1): IMPLEMENTED for closures
+ *   whose source Psalm has scanned. {@see MacroRegistry::recoverClosureStorage()}
+ *   looks up the closure in Psalm's pre-scanned {@see \Psalm\Storage\FunctionLikeStorage}
+ *   by file + line and lifts docblock-merged `@return` / `@param` types into the
+ *   pseudo-method. Coverage: autoloader files
+ *   ({@see \Psalm\Config::collectPredefinedFunctions} routes them through
+ *   `addFileToDeepScan`), projectFiles, and stubs. Out of scope: vendor closures
+ *   when those paths sit outside `<projectFiles>`, eval'd code, and the
+ *   Testbench-fallback case where the analysed package's own provider is never
+ *   booted (covered by the AST-scan follow-up below).
  * - **AST scan** (Strategy C proper): cover macros registered in the analysed
  *   package's own provider when running on a package without `bootstrap/app.php`
  *   (Testbench fallback path — issue #766). Walk every literal
@@ -203,7 +213,7 @@ final class MacroHandler implements AfterCodebasePopulatedInterface
     {
         $codebase = $event->getCodebase();
 
-        MacroRegistry::init($codebase->progress);
+        MacroRegistry::init($codebase->progress, $codebase);
 
         $macroableClasses = MacroRegistry::getKnownMacroableClasses();
         if ($macroableClasses === []) {

--- a/src/Providers/MacroRegistry.php
+++ b/src/Providers/MacroRegistry.php
@@ -294,7 +294,7 @@ final class MacroRegistry
         // generic templates — none of which reflection can surface. Falls back to
         // reflection-based extraction when storage is unavailable (no codebase,
         // closure source not scanned, or multiple closures share the start line).
-        if ($callable instanceof \Closure && $codebase !== null) {
+        if ($callable instanceof \Closure && $codebase instanceof \Psalm\Codebase) {
             $closureStorage = self::recoverClosureStorage($reflection, $codebase);
             if ($closureStorage instanceof FunctionLikeStorage) {
                 return self::buildDefinitionFromStorage(
@@ -393,6 +393,7 @@ final class MacroRegistry
         if (!\is_string($resolved)) {
             return null;
         }
+
         $normalisedPath = \strtolower(\str_replace(['/', '\\'], \DIRECTORY_SEPARATOR, $resolved));
 
         if (!$codebase->file_storage_provider->has($normalisedPath)) {

--- a/src/Providers/MacroRegistry.php
+++ b/src/Providers/MacroRegistry.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Providers;
 
+use Psalm\Codebase;
 use Psalm\Progress\Progress;
 use Psalm\Storage\FunctionLikeParameter;
+use Psalm\Storage\FunctionLikeStorage;
 use Psalm\Type;
 use Psalm\Type\Union;
 
@@ -71,8 +73,14 @@ final class MacroRegistry
      * to the more expensive checks for the small surviving set.
      *
      * Idempotent: reruns reset state. Tests rely on this for isolation.
+     *
+     * @param Codebase|null $codebase When supplied, closure macros are matched against
+     *        Psalm's pre-scanned {@see FunctionLikeStorage} so docblock-derived param
+     *        and return types are recovered ({@see self::recoverClosureStorage()}).
+     *        Null is the unit-test seam: extraction degrades to reflection-only native
+     *        types, identical to the pre-storage behaviour.
      */
-    public static function init(Progress $progress): void
+    public static function init(Progress $progress, ?Codebase $codebase = null): void
     {
         self::$macros = [];
         self::$knownMacroableClasses = [];
@@ -163,7 +171,7 @@ final class MacroRegistry
                     continue;
                 }
 
-                $def = self::buildDefinition($className, $name, $callable, $progress);
+                $def = self::buildDefinition($className, $name, $callable, $progress, $codebase);
                 if (!$def instanceof \Psalm\LaravelPlugin\Providers\MacroDefinition) {
                     continue;
                 }
@@ -261,16 +269,40 @@ final class MacroRegistry
      *
      * @param class-string $declaringClass
      * @param \Closure|non-empty-string|array{0: object|class-string, 1: non-empty-string}|object $callable
+     * @param Codebase|null $codebase Optional Psalm codebase used to recover
+     *        docblock-aware closure types from already-scanned source
+     *        ({@see self::recoverClosureStorage()}). Null when called from a unit-test
+     *        context that constructs the registry without booting Psalm.
      */
     private static function buildDefinition(
         string $declaringClass,
         string $name,
         string|array|object $callable,
         Progress $progress,
+        ?Codebase $codebase = null,
     ): ?MacroDefinition {
         $reflection = self::reflectCallable($callable, $declaringClass, $name, $progress);
         if (!$reflection instanceof \ReflectionFunctionAbstract) {
             return null;
+        }
+
+        // Strategy C / issue #899 idea #1: docblock-aware closure type extraction.
+        // For Closure callables whose source Psalm has scanned (autoloader files via
+        // `addFileToDeepScan`, projectFiles, stubs), prefer Psalm's
+        // {@see FunctionLikeStorage} over reflection. Storage holds docblock-merged
+        // types — `@return Builder<TModel>`, `@param Collection<int, string> $items`,
+        // generic templates — none of which reflection can surface. Falls back to
+        // reflection-based extraction when storage is unavailable (no codebase,
+        // closure source not scanned, or multiple closures share the start line).
+        if ($callable instanceof \Closure && $codebase !== null) {
+            $closureStorage = self::recoverClosureStorage($reflection, $codebase);
+            if ($closureStorage instanceof FunctionLikeStorage) {
+                return self::buildDefinitionFromStorage(
+                    $declaringClass,
+                    $name,
+                    $closureStorage,
+                );
+            }
         }
 
         // Native `self`/`static`/`parent` references in a `\ReflectionMethod`'s signature
@@ -323,6 +355,116 @@ final class MacroRegistry
             params: $params,
             returnType: $nativeReturnType ?? Type::getMixed(),
             signatureReturnType: $nativeReturnType,
+        );
+    }
+
+    /**
+     * Find Psalm's {@see FunctionLikeStorage} for a closure that Psalm has scanned.
+     *
+     * Psalm keys closure storage as `<lowercase-path>:<line>:<startFilePos>:-:closure`
+     * (see the closure branch in
+     * {@see \Psalm\Internal\PhpVisitor\Reflector\FunctionLikeNodeScanner}). Reflection
+     * gives us the file and line cheaply but not the byte offset — so we scan the
+     * file's storage table for any closure entry on the same line.
+     *
+     * Match policy:
+     * - Zero matches: source not scanned (vendor or out-of-scope path, eval'd code, or
+     *   missing-file edge cases). Returns null; caller falls back to reflection.
+     * - One match: returned. Common case.
+     * - Multiple matches: two or more closures starting on the same line (rare; e.g.
+     *   inline `[fn() => 1, fn() => 2]`). Reflection cannot disambiguate by byte
+     *   offset, so we return null rather than guess.
+     *
+     * Path normalisation: Psalm lowercases the path when keying storage
+     * ({@see \Psalm\Internal\Provider\FileStorageProvider::get}). The reflected file
+     * name is run through `realpath()` first to canonicalise symlinks and `..`
+     * segments, then lowercased and separator-normalised to match Psalm's key shape.
+     */
+    private static function recoverClosureStorage(\ReflectionFunctionAbstract $reflection, Codebase $codebase): ?FunctionLikeStorage
+    {
+        $filePath = $reflection->getFileName();
+        $line = $reflection->getStartLine();
+        if (!\is_string($filePath) || !\is_int($line)) {
+            // Internal closures lack a source location (`getFileName()` returns false).
+            return null;
+        }
+
+        $resolved = \realpath($filePath);
+        if (!\is_string($resolved)) {
+            return null;
+        }
+        $normalisedPath = \strtolower(\str_replace(['/', '\\'], \DIRECTORY_SEPARATOR, $resolved));
+
+        if (!$codebase->file_storage_provider->has($normalisedPath)) {
+            return null;
+        }
+
+        $fileStorage = $codebase->file_storage_provider->get($normalisedPath);
+
+        // Match by line. The closure_id format is `<path>:<line>:<startPos>:-:closure`.
+        // Anchor on both the `<path>:<line>:` prefix and the `:-:closure` suffix to
+        // avoid accidentally matching a path that contains `:<line>:` somewhere
+        // earlier (paths typically don't, but the anchors are cheap insurance).
+        $candidates = [];
+        $linePrefix = $normalisedPath . ':' . $line . ':';
+        $closureSuffix = ':-:closure';
+        foreach ($fileStorage->functions as $functionId => $functionStorage) {
+            if (\str_starts_with($functionId, $linePrefix) && \str_ends_with($functionId, $closureSuffix)) {
+                $candidates[] = $functionStorage;
+                if (\count($candidates) > 1) {
+                    // Ambiguous — bail out rather than pick wrong.
+                    return null;
+                }
+            }
+        }
+
+        return $candidates[0] ?? null;
+    }
+
+    /**
+     * Build a {@see MacroDefinition} from a Psalm {@see FunctionLikeStorage} retrieved
+     * via {@see self::recoverClosureStorage()}.
+     *
+     * Defensive copy: Psalm's storage entries are reused across analysis passes, and
+     * `FunctionLikeParameter` exposes public mutable fields (taint sinks, attribute
+     * sets) that any downstream consumer might write through. Shallow-cloning each
+     * parameter keeps the macro registry isolated from the primary
+     * {@see FunctionLikeStorage} — pseudo-method injection in
+     * {@see \Psalm\LaravelPlugin\Handlers\Magic\MacroHandler} cannot corrupt Psalm's
+     * source-of-truth storage by mutating a shared instance.
+     *
+     * `clone` is used instead of rebuilding through the 7-argument constructor
+     * because `FunctionLikeParameter` carries fields the analyser actively reads
+     * that aren't constructor arguments: `out_type` (consumed by
+     * {@see \Psalm\Internal\Analyzer\Statements\Expression\Call\ArgumentsAnalyzer}
+     * for `@param-out` narrowing), `default_type`, `attributes`, `has_docblock_type`,
+     * `description`, and several more. Constructor-only rebuilding silently dropped
+     * these on the storage path. Shallow clone preserves every public field while
+     * still decoupling the wrapper from Psalm's stored instance.
+     *
+     * `Union` types are immutable in Psalm 7, so the shared `type` / `signature_type`
+     * / `out_type` references inside the cloned parameters are safe.
+     *
+     * @param class-string $declaringClass
+     * @psalm-mutation-free
+     */
+    private static function buildDefinitionFromStorage(
+        string $declaringClass,
+        string $name,
+        FunctionLikeStorage $storage,
+    ): MacroDefinition {
+        $params = \array_map(
+            static fn(FunctionLikeParameter $p): FunctionLikeParameter => clone $p,
+            $storage->params,
+        );
+
+        return new MacroDefinition(
+            declaringClass: $declaringClass,
+            methodName: \strtolower($name),
+            casedName: $name,
+            params: $params,
+            returnType: $storage->return_type ?? Type::getMixed(),
+            signatureReturnType: $storage->signature_return_type,
         );
     }
 

--- a/tests/Type/macro-fixtures.php
+++ b/tests/Type/macro-fixtures.php
@@ -63,7 +63,7 @@ MacroFixtureBag::macro(
     /**
      * @return Collection<int, string>
      */
-    static function () {
+    static function (): \Illuminate\Support\Collection {
         return new Collection(['a', 'b']);
     },
 );

--- a/tests/Type/macro-fixtures.php
+++ b/tests/Type/macro-fixtures.php
@@ -24,10 +24,49 @@ declare(strict_types=1);
 require_once __DIR__ . '/macro-fixtures-class.phpstub';
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
 use Tests\Psalm\LaravelPlugin\Type\Fixtures\MacroFixtureBag;
 
 MacroFixtureBag::macro('shoutTest', static fn(): string => 'OK');
 MacroFixtureBag::macro('countCharsTest', static fn(string $needle): int => 0);
+
+// Locks in coverage for issue #899 idea #1: docblock-aware closure type extraction.
+// The closure has NO native return type but a `@return non-empty-string` docblock,
+// and `@param positive-int $count` narrows what reflection's plain `int` would surface.
+// Reflection cannot see the docblock at all — only Psalm's pre-scanned
+// {@see \Psalm\Storage\FunctionLikeStorage} carries the parsed `@param` / `@return`
+// Union types. `MacroRegistry::recoverClosureStorage()` looks them up by file + line
+// and `MacroRegistry::buildDefinitionFromStorage()` copies the docblock Unions into
+// the pseudo-method's params and return type.
+//
+// Without docblock recovery, the registered macro would surface as `function (int): mixed`
+// because the closure declares no native return type. With recovery, it surfaces as
+// `function (positive-int): non-empty-string`.
+MacroFixtureBag::macro(
+    'docblockReturnTest',
+    /**
+     * @param positive-int $count
+     * @return non-empty-string
+     */
+    static function (int $count) {
+        return \str_repeat('x', $count);
+    },
+);
+
+// Generic return-type recovery — the closure's `@return Collection<int, string>`
+// docblock cannot be expressed natively (PHP has no generics), so reflection sees
+// `Collection` at best and `mixed` at worst. The plugin lifts the full generic
+// shape from Psalm's storage so chained calls retain `Collection<int, string>`
+// rather than degrading to `mixed` or the raw class.
+MacroFixtureBag::macro(
+    'docblockGenericTest',
+    /**
+     * @return Collection<int, string>
+     */
+    static function () {
+        return new Collection(['a', 'b']);
+    },
+);
 
 // Fluent macro returning `static` — locks in issue #899 §C signal 1
 // (fluent return narrowing). Macroable rebinds the closure to the calling

--- a/tests/Type/tests/Macros/MacroDocblockClosureTest.phpt
+++ b/tests/Type/tests/Macros/MacroDocblockClosureTest.phpt
@@ -1,0 +1,94 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Collection;
+use Tests\Psalm\LaravelPlugin\Type\Fixtures\MacroFixtureBag;
+use Tests\Psalm\LaravelPlugin\Type\Fixtures\MacroFixtureChild;
+
+/**
+ * Docblock-aware closure type extraction — issue #899 idea #1 (Strategy C).
+ *
+ * The `docblockReturnTest` and `docblockGenericTest` macros are registered in
+ * `tests/Type/macro-fixtures.php` as closures with docblock annotations that
+ * carry MORE information than the closure's native PHP types: `positive-int`
+ * narrowing of a `int` parameter, a `non-empty-string` return, and a
+ * `Collection<int, string>` generic return.
+ *
+ * Plain runtime reflection (`ReflectionFunction::getReturnType()` /
+ * `getParameters()->getType()`) only surfaces native PHP types, so without
+ * docblock recovery these macros would resolve as:
+ *
+ *   docblockReturnTest(int):  mixed         (no native return type at all)
+ *   docblockGenericTest():    mixed         (no native return type)
+ *
+ * `MacroRegistry::recoverClosureStorage()` matches the closure to Psalm's
+ * pre-scanned `FunctionLikeStorage` by file + line, and
+ * `MacroRegistry::buildDefinitionFromStorage()` copies the docblock-derived
+ * Union types into the synthesised pseudo-method. The autoloader file is
+ * deep-scanned by `Psalm\Config` so its closure storage is populated by the
+ * time `AfterCodebasePopulated` runs.
+ *
+ * The Collection import here matches the import in `macro-fixtures.php`, so the
+ * generic-return assertion below resolves against the same FQCN that the
+ * pseudo-method's return type carries.
+ */
+
+function test_docblock_return_type_recovered_from_closure(): string
+{
+    $_ = (new MacroFixtureBag())->docblockReturnTest(3);
+    /** @psalm-check-type-exact $_ = non-empty-string */
+    return $_;
+}
+
+function test_docblock_param_type_recovered_from_closure(): string
+{
+    // The `@param positive-int $count` docblock should narrow the parameter
+    // from the native `int` to `positive-int`. Passing a literal `int<1, max>`
+    // satisfies the docblock constraint.
+    $count = 5;
+    return (new MacroFixtureBag())->docblockReturnTest($count);
+}
+
+function test_docblock_generic_return_type_recovered_from_closure(): Collection
+{
+    // Without recovery, the macro's return type would be `mixed` (no native
+    // return type on the closure). With recovery, Psalm's docblock parser
+    // produces `Collection<int, string>` — the generic shape survives chaining.
+    $_ = (new MacroFixtureBag())->docblockGenericTest();
+    /** @psalm-check-type-exact $_ = Illuminate\Support\Collection<int, string> */
+    return $_;
+}
+
+function test_docblock_return_type_recovered_on_static_dispatch(): string
+{
+    // Macroable defines __callStatic, so docblock-recovered pseudo-methods must land
+    // in pseudo_static_methods too. Without this, MacroHandler injecting the storage-
+    // recovered definition to only one of the two pseudo-method slots would silently
+    // regress static-call dispatch.
+    $_ = MacroFixtureBag::docblockReturnTest(3);
+    /** @psalm-check-type-exact $_ = non-empty-string */
+    return $_;
+}
+
+function test_docblock_return_type_recovered_on_subclass_instance(): string
+{
+    // MacroHandler explicitly propagates pseudo-methods to descendants because
+    // MissingMethodCallHandler does not walk parent_classes. Storage-recovered
+    // definitions must ride through the same propagation path so a subclass instance
+    // still resolves the docblock-narrowed return.
+    $_ = (new MacroFixtureChild())->docblockReturnTest(3);
+    /** @psalm-check-type-exact $_ = non-empty-string */
+    return $_;
+}
+
+function test_docblock_param_rejects_non_positive_int(): string
+{
+    // `positive-int` excludes 0 and negative literals. The narrowed param type
+    // should surface in argument validation — a non-positive literal must be
+    // rejected with `InvalidArgument` rather than silently accepted as the
+    // native `int` parameter would allow.
+    return (new MacroFixtureBag())->docblockReturnTest(0);
+}
+?>
+--EXPECTF--
+InvalidArgument on line %d: Argument 1 of docblockReturnTest expects int<1, max>, but 0 provided


### PR DESCRIPTION
## Issue to Solve

`MacroRegistry` builds `MacroDefinition` instances from runtime reflection of `Macroable::$macros`. For Closure callables this means `ReflectionFunction::getReturnType()` / `getParameters()->getType()` — native PHP types only. Docblock annotations on the registered closure are invisible: `@return Collection<int, string>`, `@param positive-int $count`, `@return non-empty-string`, generic templates, etc. all collapse to whatever the native type happens to be (often `mixed` when the closure has no native return).

## Related

Closes one branch of #899 (idea #1, "Docblock-aware closure type extraction" / Strategy C for the closure case).

## Solution Description

For Closure callables, `MacroRegistry::buildDefinition()` now consults Psalm's pre-scanned `FunctionLikeStorage` before falling back to reflection.

`MacroRegistry::recoverClosureStorage()` looks the closure up in the file's storage table by file + line. The closure-id format Psalm uses (`<lowercase-path>:<line>:<startFilePos>:-:closure`, set in `FunctionLikeNodeScanner` line 1140) includes a byte offset that reflection doesn't expose, so the lookup matches on the `<path>:<line>:` prefix and `:-:closure` suffix. If exactly one closure starts on that line we use it; zero or multiple matches fall back to reflection.

`MacroRegistry::buildDefinitionFromStorage()` copies the storage's `params` (via `clone` to preserve `out_type` / `default_type` / `attributes` / `has_docblock_type` / etc. that the constructor would drop) and `return_type` / `signature_return_type` directly into the new `MacroDefinition`. Defensive copy keeps the registry isolated from Psalm's source-of-truth storage; `Union` types are immutable in Psalm 7 so sharing those references is safe.

Coverage of the new path:

- App-level macros registered in `App\Providers\*::boot()`: in `<projectFiles>`, scanned.
- Test fixtures and bootstrap-time registrations through the `autoloader` attribute: Psalm's `Config::collectPredefinedFunctions` routes them through `addFileToDeepScan`, so they end up in `FileStorage` too.
- Stub-registered macros: scanned as part of the stub pass.

Falls back to reflection when storage is unavailable: vendor closures outside projectFiles, eval'd code, missing source files, or the Testbench-fallback case where the analysed package's own provider is never booted. That remaining gap is the broader Strategy C AST-scan follow-up tracked in `MacroHandler`'s TODO note (idea #1's vendor coverage + the AST-scan-proper item).

`MacroRegistry::init()` now takes an optional `Codebase` parameter so unit tests (which don't boot Psalm) keep working unchanged via the `null` default. `MacroHandler` passes `$event->getCodebase()` through.

### How verified

Three layers:

- Type test: `tests/Type/tests/Macros/MacroDocblockClosureTest.phpt` (6 assertions) covers docblock return-type recovery (`@return non-empty-string`), generic recovery (`@return Collection<int, string>`), `@param positive-int` narrowing including a hard `InvalidArgument` negative, plus static-dispatch and subclass-instance coverage of the same recovered macro.
- Type test fixtures: two new closures in `tests/Type/macro-fixtures.php` (`docblockReturnTest`, `docblockGenericTest`) registered with docblocks that have no native equivalent.
- Existing tests retained: `MacroDispatchTest.phpt`, `MacroFluentStaticTest.phpt`, `BuilderMacroTest.phpt`, `MacroFacadeDispatchTest.phpt` continue to pass, locking in the unchanged reflection-only behaviour for callables that don't (or can't) recover storage.
- `composer test:type` (full): 415/415 pass. `composer psalm`: clean. `composer cs`: clean.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
- [x] Documentation is updated (TODO note in `MacroHandler` updated to reflect partial closure-of Strategy C)
