### PR TITLE
Recover macro closure docblocks from vendor packages via AST scan

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -21,6 +21,13 @@ return RectorConfig::configure()
     // that never matches the lowercase method id. (::class IS valid in const arrays on
     // PHP 8.3+; the problem is the casing, not the const-context.)
     ->withSkipPath('src/Handlers/Rules/OctaneIncompatibleBindingHandler.php')
+    // The vendor-style macro fixture (PR #991 + PR #994) deliberately exercises
+    // closures without native return types or docblock `@return` so the
+    // AST-scan + body-inference paths are the only sources of narrowing.
+    // Rector's `typeDeclarations` set keeps "fixing" them back to declared
+    // return types, which silently turns the body-inference assertions into
+    // native-return-type assertions and the feature stops being tested.
+    ->withSkipPath('tests/Type/macro-fixtures-vendor-style.php')
     ->withPhpVersion(PhpVersion::PHP_82)
     ->withSets([PHPUnitSetList::PHPUNIT_120])
     ->withPreparedSets(deadCode: true, codingStyle: true, typeDeclarations: true, codeQuality: true, phpunitCodeQuality: true)

--- a/src/Providers/MacroRegistry.php
+++ b/src/Providers/MacroRegistry.php
@@ -323,7 +323,7 @@ final class MacroRegistry
         if ($callable instanceof \Closure) {
             $closureType = CachedClosureTypeFactory::fromClosureObject($callable);
 
-            if ($closureType === null && $codebase instanceof \Psalm\Codebase) {
+            if (!$closureType instanceof \Psalm\Type\Atomic\TClosure && $codebase instanceof \Psalm\Codebase) {
                 $closureStorage = self::recoverClosureStorage($reflection, $codebase);
                 if ($closureStorage instanceof FunctionLikeStorage) {
                     return self::buildDefinitionFromStorage(

--- a/src/Providers/MacroRegistry.php
+++ b/src/Providers/MacroRegistry.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Psalm\LaravelPlugin\Providers;
 
 use Psalm\Codebase;
+use Psalm\LaravelPlugin\Util\Ast\CachedClosureTypeFactory;
+use Psalm\LaravelPlugin\Util\Ast\ClosureTypeFactory;
 use Psalm\Progress\Progress;
 use Psalm\Storage\FunctionLikeParameter;
 use Psalm\Storage\FunctionLikeStorage;
@@ -244,6 +246,11 @@ final class MacroRegistry
     {
         self::$macros = [];
         self::$knownMacroableClasses = [];
+        // Cascade into the AST docblock cache — tests rely on this for isolation
+        // between runs, and the cache is keyed by realpath+mtime so leaking it
+        // across test cases would produce phantom hits on fixture files that
+        // were rewritten between runs.
+        CachedClosureTypeFactory::reset();
     }
 
     /**
@@ -286,23 +293,66 @@ final class MacroRegistry
             return null;
         }
 
-        // Strategy C / issue #899 idea #1: docblock-aware closure type extraction.
-        // For Closure callables whose source Psalm has scanned (autoloader files via
-        // `addFileToDeepScan`, projectFiles, stubs), prefer Psalm's
-        // {@see FunctionLikeStorage} over reflection. Storage holds docblock-merged
-        // types — `@return Builder<TModel>`, `@param Collection<int, string> $items`,
-        // generic templates — none of which reflection can surface. Falls back to
-        // reflection-based extraction when storage is unavailable (no codebase,
-        // closure source not scanned, or multiple closures share the start line).
-        if ($callable instanceof \Closure && $codebase instanceof \Psalm\Codebase) {
-            $closureStorage = self::recoverClosureStorage($reflection, $codebase);
-            if ($closureStorage instanceof FunctionLikeStorage) {
-                return self::buildDefinitionFromStorage(
-                    $declaringClass,
-                    $name,
-                    $closureStorage,
-                );
+        // Docblock-aware closure type extraction (Strategy C / issue #899 idea #1,
+        // expanded by issue #991).
+        //
+        // Two recovery paths in priority order:
+        //
+        // 1. **AST scan** ({@see CachedClosureTypeFactory}, wrapping
+        //    {@see ClosureTypeFactory}): builds a {@see TClosure} from the
+        //    closure's
+        //    source file with `nikic/php-parser`, locates the closure by start
+        //    line, and lifts `@param` / `@return` from the docblock attached
+        //    either directly to the closure node OR to the wrapping
+        //    `Stmt\Expression` (Inertia's `Router::macro('inertia', fn () { ... })`
+        //    pattern). This works regardless of whether Psalm scanned the file,
+        //    so it catches both project source and vendor packages outside
+        //    `<projectFiles>`.
+        //
+        // 2. **Psalm storage** ({@see self::recoverClosureStorage()}): looks up
+        //    Psalm's pre-scanned {@see FunctionLikeStorage} for the closure. This
+        //    only fires when AST scan yielded nothing — file unreadable /
+        //    unparseable, no closure starts at the reflected line, or no docblock.
+        //    For closures with a docblock attached directly to the closure node,
+        //    storage and AST produce the same types; for the Stmt\Expression
+        //    docblock pattern, storage's scan does not attach the outer docblock
+        //    to the inner closure, which is exactly why AST is tried first.
+        //
+        // 3. Falls through to **native reflection** when neither path yields data.
+        $closureType = null;
+        if ($callable instanceof \Closure) {
+            $closureType = CachedClosureTypeFactory::fromClosureObject($callable);
+
+            if ($closureType === null && $codebase instanceof \Psalm\Codebase) {
+                $closureStorage = self::recoverClosureStorage($reflection, $codebase);
+                if ($closureStorage instanceof FunctionLikeStorage) {
+                    return self::buildDefinitionFromStorage(
+                        $declaringClass,
+                        $name,
+                        $closureStorage,
+                    );
+                }
             }
+        }
+
+        // For Closure callables, the factory's TClosure already carries the
+        // narrowed params + return type. Unpack and short-circuit the rest of
+        // the build pipeline — no `self`/`static` host expansion needed here
+        // (closures don't bind a host class at definition site; see the
+        // long-form comment below).
+        if ($closureType instanceof \Psalm\Type\Atomic\TClosure) {
+            return new MacroDefinition(
+                declaringClass: $declaringClass,
+                methodName: \strtolower($name),
+                casedName: $name,
+                params: $closureType->params ?? [],
+                returnType: $closureType->return_type ?? Type::getMixed(),
+                // `signature_return_type` carries only the native PHP type;
+                // grab it from reflection so the docblock-narrowed
+                // `return_type` and the native `signature_return_type` stay
+                // independent slots.
+                signatureReturnType: self::reflectionTypeToUnion($reflection->getReturnType()),
+            );
         }
 
         // Native `self`/`static`/`parent` references in a `\ReflectionMethod`'s signature
@@ -338,6 +388,11 @@ final class MacroRegistry
             }
         }
 
+        // Non-closure callables (string `'Class::method'`, array
+        // `[$obj, 'method']`, invokable objects) reach this branch. Their
+        // docblock — if any — lives on the resolved method/function and is
+        // recovered by Psalm's normal scan, so no AST extraction is needed
+        // here; reflection alone produces the param + return types.
         $params = [];
         foreach ($reflection->getParameters() as $reflParam) {
             $params[] = self::buildParameter($reflParam, $selfHostClass, $staticHostClass);
@@ -588,11 +643,11 @@ final class MacroRegistry
 
     /**
      * @param class-string|null $selfHostClass The method's declaring class (binds `self`,
-     *                                          `parent`). Null for free functions and Closures.
+     *                                          `parent`). Null for free functions.
      * @param class-string|null $staticHostClass The class `static` should expand to: for
      *                                            object callables, `get_class($obj)`; otherwise
      *                                            same as `$selfHostClass`. Null for free
-     *                                            functions and Closures.
+     *                                            functions.
      */
     private static function buildParameter(\ReflectionParameter $reflParam, ?string $selfHostClass, ?string $staticHostClass): FunctionLikeParameter
     {

--- a/src/Providers/MacroRegistry.php
+++ b/src/Providers/MacroRegistry.php
@@ -188,6 +188,16 @@ final class MacroRegistry
             self::$macros[\strtolower($className)] = $classMacros;
             self::$knownMacroableClasses[] = $className;
         }
+
+        // Drop the AST-scan cache now that every macro definition is built.
+        // The cache holds full `Closure` / `ArrowFunction` PhpParser subtrees
+        // per visited file; once we're past the foreach above, none of those
+        // nodes are reachable from `MacroDefinition` instances anymore. Holding
+        // them until session teardown would (a) keep the AST pinned for the
+        // rest of analysis and (b) replicate it into every pcntl fork worker
+        // via copy-on-write, which is exactly the cost we wanted to avoid by
+        // not re-parsing in the first place.
+        CachedClosureTypeFactory::reset();
     }
 
     /**

--- a/src/Util/Ast/BodyReturnCollectorVisitor.php
+++ b/src/Util/Ast/BodyReturnCollectorVisitor.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Util\Ast;
+
+use PhpParser\Node;
+use PhpParser\NodeVisitor;
+use PhpParser\NodeVisitorAbstract;
+
+/**
+ * Walks a `Closure`'s body collecting every `return` statement's expression
+ * while refusing to descend into nested closures / arrow functions / function
+ * declarations / class methods (their returns belong to the inner function,
+ * not the outer one we are inferring for).
+ *
+ * Sets `$bailed = true` and stops traversal when a `return;` with no
+ * expression is encountered — the caller treats that the same as any other
+ * unhandled shape and abandons inference for the closure.
+ *
+ * @internal Helper for {@see ClosureTypeFactory::inferReturnFromBody()}.
+ */
+final class BodyReturnCollectorVisitor extends NodeVisitorAbstract
+{
+    /** @var list<Node\Expr> */
+    private array $returnExprs = [];
+
+    private bool $bailed = false;
+
+    /**
+     * Collected `return <expr>;` expressions in source order, or an empty list
+     * when the body contained no returns. Read-only after traversal; mirrors
+     * the accessor convention in {@see ClosureDocblockIndexVisitor::getEntries()}
+     * so the two visitors in this directory expose the same shape.
+     *
+     * @return list<Node\Expr>
+     */
+    public function getReturnExpressions(): array
+    {
+        return $this->returnExprs;
+    }
+
+    /**
+     * `true` when the walker hit `return;` (no expression). Load-bearing
+     * because it distinguishes "the closure has explicit returns AND a
+     * fall-through `return null`" from "the closure has no returns at all".
+     * The first case must bail (some-returns-plus-implicit-null would
+     * silently miss `null` in the inferred union); the second case is the
+     * same as a body the visitor never finds returns in.
+     */
+    public function hasBailed(): bool
+    {
+        return $this->bailed;
+    }
+
+    /**
+     * Reset per-traversal state so the visitor can be reused safely against
+     * multiple closure bodies. Mirrors the sibling
+     * {@see ClosureDocblockIndexVisitor::beforeTraverse()} — without this
+     * reset, a second `traverse()` call would accumulate returns from the
+     * first run AND keep a stale `bailed = true` indefinitely.
+     *
+     * @psalm-external-mutation-free Mutation stays inside the visitor.
+     */
+    #[\Override]
+    public function beforeTraverse(array $nodes): ?array
+    {
+        $this->returnExprs = [];
+        $this->bailed = false;
+
+        return null;
+    }
+
+    /**
+     * @psalm-external-mutation-free The visitor mutates its own `returnExprs`
+     *         / `bailed` fields; nothing outside the instance changes. Same
+     *         posture as {@see ClosureDocblockIndexVisitor::enterNode()}.
+     */
+    #[\Override]
+    public function enterNode(Node $node): ?int
+    {
+        if ($node instanceof Node\Expr\Closure
+            || $node instanceof Node\Expr\ArrowFunction
+            || $node instanceof Node\Stmt\Function_
+            || $node instanceof Node\Stmt\ClassMethod
+        ) {
+            return NodeVisitor::DONT_TRAVERSE_CHILDREN;
+        }
+
+        if ($node instanceof Node\Stmt\Return_) {
+            if (!$node->expr instanceof \PhpParser\Node\Expr) {
+                $this->bailed = true;
+                return NodeVisitor::STOP_TRAVERSAL;
+            }
+
+            $this->returnExprs[] = $node->expr;
+        }
+
+        return null;
+    }
+}

--- a/src/Util/Ast/CachedClosureTypeFactory.php
+++ b/src/Util/Ast/CachedClosureTypeFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Psalm\LaravelPlugin\Util\Ast;
 
 use PhpParser\Comment\Doc;
+use PhpParser\Node;
 use Psalm\Aliases;
 use Psalm\Type\Atomic\TClosure;
 
@@ -41,7 +42,7 @@ use Psalm\Type\Atomic\TClosure;
 final class CachedClosureTypeFactory
 {
     /**
-     * @var array<string, array{mtime: int, entries: array<int, list<array{0: ?Doc, 1: Aliases}>>|null}>
+     * @var array<string, array{mtime: int, entries: array<int, list<array{0: ?Doc, 1: Aliases, 2: Node\Expr\Closure|Node\Expr\ArrowFunction}>>|null}>
      */
     private static array $cache = [];
 
@@ -81,7 +82,7 @@ final class CachedClosureTypeFactory
      * inside `buildWithIndexer`). Mtime stamp guards against in-run rewrites
      * (rare, but happens in test fixtures); a fresh mtime forces a re-parse.
      *
-     * @return array<int, list<array{0: ?Doc, 1: Aliases}>>|null
+     * @return array<int, list<array{0: ?Doc, 1: Aliases, 2: Node\Expr\Closure|Node\Expr\ArrowFunction}>>|null
      */
     private static function indexFile(string $realpath): ?array
     {

--- a/src/Util/Ast/CachedClosureTypeFactory.php
+++ b/src/Util/Ast/CachedClosureTypeFactory.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Util\Ast;
+
+use PhpParser\Comment\Doc;
+use Psalm\Aliases;
+use Psalm\Type\Atomic\TClosure;
+
+/**
+ * Memoizing decorator around {@see ClosureTypeFactory}.
+ *
+ * The expensive part of the factory pipeline is the per-file AST parse +
+ * visitor walk that builds the per-start-line index of `Closure` /
+ * `ArrowFunction` nodes. The downstream parameter / return type construction
+ * is cheap by comparison. This wrapper caches only the expensive bit, keyed
+ * by `(realpath, mtime)`, so a vendor file registering N macros parses once
+ * per analysis run.
+ *
+ * Composition is intentional: {@see ClosureTypeFactory} owns "build a
+ * `TClosure` from a closure"; this class owns "memoize the file index".
+ * Adding TTL / LRU / cross-run persistence later means another wrapper, not
+ * a rewrite of the factory.
+ *
+ * Lifetime:
+ * - Per-(file, mtime) results are cached in-memory for the current analysis
+ *   run only. Psalm's own `StatementsProvider` explicitly bypasses its
+ *   on-disk parser cache for vendor paths (`StatementsProvider::getStatementsForFile()`
+ *   line 103 in vendor/vimeo/psalm), so cross-run persistence would require
+ *   its own infrastructure and is out of scope here.
+ * - Negative entries (parse error, unreadable file, no closure-bearing nodes)
+ *   are cached too, so a single broken vendor file doesn't trigger N parse
+ *   retries within one run.
+ * - {@see self::reset()} drops the cache.
+ *   {@see \Psalm\LaravelPlugin\Providers\MacroRegistry::reset()} chains into
+ *   it for test isolation.
+ *
+ * @internal
+ */
+final class CachedClosureTypeFactory
+{
+    /**
+     * @var array<string, array{mtime: int, entries: array<int, list<array{0: ?Doc, 1: Aliases}>>|null}>
+     */
+    private static array $cache = [];
+
+    /**
+     * Memoized counterpart of {@see ClosureTypeFactory::fromClosureObject()}.
+     *
+     * Delegates to the factory via `buildWithIndexer()` so the realpath →
+     * line-lookup → type-build pipeline lives in one place; this class only
+     * substitutes a memoized file-indexer.
+     */
+    public static function fromClosureObject(\Closure $closure): ?TClosure
+    {
+        return ClosureTypeFactory::buildWithIndexer($closure, self::indexFile(...));
+    }
+
+    /**
+     * Reset the cache. Tests rely on this for isolation between runs;
+     * production code calls it indirectly via
+     * {@see \Psalm\LaravelPlugin\Providers\MacroRegistry::reset()}.
+     *
+     * @psalm-external-mutation-free Same convention as
+     *         {@see \Psalm\LaravelPlugin\Providers\MacroRegistry::reset()} and
+     *         the other static-cache resets in this namespace: mutates only
+     *         this class's own static state, never anything reachable from
+     *         the caller, so for Psalm's purity tracking it counts as
+     *         effect-free.
+     */
+    public static function reset(): void
+    {
+        self::$cache = [];
+    }
+
+    /**
+     * Memoized wrapper around {@see ClosureTypeFactory::indexFile()}.
+     *
+     * Cache key is the resolved path (already canonicalised by the caller
+     * inside `buildWithIndexer`). Mtime stamp guards against in-run rewrites
+     * (rare, but happens in test fixtures); a fresh mtime forces a re-parse.
+     *
+     * @return array<int, list<array{0: ?Doc, 1: Aliases}>>|null
+     */
+    private static function indexFile(string $realpath): ?array
+    {
+        $mtime = @\filemtime($realpath);
+        if ($mtime === false) {
+            return null;
+        }
+
+        if (isset(self::$cache[$realpath]) && self::$cache[$realpath]['mtime'] === $mtime) {
+            return self::$cache[$realpath]['entries'];
+        }
+
+        $entries = ClosureTypeFactory::indexFile($realpath);
+        self::$cache[$realpath] = ['mtime' => $mtime, 'entries' => $entries];
+
+        return $entries;
+    }
+}

--- a/src/Util/Ast/ClosureDocblockIndexVisitor.php
+++ b/src/Util/Ast/ClosureDocblockIndexVisitor.php
@@ -28,11 +28,16 @@ use Psalm\Aliases;
  * files don't bleed aliases across sections, and pre-namespace top-level `use`
  * statements don't leak into a later `namespace { ... }` block.
  *
+ * Each entry also retains the raw `Closure` / `ArrowFunction` node. PR #994 uses
+ * it for body-flow return inference when neither docblock `@return` nor native
+ * reflection covers the closure — without the node the factory would have to
+ * re-parse the file just to walk the body, defeating the per-run cache.
+ *
  * @internal Helper for {@see ClosureTypeFactory::indexFile()}.
  */
 final class ClosureDocblockIndexVisitor extends NodeVisitorAbstract
 {
-    /** @var array<int, list<array{0: ?Doc, 1: Aliases}>> startLine => list of (doc, aliases) */
+    /** @var array<int, list<array{0: ?Doc, 1: Aliases, 2: Node\Expr\Closure|Node\Expr\ArrowFunction}>> startLine => list of (doc, aliases, node) */
     private array $entries = [];
 
     /** @var list<Node> stack of currently-open ancestor nodes (parent at the tail). */
@@ -65,7 +70,7 @@ final class ClosureDocblockIndexVisitor extends NodeVisitorAbstract
      * exclusively from `beforeTraverse` / `enterNode`. Exposed via a method
      * rather than a public field so callers cannot tamper with the storage.
      *
-     * @return array<int, list<array{0: ?Doc, 1: Aliases}>>
+     * @return array<int, list<array{0: ?Doc, 1: Aliases, 2: Node\Expr\Closure|Node\Expr\ArrowFunction}>>
      */
     public function getEntries(): array
     {
@@ -133,7 +138,7 @@ final class ClosureDocblockIndexVisitor extends NodeVisitorAbstract
                 $doc = $this->findWrappingExpressionDoc();
             }
 
-            $this->entries[$node->getStartLine()][] = [$doc, $this->aliasesForCurrentFrame()];
+            $this->entries[$node->getStartLine()][] = [$doc, $this->aliasesForCurrentFrame(), $node];
         }
 
         $this->nodeStack[] = $node;

--- a/src/Util/Ast/ClosureDocblockIndexVisitor.php
+++ b/src/Util/Ast/ClosureDocblockIndexVisitor.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Util\Ast;
+
+use PhpParser\Comment\Doc;
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+use Psalm\Aliases;
+
+/**
+ * Walks a parsed file once, indexing every {@see Node\Expr\Closure} /
+ * {@see Node\Expr\ArrowFunction} by its start line and pairing it with both the
+ * attached docblock and the namespace + `use` aliases active at that location.
+ *
+ * Doc attachment rule (deliberately strict): own docblock first, then the docblock
+ * on the immediately wrapping `Stmt\Expression`. The wrapping-statement fallback is
+ * what catches the Inertia-style call site:
+ *
+ *     /** @param array<array-key, mixed>  $props *\/
+ *     Router::macro('inertia', function ($uri, $component, $props = []) { ... });
+ *
+ * Walking further up the ancestor chain would risk attaching an outer function's
+ * docblock to a nested inline closure — explicitly out of scope.
+ *
+ * Namespace and `use` state are tracked on push/pop stacks so braced multi-namespace
+ * files don't bleed aliases across sections, and pre-namespace top-level `use`
+ * statements don't leak into a later `namespace { ... }` block.
+ *
+ * @internal Helper for {@see ClosureTypeFactory::indexFile()}.
+ */
+final class ClosureDocblockIndexVisitor extends NodeVisitorAbstract
+{
+    /** @var array<int, list<array{0: ?Doc, 1: Aliases}>> startLine => list of (doc, aliases) */
+    private array $entries = [];
+
+    /** @var list<Node> stack of currently-open ancestor nodes (parent at the tail). */
+    private array $nodeStack = [];
+
+    /**
+     * Stack of {namespace, uses, uses_flipped, aliases_obj} frames. A bottom
+     * sentinel frame holds top-level file-scope state; entering a
+     * {@see Node\Stmt\Namespace_} pushes a fresh frame, leaving it pops.
+     *
+     * `aliases_obj` is a lazily-built {@see Aliases} cached for the frame so
+     * the N closures sharing one namespace allocate exactly one `Aliases`
+     * instance between them. Invalidated to `null` whenever `recordUse()`
+     * extends `uses` / `uses_flipped`, so an inner closure sees aliases that
+     * appeared before it in source order.
+     *
+     * Annotated as `non-empty-array<int<0, max>, …>` rather than
+     * `non-empty-list<…>` because mutating nested elements via index access
+     * (`$stack[$tip]['uses'][$alias] = …`) makes Psalm widen the inferred
+     * shape to `non-empty-array`. The semantic invariant (push/pop only at
+     * the tail) still holds.
+     *
+     * @var non-empty-array<int<0, max>, array{namespace: ?string, uses: array<lowercase-string, string>, uses_flipped: array<lowercase-string, string>, aliases_obj: ?Aliases}>
+     */
+    private array $aliasStack = [['namespace' => null, 'uses' => [], 'uses_flipped' => [], 'aliases_obj' => null]];
+
+    /**
+     * Returns the index of closures keyed by start line, as built by the
+     * traversal. Read-only after traversal completes; mutating writes happen
+     * exclusively from `beforeTraverse` / `enterNode`. Exposed via a method
+     * rather than a public field so callers cannot tamper with the storage.
+     *
+     * @return array<int, list<array{0: ?Doc, 1: Aliases}>>
+     */
+    public function getEntries(): array
+    {
+        return $this->entries;
+    }
+
+    /**
+     * @psalm-external-mutation-free Visitor state mutation is the entire point of
+     *         a traversal callback; the parent's stub doesn't carry purity tags
+     *         but Psalm's own pure-method analysis flags any mutating override
+     *         without one. None of the mutation escapes the visitor instance.
+     */
+    #[\Override]
+    public function beforeTraverse(array $nodes): ?array
+    {
+        $this->entries = [];
+        $this->nodeStack = [];
+        $this->aliasStack = [['namespace' => null, 'uses' => [], 'uses_flipped' => [], 'aliases_obj' => null]];
+
+        return null;
+    }
+
+    #[\Override]
+    public function enterNode(Node $node): ?Node
+    {
+        if ($node instanceof Node\Stmt\Namespace_) {
+            $this->aliasStack[] = [
+                'namespace' => $node->name?->toString(),
+                'uses' => [],
+                'uses_flipped' => [],
+                'aliases_obj' => null,
+            ];
+        } elseif ($node instanceof Node\Stmt\Use_ && $node->type === Node\Stmt\Use_::TYPE_NORMAL) {
+            foreach ($node->uses as $use) {
+                $this->recordUse($use->name->toString(), $use->getAlias()->toString());
+            }
+        } elseif ($node instanceof Node\Stmt\GroupUse && $node->type === Node\Stmt\Use_::TYPE_NORMAL) {
+            $prefix = $node->prefix->toString();
+            foreach ($node->uses as $use) {
+                // Mixed groups allow per-entry `function` / `const` typing; only
+                // normal or unspecified entries contribute class aliases.
+                if ($use->type !== Node\Stmt\Use_::TYPE_UNKNOWN && $use->type !== Node\Stmt\Use_::TYPE_NORMAL) {
+                    continue;
+                }
+
+                $this->recordUse($prefix . '\\' . $use->name->toString(), $use->getAlias()->toString());
+            }
+        }
+
+        if ($node instanceof Node\Expr\Closure || $node instanceof Node\Expr\ArrowFunction) {
+            $doc = $node->getDocComment();
+            if (!$doc instanceof Doc) {
+                // Inertia-style: the closure's nearest *enclosing statement* is a
+                // `Stmt\Expression` wrapping the `Router::macro('inertia', fn(){...})`
+                // call, and the docblock is attached to that statement. The
+                // closure's direct parent in the AST is usually an `Arg` /
+                // `StaticCall` / `MethodCall` chain — not a Stmt — so we walk
+                // upward through expression nodes until we hit the first Stmt.
+                //
+                // Deliberately strict: if the enclosing statement is anything
+                // other than `Stmt\Expression` (e.g. `Stmt\Return_`,
+                // `Stmt\Function_`, `Stmt\If_`), we ignore its docblock —
+                // attaching an outer function's `@return Foo` to a nested closure
+                // would be wrong.
+                $doc = $this->findWrappingExpressionDoc();
+            }
+
+            $this->entries[$node->getStartLine()][] = [$doc, $this->aliasesForCurrentFrame()];
+        }
+
+        $this->nodeStack[] = $node;
+
+        return null;
+    }
+
+    /**
+     * @psalm-external-mutation-free
+     */
+    #[\Override]
+    public function leaveNode(Node $node): ?Node
+    {
+        \array_pop($this->nodeStack);
+        if ($node instanceof Node\Stmt\Namespace_ && \count($this->aliasStack) > 1) {
+            \array_pop($this->aliasStack);
+        }
+
+        return null;
+    }
+
+    /**
+     * Walk upward from the current closure node through any chain of expression
+     * nodes (`Arg`, `MethodCall`, `StaticCall`, `Array_`, etc.) until reaching
+     * the first enclosing statement. Return its docblock only when that statement
+     * is a `Stmt\Expression` — i.e. the closure is the result expression of a
+     * statement like `Foo::macro('name', fn () => ...);`.
+     *
+     * Any other enclosing-statement kind (return, throw, function body opener,
+     * control-flow construct) yields `null` — its docblock semantically belongs
+     * to the statement, not to a closure embedded inside it.
+     */
+    private function findWrappingExpressionDoc(): ?Doc
+    {
+        for ($i = \count($this->nodeStack) - 1; $i >= 0; --$i) {
+            $candidate = $this->nodeStack[$i];
+            if (!$candidate instanceof Node\Stmt) {
+                continue;
+            }
+
+            if ($candidate instanceof Node\Stmt\Expression) {
+                return $candidate->getDocComment();
+            }
+
+            return null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Build (or return) the `Aliases` for the current namespace frame. Cached
+     * on the frame itself so a file with N closures in one namespace allocates
+     * exactly one `Aliases` instance for them — important for large vendor
+     * files where N can reach the thousands.
+     *
+     * Cache is invalidated by {@see self::recordUse()} whenever the frame's
+     * `uses` / `uses_flipped` arrays grow, so a closure declared after a `use`
+     * statement still sees the freshly-added alias.
+     */
+    /**
+     * @psalm-external-mutation-free Caches the result on the frame; mutation
+     *         stays inside the visitor instance.
+     */
+    private function aliasesForCurrentFrame(): Aliases
+    {
+        $tipIndex = \count($this->aliasStack) - 1;
+        $frame = $this->aliasStack[$tipIndex];
+        if ($frame['aliases_obj'] instanceof Aliases) {
+            return $frame['aliases_obj'];
+        }
+
+        $aliases = new Aliases(
+            $frame['namespace'],
+            $frame['uses'],
+            [],
+            [],
+            $frame['uses_flipped'],
+            [],
+            [],
+        );
+
+        $this->aliasStack[$tipIndex]['aliases_obj'] = $aliases;
+
+        return $aliases;
+    }
+
+    /**
+     * @psalm-external-mutation-free Mutation stays inside the visitor.
+     */
+    private function recordUse(string $fqcn, string $alias): void
+    {
+        $tipIndex = \count($this->aliasStack) - 1;
+        $aliasLower = \strtolower($alias);
+        $this->aliasStack[$tipIndex]['uses'][$aliasLower] = $fqcn;
+        $this->aliasStack[$tipIndex]['uses_flipped'][\strtolower($fqcn)] = $alias;
+        // Drop the cached Aliases so the next closure rebuilds it with the
+        // newly-recorded use entry. Cheap — closures are rarer than `use`
+        // statements at the top of a file.
+        $this->aliasStack[$tipIndex]['aliases_obj'] = null;
+    }
+}

--- a/src/Util/Ast/ClosureTypeFactory.php
+++ b/src/Util/Ast/ClosureTypeFactory.php
@@ -1,0 +1,438 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Util\Ast;
+
+use PhpParser\Comment\Doc;
+use PhpParser\Error as PhpParserError;
+use PhpParser\NodeTraverser;
+use PhpParser\ParserFactory;
+use Psalm\Aliases;
+use Psalm\DocComment;
+use Psalm\Exception\DocblockParseException;
+use Psalm\Exception\TypeParseTreeException;
+use Psalm\Internal\Analyzer\CommentAnalyzer;
+use Psalm\Internal\Type\TypeParser;
+use Psalm\Internal\Type\TypeTokenizer;
+use Psalm\Storage\FunctionLikeParameter;
+use Psalm\Type;
+use Psalm\Type\Atomic\TClosure;
+use Psalm\Type\Union;
+
+/**
+ * Build a {@see TClosure} description for a runtime closure object.
+ *
+ * Mirrors PHPStan's {@see \PHPStan\Type\ClosureTypeFactory} (consumed by
+ * Larastan's `MacroMethodsClassReflectionExtension`): given a `\Closure`,
+ * return a fully-typed closure description with parameter + return Unions.
+ * Psalm exposes no equivalent core service, so this factory plays the same
+ * role inside the plugin.
+ *
+ * Coverage today (post-issue #991): native reflection signature + docblock
+ * `@param` / `@return` narrowing extracted from the closure's source file via
+ * `nikic/php-parser`. The factory reads the source on demand, so closures
+ * registered from `vendor/` packages outside `<projectFiles>` work the same
+ * as project-source closures.
+ *
+ * Gap vs PHPStan: body-flow inference. PHPStan's `ClosureTypeFactory` infers
+ * the return type from `return` statements when no `@return` docblock is
+ * present (e.g. `fn () => 'x'` produces a literal-string return). We
+ * currently fall back to the native reflection return type or `mixed`.
+ * Tracked as follow-up work — see the "Body-flow inference" plan in PR #994's
+ * description.
+ *
+ * Stateless by design. Caching is a separate concern handled by
+ * {@see CachedClosureTypeFactory}, which composes via callable injection at
+ * {@see self::buildWithIndexer()}.
+ *
+ * @internal
+ */
+final class ClosureTypeFactory
+{
+    /**
+     * Build a {@see TClosure} from a runtime closure object.
+     *
+     * Public shape matches PHPStan's `ClosureTypeFactory::fromClosureObject()`:
+     * caller hands over a `\Closure`, gets back a typed closure description
+     * (params + return) or `null` when no usable source-level information is
+     * recoverable.
+     *
+     * Returns `null` when:
+     * - reflection lacks a file location (internal closures, runtime-generated
+     *   sources with synthetic paths);
+     * - the source file is unreadable or fails to parse;
+     * - no closure starts at the reflected line, or multiple closures share
+     *   the start line (ambiguity → bail rather than guess);
+     * - the closure has no docblock-derived narrowing the caller could not
+     *   already produce from reflection alone. Caller falls back to a
+     *   reflection-only pseudo-method in that case.
+     *
+     * @psalm-api Public convenience for callers that opt out of the memoizing
+     *            wrapper (notably the unit tests). Production callers go
+     *            through {@see CachedClosureTypeFactory::fromClosureObject()},
+     *            which delegates via {@see self::buildWithIndexer()}.
+     */
+    public static function fromClosureObject(\Closure $closure): ?TClosure
+    {
+        return self::buildWithIndexer($closure, self::indexFile(...));
+    }
+
+    /**
+     * Decorator-friendly variant: accepts an external `(realpath): ?index`
+     * callable so wrappers like {@see CachedClosureTypeFactory} can substitute
+     * a memoized indexer without re-implementing the reflection → realpath →
+     * line-lookup → build pipeline.
+     *
+     * The default indexer (used by {@see self::fromClosureObject()}) is
+     * {@see self::indexFile()}, which re-parses on every call. Caching belongs
+     * to wrappers, not to this class.
+     *
+     * @internal Decorator injection seam.
+     * @param callable(string): ?array<int, list<array{0: ?Doc, 1: Aliases}>> $indexer
+     */
+    public static function buildWithIndexer(\Closure $closure, callable $indexer): ?TClosure
+    {
+        $reflection = new \ReflectionFunction($closure);
+
+        $docblock = self::recoverDocblock($reflection, $indexer);
+
+        return self::buildClosureType($reflection, $docblock);
+    }
+
+    /**
+     * Parse a source file once and return a per-start-line index of every
+     * `Closure` / `ArrowFunction` node along with its attached docblock and
+     * the namespace + `use` aliases visible at that point.
+     *
+     * No caching: every call re-parses. Wrap with
+     * {@see CachedClosureTypeFactory} (or any compatible memoizer) for
+     * repeated lookups against the same file.
+     *
+     * @return array<int, list<array{0: ?Doc, 1: Aliases}>>|null
+     */
+    public static function indexFile(string $realpath): ?array
+    {
+        $contents = @\file_get_contents($realpath);
+        if ($contents === false) {
+            return null;
+        }
+
+        try {
+            // `createForHostVersion()` matches the runtime PHP version, which
+            // produced the reflected closure in the first place — so any
+            // feature the file uses is necessarily supported by the host's
+            // parser flavor.
+            $parser = (new ParserFactory())->createForHostVersion();
+            $ast = $parser->parse($contents);
+        } catch (PhpParserError) {
+            return null;
+        }
+
+        if (!\is_array($ast)) {
+            return null;
+        }
+
+        $visitor = new ClosureDocblockIndexVisitor();
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        return $visitor->getEntries();
+    }
+
+    /**
+     * Lift `@param` and `@return` Unions from the closure's source-attached
+     * docblock, or `null` when no usable docblock is reachable.
+     *
+     * @param callable(string): ?array<int, list<array{0: ?Doc, 1: Aliases}>> $indexer
+     * @return array{params: array<string, Union>, return: ?Union}|null
+     */
+    private static function recoverDocblock(\ReflectionFunctionAbstract $reflection, callable $indexer): ?array
+    {
+        $filePath = $reflection->getFileName();
+        $line = $reflection->getStartLine();
+        if (!\is_string($filePath) || !\is_int($line)) {
+            return null;
+        }
+
+        // `realpath()` already returns false for synthetic paths produced by
+        // runtime code generation and for removed-file edge cases — no
+        // separate guard needed.
+        $resolved = \realpath($filePath);
+        if (!\is_string($resolved) || !\is_readable($resolved)) {
+            return null;
+        }
+
+        $entries = $indexer($resolved);
+        if ($entries === null) {
+            return null;
+        }
+
+        $matches = $entries[$line] ?? [];
+        // Mirror the storage-recovery path in MacroRegistry: bail on
+        // ambiguity rather than pick wrong. Two closures starting on the
+        // same line is rare in vendor code but possible (e.g. inline
+        // `[fn() => 1, fn() => 2]`).
+        if (\count($matches) !== 1) {
+            return null;
+        }
+
+        [$doc, $aliases] = $matches[0];
+        if (!$doc instanceof Doc) {
+            return null;
+        }
+
+        return self::extractDocblock($doc, $aliases);
+    }
+
+    /**
+     * Build the final {@see TClosure}: reflection-derived parameter list with
+     * docblock narrowing per parameter, plus the docblock return type when
+     * present, otherwise the native return type or `mixed`.
+     *
+     * Returns `null` when no docblock narrowing was recovered — the caller
+     * would not learn anything beyond what reflection already exposes, so it
+     * keeps its existing reflection-only pseudo-method path instead.
+     *
+     * @param array{params: array<string, Union>, return: ?Union}|null $docblock
+     */
+    private static function buildClosureType(\ReflectionFunctionAbstract $reflection, ?array $docblock): ?TClosure
+    {
+        if ($docblock === null) {
+            return null;
+        }
+
+        $params = [];
+        foreach ($reflection->getParameters() as $reflParam) {
+            $params[] = self::buildClosureParameter($reflParam, $docblock['params'][$reflParam->getName()] ?? null);
+        }
+
+        $nativeReturn = self::reflectionTypeToUnion($reflection->getReturnType());
+        // Issue #991: docblock `@return` (when present) wins over the native
+        // reflection return — that's the whole point of recovery. Native
+        // return is preserved only when the docblock is silent.
+        $returnType = $docblock['return'] ?? $nativeReturn ?? Type::getMixed();
+
+        return new TClosure(
+            params: $params,
+            return_type: $returnType,
+        );
+    }
+
+    /**
+     * Build a single {@see FunctionLikeParameter} for a closure parameter.
+     *
+     * Reflection owns name + by-ref / variadic / optional / nullable flags;
+     * the docblock contributes type narrowing when it has a matching `@param`.
+     * `signature_type` always reflects the native PHP type (used by Psalm to
+     * validate the closure body's argument uses), while `type` carries the
+     * docblock-narrowed Union when present.
+     */
+    private static function buildClosureParameter(\ReflectionParameter $reflParam, ?Union $docblockType): FunctionLikeParameter
+    {
+        $reflType = $reflParam->getType();
+        $signatureType = self::reflectionTypeToUnion($reflType);
+
+        return new FunctionLikeParameter(
+            name: $reflParam->getName(),
+            by_ref: $reflParam->isPassedByReference(),
+            type: $docblockType ?? $signatureType,
+            signature_type: $signatureType,
+            is_optional: $reflParam->isOptional() || $reflParam->isDefaultValueAvailable(),
+            // `allowsNull()` covers both `?string` syntax and `string|null`
+            // unions, and is more reliable than asking the parsed Union —
+            // Psalm's parseString of `?string` does not always set the
+            // nullable flag the way we'd expect.
+            is_nullable: $reflType?->allowsNull() ?? false,
+            is_variadic: $reflParam->isVariadic(),
+        );
+    }
+
+    /**
+     * Convert PHP's reflected type to a Psalm Union. Closures never bind
+     * `self`/`static`/`parent` at the *definition* site (only at the call
+     * site, via Macroable's `bindTo`), so the simpler form here doesn't take
+     * a host class — `static` survives as the literal token for the caller's
+     * `TypeExpander` pass to resolve.
+     */
+    private static function reflectionTypeToUnion(?\ReflectionType $type): ?Union
+    {
+        if (!$type instanceof \ReflectionType) {
+            return null;
+        }
+
+        $typeString = (string) $type;
+        if ($typeString === '') {
+            return null;
+        }
+
+        try {
+            return Type::parseString($typeString);
+        } catch (TypeParseTreeException) {
+            return null;
+        } catch (\Error $error) {
+            // Only the specific "ProjectAnalyzer not initialised" path is
+            // benign. Anything else is a real bug — re-throw.
+            if (!\str_contains($error->getMessage(), 'ProjectAnalyzer')) {
+                throw $error;
+            }
+
+            return null;
+        }
+    }
+
+    /**
+     * Extract `@param` and `@return` Unions from a closure's docblock.
+     *
+     * Reuses Psalm's own {@see DocComment::parsePreservingLength()} for
+     * tokenisation and {@see CommentAnalyzer::splitDocLine()} for value-line
+     * splitting — the same machinery the analyser runs for stub files and
+     * project source. Types are resolved against the closure's enclosing
+     * namespace+use aliases (captured by the visitor), so
+     * `Collection<int, string>` in vendor code resolves to the
+     * fully-qualified `Illuminate\Support\Collection<int, string>` exactly as
+     * Psalm would resolve it during a normal scan.
+     *
+     * Returns `null` when the docblock yields no usable `@param`/`@return`
+     * narrowing — empty result means "fall back to reflection".
+     *
+     * @return array{params: array<string, Union>, return: ?Union}|null
+     */
+    private static function extractDocblock(Doc $doc, Aliases $aliases): ?array
+    {
+        // Wraps the whole tag-extraction pass because every helper that
+        // touches `CommentAnalyzer::splitDocLine()` can raise
+        // `DocblockParseException` (and its subclass
+        // `IncorrectDocblockException`) on malformed input — unbalanced
+        // brackets, missing newline after a `//` comment inside the docblock,
+        // misplaced `$var` token. A vendor file with one bad `@param` would
+        // otherwise propagate out of `MacroRegistry::buildDefinition()` and
+        // silently break unrelated macros for the rest of the analysis. We
+        // degrade to reflection instead — same posture Psalm's own
+        // `FunctionLikeDocblockParser` takes when fed a bad docblock.
+        //
+        // `$no_psalm_error = true` keeps the docblock validator quiet — we
+        // are a side-channel extractor, not the primary scanner.
+        try {
+            $parsed = DocComment::parsePreservingLength($doc, true);
+
+            $paramTypes = [];
+            if (isset($parsed->combined_tags['param'])) {
+                foreach ($parsed->combined_tags['param'] as $line) {
+                    $entry = self::extractParamFromLine($line, $aliases);
+                    if ($entry === null) {
+                        continue;
+                    }
+
+                    [$paramName, $union] = $entry;
+                    $paramTypes[$paramName] = $union;
+                }
+            }
+
+            $returnType = null;
+            if (isset($parsed->combined_tags['return'])) {
+                foreach ($parsed->combined_tags['return'] as $line) {
+                    $returnType = self::extractReturnFromLine($line, $aliases);
+                    if ($returnType instanceof Union) {
+                        // Take the first usable `@return` — multiple `@return`
+                        // tags would be a docblock error, but we'd rather take
+                        // the first valid one than silently keep the last.
+                        break;
+                    }
+                }
+            }
+        } catch (DocblockParseException) {
+            return null;
+        }
+
+        if ($paramTypes === [] && !$returnType instanceof Union) {
+            return null;
+        }
+
+        return ['params' => $paramTypes, 'return' => $returnType];
+    }
+
+    /**
+     * Parse a single `@param <type> $name` docblock value line.
+     *
+     * Returns `[paramName, Union]` (paramName has the leading `$` stripped to
+     * match `\ReflectionParameter::getName()`), or `null` when the line is
+     * malformed, has no `$name`, or the type fails to parse.
+     *
+     * @return array{0: string, 1: Union}|null
+     */
+    private static function extractParamFromLine(string $line, Aliases $aliases): ?array
+    {
+        $parts = CommentAnalyzer::splitDocLine($line);
+        if (\count($parts) < 2) {
+            return null;
+        }
+
+        $typeString = CommentAnalyzer::sanitizeDocblockType($parts[0]);
+        if ($typeString === '' || $typeString[0] === '$') {
+            // First token is a variable name, not a type (`@param $x ...`) —
+            // no narrowing to lift.
+            return null;
+        }
+
+        // Accept optional `&` (by-ref) and `...` (variadic) prefixes and a
+        // trailing comma. Reflection already knows by-ref/variadic, so we
+        // only capture the bare identifier for the map key.
+        if (!\preg_match('/^&?(?:\.\.\.)?\$([A-Za-z_]\w*),?$/', $parts[1], $matches)) {
+            return null;
+        }
+
+        $union = self::parseDocblockTypeString($typeString, $aliases);
+        if (!$union instanceof Union) {
+            return null;
+        }
+
+        return [$matches[1], $union];
+    }
+
+    /**
+     * Parse a single `@return <type> [description]` docblock value line into
+     * a {@see Union}, or `null` when malformed / unparseable.
+     */
+    private static function extractReturnFromLine(string $line, Aliases $aliases): ?Union
+    {
+        // `splitDocLine()` is typed `non-empty-list<string>` so there is
+        // always at least one part; the first part holds the type (or a
+        // description in the degenerate case where the docblock writer left
+        // the type off).
+        $parts = CommentAnalyzer::splitDocLine($line);
+
+        $typeString = CommentAnalyzer::sanitizeDocblockType($parts[0]);
+        if ($typeString === '') {
+            return null;
+        }
+
+        return self::parseDocblockTypeString($typeString, $aliases);
+    }
+
+    /**
+     * Tokenise a docblock type string against the closure's enclosing aliases
+     * and parse to a {@see Union}. Failure-mode shape matches
+     * {@see self::reflectionTypeToUnion()}: degrade quietly for unparseable
+     * input or the test-only `ProjectAnalyzer not initialised` case; re-throw
+     * any other engine error so genuine Psalm bugs surface instead of being
+     * masked.
+     */
+    private static function parseDocblockTypeString(string $typeString, Aliases $aliases): ?Union
+    {
+        try {
+            $tokens = TypeTokenizer::getFullyQualifiedTokens($typeString, $aliases);
+
+            return TypeParser::parseTokens($tokens, null, [], [], true);
+        } catch (TypeParseTreeException) {
+            return null;
+        } catch (\Error $error) {
+            if (!\str_contains($error->getMessage(), 'ProjectAnalyzer')) {
+                throw $error;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Util/Ast/ClosureTypeFactory.php
+++ b/src/Util/Ast/ClosureTypeFactory.php
@@ -6,6 +6,7 @@ namespace Psalm\LaravelPlugin\Util\Ast;
 
 use PhpParser\Comment\Doc;
 use PhpParser\Error as PhpParserError;
+use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\ParserFactory;
 use Psalm\Aliases;
@@ -18,6 +19,8 @@ use Psalm\Internal\Type\TypeTokenizer;
 use Psalm\Storage\FunctionLikeParameter;
 use Psalm\Type;
 use Psalm\Type\Atomic\TClosure;
+use Psalm\Type\Atomic\TKeyedArray;
+use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Union;
 
 /**
@@ -35,12 +38,15 @@ use Psalm\Type\Union;
  * registered from `vendor/` packages outside `<projectFiles>` work the same
  * as project-source closures.
  *
- * Gap vs PHPStan: body-flow inference. PHPStan's `ClosureTypeFactory` infers
- * the return type from `return` statements when no `@return` docblock is
- * present (e.g. `fn () => 'x'` produces a literal-string return). We
- * currently fall back to the native reflection return type or `mixed`.
- * Tracked as follow-up work — see the "Body-flow inference" plan in PR #994's
- * description.
+ * Coverage extended in PR #994: body-flow inference for the narrow subset of
+ * `return` expressions whose static value is obvious without any semantic
+ * analysis — literal scalars (`'x'`, `42`, `1.5`, `true`/`false`/`null`),
+ * concatenations of inferable strings, arithmetic of inferable numerics, and
+ * shaped arrays whose keys and values are themselves inferable. Any unhandled
+ * node anywhere in the closure body bails the entire inference. This is
+ * deliberately narrower than PHPStan's equivalent: we never trigger Psalm's
+ * `StatementsAnalyzer` (would re-enter the scanner mid-scan) and never follow
+ * variable references — both are explicitly out of scope for the PR.
  *
  * Stateless by design. Caching is a separate concern handled by
  * {@see CachedClosureTypeFactory}, which composes via callable injection at
@@ -64,9 +70,9 @@ final class ClosureTypeFactory
      * - the source file is unreadable or fails to parse;
      * - no closure starts at the reflected line, or multiple closures share
      *   the start line (ambiguity → bail rather than guess);
-     * - the closure has no docblock-derived narrowing the caller could not
-     *   already produce from reflection alone. Caller falls back to a
-     *   reflection-only pseudo-method in that case.
+     * - neither docblock recovery nor PR #994 body-flow inference can add
+     *   anything beyond what reflection already exposes. Caller falls back to
+     *   a reflection-only pseudo-method in that case.
      *
      * @psalm-api Public convenience for callers that opt out of the memoizing
      *            wrapper (notably the unit tests). Production callers go
@@ -89,15 +95,15 @@ final class ClosureTypeFactory
      * to wrappers, not to this class.
      *
      * @internal Decorator injection seam.
-     * @param callable(string): ?array<int, list<array{0: ?Doc, 1: Aliases}>> $indexer
+     * @param callable(string): ?array<int, list<array{0: ?Doc, 1: Aliases, 2: Node\Expr\Closure|Node\Expr\ArrowFunction}>> $indexer
      */
     public static function buildWithIndexer(\Closure $closure, callable $indexer): ?TClosure
     {
         $reflection = new \ReflectionFunction($closure);
 
-        $docblock = self::recoverDocblock($reflection, $indexer);
+        $recovered = self::recoverFromSource($reflection, $indexer);
 
-        return self::buildClosureType($reflection, $docblock);
+        return self::buildClosureType($reflection, $recovered);
     }
 
     /**
@@ -109,7 +115,7 @@ final class ClosureTypeFactory
      * {@see CachedClosureTypeFactory} (or any compatible memoizer) for
      * repeated lookups against the same file.
      *
-     * @return array<int, list<array{0: ?Doc, 1: Aliases}>>|null
+     * @return array<int, list<array{0: ?Doc, 1: Aliases, 2: Node\Expr\Closure|Node\Expr\ArrowFunction}>>|null
      */
     public static function indexFile(string $realpath): ?array
     {
@@ -142,13 +148,16 @@ final class ClosureTypeFactory
     }
 
     /**
-     * Lift `@param` and `@return` Unions from the closure's source-attached
-     * docblock, or `null` when no usable docblock is reachable.
+     * Resolve the closure's source entry: the parsed AST node, plus its
+     * docblock-derived narrowing when present. Returns `null` only when the
+     * indexer cannot uniquely identify a closure at the reflected line — in
+     * every other case we surface the node so the body-inference path can
+     * still run when the docblock is silent.
      *
-     * @param callable(string): ?array<int, list<array{0: ?Doc, 1: Aliases}>> $indexer
-     * @return array{params: array<string, Union>, return: ?Union}|null
+     * @param callable(string): ?array<int, list<array{0: ?Doc, 1: Aliases, 2: Node\Expr\Closure|Node\Expr\ArrowFunction}>> $indexer
+     * @return array{docblock: ?array{params: array<string, Union>, return: ?Union}, node: Node\Expr\Closure|Node\Expr\ArrowFunction}|null
      */
-    private static function recoverDocblock(\ReflectionFunctionAbstract $reflection, callable $indexer): ?array
+    private static function recoverFromSource(\ReflectionFunctionAbstract $reflection, callable $indexer): ?array
     {
         $filePath = $reflection->getFileName();
         $line = $reflection->getStartLine();
@@ -178,28 +187,48 @@ final class ClosureTypeFactory
             return null;
         }
 
-        [$doc, $aliases] = $matches[0];
-        if (!$doc instanceof Doc) {
-            return null;
-        }
+        [$doc, $aliases, $node] = $matches[0];
+        $docblock = $doc instanceof Doc ? self::extractDocblock($doc, $aliases) : null;
 
-        return self::extractDocblock($doc, $aliases);
+        return ['docblock' => $docblock, 'node' => $node];
     }
 
     /**
      * Build the final {@see TClosure}: reflection-derived parameter list with
-     * docblock narrowing per parameter, plus the docblock return type when
-     * present, otherwise the native return type or `mixed`.
+     * docblock narrowing per parameter, plus the best available return type.
      *
-     * Returns `null` when no docblock narrowing was recovered — the caller
-     * would not learn anything beyond what reflection already exposes, so it
-     * keeps its existing reflection-only pseudo-method path instead.
+     * Return-type precedence:
+     * 1. Docblock `@return` (issue #991 — wins because it can express types
+     *    PHP cannot, like `non-empty-string` or `Collection<int, string>`).
+     * 2. Native reflected return type.
+     * 3. PR #994 body-flow inference (literal-value `return`s and arrow
+     *    functions), invoked only when both the docblock and reflection
+     *    are silent on the return type — anything coarser than `mixed`
+     *    beats `mixed` for callers chaining off the closure's result.
+     * 4. `Type::getMixed()` as the bottom fallback.
      *
-     * @param array{params: array<string, Union>, return: ?Union}|null $docblock
+     * Returns `null` only when none of those steps improves on what
+     * reflection already exposes — caller keeps its existing reflection-only
+     * pseudo-method path instead.
+     *
+     * @param array{docblock: ?array{params: array<string, Union>, return: ?Union}, node: Node\Expr\Closure|Node\Expr\ArrowFunction}|null $recovered
      */
-    private static function buildClosureType(\ReflectionFunctionAbstract $reflection, ?array $docblock): ?TClosure
+    private static function buildClosureType(\ReflectionFunctionAbstract $reflection, ?array $recovered): ?TClosure
     {
-        if ($docblock === null) {
+        $docblock = $recovered === null ? null : $recovered['docblock'];
+        $node = $recovered === null ? null : $recovered['node'];
+        $nativeReturn = self::reflectionTypeToUnion($reflection->getReturnType());
+
+        // Body-flow inference (PR #994) only runs when both the docblock and
+        // the native reflected return are silent. With either present, the
+        // existing precedence already wins — body inference would at best
+        // duplicate work, at worst contradict the explicit declaration.
+        $bodyReturn = null;
+        if ($docblock === null && !$nativeReturn instanceof \Psalm\Type\Union && $node !== null) {
+            $bodyReturn = self::inferReturnFromBody($node);
+        }
+
+        if ($docblock === null && !$bodyReturn instanceof \Psalm\Type\Union) {
             return null;
         }
 
@@ -208,16 +237,357 @@ final class ClosureTypeFactory
             $params[] = self::buildClosureParameter($reflParam, $docblock['params'][$reflParam->getName()] ?? null);
         }
 
-        $nativeReturn = self::reflectionTypeToUnion($reflection->getReturnType());
-        // Issue #991: docblock `@return` (when present) wins over the native
-        // reflection return — that's the whole point of recovery. Native
-        // return is preserved only when the docblock is silent.
-        $returnType = $docblock['return'] ?? $nativeReturn ?? Type::getMixed();
+        $returnType = $docblock['return'] ?? $nativeReturn ?? $bodyReturn ?? Type::getMixed();
 
         return new TClosure(
             params: $params,
             return_type: $returnType,
         );
+    }
+
+    /**
+     * PR #994 — narrow body-flow inference for a closure or arrow function.
+     *
+     * `ArrowFunction` has a single expression body (`$node->expr`) which is by
+     * definition the return value. `Closure` may have any number of `return`
+     * statements: we walk the body collecting them, infer each, and union the
+     * results. Any unhandled node in the expression position bails the entire
+     * inference — we never produce a partial answer, because doing so would
+     * silently disagree with the closure's actual semantics.
+     *
+     * Deliberately stops at nested closures / arrow functions / function
+     * declarations / class methods: their `return` statements belong to the
+     * nested function, not the outer one.
+     */
+    private static function inferReturnFromBody(Node\Expr\Closure|Node\Expr\ArrowFunction $node): ?Union
+    {
+        if ($node instanceof Node\Expr\ArrowFunction) {
+            return self::inferExpression($node->expr);
+        }
+
+        // Guard against implicit-`null` fall-through. PHP returns `null` from a
+        // closure whose control flow reaches the closing brace without hitting
+        // an explicit `return`. If we ignored that path we would silently
+        // produce a narrower type than runtime — e.g. `static function () {
+        // if (cond) return 1; }` would surface as `1` instead of `1|null`.
+        // Conservatively require the last top-level statement to be a
+        // terminating `return` or `throw`; anything else (including
+        // `if/else { return; }` symmetric pairs) bails. PHPStan's body inference
+        // takes the same conservative posture here.
+        if (!self::bodyAlwaysTerminates($node->stmts)) {
+            return null;
+        }
+
+        $collector = new BodyReturnCollectorVisitor();
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($collector);
+        $traverser->traverse($node->stmts);
+
+        $returnExprs = $collector->getReturnExpressions();
+        if ($collector->hasBailed() || $returnExprs === []) {
+            return null;
+        }
+
+        $unions = [];
+        foreach ($returnExprs as $expr) {
+            $inferred = self::inferExpression($expr);
+            if (!$inferred instanceof Union) {
+                return null;
+            }
+
+            $unions[] = $inferred;
+        }
+
+        return Type::combineUnionTypeArray($unions, null);
+    }
+
+    /**
+     * Conservative reachability check: returns `true` only when control flow
+     * provably cannot reach the closing brace of the closure body without
+     * hitting a `return` or `throw`. Anything more nuanced (e.g. "every branch
+     * of this `if/elseif/else` returns") would need a full CFG pass — and
+     * since the PR's inference target is short macro closures (one expression
+     * body, one straight return, or a final `return` after early-exit guards),
+     * the cheap check is enough. False negatives just bail to `mixed`, which
+     * is the existing fallback.
+     *
+     * PhpParser 5 models `throw new X;` as `Stmt\Expression` wrapping
+     * `Expr\Throw_` (PHP 8 promoted `throw` to an expression), so the
+     * statement-level check has to peek through the expression wrapper.
+     *
+     * @param array<array-key, Node\Stmt> $stmts
+     * @psalm-mutation-free Reads node properties only, mutates nothing.
+     */
+    private static function bodyAlwaysTerminates(array $stmts): bool
+    {
+        if ($stmts === []) {
+            return false;
+        }
+
+        $last = \end($stmts);
+        if ($last instanceof Node\Stmt\Return_) {
+            return true;
+        }
+
+        return $last instanceof Node\Stmt\Expression && $last->expr instanceof Node\Expr\Throw_;
+    }
+
+    /**
+     * Infer a {@see Union} for a single expression node, or `null` when the
+     * node falls outside the deliberately-narrow set the PR supports.
+     *
+     * Rule table — see PR #994's prompt for the source spec:
+     *
+     * | Node                            | Inferred                                  |
+     * |---------------------------------|-------------------------------------------|
+     * | `Scalar\String_`                | `Type::getString($value)`                 |
+     * | `Scalar\Int_`                   | `Type::getInt(false, $value)`             |
+     * | `Scalar\Float_`                 | `Type::getFloat($value)`                  |
+     * | `Expr\ConstFetch` true/false/null | matching constant Union                 |
+     * | `Expr\Array_` (all inferable)   | shaped array via `TKeyedArray::make()`    |
+     * | `Expr\BinaryOp\Concat` of literal strings | concatenated literal-string     |
+     * | `Expr\BinaryOp` arithmetic of inferable numerics | `int|float`            |
+     * | anything else                   | `null` (caller bails)                     |
+     */
+    private static function inferExpression(Node\Expr $expr): ?Union
+    {
+        if ($expr instanceof Node\Scalar\String_) {
+            return self::literalStringUnion($expr->value);
+        }
+
+        if ($expr instanceof Node\Scalar\Int_) {
+            return Type::getInt(false, $expr->value);
+        }
+
+        if ($expr instanceof Node\Scalar\Float_) {
+            return Type::getFloat($expr->value);
+        }
+
+        if ($expr instanceof Node\Expr\ConstFetch) {
+            // Globally-namespaced `true`/`false`/`null`. We do not honour
+            // `use const` aliases or user-defined constants — those would
+            // require a constant resolver, well outside the PR's scope.
+            return match (\strtolower($expr->name->toString())) {
+                'true' => Type::getTrue(),
+                'false' => Type::getFalse(),
+                'null' => Type::getNull(),
+                default => null,
+            };
+        }
+
+        if ($expr instanceof Node\Expr\Array_) {
+            return self::inferArray($expr);
+        }
+
+        if ($expr instanceof Node\Expr\BinaryOp\Concat) {
+            return self::inferConcat($expr);
+        }
+
+        if ($expr instanceof Node\Expr\BinaryOp && self::isArithmeticBinaryOp($expr)) {
+            return self::inferArithmetic($expr);
+        }
+
+        return null;
+    }
+
+    /**
+     * The six PHP-Parser binary-op nodes that produce a numeric result and
+     * share a single dispatch branch in {@see self::inferExpression()}.
+     * Comparison and boolean operators (`==`, `&&`, `<=>`, …) are deliberately
+     * excluded: they widen to `bool` / `int<-1, 1>` and would need their own
+     * rules. Named predicate (vs. a six-way `instanceof` chain) makes the
+     * arithmetic-vs-other split obvious to readers.
+     *
+     * @psalm-pure
+     */
+    private static function isArithmeticBinaryOp(Node\Expr\BinaryOp $expr): bool
+    {
+        return $expr instanceof Node\Expr\BinaryOp\Plus
+            || $expr instanceof Node\Expr\BinaryOp\Minus
+            || $expr instanceof Node\Expr\BinaryOp\Mul
+            || $expr instanceof Node\Expr\BinaryOp\Div
+            || $expr instanceof Node\Expr\BinaryOp\Mod
+            || $expr instanceof Node\Expr\BinaryOp\Pow;
+    }
+
+    /**
+     * Build a {@see Union} for `'a' . 'b'`-style concatenations whose operands
+     * both reduce to single string literals. Anything coarser (mixed types,
+     * non-literal operand, nested non-string union) bails, because we cannot
+     * produce a single literal value to fold the result into.
+     */
+    private static function inferConcat(Node\Expr\BinaryOp\Concat $expr): ?Union
+    {
+        $left = self::inferExpression($expr->left);
+        $right = self::inferExpression($expr->right);
+        if (!$left instanceof Union || !$right instanceof Union) {
+            return null;
+        }
+
+        if (!$left->isSingleStringLiteral() || !$right->isSingleStringLiteral()) {
+            return null;
+        }
+
+        return self::literalStringUnion($left->getSingleStringLiteral()->value . $right->getSingleStringLiteral()->value);
+    }
+
+    /**
+     * Build a single-literal-string {@see Union}, bypassing
+     * {@see Type::getString()}: that helper routes through
+     * `StringInterpreterEvent` and {@see \Psalm\Internal\Analyzer\ProjectAnalyzer},
+     * which is unsafe to touch before Psalm's project analyser is bootstrapped
+     * (notably during unit tests). Returns `null` on `max_string_length`
+     * overflow or when `Config` itself is missing.
+     *
+     * @psalm-pure
+     */
+    private static function literalStringUnion(string $value): ?Union
+    {
+        try {
+            // `from_docblock=false`: the value comes from the closure's actual
+            // source AST, not a docblock annotation. Matches Psalm's own
+            // convention in `ArrayAnalyzer::analyzeArray()` for source-literal
+            // arrays, and keeps `from_docblock` aligned with the other
+            // source-derived atomics built in `inferExpression()`
+            // (`Type::getInt(false, $value)`, `Type::getFloat($value)`,
+            // `Type::getTrue/False/Null()`).
+            return new Union([TLiteralString::make($value)]);
+        } catch (\InvalidArgumentException) {
+            // Value exceeds Psalm's configured `max_string_length` — degrade
+            // to "no inference" rather than fall back to a wider type the
+            // caller would not expect.
+            return null;
+        } catch (\UnexpectedValueException) {
+            // `Config::getInstance()` not initialised. Same posture as
+            // PluginConfig::getCacheDir(): treat as "no inference available".
+            return null;
+        }
+    }
+
+    /**
+     * Build an `int|float` union for arithmetic operators on numerics. We do
+     * not try to fold to a single literal: `1 + 2` could be told to surface
+     * as `int(3)`, but the moment the operand list grows (or a `Float_`
+     * appears anywhere) the result type can flip integer↔float in ways that
+     * are easier to express as `int|float` than to model exactly.
+     *
+     * The result is constant — operand inference exists purely as a numeric
+     * gate, NOT as input to the type. Do not "simplify" by dropping the
+     * `inferExpression()` calls: that gate is what prevents `1 + 'x'` from
+     * widening to `int|float` (which would be wrong, since the runtime
+     * outcome is a `TypeError`).
+     */
+    private static function inferArithmetic(Node\Expr\BinaryOp $expr): ?Union
+    {
+        $left = self::inferExpression($expr->left);
+        $right = self::inferExpression($expr->right);
+        if (!$left instanceof Union || !$right instanceof Union) {
+            return null;
+        }
+
+        if (!self::isNumericUnion($left) || !self::isNumericUnion($right)) {
+            return null;
+        }
+
+        // Build a fresh Union per call rather than memoizing. Psalm 7's Union
+        // has public mutable fields (`from_docblock`, `ignore_nullable_issues`,
+        // …). The instance flows into every `TClosure->return_type` we hand
+        // to `MacroDefinition`; an aliased memo would let a downstream
+        // mutation on one macro pollute every other arithmetic macro built
+        // this run. Psalm itself uses functional setters in practice, but
+        // the savings (one `combineUnionTypes` call per arithmetic body
+        // return, typically <10 per run) are not worth the risk.
+        return Type::combineUnionTypes(Type::getInt(), Type::getFloat());
+    }
+
+    /**
+     * `int|float`-only check used by {@see self::inferArithmetic()}. We only
+     * accept fully-known numeric unions — partial unions like `int|string`
+     * would force us to drop into a wider type that defeats the inference.
+     *
+     * @psalm-mutation-free
+     */
+    private static function isNumericUnion(Union $union): bool
+    {
+        foreach ($union->getAtomicTypes() as $atomic) {
+            if (!$atomic instanceof Type\Atomic\TInt && !$atomic instanceof Type\Atomic\TFloat) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Build a shaped {@see Union} for `[…]` literals. Every entry must have
+     * an inferable value AND (if keyed) a literal int/string key. Unpacks
+     * (`...$x`) and unkeyed entries with non-sequential mix of keyed entries
+     * are conservative bails: we deliberately don't try to model partial
+     * arrays. The empty array is its own degenerate case — Psalm exposes a
+     * dedicated empty-array Union for it.
+     */
+    private static function inferArray(Node\Expr\Array_ $expr): ?Union
+    {
+        if ($expr->items === []) {
+            return Type::getEmptyArray();
+        }
+
+        $properties = [];
+        $nextAutoIndex = 0;
+        $anyExplicitKey = false;
+        foreach ($expr->items as $item) {
+            // `Array_->items` is `list<ArrayItem|null>`: PHP-Parser preserves
+            // `null` for skipped positions inside `list(...)`-style destructuring.
+            // That is destructuring metadata, not a value-producing literal, so
+            // we bail on it.
+            if ($item === null || $item->unpack) {
+                return null;
+            }
+
+            $valueUnion = self::inferExpression($item->value);
+            if (!$valueUnion instanceof Union) {
+                return null;
+            }
+
+            if ($item->key === null) {
+                $properties[$nextAutoIndex] = $valueUnion;
+                $nextAutoIndex++;
+                continue;
+            }
+
+            $anyExplicitKey = true;
+
+            $keyExpr = $item->key;
+            if ($keyExpr instanceof Node\Scalar\String_) {
+                $properties[$keyExpr->value] = $valueUnion;
+                continue;
+            }
+
+            if ($keyExpr instanceof Node\Scalar\Int_) {
+                $properties[$keyExpr->value] = $valueUnion;
+                // Subsequent unkeyed entries continue from one past the
+                // largest seen integer key — matches PHP's auto-indexing.
+                if ($keyExpr->value >= $nextAutoIndex) {
+                    $nextAutoIndex = $keyExpr->value + 1;
+                }
+
+                continue;
+            }
+
+            return null;
+        }
+
+        if ($properties === []) {
+            return Type::getEmptyArray();
+        }
+
+        $isList = !$anyExplicitKey;
+
+        // `from_docblock=false`: matches Psalm's own source-literal convention
+        // (`ArrayAnalyzer::analyzeArray()` calls `TKeyedArray::make` with the
+        // default `false`). `from_docblock=true` relaxes comparison strictness
+        // at call sites — wrong choice for a value we recovered from PHP source.
+        return new Union([TKeyedArray::make($properties, null, null, $isList)]);
     }
 
     /**

--- a/tests/Type/macro-fixtures-vendor-style.php
+++ b/tests/Type/macro-fixtures-vendor-style.php
@@ -64,3 +64,33 @@ MacroFixtureBag::macro('astDocblockParamOnlyTest', static function (int $count):
  * @return non-empty-string
  */
 MacroFixtureBag::macro('astDocblockArrowFnTest', static fn(int $count) => \str_repeat('a', $count));
+
+// PR #994 fixtures — body-flow inference. None of the closures below have a
+// docblock @return OR a native return type, so storage-only and reflection
+// recovery both bottom out at `mixed`. The factory's new body-flow inference
+// is the only path that can produce a narrower return type.
+
+// Literal string: `fn () => 'hello'` should surface as `'hello'`.
+MacroFixtureBag::macro('astBodyInferLiteralStringTest', static fn() => 'hello');
+
+// Multi-return union: each branch is a literal, the result is their union.
+MacroFixtureBag::macro('astBodyInferUnionTest', static function () {
+    if (\random_int(0, 1) === 0) {
+        return 1;
+    }
+    return 'x';
+});
+
+// Unhandled node (`new` expression) — body inference bails. `Expr\New_` is
+// firmly outside the PR's rule table; adding it later would be a deliberate
+// spec change, not a sloppy refactor of `inferExpression()`. Without any
+// source of narrowing, the factory falls back to its null-return path and
+// the caller's reflection-only pseudo-method surfaces `mixed`.
+MacroFixtureBag::macro('astBodyInferBailsOnComplex', static fn() => new \stdClass());
+
+// Concat of two literal strings should fold to a single literal. The fixture
+// MUST keep the `.` operator (not a pre-folded `'ab'`) — rector's
+// `typeDeclarations` set is configured to skip this file, but any future
+// constant-folding pass would defeat the test if it collapses the concat at
+// authoring time. See rector.php skip-path comment.
+MacroFixtureBag::macro('astBodyInferConcatTest', static fn() => 'a' . 'b');

--- a/tests/Type/macro-fixtures-vendor-style.php
+++ b/tests/Type/macro-fixtures-vendor-style.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Issue #991 fixture. Simulates a vendor package registering closure macros from
+ * a file Psalm does NOT scan ahead of time.
+ *
+ * This file is intentionally NOT listed under `<projectFiles>`, the `autoloader`
+ * attribute, or `<stubs>` in `tests/Type/psalm.xml`. It only reaches PHP at
+ * runtime via `require_once` from `macro-fixtures.php` (the autoloader file),
+ * which is enough for `Macroable::$macros` to be populated by the time
+ * `AfterCodebasePopulated` runs — but not enough for Psalm's
+ * {@see \Psalm\Storage\FunctionLikeStorage} to exist for the closure source.
+ *
+ * The storage path added by #989 misses (`file_storage_provider->has()` returns
+ * `false`), and the AST-scan fallback added by #991 (
+ * {@see \Psalm\LaravelPlugin\Util\Ast\CachedClosureTypeFactory::fromClosureObject()}
+ * ) is the only way for the docblock-only `@param positive-int $count` and
+ * `@return non-empty-string` narrowing below to survive into the synthesised
+ * pseudo-method.
+ *
+ * Docblock placement mirrors the motivating Inertia case: the docblock is
+ * attached to the wrapping `Stmt\Expression` (the `MacroFixtureBag::macro(...)`
+ * call), NOT to the closure node directly. That's the row the issue table
+ * identifies as "closure in vendor with docblock-only types".
+ */
+
+use Illuminate\Support\Collection;
+use Tests\Psalm\LaravelPlugin\Type\Fixtures\MacroFixtureBag;
+
+/**
+ * @param positive-int $count
+ * @return non-empty-string
+ */
+MacroFixtureBag::macro('astDocblockReturnTest', static function (int $count) {
+    return \str_repeat('y', $count);
+});
+
+/**
+ * @return Collection<int, string>
+ */
+MacroFixtureBag::macro('astDocblockGenericTest', static function (): \Illuminate\Support\Collection {
+    return new Collection(['a', 'b']);
+});
+
+// Issue #991 coverage matrix row 3 — "closure with native return type +
+// @param-only narrowing". Reflection sees `int $count`/`string` return; the
+// docblock only narrows the parameter to `positive-int`. The recovery path
+// must preserve the native string return (no docblock @return) while still
+// applying the @param narrowing.
+/**
+ * @param positive-int $count
+ */
+MacroFixtureBag::macro('astDocblockParamOnlyTest', static function (int $count): string {
+    return \str_repeat('p', $count);
+});
+
+// Arrow-function syntax (`fn () => …`) — a common shape for one-liner
+// macros in modern Laravel code. The visitor handles `ArrowFunction` and
+// `Closure` symmetrically; this fixture locks that branch in.
+/**
+ * @param positive-int $count
+ * @return non-empty-string
+ */
+MacroFixtureBag::macro('astDocblockArrowFnTest', static fn(int $count) => \str_repeat('a', $count));

--- a/tests/Type/macro-fixtures.php
+++ b/tests/Type/macro-fixtures.php
@@ -23,6 +23,15 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/macro-fixtures-class.phpstub';
 
+// Issue #991 — the AST-scan fallback path requires a closure registered from a
+// file Psalm does NOT scan. We deliberately keep `macro-fixtures-vendor-style.php`
+// out of `<projectFiles>`, `<stubs>`, and the `autoloader` attribute; PHP still
+// executes it because this autoloader `require_once`s it at boot, so reflection
+// finds the closure, but Psalm's `file_storage_provider->has()` returns false.
+// That gap is what {@see \Psalm\LaravelPlugin\Util\Ast\CachedClosureTypeFactory::fromClosureObject()}
+// closes by parsing the file with `nikic/php-parser` on demand.
+require_once __DIR__ . '/macro-fixtures-vendor-style.php';
+
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Tests\Psalm\LaravelPlugin\Type\Fixtures\MacroFixtureBag;

--- a/tests/Type/tests/Macros/MacroAstBodyInferenceTest.phpt
+++ b/tests/Type/tests/Macros/MacroAstBodyInferenceTest.phpt
@@ -1,0 +1,54 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Tests\Psalm\LaravelPlugin\Type\Fixtures\MacroFixtureBag;
+
+/**
+ * AST body-flow inference — PR #994.
+ *
+ * Companion to `MacroAstScanVendorClosureTest.phpt`. Same vendor-style file
+ * (`macro-fixtures-vendor-style.php`), but the closures registered here have
+ * neither a docblock `@return` nor a native return type. The PR's body-flow
+ * inference is the only path that can produce a narrower return type than the
+ * pseudo-method fallback's `mixed`.
+ *
+ * Bring the inference back to PHPStan parity:
+ *
+ *   astBodyInferLiteralStringTest:  () => 'hello'
+ *   astBodyInferUnionTest:          () => 1|'x' (multi-return union)
+ *   astBodyInferConcatTest:         () => 'ab'  (literal-string folding)
+ *   astBodyInferBailsOnComplex:     () => mixed (unhandled expression bails)
+ *
+ * If body inference regresses, the call sites below will read back the wrong
+ * narrowed type and `@psalm-check-type-exact` will fail loud.
+ */
+
+function test_ast_body_infer_literal_string(): string
+{
+    $_ = (new MacroFixtureBag())->astBodyInferLiteralStringTest();
+    /** @psalm-check-type-exact $_ = 'hello' */
+    return $_;
+}
+
+function test_ast_body_infer_multi_return_union(): int|string
+{
+    $_ = (new MacroFixtureBag())->astBodyInferUnionTest();
+    /** @psalm-check-type-exact $_ = 1|'x' */
+    return $_;
+}
+
+function test_ast_body_infer_bails_on_complex(): mixed
+{
+    $_ = (new MacroFixtureBag())->astBodyInferBailsOnComplex();
+    /** @psalm-check-type-exact $_ = mixed */
+    return $_;
+}
+
+function test_ast_body_infer_concat_folds_to_literal(): string
+{
+    $_ = (new MacroFixtureBag())->astBodyInferConcatTest();
+    /** @psalm-check-type-exact $_ = 'ab' */
+    return $_;
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Macros/MacroAstScanVendorClosureTest.phpt
+++ b/tests/Type/tests/Macros/MacroAstScanVendorClosureTest.phpt
@@ -1,0 +1,88 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Collection;
+use Tests\Psalm\LaravelPlugin\Type\Fixtures\MacroFixtureBag;
+
+/**
+ * AST-scan closure type extraction — issue #991.
+ *
+ * Companion to `MacroDocblockClosureTest.phpt` (issue #989): same docblock
+ * narrowing, but the closure lives in `tests/Type/macro-fixtures-vendor-style.php`,
+ * a file Psalm does NOT scan (not listed under `<projectFiles>`, `<stubs>`, or
+ * the `autoloader` attribute). It only reaches PHP via `require_once` from the
+ * autoloader file, mirroring the Inertia / vendor-package call site.
+ *
+ * The storage-based docblock recovery shipped in #989 misses for these closures
+ * (`file_storage_provider->has()` returns `false`). The AST-scan fallback in
+ * `CachedClosureTypeFactory::fromClosureObject()` parses the file on demand with
+ * `nikic/php-parser`, locates the closure by start line, and lifts `@param`
+ * and `@return` Unions from the wrapping `Stmt\Expression`'s docblock into the
+ * synthesised pseudo-method.
+ *
+ * Without this path the macros would resolve as:
+ *
+ *   astDocblockReturnTest(int):    mixed         (no native return type)
+ *   astDocblockGenericTest():      Collection    (generic args erased)
+ *
+ * With AST recovery they surface as the docblock-narrowed forms below.
+ */
+
+function test_ast_scan_recovers_return_type_from_vendor_closure(): string
+{
+    $_ = (new MacroFixtureBag())->astDocblockReturnTest(3);
+    /** @psalm-check-type-exact $_ = non-empty-string */
+    return $_;
+}
+
+function test_ast_scan_recovers_param_narrowing_from_vendor_closure(): string
+{
+    // `@param positive-int $count` should narrow the native `int` parameter so
+    // passing an `int<1, max>` literal is accepted, while a non-positive literal
+    // is rejected (see test_ast_scan_rejects_non_positive_int below).
+    $count = 5;
+    return (new MacroFixtureBag())->astDocblockReturnTest($count);
+}
+
+function test_ast_scan_recovers_generic_return_from_vendor_closure(): Collection
+{
+    $_ = (new MacroFixtureBag())->astDocblockGenericTest();
+    /** @psalm-check-type-exact $_ = Illuminate\Support\Collection<int, string> */
+    return $_;
+}
+
+function test_ast_scan_partial_param_only_preserves_native_return(): string
+{
+    // Coverage matrix row 3: docblock narrows `@param positive-int $count` but
+    // declares no `@return`. The recovered macro must keep the native `string`
+    // return (signature_return_type → return_type fallback) AND apply the
+    // narrower param type.
+    $_ = (new MacroFixtureBag())->astDocblockParamOnlyTest(2);
+    /** @psalm-check-type-exact $_ = string */
+    return $_;
+}
+
+function test_ast_scan_param_only_still_rejects_non_positive(): string
+{
+    // Same fixture as above — the docblock-derived `positive-int` narrowing
+    // must still reject 0 even when there is no docblock `@return`.
+    return (new MacroFixtureBag())->astDocblockParamOnlyTest(-1);
+}
+
+function test_ast_scan_recovers_docblock_on_arrow_function(): string
+{
+    // `fn () => …` (ArrowFunction node) shares the visitor's recovery branch
+    // with `Closure`. Locks in that branch.
+    $_ = (new MacroFixtureBag())->astDocblockArrowFnTest(4);
+    /** @psalm-check-type-exact $_ = non-empty-string */
+    return $_;
+}
+
+function test_ast_scan_rejects_non_positive_int(): string
+{
+    return (new MacroFixtureBag())->astDocblockReturnTest(0);
+}
+?>
+--EXPECTF--
+InvalidArgument on line %d: Argument 1 of astDocblockParamOnlyTest expects int<1, max>, but -1 provided
+InvalidArgument on line %d: Argument 1 of astDocblockReturnTest expects int<1, max>, but 0 provided

--- a/tests/Type/tests/Macros/MacroDocblockClosureTest.phpt
+++ b/tests/Type/tests/Macros/MacroDocblockClosureTest.phpt
@@ -21,12 +21,14 @@ use Tests\Psalm\LaravelPlugin\Type\Fixtures\MacroFixtureChild;
  *   docblockReturnTest(int):  mixed         (no native return type at all)
  *   docblockGenericTest():    mixed         (no native return type)
  *
- * `MacroRegistry::recoverClosureStorage()` matches the closure to Psalm's
- * pre-scanned `FunctionLikeStorage` by file + line, and
- * `MacroRegistry::buildDefinitionFromStorage()` copies the docblock-derived
- * Union types into the synthesised pseudo-method. The autoloader file is
- * deep-scanned by `Psalm\Config` so its closure storage is populated by the
- * time `AfterCodebasePopulated` runs.
+ * After issue #991 the recovery pipeline tries AST first
+ * ({@see \Psalm\LaravelPlugin\Util\Ast\CachedClosureTypeFactory::fromClosureObject()}):
+ * the autoloader file is on disk, php-parser parses it on demand, the closure
+ * node's own docblock is read directly. The pre-#991 Psalm-storage path
+ * ({@see \Psalm\LaravelPlugin\Providers\MacroRegistry::recoverClosureStorage()}
+ * / `buildDefinitionFromStorage()`) is still the second-tier fallback for
+ * closures whose source AST fails to recover (parse error, ambiguous start
+ * line, no usable docblock).
  *
  * The Collection import here matches the import in `macro-fixtures.php`, so the
  * generic-return assertion below resolves against the same FQCN that the

--- a/tests/Unit/Util/Ast/CachedClosureTypeFactoryTest.php
+++ b/tests/Unit/Util/Ast/CachedClosureTypeFactoryTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\TestCase;
 use Psalm\LaravelPlugin\Util\Ast\CachedClosureTypeFactory;
 use Psalm\Type\Atomic\TClosure;
 use Psalm\Type\Union;
+use Tests\Psalm\LaravelPlugin\Unit\Util\Ast\Concerns\InitializesPsalmConfigSingleton;
 
 /**
  * Targeted coverage for the memoizing decorator. The stateless build
@@ -31,6 +32,8 @@ use Psalm\Type\Union;
 #[CoversClass(CachedClosureTypeFactory::class)]
 final class CachedClosureTypeFactoryTest extends TestCase
 {
+    use InitializesPsalmConfigSingleton;
+
     /** @var list<string> */
     private array $tempFiles = [];
 
@@ -183,6 +186,30 @@ PHP,
         $second = CachedClosureTypeFactory::fromClosureObject($this->loadClosureFromFile($file));
         $this->assertInstanceOf(TClosure::class, $second);
         $this->assertSame('literal-string', $second->return_type?->getId());
+    }
+
+    #[Test]
+    public function delegates_to_body_flow_inference_when_docblock_absent(): void
+    {
+        // PR #994: the cached wrapper must also reach the body-flow path.
+        // Without this test, an accidental "cache `null` results forever"
+        // bug in the wrapper could silently keep callers on `mixed` for
+        // closures that should now narrow via body inference. The
+        // un-cached factory has its own coverage for the rule table; this
+        // test only verifies the wrapper does not block the inference
+        // result from surfacing.
+        $file = $this->writeTempFile(
+            <<<'PHP'
+<?php
+$register(static fn () => 'cached-hello');
+PHP,
+        );
+
+        $closure = $this->loadClosureFromFile($file);
+        $result = CachedClosureTypeFactory::fromClosureObject($closure);
+
+        $this->assertInstanceOf(TClosure::class, $result);
+        $this->assertSame("'cached-hello'", $result->return_type?->getId());
     }
 
     private function writeTempFile(string $contents): string

--- a/tests/Unit/Util/Ast/CachedClosureTypeFactoryTest.php
+++ b/tests/Unit/Util/Ast/CachedClosureTypeFactoryTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Tests\Unit\Util\Ast;
+
+use Closure;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Util\Ast\CachedClosureTypeFactory;
+use Psalm\Type\Atomic\TClosure;
+use Psalm\Type\Union;
+
+/**
+ * Targeted coverage for the memoizing decorator. The stateless build
+ * pipeline is exercised by {@see ClosureTypeFactoryTest}; this class only
+ * locks in the cache-specific behaviour:
+ *
+ * - First-call result matches the un-cached factory (no semantic regression).
+ * - Second call against the same (realpath, mtime) reuses the cached index
+ *   even if the underlying file changes mid-run BUT keeps the same mtime.
+ * - `reset()` drops the cache so a subsequent call re-reads from disk.
+ *
+ * We do not assert exact call counts on the underlying factory — there is
+ * no test seam for it and adding one would expose internals just to count.
+ * Instead we verify the observable contract: cache returns yield the same
+ * result, and `reset()` causes a re-read by changing the fixture and
+ * asserting the new content surfaces.
+ */
+#[CoversClass(CachedClosureTypeFactory::class)]
+final class CachedClosureTypeFactoryTest extends TestCase
+{
+    /** @var list<string> */
+    private array $tempFiles = [];
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        CachedClosureTypeFactory::reset();
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        CachedClosureTypeFactory::reset();
+        foreach ($this->tempFiles as $path) {
+            if (\is_file($path)) {
+                \unlink($path);
+            }
+        }
+
+        $this->tempFiles = [];
+    }
+
+    #[Test]
+    public function from_closure_object_delegates_on_cache_miss(): void
+    {
+        // Cold cache: the wrapper must reach the factory and produce a
+        // result indistinguishable from the un-cached path.
+        $file = $this->writeTempFile(
+            <<<'PHP'
+<?php
+declare(strict_types=1);
+
+namespace Tests\Cached\Closure;
+
+/**
+ * @param positive-int $count
+ * @return non-empty-string
+ */
+$register('cachedStmtExpression', static function (int $count) {
+    return \str_repeat('z', $count);
+});
+PHP,
+        );
+
+        $closure = $this->loadClosureFromFile($file);
+        $result = CachedClosureTypeFactory::fromClosureObject($closure);
+
+        $this->assertInstanceOf(TClosure::class, $result);
+        $params = $result->params ?? [];
+        $this->assertCount(1, $params);
+        $this->assertSame('count', $params[0]->name);
+        $this->assertInstanceOf(Union::class, $params[0]->type);
+        $this->assertSame('int<1, max>', $params[0]->type->getId());
+        $this->assertInstanceOf(Union::class, $result->return_type);
+        $this->assertSame('non-empty-string', $result->return_type->getId());
+    }
+
+    #[Test]
+    public function second_call_with_same_mtime_returns_cached_result(): void
+    {
+        // First call populates the cache. Subsequent call against the same
+        // (realpath, mtime) must return the SAME outcome — verified here by
+        // overwriting the file's contents WITHOUT touching its mtime: a
+        // re-read would surface the new content; a cache hit returns the old.
+        $file = $this->writeTempFile(
+            <<<'PHP'
+<?php
+
+/**
+ * @return non-empty-string
+ */
+$register(static function (): string {
+    return 'first';
+});
+PHP,
+        );
+
+        $closure = $this->loadClosureFromFile($file);
+        $first = CachedClosureTypeFactory::fromClosureObject($closure);
+        $this->assertInstanceOf(TClosure::class, $first);
+        $this->assertSame('non-empty-string', $first->return_type?->getId());
+
+        // Capture the mtime, rewrite contents to something parse-incompatible,
+        // then restore the mtime so the cache key still matches. A re-read
+        // would either fail to parse (returning null) or return a different
+        // shape; a cache hit returns the original.
+        $mtime = \filemtime($file);
+        \file_put_contents($file, "<?php\n// no closure here\n");
+        \touch($file, (int) $mtime);
+
+        $second = CachedClosureTypeFactory::fromClosureObject($closure);
+        // Semantic comparison via the Union's getId() — the cache stores
+        // the per-file index, not the final TClosure, so the build stage
+        // produces fresh objects on every call. What we care about is that
+        // the second call returns the same shape, proving the cache
+        // shielded us from the rewritten file's content.
+        $this->assertInstanceOf(TClosure::class, $second, 'Cache hit must still produce a TClosure');
+        $this->assertSame(
+            $first->return_type?->getId(),
+            $second->return_type?->getId(),
+            'Cache hit must return the prior return-type',
+        );
+    }
+
+    #[Test]
+    public function reset_drops_cache_and_re_reads_on_next_call(): void
+    {
+        // After `reset()`, the next call must re-read the file — observable
+        // by rewriting the fixture's docblock and asserting the new types
+        // surface. Without `reset()` the first cache entry would mask the
+        // change.
+        $file = $this->writeTempFile(
+            <<<'PHP'
+<?php
+
+/**
+ * @return non-empty-string
+ */
+$register(static function () {
+    return 'x';
+});
+PHP,
+        );
+        $closure = $this->loadClosureFromFile($file);
+
+        $first = CachedClosureTypeFactory::fromClosureObject($closure);
+        $this->assertInstanceOf(TClosure::class, $first);
+        $this->assertSame('non-empty-string', $first->return_type?->getId());
+
+        CachedClosureTypeFactory::reset();
+
+        // Rewrite the file with a narrower return type; bump mtime so the
+        // realpath cache invariant is honoured too.
+        \file_put_contents(
+            $file,
+            <<<'PHP'
+<?php
+
+/**
+ * @return literal-string
+ */
+$register(static function () {
+    return 'x';
+});
+PHP,
+        );
+        \touch($file, \time() + 1);
+        \clearstatcache(true, $file);
+
+        $second = CachedClosureTypeFactory::fromClosureObject($this->loadClosureFromFile($file));
+        $this->assertInstanceOf(TClosure::class, $second);
+        $this->assertSame('literal-string', $second->return_type?->getId());
+    }
+
+    private function writeTempFile(string $contents): string
+    {
+        $base = \tempnam(\sys_get_temp_dir(), 'psalm-laravel-closure-doc-');
+        $path = $base . '.php';
+        \rename($base, $path);
+        \file_put_contents($path, $contents);
+        $this->tempFiles[] = $path;
+
+        return $path;
+    }
+
+    /**
+     * Mirrors the helper in {@see ClosureTypeFactoryTest}: requires the
+     * fixture in an isolated scope where `$register(...)` captures the
+     * Closure-typed argument so we can reflect it.
+     */
+    private function loadClosureFromFile(string $path): \Closure
+    {
+        $closure = (static function (string $path): ?\Closure {
+            $captured = null;
+            $register = static function (...$args) use (&$captured): \Closure {
+                foreach ($args as $arg) {
+                    if ($arg instanceof \Closure) {
+                        $captured = $arg;
+                    }
+                }
+
+                return $captured ?? static fn(): null => null;
+            };
+            require $path;
+
+            return $captured;
+        })($path);
+
+        $this->assertInstanceOf(\Closure::class, $closure, 'Fixture did not register a closure');
+
+        return $closure;
+    }
+}

--- a/tests/Unit/Util/Ast/ClosureTypeFactoryTest.php
+++ b/tests/Unit/Util/Ast/ClosureTypeFactoryTest.php
@@ -12,6 +12,7 @@ use Psalm\LaravelPlugin\Util\Ast\ClosureDocblockIndexVisitor;
 use Psalm\LaravelPlugin\Util\Ast\ClosureTypeFactory;
 use Psalm\Type\Atomic\TClosure;
 use Psalm\Type\Union;
+use Tests\Psalm\LaravelPlugin\Unit\Util\Ast\Concerns\InitializesPsalmConfigSingleton;
 
 /**
  * Unit coverage for the stateless AST-scan path that recovers `@param` /
@@ -35,6 +36,8 @@ use Psalm\Type\Union;
 #[CoversClass(ClosureDocblockIndexVisitor::class)]
 final class ClosureTypeFactoryTest extends TestCase
 {
+    use InitializesPsalmConfigSingleton;
+
     /** @var list<string> */
     private array $tempFiles = [];
 
@@ -127,6 +130,392 @@ $register(static function (int $x): int { return $x; });
 PHP,
         );
 
+        $closure = $this->loadClosureFromFile($file);
+
+        $this->assertNull(ClosureTypeFactory::fromClosureObject($closure));
+    }
+
+    /**
+     * PR #994 body-flow inference fixtures. Each test installs a closure that
+     * has NO docblock and NO native return type, so the factory has nothing to
+     * fall back on except the body-flow inference path. The asserted `getId()`
+     * is what callers see as the closure's recovered return type.
+     */
+    #[Test]
+    public function body_infer_literal_string(): void
+    {
+        $result = $this->buildInferredFromBody("static fn () => 'hello'");
+        $this->assertSame("'hello'", $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_literal_int(): void
+    {
+        $result = $this->buildInferredFromBody('static fn () => 42');
+        $this->assertSame('42', $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_literal_float(): void
+    {
+        $result = $this->buildInferredFromBody('static fn () => 1.5');
+        // `getId(exact: true)` on TLiteralFloat renders as `float(<value>)` —
+        // distinct from TLiteralInt and TLiteralString, which render as bare
+        // numerals and quoted strings respectively. Lock the exact rendering
+        // so a Psalm-side change to literal-float formatting is caught.
+        $this->assertSame('float(1.5)', $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_const_true(): void
+    {
+        $result = $this->buildInferredFromBody('static fn () => true');
+        $this->assertSame('true', $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_const_false(): void
+    {
+        $result = $this->buildInferredFromBody('static fn () => false');
+        $this->assertSame('false', $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_const_null(): void
+    {
+        $result = $this->buildInferredFromBody('static fn () => null');
+        $this->assertSame('null', $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_concat_literal_strings(): void
+    {
+        $result = $this->buildInferredFromBody("static fn () => 'a' . 'b'");
+        $this->assertSame("'ab'", $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_arithmetic_returns_int_or_float(): void
+    {
+        // The spec deliberately widens arithmetic to `int|float` even when
+        // both operands are int literals: the same operator can produce a
+        // float at runtime (1/2, intdiv overflow on 32-bit, etc.), and
+        // modelling each case exactly would explode the rule table.
+        $result = $this->buildInferredFromBody('static fn () => 1 + 2');
+        $this->assertSame('float|int', $result->return_type?->getId());
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function mixedNumericOperands(): iterable
+    {
+        // `inferArithmetic()` accepts float-flavoured operands on either side
+        // and on both sides. All three shapes must still widen to `int|float`.
+        yield 'int + float' => ['1 + 2.5'];
+        yield 'float + int' => ['1.5 + 2'];
+        yield 'float * float' => ['1.5 * 2.5'];
+    }
+
+    #[Test]
+    #[\PHPUnit\Framework\Attributes\DataProvider('mixedNumericOperands')]
+    public function body_infer_arithmetic_accepts_mixed_numeric_operands(string $expression): void
+    {
+        $result = $this->buildInferredFromBody("static fn () => {$expression}");
+        $this->assertSame('float|int', $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_arithmetic_bails_on_non_numeric_operand(): void
+    {
+        // Without `isNumericUnion()` gate, `1 + 'x'` would widen to `int|float`
+        // — but runtime is a `TypeError`. The inferArithmetic docblock calls
+        // out the operand inference as the load-bearing numeric gate; this
+        // test locks it in so any "simplification" of that gate fails loud.
+        $this->assertBailsForBody(<<<'PHP'
+<?php
+$register(static fn () => 1 + 'x');
+PHP);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function arithmeticOperators(): iterable
+    {
+        // All six arithmetic operators share a single branch in
+        // {@see ClosureTypeFactory::inferExpression()}. If a future refactor
+        // splits the implementation per-operator (e.g. modeling `Mod` as
+        // int-only), the data provider catches the regression.
+        yield 'plus' => ['1 + 2'];
+        yield 'minus' => ['5 - 2'];
+        yield 'mul' => ['3 * 4'];
+        yield 'div' => ['8 / 2'];
+        yield 'mod' => ['7 % 3'];
+        yield 'pow' => ['2 ** 8'];
+    }
+
+    #[Test]
+    #[\PHPUnit\Framework\Attributes\DataProvider('arithmeticOperators')]
+    public function body_infer_arithmetic_widens_uniformly_for_every_operator(string $expression): void
+    {
+        $result = $this->buildInferredFromBody("static fn () => {$expression}");
+        $this->assertSame('float|int', $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_chained_concat_folds_to_literal(): void
+    {
+        // Left-associative parsing makes `'a' . 'b' . 'c'` a Concat of
+        // (Concat('a','b'), 'c'). The inner Concat must recurse through
+        // `inferExpression()` and surface its folded literal so the outer
+        // Concat sees a single-string-literal operand.
+        $result = $this->buildInferredFromBody("static fn () => 'a' . 'b' . 'c'");
+        $this->assertSame("'abc'", $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_concat_bails_on_non_string_operand(): void
+    {
+        // PHP coerces `'a' . 1` to `'a1'` at runtime, but `inferConcat()`
+        // requires both operands to be single string literals — the gate
+        // exists so we don't accidentally fold types Psalm renders as
+        // `numeric-string` or `int`. Lock it in so future "obvious" relaxation
+        // doesn't silently produce wrong literals.
+        $this->assertBailsForBody(<<<'PHP'
+<?php
+$register(static fn () => 'a' . 1);
+PHP);
+    }
+
+    #[Test]
+    public function body_infer_bails_on_unary_minus(): void
+    {
+        // PhpParser models `-1` as `UnaryMinus(Int_(1))` — not a literal
+        // scalar. The spec's rule table covers `Scalar\Int_` but not
+        // `UnaryMinus`, so signed-literal closures bail. Lock that in so a
+        // later "obvious" widening doesn't silently start producing `-1`
+        // (or worse, `1`) for sloppy callers that wrote `fn() => -1`.
+        $this->assertBailsForBody(<<<'PHP'
+<?php
+$register(static fn () => -1);
+PHP);
+    }
+
+    #[Test]
+    public function body_infer_bails_on_throw_only_terminator(): void
+    {
+        // `bodyAlwaysTerminates()` considers a `Stmt\Expression(Expr\Throw_)`
+        // tail as terminating, but there is no `return` to feed the inference
+        // engine — so we still bail to `null`, just on a different code path
+        // than `bodyAlwaysTerminates() === false`. Lock both branches in.
+        $this->assertBailsForBody(<<<'PHP'
+<?php
+$register(static function () { throw new \RuntimeException(); });
+PHP);
+    }
+
+    #[Test]
+    public function body_infer_bails_when_terminator_is_try_catch(): void
+    {
+        // `try { return 1; } catch { return 2; }` terminates in both arms,
+        // but `bodyAlwaysTerminates()` is intentionally conservative: it
+        // only accepts a plain `Return_` or `Throw_` as the last top-level
+        // statement. A `Stmt\TryCatch` fails the check, so inference bails.
+        // Documenting the limit here ensures a future relaxation (e.g.
+        // teaching `bodyAlwaysTerminates()` to peek inside `try/catch`)
+        // is a deliberate change, not a silent drift.
+        $this->assertBailsForBody(<<<'PHP'
+<?php
+$register(static function () {
+    try { return 1; } catch (\Throwable) { return 2; }
+});
+PHP);
+    }
+
+    #[Test]
+    public function body_infer_nested_shaped_array(): void
+    {
+        // `inferArray()` recurses through `inferExpression()`, so nested
+        // arrays should compose into a nested shaped array. If someone
+        // "simplifies" the recursion to only accept literal scalars at the
+        // leaves, the per-rule tests still pass but this composition test
+        // fails — that's the regression-protection value.
+        $result = $this->buildInferredFromBody("static fn () => [[1, 2], 3]");
+        $this->assertSame('list{list{1, 2}, 3}', $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_mixed_key_array_drops_list_marker(): void
+    {
+        // Any explicit key flips `$isList` to false. Verifies the auto-index
+        // path interacts correctly with explicit keys in the same array.
+        $result = $this->buildInferredFromBody("static fn () => [1, 'k' => 2]");
+        $this->assertSame("array{0: 1, k: 2}", $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_shaped_list_array(): void
+    {
+        $result = $this->buildInferredFromBody("static fn () => [1, 'x']");
+        $this->assertSame("list{1, 'x'}", $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_shaped_keyed_array(): void
+    {
+        $result = $this->buildInferredFromBody("static fn () => ['k' => 1]");
+        $this->assertSame("array{k: 1}", $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_multi_return_unions_branches(): void
+    {
+        // `if/else`: both branches yield literal returns; the result should be
+        // their union. Locks in `combineUnionTypeArray()` wiring.
+        $closureSource = <<<'PHP'
+static function () {
+    if (\random_int(0, 1) === 0) {
+        return 1;
+    }
+    return 'x';
+}
+PHP;
+        $result = $this->buildInferredFromBody($closureSource);
+        // Union::getId() sorts atomics alphabetically — apostrophe (39) sorts
+        // before digit (49), so `'x'` precedes `1` in the rendered output.
+        $this->assertSame("'x'|1", $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_bails_on_variable_return(): void
+    {
+        // Variable returns are out of scope (the spec explicitly excludes
+        // variable type-flow). Without docblock and without a native return,
+        // body inference bails and the factory returns `null`.
+        $this->assertBailsForBody(<<<'PHP'
+<?php
+$register(static function () { $x = 1; return $x; });
+PHP);
+    }
+
+    #[Test]
+    public function body_infer_bails_on_unhandled_node(): void
+    {
+        // Property fetch inside the return is outside the rule table — the
+        // factory bails the entire inference rather than guess.
+        $this->assertBailsForBody(<<<'PHP'
+<?php
+$register(static fn () => (new \stdClass())->foo);
+PHP);
+    }
+
+    #[Test]
+    public function body_infer_does_not_run_when_native_return_present(): void
+    {
+        // Reflection sees `: int`, so the existing precedence (docblock then
+        // native) wins. Body inference is suppressed, and since the closure
+        // also has no docblock the factory falls back to `null` — caller
+        // keeps its reflection-only pseudo-method path.
+        $this->assertBailsForBody(<<<'PHP'
+<?php
+$register(static function (): int { return 7; });
+PHP);
+    }
+
+    #[Test]
+    public function body_infer_bails_on_empty_body(): void
+    {
+        // PHPStan's own `ClosureTypeFactoryTest` returns `mixed` for an
+        // empty-body closure (`function () {}`). Our factory bails (the
+        // visitor finds no returns AND `bodyAlwaysTerminates([])` is false),
+        // so the caller falls back to its reflection-only pseudo-method
+        // which has no native return → surfaces as `mixed`. Same effective
+        // outcome on a different code path; lock both branches in.
+        $this->assertBailsForBody(<<<'PHP'
+<?php
+$register(static function () {});
+PHP);
+    }
+
+    #[Test]
+    public function body_infer_bails_on_non_literal_const_fetch(): void
+    {
+        // ConstFetch handling only resolves globally-namespaced `true`,
+        // `false`, `null`. Anything else (`PHP_EOL`, user-defined
+        // constants, `use const` aliases) bails — adding general constant
+        // resolution would require a constant resolver and is firmly out
+        // of the PR's scope.
+        $this->assertBailsForBody(<<<'PHP'
+<?php
+$register(static fn () => PHP_EOL);
+PHP);
+    }
+
+    #[Test]
+    public function body_infer_bails_on_implicit_null_fallthrough(): void
+    {
+        // Conservatively bail when the body has a code path that reaches the
+        // closing brace without an explicit `return` — PHP returns `null` in
+        // that case, and inferring just the explicit return value would
+        // silently disagree with runtime.
+        $this->assertBailsForBody(<<<'PHP'
+<?php
+$register(static function () {
+    if (\random_int(0, 1) === 0) {
+        return 1;
+    }
+});
+PHP);
+    }
+
+    #[Test]
+    public function body_infer_skips_nested_closure_returns(): void
+    {
+        // The outer closure's only `return` yields a literal; the inner
+        // closure also returns something, but its return belongs to the inner
+        // function and must NOT contaminate the outer inference.
+        $file = $this->writeTempFile(
+            <<<'PHP'
+<?php
+$register(static function () {
+    $cb = static function () { return 'inner'; };
+    return 'outer';
+});
+PHP,
+        );
+        $closure = $this->loadClosureFromFile($file);
+        $result = ClosureTypeFactory::fromClosureObject($closure);
+
+        $this->assertInstanceOf(TClosure::class, $result);
+        $this->assertSame("'outer'", $result->return_type?->getId());
+    }
+
+    /**
+     * Helper: write a fixture file whose only closure is `$closureSource`,
+     * load it, and assert the recovered TClosure exists. Body-only inference
+     * tests share this scaffolding because they all want a fresh single-closure
+     * file with no docblock and no native return type.
+     */
+    private function buildInferredFromBody(string $closureSource): TClosure
+    {
+        $file = $this->writeTempFile("<?php\n\$register({$closureSource});\n");
+        $closure = $this->loadClosureFromFile($file);
+        $result = ClosureTypeFactory::fromClosureObject($closure);
+
+        $this->assertInstanceOf(TClosure::class, $result, 'Body inference should have produced a TClosure');
+
+        return $result;
+    }
+
+    /**
+     * Companion to {@see self::buildInferredFromBody()} for the bail tests.
+     * Same fixture-load pipeline, but asserts the factory returned `null`
+     * (caller falls back to its reflection-only pseudo-method path).
+     */
+    private function assertBailsForBody(string $fixturePhp): void
+    {
+        $file = $this->writeTempFile($fixturePhp);
         $closure = $this->loadClosureFromFile($file);
 
         $this->assertNull(ClosureTypeFactory::fromClosureObject($closure));

--- a/tests/Unit/Util/Ast/ClosureTypeFactoryTest.php
+++ b/tests/Unit/Util/Ast/ClosureTypeFactoryTest.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Tests\Unit\Util\Ast;
+
+use Closure;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Util\Ast\ClosureDocblockIndexVisitor;
+use Psalm\LaravelPlugin\Util\Ast\ClosureTypeFactory;
+use Psalm\Type\Atomic\TClosure;
+use Psalm\Type\Union;
+
+/**
+ * Unit coverage for the stateless AST-scan path that recovers `@param` /
+ * `@return` from closure source files Psalm did not scan ahead of time
+ * (issue #991).
+ *
+ * The type test (`MacroAstScanVendorClosureTest.phpt`) exercises the same
+ * pipeline end-to-end through the plugin's macro pseudo-method synthesis;
+ * this test targets {@see ClosureTypeFactory} in isolation so failures
+ * point at the factory layer rather than at the broader registry / handler
+ * stack. The memoizing wrapper
+ * {@see \Psalm\LaravelPlugin\Util\Ast\CachedClosureTypeFactory} has its own
+ * dedicated test ({@see CachedClosureTypeFactoryTest}); we deliberately do
+ * not exercise it here so failures in one layer cannot mask failures in
+ * the other.
+ *
+ * Fixtures are written to disk-temp files because the factory reads closure
+ * source via `realpath()` + `file_get_contents()`.
+ */
+#[CoversClass(ClosureTypeFactory::class)]
+#[CoversClass(ClosureDocblockIndexVisitor::class)]
+final class ClosureTypeFactoryTest extends TestCase
+{
+    /** @var list<string> */
+    private array $tempFiles = [];
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        foreach ($this->tempFiles as $path) {
+            if (\is_file($path)) {
+                \unlink($path);
+            }
+        }
+
+        $this->tempFiles = [];
+    }
+
+    #[Test]
+    public function builds_tclosure_from_wrapping_expression_docblock(): void
+    {
+        // Mirrors the Inertia call site: docblock attaches to the wrapping
+        // `Stmt\Expression`, not to the closure itself. This is exactly the
+        // case issue #991 set out to fix — storage-only recovery would miss
+        // it.
+        $file = $this->writeTempFile(
+            <<<'PHP'
+<?php
+declare(strict_types=1);
+
+namespace Tests\Closure\Vendor;
+
+/**
+ * @param positive-int $count
+ * @return non-empty-string
+ */
+$register('astStmtExpression', static function (int $count) {
+    return \str_repeat('z', $count);
+});
+PHP,
+        );
+
+        $closure = $this->loadClosureFromFile($file);
+        $result = ClosureTypeFactory::fromClosureObject($closure);
+
+        $this->assertInstanceOf(TClosure::class, $result);
+        $this->assertCount(1, $result->params ?? []);
+        $countParam = ($result->params ?? [])[0];
+        $this->assertSame('count', $countParam->name);
+        $this->assertInstanceOf(Union::class, $countParam->type);
+        $this->assertSame('int<1, max>', $countParam->type->getId());
+        $this->assertInstanceOf(Union::class, $result->return_type);
+        $this->assertSame('non-empty-string', $result->return_type->getId());
+    }
+
+    // The namespace + `use`-alias resolution path is exercised end-to-end by
+    // the companion type test (`MacroAstScanVendorClosureTest.phpt`'s
+    // `astDocblockGenericTest` assertion). Re-covering it here would require
+    // bootstrapping `ProjectAnalyzer::$instance` (touched indirectly by
+    // `TypeParser::parseTokens()` when resolving generic class references),
+    // which the unit-test harness deliberately avoids — see the
+    // `is_nullable_via_reflection` note in MacroRegistryTest for the same
+    // trade-off.
+
+    #[Test]
+    public function returns_null_when_two_closures_share_a_start_line(): void
+    {
+        // Correctness guard: when reflection points at a line with multiple
+        // closures (rare but possible — e.g. `[fn() => 1, fn() => 2]`), the
+        // factory bails rather than pick the wrong one. Mirrors the same
+        // ambiguity policy in `MacroRegistry::recoverClosureStorage()`.
+        $file = $this->writeTempFile(
+            <<<'PHP'
+<?php
+
+$register(static fn (int $a): int => $a, static fn (int $b): int => $b);
+PHP,
+        );
+
+        $closure = $this->loadClosureFromFile($file);
+
+        $this->assertNull(ClosureTypeFactory::fromClosureObject($closure));
+    }
+
+    #[Test]
+    public function returns_null_when_closure_has_no_docblock(): void
+    {
+        $file = $this->writeTempFile(
+            <<<'PHP'
+<?php
+
+$register(static function (int $x): int { return $x; });
+PHP,
+        );
+
+        $closure = $this->loadClosureFromFile($file);
+
+        $this->assertNull(ClosureTypeFactory::fromClosureObject($closure));
+    }
+
+    #[Test]
+    public function ignores_outer_function_docblock_for_nested_closure(): void
+    {
+        // Doc-attachment rule (strict): walk up to the nearest *Stmt*, accept
+        // its docblock only when it is a `Stmt\Expression`. A
+        // `@return non-empty-string` on a surrounding `function makeCallback()`
+        // declaration must NOT leak onto a closure returned from inside that
+        // function — its `@return` describes `makeCallback()`'s own return,
+        // not the inner closure.
+        //
+        // Unique namespace per test run keeps repeated requires from
+        // triggering PHP's "Cannot redeclare function" error.
+        $namespace = 'Tests\\Closure\\OuterDoc\\Ns' . \bin2hex(\random_bytes(4));
+        $file = $this->writeTempFile(
+            <<<PHP
+<?php
+declare(strict_types=1);
+
+namespace {$namespace};
+
+/**
+ * @return non-empty-string
+ */
+function makeCallback(): \\Closure {
+    return static function (int \$n) {
+        return \$n * 2;
+    };
+}
+PHP,
+        );
+        require_once $file;
+
+        $functionName = $namespace . '\\makeCallback';
+        $closure = $functionName();
+        $this->assertInstanceOf(\Closure::class, $closure);
+
+        $this->assertNull(ClosureTypeFactory::fromClosureObject($closure));
+    }
+
+    private function writeTempFile(string $contents): string
+    {
+        $base = \tempnam(\sys_get_temp_dir(), 'psalm-laravel-closure-doc-');
+        $path = $base . '.php';
+        // Move the tempnam-placeholder file so the `.php` extension applies.
+        \rename($base, $path);
+        \file_put_contents($path, $contents);
+        $this->tempFiles[] = $path;
+
+        return $path;
+    }
+
+    /**
+     * Each fixture file ends with `$register(...)` calls whose last argument
+     * is the closure we want to inspect. The fake `$register` captures every
+     * Closure-typed argument; the last capture is returned.
+     */
+    private function loadClosureFromFile(string $path): \Closure
+    {
+        $closure = (static function (string $path): ?\Closure {
+            $captured = null;
+            $register = static function (...$args) use (&$captured): \Closure {
+                foreach ($args as $arg) {
+                    if ($arg instanceof \Closure) {
+                        $captured = $arg;
+                    }
+                }
+
+                return $captured ?? static fn(): null => null;
+            };
+            require $path;
+
+            return $captured;
+        })($path);
+
+        $this->assertInstanceOf(\Closure::class, $closure, 'Fixture did not register a closure');
+
+        return $closure;
+    }
+}

--- a/tests/Unit/Util/Ast/Concerns/InitializesPsalmConfigSingleton.php
+++ b/tests/Unit/Util/Ast/Concerns/InitializesPsalmConfigSingleton.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Util\Ast\Concerns;
+
+use Psalm\Config;
+use Psalm\Internal\EventDispatcher;
+
+/**
+ * Plants a minimal `Psalm\Config` singleton so test paths that touch
+ * `TLiteralString::make()` (reads `Config::getInstance()->max_string_length`)
+ * succeed without bootstrapping the full Psalm project analyser.
+ *
+ * Used by the body-flow inference tests in {@see ClosureTypeFactoryTest} and
+ * {@see CachedClosureTypeFactoryTest}. Heavier alternatives (loading
+ * `tests/Type/psalm.xml` through `Config::loadFromXMLFile()`) pull in schema
+ * validation and composer-classmap warmups that aren't relevant here.
+ *
+ * `tearDownAfterClass` MUST null the singleton: otherwise sibling test
+ * classes (notably `NoEnvOutsideConfigHandlerTest`) that rely on the
+ * "no Config initialized" precondition see a stale instance.
+ */
+trait InitializesPsalmConfigSingleton
+{
+    public static function setUpBeforeClass(): void
+    {
+        $rc = new \ReflectionClass(Config::class);
+        $instance = $rc->newInstanceWithoutConstructor();
+        $rc->getProperty('instance')->setValue(null, $instance);
+        $rc->getProperty('eventDispatcher')->setValue($instance, new EventDispatcher());
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        (new \ReflectionClass(Config::class))->getProperty('instance')->setValue(null, null);
+    }
+}


### PR DESCRIPTION
## Issue to Solve

The storage-based closure docblock recovery shipped in #989 only fires when Psalm has scanned the closure's source file. For closures registered from `vendor/` packages outside `<projectFiles>`, the storage lookup misses and the registry falls back to reflection-only types, discarding the docblock entirely.

Motivating example (Inertia, current master):

```php
// vendor/inertiajs/inertia-laravel/src/ServiceProvider.php
/**
 * @param array<array-key, mixed> $props
 */
Router::macro('inertia', function ($uri, $component, $props = []) {
    return $this->match(['GET', 'HEAD'], $uri, '\\'.Controller::class)
        ->defaults('component', $component)
        ->defaults('props', $props);
});
```

The closure has no native param types and no native return type. The docblock narrows `$props` to `array<array-key, mixed>`. Under a typical project config (`<projectFiles><directory name="app"/></projectFiles>`), the closure's source file is never deep-scanned by Psalm and the docblock narrowing is lost.

## Related

Closes #991. Builds on #989 (storage-path recovery). Parent #758 (umbrella).

## Solution Description

Adds `Psalm\LaravelPlugin\Util\Ast\ClosureDocblockFactory` (analogue of Larastan's `ClosureTypeFactory::fromClosureObject`) which parses the closure's source file directly with `nikic/php-parser` on demand, locates the matching `Closure` / `ArrowFunction` by start line via a `ClosureDocblockIndexVisitor`, and lifts `@param` / `@return` Unions from the docblock attached either directly to the closure node OR to the immediately wrapping `Stmt\Expression`. Reflection still owns parameter order, by-ref, variadic, and defaults; the docblock contributes type narrowing only.

`MacroRegistry::buildDefinition()` now prioritises the AST path: AST first, then the pre-#989 storage path as second-tier fallback, then reflection-only. AST-first matters even for files Psalm did scan — Psalm's own scanner does not attach a `Stmt\Expression` docblock to an inner closure, so the Inertia-style pattern would otherwise miss even when storage exists for the file.

Caching:
- Per-(file, mtime) parse results so a vendor file registering N macros parses once per analysis run.
- Per-namespace-frame `Aliases` so N closures sharing one namespace allocate one shared `Aliases` instance.
- Negative cache entries for parse errors / unreadable files so a single broken file is not re-attempted N times.
- `MacroRegistry::reset()` cascades into `ClosureDocblockFactory::reset()` for test isolation.

Doc-attachment policy is deliberately strict: own docblock first, then the wrapping `Stmt\Expression` only. Walking further up the ancestor chain would risk attaching an outer function's `/** @return Foo */` to a nested closure.

Failure modes (file unreadable, parse error, no closure starts at the reflected line, multiple closures share the start line, no docblock) all degrade silently to the storage fallback or reflection. Vendor-package code paths should never surface plugin warnings for files the user does not control.

## Coverage

- **Type test** `tests/Type/tests/Macros/MacroAstScanVendorClosureTest.phpt` registers macros from `tests/Type/macro-fixtures-vendor-style.php`, a file deliberately excluded from `<projectFiles>`, `<stubs>`, and the `autoloader` attribute. It only reaches PHP via `require_once` from the autoloader file, mirroring the Inertia case. Exercises:
  - Full `@param positive-int` + `@return non-empty-string` narrowing through the synthesised pseudo-method.
  - Generic return-type recovery (`@return Collection<int, string>`) with `use`-alias resolution.
  - Matrix row 3: `@param`-only narrowing while the native string return survives.
  - Arrow-function syntax (`static fn(int $count) => ...`).
  - `InvalidArgument` rejection of non-positive ints on the docblock-narrowed parameter.
- **Unit test** `tests/Unit/Util/Ast/ClosureDocblockFactoryTest.php` locks in the wrapping-`Stmt\Expression` doc attachment, outer-function docblock isolation, the multi-closure-on-same-line ambiguity bail, and the no-docblock null return.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and unit test in `tests/Unit/`)
