### PR TITLE
Recover closure return type from body when docblock and reflection are silent

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -21,6 +21,13 @@ return RectorConfig::configure()
     // that never matches the lowercase method id. (::class IS valid in const arrays on
     // PHP 8.3+; the problem is the casing, not the const-context.)
     ->withSkipPath('src/Handlers/Rules/OctaneIncompatibleBindingHandler.php')
+    // The vendor-style macro fixture (PR #991 + PR #994) deliberately exercises
+    // closures without native return types or docblock `@return` so the
+    // AST-scan + body-inference paths are the only sources of narrowing.
+    // Rector's `typeDeclarations` set keeps "fixing" them back to declared
+    // return types, which silently turns the body-inference assertions into
+    // native-return-type assertions and the feature stops being tested.
+    ->withSkipPath('tests/Type/macro-fixtures-vendor-style.php')
     ->withPhpVersion(PhpVersion::PHP_82)
     ->withSets([PHPUnitSetList::PHPUNIT_120])
     ->withPreparedSets(deadCode: true, codingStyle: true, typeDeclarations: true, codeQuality: true, phpunitCodeQuality: true)

--- a/src/Providers/MacroRegistry.php
+++ b/src/Providers/MacroRegistry.php
@@ -188,6 +188,16 @@ final class MacroRegistry
             self::$macros[\strtolower($className)] = $classMacros;
             self::$knownMacroableClasses[] = $className;
         }
+
+        // Drop the AST-scan cache now that every macro definition is built.
+        // The cache holds full `Closure` / `ArrowFunction` PhpParser subtrees
+        // per visited file; once we're past the foreach above, none of those
+        // nodes are reachable from `MacroDefinition` instances anymore. Holding
+        // them until session teardown would (a) keep the AST pinned for the
+        // rest of analysis and (b) replicate it into every pcntl fork worker
+        // via copy-on-write, which is exactly the cost we wanted to avoid by
+        // not re-parsing in the first place.
+        CachedClosureTypeFactory::reset();
     }
 
     /**

--- a/src/Util/Ast/BodyReturnCollectorVisitor.php
+++ b/src/Util/Ast/BodyReturnCollectorVisitor.php
@@ -88,7 +88,7 @@ final class BodyReturnCollectorVisitor extends NodeVisitorAbstract
         }
 
         if ($node instanceof Node\Stmt\Return_) {
-            if ($node->expr === null) {
+            if (!$node->expr instanceof \PhpParser\Node\Expr) {
                 $this->bailed = true;
                 return NodeVisitor::STOP_TRAVERSAL;
             }

--- a/src/Util/Ast/BodyReturnCollectorVisitor.php
+++ b/src/Util/Ast/BodyReturnCollectorVisitor.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Util\Ast;
+
+use PhpParser\Node;
+use PhpParser\NodeVisitor;
+use PhpParser\NodeVisitorAbstract;
+
+/**
+ * Walks a `Closure`'s body collecting every `return` statement's expression
+ * while refusing to descend into nested closures / arrow functions / function
+ * declarations / class methods (their returns belong to the inner function,
+ * not the outer one we are inferring for).
+ *
+ * Sets `$bailed = true` and stops traversal when a `return;` with no
+ * expression is encountered — the caller treats that the same as any other
+ * unhandled shape and abandons inference for the closure.
+ *
+ * @internal Helper for {@see ClosureTypeFactory::inferReturnFromBody()}.
+ */
+final class BodyReturnCollectorVisitor extends NodeVisitorAbstract
+{
+    /** @var list<Node\Expr> */
+    private array $returnExprs = [];
+
+    private bool $bailed = false;
+
+    /**
+     * Collected `return <expr>;` expressions in source order, or an empty list
+     * when the body contained no returns. Read-only after traversal; mirrors
+     * the accessor convention in {@see ClosureDocblockIndexVisitor::getEntries()}
+     * so the two visitors in this directory expose the same shape.
+     *
+     * @return list<Node\Expr>
+     */
+    public function getReturnExpressions(): array
+    {
+        return $this->returnExprs;
+    }
+
+    /**
+     * `true` when the walker hit `return;` (no expression). Load-bearing
+     * because it distinguishes "the closure has explicit returns AND a
+     * fall-through `return null`" from "the closure has no returns at all".
+     * The first case must bail (some-returns-plus-implicit-null would
+     * silently miss `null` in the inferred union); the second case is the
+     * same as a body the visitor never finds returns in.
+     */
+    public function hasBailed(): bool
+    {
+        return $this->bailed;
+    }
+
+    /**
+     * Reset per-traversal state so the visitor can be reused safely against
+     * multiple closure bodies. Mirrors the sibling
+     * {@see ClosureDocblockIndexVisitor::beforeTraverse()} — without this
+     * reset, a second `traverse()` call would accumulate returns from the
+     * first run AND keep a stale `bailed = true` indefinitely.
+     *
+     * @psalm-external-mutation-free Mutation stays inside the visitor.
+     */
+    #[\Override]
+    public function beforeTraverse(array $nodes): ?array
+    {
+        $this->returnExprs = [];
+        $this->bailed = false;
+
+        return null;
+    }
+
+    /**
+     * @psalm-external-mutation-free The visitor mutates its own `returnExprs`
+     *         / `bailed` fields; nothing outside the instance changes. Same
+     *         posture as {@see ClosureDocblockIndexVisitor::enterNode()}.
+     */
+    #[\Override]
+    public function enterNode(Node $node): ?int
+    {
+        if ($node instanceof Node\Expr\Closure
+            || $node instanceof Node\Expr\ArrowFunction
+            || $node instanceof Node\Stmt\Function_
+            || $node instanceof Node\Stmt\ClassMethod
+        ) {
+            return NodeVisitor::DONT_TRAVERSE_CHILDREN;
+        }
+
+        if ($node instanceof Node\Stmt\Return_) {
+            if ($node->expr === null) {
+                $this->bailed = true;
+                return NodeVisitor::STOP_TRAVERSAL;
+            }
+
+            $this->returnExprs[] = $node->expr;
+        }
+
+        return null;
+    }
+}

--- a/src/Util/Ast/CachedClosureTypeFactory.php
+++ b/src/Util/Ast/CachedClosureTypeFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Psalm\LaravelPlugin\Util\Ast;
 
 use PhpParser\Comment\Doc;
+use PhpParser\Node;
 use Psalm\Aliases;
 use Psalm\Type\Atomic\TClosure;
 
@@ -41,7 +42,7 @@ use Psalm\Type\Atomic\TClosure;
 final class CachedClosureTypeFactory
 {
     /**
-     * @var array<string, array{mtime: int, entries: array<int, list<array{0: ?Doc, 1: Aliases}>>|null}>
+     * @var array<string, array{mtime: int, entries: array<int, list<array{0: ?Doc, 1: Aliases, 2: Node\Expr\Closure|Node\Expr\ArrowFunction}>>|null}>
      */
     private static array $cache = [];
 
@@ -81,7 +82,7 @@ final class CachedClosureTypeFactory
      * inside `buildWithIndexer`). Mtime stamp guards against in-run rewrites
      * (rare, but happens in test fixtures); a fresh mtime forces a re-parse.
      *
-     * @return array<int, list<array{0: ?Doc, 1: Aliases}>>|null
+     * @return array<int, list<array{0: ?Doc, 1: Aliases, 2: Node\Expr\Closure|Node\Expr\ArrowFunction}>>|null
      */
     private static function indexFile(string $realpath): ?array
     {

--- a/src/Util/Ast/ClosureDocblockIndexVisitor.php
+++ b/src/Util/Ast/ClosureDocblockIndexVisitor.php
@@ -28,11 +28,16 @@ use Psalm\Aliases;
  * files don't bleed aliases across sections, and pre-namespace top-level `use`
  * statements don't leak into a later `namespace { ... }` block.
  *
+ * Each entry also retains the raw `Closure` / `ArrowFunction` node. PR #994 uses
+ * it for body-flow return inference when neither docblock `@return` nor native
+ * reflection covers the closure — without the node the factory would have to
+ * re-parse the file just to walk the body, defeating the per-run cache.
+ *
  * @internal Helper for {@see ClosureTypeFactory::indexFile()}.
  */
 final class ClosureDocblockIndexVisitor extends NodeVisitorAbstract
 {
-    /** @var array<int, list<array{0: ?Doc, 1: Aliases}>> startLine => list of (doc, aliases) */
+    /** @var array<int, list<array{0: ?Doc, 1: Aliases, 2: Node\Expr\Closure|Node\Expr\ArrowFunction}>> startLine => list of (doc, aliases, node) */
     private array $entries = [];
 
     /** @var list<Node> stack of currently-open ancestor nodes (parent at the tail). */
@@ -65,7 +70,7 @@ final class ClosureDocblockIndexVisitor extends NodeVisitorAbstract
      * exclusively from `beforeTraverse` / `enterNode`. Exposed via a method
      * rather than a public field so callers cannot tamper with the storage.
      *
-     * @return array<int, list<array{0: ?Doc, 1: Aliases}>>
+     * @return array<int, list<array{0: ?Doc, 1: Aliases, 2: Node\Expr\Closure|Node\Expr\ArrowFunction}>>
      */
     public function getEntries(): array
     {
@@ -133,7 +138,7 @@ final class ClosureDocblockIndexVisitor extends NodeVisitorAbstract
                 $doc = $this->findWrappingExpressionDoc();
             }
 
-            $this->entries[$node->getStartLine()][] = [$doc, $this->aliasesForCurrentFrame()];
+            $this->entries[$node->getStartLine()][] = [$doc, $this->aliasesForCurrentFrame(), $node];
         }
 
         $this->nodeStack[] = $node;

--- a/src/Util/Ast/ClosureTypeFactory.php
+++ b/src/Util/Ast/ClosureTypeFactory.php
@@ -224,11 +224,11 @@ final class ClosureTypeFactory
         // existing precedence already wins — body inference would at best
         // duplicate work, at worst contradict the explicit declaration.
         $bodyReturn = null;
-        if ($docblock === null && $nativeReturn === null && $node !== null) {
+        if ($docblock === null && !$nativeReturn instanceof \Psalm\Type\Union && $node !== null) {
             $bodyReturn = self::inferReturnFromBody($node);
         }
 
-        if ($docblock === null && $bodyReturn === null) {
+        if ($docblock === null && !$bodyReturn instanceof \Psalm\Type\Union) {
             return null;
         }
 
@@ -294,6 +294,7 @@ final class ClosureTypeFactory
             if (!$inferred instanceof Union) {
                 return null;
             }
+
             $unions[] = $inferred;
         }
 
@@ -561,6 +562,7 @@ final class ClosureTypeFactory
                 if ($keyExpr->value >= $nextAutoIndex) {
                     $nextAutoIndex = $keyExpr->value + 1;
                 }
+
                 continue;
             }
 

--- a/src/Util/Ast/ClosureTypeFactory.php
+++ b/src/Util/Ast/ClosureTypeFactory.php
@@ -57,14 +57,6 @@ use Psalm\Type\Union;
 final class ClosureTypeFactory
 {
     /**
-     * Constant return type of {@see self::inferArithmetic()}. The value never
-     * depends on operands (see that method's docblock for why), so building
-     * it once and re-handing the same `Union` saves a `combineUnionTypes` +
-     * `TypeCombiner::combine` call per arithmetic body return.
-     */
-    private static ?Union $intOrFloatUnion = null;
-
-    /**
      * Build a {@see TClosure} from a runtime closure object.
      *
      * Public shape matches PHPStan's `ClosureTypeFactory::fromClosureObject()`:
@@ -497,7 +489,15 @@ final class ClosureTypeFactory
             return null;
         }
 
-        return self::$intOrFloatUnion ??= Type::combineUnionTypes(Type::getInt(), Type::getFloat());
+        // Build a fresh Union per call rather than memoizing. Psalm 7's Union
+        // has public mutable fields (`from_docblock`, `ignore_nullable_issues`,
+        // …). The instance flows into every `TClosure->return_type` we hand
+        // to `MacroDefinition`; an aliased memo would let a downstream
+        // mutation on one macro pollute every other arithmetic macro built
+        // this run. Psalm itself uses functional setters in practice, but
+        // the savings (one `combineUnionTypes` call per arithmetic body
+        // return, typically <10 per run) are not worth the risk.
+        return Type::combineUnionTypes(Type::getInt(), Type::getFloat());
     }
 
     /**

--- a/src/Util/Ast/ClosureTypeFactory.php
+++ b/src/Util/Ast/ClosureTypeFactory.php
@@ -6,6 +6,7 @@ namespace Psalm\LaravelPlugin\Util\Ast;
 
 use PhpParser\Comment\Doc;
 use PhpParser\Error as PhpParserError;
+use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\ParserFactory;
 use Psalm\Aliases;
@@ -18,6 +19,8 @@ use Psalm\Internal\Type\TypeTokenizer;
 use Psalm\Storage\FunctionLikeParameter;
 use Psalm\Type;
 use Psalm\Type\Atomic\TClosure;
+use Psalm\Type\Atomic\TKeyedArray;
+use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Union;
 
 /**
@@ -35,12 +38,15 @@ use Psalm\Type\Union;
  * registered from `vendor/` packages outside `<projectFiles>` work the same
  * as project-source closures.
  *
- * Gap vs PHPStan: body-flow inference. PHPStan's `ClosureTypeFactory` infers
- * the return type from `return` statements when no `@return` docblock is
- * present (e.g. `fn () => 'x'` produces a literal-string return). We
- * currently fall back to the native reflection return type or `mixed`.
- * Tracked as follow-up work — see the "Body-flow inference" plan in PR #994's
- * description.
+ * Coverage extended in PR #994: body-flow inference for the narrow subset of
+ * `return` expressions whose static value is obvious without any semantic
+ * analysis — literal scalars (`'x'`, `42`, `1.5`, `true`/`false`/`null`),
+ * concatenations of inferable strings, arithmetic of inferable numerics, and
+ * shaped arrays whose keys and values are themselves inferable. Any unhandled
+ * node anywhere in the closure body bails the entire inference. This is
+ * deliberately narrower than PHPStan's equivalent: we never trigger Psalm's
+ * `StatementsAnalyzer` (would re-enter the scanner mid-scan) and never follow
+ * variable references — both are explicitly out of scope for the PR.
  *
  * Stateless by design. Caching is a separate concern handled by
  * {@see CachedClosureTypeFactory}, which composes via callable injection at
@@ -64,9 +70,9 @@ final class ClosureTypeFactory
      * - the source file is unreadable or fails to parse;
      * - no closure starts at the reflected line, or multiple closures share
      *   the start line (ambiguity → bail rather than guess);
-     * - the closure has no docblock-derived narrowing the caller could not
-     *   already produce from reflection alone. Caller falls back to a
-     *   reflection-only pseudo-method in that case.
+     * - neither docblock recovery nor PR #994 body-flow inference can add
+     *   anything beyond what reflection already exposes. Caller falls back to
+     *   a reflection-only pseudo-method in that case.
      *
      * @psalm-api Public convenience for callers that opt out of the memoizing
      *            wrapper (notably the unit tests). Production callers go
@@ -89,15 +95,15 @@ final class ClosureTypeFactory
      * to wrappers, not to this class.
      *
      * @internal Decorator injection seam.
-     * @param callable(string): ?array<int, list<array{0: ?Doc, 1: Aliases}>> $indexer
+     * @param callable(string): ?array<int, list<array{0: ?Doc, 1: Aliases, 2: Node\Expr\Closure|Node\Expr\ArrowFunction}>> $indexer
      */
     public static function buildWithIndexer(\Closure $closure, callable $indexer): ?TClosure
     {
         $reflection = new \ReflectionFunction($closure);
 
-        $docblock = self::recoverDocblock($reflection, $indexer);
+        $recovered = self::recoverFromSource($reflection, $indexer);
 
-        return self::buildClosureType($reflection, $docblock);
+        return self::buildClosureType($reflection, $recovered);
     }
 
     /**
@@ -109,7 +115,7 @@ final class ClosureTypeFactory
      * {@see CachedClosureTypeFactory} (or any compatible memoizer) for
      * repeated lookups against the same file.
      *
-     * @return array<int, list<array{0: ?Doc, 1: Aliases}>>|null
+     * @return array<int, list<array{0: ?Doc, 1: Aliases, 2: Node\Expr\Closure|Node\Expr\ArrowFunction}>>|null
      */
     public static function indexFile(string $realpath): ?array
     {
@@ -142,13 +148,16 @@ final class ClosureTypeFactory
     }
 
     /**
-     * Lift `@param` and `@return` Unions from the closure's source-attached
-     * docblock, or `null` when no usable docblock is reachable.
+     * Resolve the closure's source entry: the parsed AST node, plus its
+     * docblock-derived narrowing when present. Returns `null` only when the
+     * indexer cannot uniquely identify a closure at the reflected line — in
+     * every other case we surface the node so the body-inference path can
+     * still run when the docblock is silent.
      *
-     * @param callable(string): ?array<int, list<array{0: ?Doc, 1: Aliases}>> $indexer
-     * @return array{params: array<string, Union>, return: ?Union}|null
+     * @param callable(string): ?array<int, list<array{0: ?Doc, 1: Aliases, 2: Node\Expr\Closure|Node\Expr\ArrowFunction}>> $indexer
+     * @return array{docblock: ?array{params: array<string, Union>, return: ?Union}, node: Node\Expr\Closure|Node\Expr\ArrowFunction}|null
      */
-    private static function recoverDocblock(\ReflectionFunctionAbstract $reflection, callable $indexer): ?array
+    private static function recoverFromSource(\ReflectionFunctionAbstract $reflection, callable $indexer): ?array
     {
         $filePath = $reflection->getFileName();
         $line = $reflection->getStartLine();
@@ -178,28 +187,48 @@ final class ClosureTypeFactory
             return null;
         }
 
-        [$doc, $aliases] = $matches[0];
-        if (!$doc instanceof Doc) {
-            return null;
-        }
+        [$doc, $aliases, $node] = $matches[0];
+        $docblock = $doc instanceof Doc ? self::extractDocblock($doc, $aliases) : null;
 
-        return self::extractDocblock($doc, $aliases);
+        return ['docblock' => $docblock, 'node' => $node];
     }
 
     /**
      * Build the final {@see TClosure}: reflection-derived parameter list with
-     * docblock narrowing per parameter, plus the docblock return type when
-     * present, otherwise the native return type or `mixed`.
+     * docblock narrowing per parameter, plus the best available return type.
      *
-     * Returns `null` when no docblock narrowing was recovered — the caller
-     * would not learn anything beyond what reflection already exposes, so it
-     * keeps its existing reflection-only pseudo-method path instead.
+     * Return-type precedence:
+     * 1. Docblock `@return` (issue #991 — wins because it can express types
+     *    PHP cannot, like `non-empty-string` or `Collection<int, string>`).
+     * 2. Native reflected return type.
+     * 3. PR #994 body-flow inference (literal-value `return`s and arrow
+     *    functions), invoked only when both the docblock and reflection
+     *    are silent on the return type — anything coarser than `mixed`
+     *    beats `mixed` for callers chaining off the closure's result.
+     * 4. `Type::getMixed()` as the bottom fallback.
      *
-     * @param array{params: array<string, Union>, return: ?Union}|null $docblock
+     * Returns `null` only when none of those steps improves on what
+     * reflection already exposes — caller keeps its existing reflection-only
+     * pseudo-method path instead.
+     *
+     * @param array{docblock: ?array{params: array<string, Union>, return: ?Union}, node: Node\Expr\Closure|Node\Expr\ArrowFunction}|null $recovered
      */
-    private static function buildClosureType(\ReflectionFunctionAbstract $reflection, ?array $docblock): ?TClosure
+    private static function buildClosureType(\ReflectionFunctionAbstract $reflection, ?array $recovered): ?TClosure
     {
-        if ($docblock === null) {
+        $docblock = $recovered['docblock'] ?? null;
+        $node = $recovered['node'] ?? null;
+        $nativeReturn = self::reflectionTypeToUnion($reflection->getReturnType());
+
+        // Body-flow inference (PR #994) only runs when both the docblock and
+        // the native reflected return are silent. With either present, the
+        // existing precedence already wins — body inference would at best
+        // duplicate work, at worst contradict the explicit declaration.
+        $bodyReturn = null;
+        if ($docblock === null && $nativeReturn === null && $node !== null) {
+            $bodyReturn = self::inferReturnFromBody($node);
+        }
+
+        if ($docblock === null && $bodyReturn === null) {
             return null;
         }
 
@@ -208,16 +237,347 @@ final class ClosureTypeFactory
             $params[] = self::buildClosureParameter($reflParam, $docblock['params'][$reflParam->getName()] ?? null);
         }
 
-        $nativeReturn = self::reflectionTypeToUnion($reflection->getReturnType());
-        // Issue #991: docblock `@return` (when present) wins over the native
-        // reflection return — that's the whole point of recovery. Native
-        // return is preserved only when the docblock is silent.
-        $returnType = $docblock['return'] ?? $nativeReturn ?? Type::getMixed();
+        $returnType = $docblock['return'] ?? $nativeReturn ?? $bodyReturn ?? Type::getMixed();
 
         return new TClosure(
             params: $params,
             return_type: $returnType,
         );
+    }
+
+    /**
+     * PR #994 — narrow body-flow inference for a closure or arrow function.
+     *
+     * `ArrowFunction` has a single expression body (`$node->expr`) which is by
+     * definition the return value. `Closure` may have any number of `return`
+     * statements: we walk the body collecting them, infer each, and union the
+     * results. Any unhandled node in the expression position bails the entire
+     * inference — we never produce a partial answer, because doing so would
+     * silently disagree with the closure's actual semantics.
+     *
+     * Deliberately stops at nested closures / arrow functions / function
+     * declarations / class methods: their `return` statements belong to the
+     * nested function, not the outer one.
+     */
+    private static function inferReturnFromBody(Node\Expr\Closure|Node\Expr\ArrowFunction $node): ?Union
+    {
+        if ($node instanceof Node\Expr\ArrowFunction) {
+            return self::inferExpression($node->expr);
+        }
+
+        // Guard against implicit-`null` fall-through. PHP returns `null` from a
+        // closure whose control flow reaches the closing brace without hitting
+        // an explicit `return`. If we ignored that path we would silently
+        // produce a narrower type than runtime — e.g. `static function () {
+        // if (cond) return 1; }` would surface as `1` instead of `1|null`.
+        // Conservatively require the last top-level statement to be a
+        // terminating `return` or `throw`; anything else (including
+        // `if/else { return; }` symmetric pairs) bails. PHPStan's body inference
+        // takes the same conservative posture here.
+        if (!self::bodyAlwaysTerminates($node->stmts)) {
+            return null;
+        }
+
+        $collector = new BodyReturnCollectorVisitor();
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($collector);
+        $traverser->traverse($node->stmts);
+
+        $returnExprs = $collector->getReturnExpressions();
+        if ($collector->hasBailed() || $returnExprs === []) {
+            return null;
+        }
+
+        $unions = [];
+        foreach ($returnExprs as $expr) {
+            $inferred = self::inferExpression($expr);
+            if (!$inferred instanceof Union) {
+                return null;
+            }
+            $unions[] = $inferred;
+        }
+
+        return Type::combineUnionTypeArray($unions, null);
+    }
+
+    /**
+     * Conservative reachability check: returns `true` only when control flow
+     * provably cannot reach the closing brace of the closure body without
+     * hitting a `return` or `throw`. Anything more nuanced (e.g. "every branch
+     * of this `if/elseif/else` returns") would need a full CFG pass — and
+     * since the PR's inference target is short macro closures (one expression
+     * body, one straight return, or a final `return` after early-exit guards),
+     * the cheap check is enough. False negatives just bail to `mixed`, which
+     * is the existing fallback.
+     *
+     * PhpParser 5 models `throw new X;` as `Stmt\Expression` wrapping
+     * `Expr\Throw_` (PHP 8 promoted `throw` to an expression), so the
+     * statement-level check has to peek through the expression wrapper.
+     *
+     * @param array<array-key, Node\Stmt> $stmts
+     * @psalm-mutation-free Reads node properties only, mutates nothing.
+     */
+    private static function bodyAlwaysTerminates(array $stmts): bool
+    {
+        if ($stmts === []) {
+            return false;
+        }
+
+        $last = \end($stmts);
+        if ($last instanceof Node\Stmt\Return_) {
+            return true;
+        }
+
+        return $last instanceof Node\Stmt\Expression && $last->expr instanceof Node\Expr\Throw_;
+    }
+
+    /**
+     * Infer a {@see Union} for a single expression node, or `null` when the
+     * node falls outside the deliberately-narrow set the PR supports.
+     *
+     * Rule table — see PR #994's prompt for the source spec:
+     *
+     * | Node                            | Inferred                                  |
+     * |---------------------------------|-------------------------------------------|
+     * | `Scalar\String_`                | `Type::getString($value)`                 |
+     * | `Scalar\Int_`                   | `Type::getInt(false, $value)`             |
+     * | `Scalar\Float_`                 | `Type::getFloat($value)`                  |
+     * | `Expr\ConstFetch` true/false/null | matching constant Union                 |
+     * | `Expr\Array_` (all inferable)   | shaped array via `TKeyedArray::make()`    |
+     * | `Expr\BinaryOp\Concat` of literal strings | concatenated literal-string     |
+     * | `Expr\BinaryOp` arithmetic of inferable numerics | `int|float`            |
+     * | anything else                   | `null` (caller bails)                     |
+     */
+    private static function inferExpression(Node\Expr $expr): ?Union
+    {
+        if ($expr instanceof Node\Scalar\String_) {
+            return self::literalStringUnion($expr->value);
+        }
+
+        if ($expr instanceof Node\Scalar\Int_) {
+            return Type::getInt(false, $expr->value);
+        }
+
+        if ($expr instanceof Node\Scalar\Float_) {
+            return Type::getFloat($expr->value);
+        }
+
+        if ($expr instanceof Node\Expr\ConstFetch) {
+            // Globally-namespaced `true`/`false`/`null`. We do not honour
+            // `use const` aliases or user-defined constants — those would
+            // require a constant resolver, well outside the PR's scope.
+            return match (\strtolower($expr->name->toString())) {
+                'true' => Type::getTrue(),
+                'false' => Type::getFalse(),
+                'null' => Type::getNull(),
+                default => null,
+            };
+        }
+
+        if ($expr instanceof Node\Expr\Array_) {
+            return self::inferArray($expr);
+        }
+
+        if ($expr instanceof Node\Expr\BinaryOp\Concat) {
+            return self::inferConcat($expr);
+        }
+
+        if ($expr instanceof Node\Expr\BinaryOp && self::isArithmeticBinaryOp($expr)) {
+            return self::inferArithmetic($expr);
+        }
+
+        return null;
+    }
+
+    /**
+     * The six PHP-Parser binary-op nodes that produce a numeric result and
+     * share a single dispatch branch in {@see self::inferExpression()}.
+     * Comparison and boolean operators (`==`, `&&`, `<=>`, …) are deliberately
+     * excluded: they widen to `bool` / `int<-1, 1>` and would need their own
+     * rules. Named predicate (vs. a six-way `instanceof` chain) makes the
+     * arithmetic-vs-other split obvious to readers.
+     *
+     * @psalm-pure
+     */
+    private static function isArithmeticBinaryOp(Node\Expr\BinaryOp $expr): bool
+    {
+        return $expr instanceof Node\Expr\BinaryOp\Plus
+            || $expr instanceof Node\Expr\BinaryOp\Minus
+            || $expr instanceof Node\Expr\BinaryOp\Mul
+            || $expr instanceof Node\Expr\BinaryOp\Div
+            || $expr instanceof Node\Expr\BinaryOp\Mod
+            || $expr instanceof Node\Expr\BinaryOp\Pow;
+    }
+
+    /**
+     * Build a {@see Union} for `'a' . 'b'`-style concatenations whose operands
+     * both reduce to single string literals. Anything coarser (mixed types,
+     * non-literal operand, nested non-string union) bails, because we cannot
+     * produce a single literal value to fold the result into.
+     */
+    private static function inferConcat(Node\Expr\BinaryOp\Concat $expr): ?Union
+    {
+        $left = self::inferExpression($expr->left);
+        $right = self::inferExpression($expr->right);
+        if (!$left instanceof Union || !$right instanceof Union) {
+            return null;
+        }
+
+        if (!$left->isSingleStringLiteral() || !$right->isSingleStringLiteral()) {
+            return null;
+        }
+
+        return self::literalStringUnion($left->getSingleStringLiteral()->value . $right->getSingleStringLiteral()->value);
+    }
+
+    /**
+     * Build a single-literal-string {@see Union}, bypassing
+     * {@see Type::getString()}: that helper routes through
+     * `StringInterpreterEvent` and {@see \Psalm\Internal\Analyzer\ProjectAnalyzer},
+     * which is unsafe to touch before Psalm's project analyser is bootstrapped
+     * (notably during unit tests). Returns `null` on `max_string_length`
+     * overflow or when `Config` itself is missing.
+     *
+     * @psalm-pure
+     */
+    private static function literalStringUnion(string $value): ?Union
+    {
+        try {
+            // `from_docblock=false`: the value comes from the closure's actual
+            // source AST, not a docblock annotation. Matches Psalm's own
+            // convention in `ArrayAnalyzer::analyzeArray()` for source-literal
+            // arrays, and keeps `from_docblock` aligned with the other
+            // source-derived atomics built in `inferExpression()`
+            // (`Type::getInt(false, $value)`, `Type::getFloat($value)`,
+            // `Type::getTrue/False/Null()`).
+            return new Union([TLiteralString::make($value)]);
+        } catch (\InvalidArgumentException) {
+            // Value exceeds Psalm's configured `max_string_length` — degrade
+            // to "no inference" rather than fall back to a wider type the
+            // caller would not expect.
+            return null;
+        } catch (\UnexpectedValueException) {
+            // `Config::getInstance()` not initialised. Same posture as
+            // PluginConfig::getCacheDir(): treat as "no inference available".
+            return null;
+        }
+    }
+
+    /**
+     * Build an `int|float` union for arithmetic operators on numerics. We do
+     * not try to fold to a single literal: `1 + 2` could be told to surface
+     * as `int(3)`, but the moment the operand list grows (or a `Float_`
+     * appears anywhere) the result type can flip integer↔float in ways that
+     * are easier to express as `int|float` than to model exactly.
+     *
+     * The result is constant — operand inference exists purely as a numeric
+     * gate, NOT as input to the type. Do not "simplify" by dropping the
+     * `inferExpression()` calls: that gate is what prevents `1 + 'x'` from
+     * widening to `int|float` (which would be wrong, since the runtime
+     * outcome is a `TypeError`).
+     */
+    private static function inferArithmetic(Node\Expr\BinaryOp $expr): ?Union
+    {
+        $left = self::inferExpression($expr->left);
+        $right = self::inferExpression($expr->right);
+        if (!$left instanceof Union || !$right instanceof Union) {
+            return null;
+        }
+
+        if (!self::isNumericUnion($left) || !self::isNumericUnion($right)) {
+            return null;
+        }
+
+        return Type::combineUnionTypes(Type::getInt(), Type::getFloat());
+    }
+
+    /**
+     * `int|float`-only check used by {@see self::inferArithmetic()}. We only
+     * accept fully-known numeric unions — partial unions like `int|string`
+     * would force us to drop into a wider type that defeats the inference.
+     *
+     * @psalm-mutation-free
+     */
+    private static function isNumericUnion(Union $union): bool
+    {
+        foreach ($union->getAtomicTypes() as $atomic) {
+            if (!$atomic instanceof Type\Atomic\TInt && !$atomic instanceof Type\Atomic\TFloat) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Build a shaped {@see Union} for `[…]` literals. Every entry must have
+     * an inferable value AND (if keyed) a literal int/string key. Unpacks
+     * (`...$x`) and unkeyed entries with non-sequential mix of keyed entries
+     * are conservative bails: we deliberately don't try to model partial
+     * arrays. The empty array is its own degenerate case — Psalm exposes a
+     * dedicated empty-array Union for it.
+     */
+    private static function inferArray(Node\Expr\Array_ $expr): ?Union
+    {
+        if ($expr->items === []) {
+            return Type::getEmptyArray();
+        }
+
+        $properties = [];
+        $nextAutoIndex = 0;
+        $anyExplicitKey = false;
+        foreach ($expr->items as $item) {
+            // `Array_->items` is `list<ArrayItem|null>`: PHP-Parser preserves
+            // `null` for skipped positions inside `list(...)`-style destructuring.
+            // That is destructuring metadata, not a value-producing literal, so
+            // we bail on it.
+            if ($item === null || $item->unpack) {
+                return null;
+            }
+
+            $valueUnion = self::inferExpression($item->value);
+            if (!$valueUnion instanceof Union) {
+                return null;
+            }
+
+            if ($item->key === null) {
+                $properties[$nextAutoIndex] = $valueUnion;
+                $nextAutoIndex++;
+                continue;
+            }
+
+            $anyExplicitKey = true;
+
+            $keyExpr = $item->key;
+            if ($keyExpr instanceof Node\Scalar\String_) {
+                $properties[$keyExpr->value] = $valueUnion;
+                continue;
+            }
+
+            if ($keyExpr instanceof Node\Scalar\Int_) {
+                $properties[$keyExpr->value] = $valueUnion;
+                // Subsequent unkeyed entries continue from one past the
+                // largest seen integer key — matches PHP's auto-indexing.
+                if ($keyExpr->value >= $nextAutoIndex) {
+                    $nextAutoIndex = $keyExpr->value + 1;
+                }
+                continue;
+            }
+
+            return null;
+        }
+
+        if ($properties === []) {
+            return Type::getEmptyArray();
+        }
+
+        $isList = !$anyExplicitKey;
+
+        // `from_docblock=false`: matches Psalm's own source-literal convention
+        // (`ArrayAnalyzer::analyzeArray()` calls `TKeyedArray::make` with the
+        // default `false`). `from_docblock=true` relaxes comparison strictness
+        // at call sites — wrong choice for a value we recovered from PHP source.
+        return new Union([TKeyedArray::make($properties, null, null, $isList)]);
     }
 
     /**

--- a/src/Util/Ast/ClosureTypeFactory.php
+++ b/src/Util/Ast/ClosureTypeFactory.php
@@ -57,6 +57,14 @@ use Psalm\Type\Union;
 final class ClosureTypeFactory
 {
     /**
+     * Constant return type of {@see self::inferArithmetic()}. The value never
+     * depends on operands (see that method's docblock for why), so building
+     * it once and re-handing the same `Union` saves a `combineUnionTypes` +
+     * `TypeCombiner::combine` call per arithmetic body return.
+     */
+    private static ?Union $intOrFloatUnion = null;
+
+    /**
      * Build a {@see TClosure} from a runtime closure object.
      *
      * Public shape matches PHPStan's `ClosureTypeFactory::fromClosureObject()`:
@@ -215,8 +223,8 @@ final class ClosureTypeFactory
      */
     private static function buildClosureType(\ReflectionFunctionAbstract $reflection, ?array $recovered): ?TClosure
     {
-        $docblock = $recovered['docblock'] ?? null;
-        $node = $recovered['node'] ?? null;
+        $docblock = $recovered === null ? null : $recovered['docblock'];
+        $node = $recovered === null ? null : $recovered['node'];
         $nativeReturn = self::reflectionTypeToUnion($reflection->getReturnType());
 
         // Body-flow inference (PR #994) only runs when both the docblock and
@@ -489,7 +497,7 @@ final class ClosureTypeFactory
             return null;
         }
 
-        return Type::combineUnionTypes(Type::getInt(), Type::getFloat());
+        return self::$intOrFloatUnion ??= Type::combineUnionTypes(Type::getInt(), Type::getFloat());
     }
 
     /**

--- a/tests/Type/macro-fixtures-vendor-style.php
+++ b/tests/Type/macro-fixtures-vendor-style.php
@@ -64,3 +64,29 @@ MacroFixtureBag::macro('astDocblockParamOnlyTest', static function (int $count):
  * @return non-empty-string
  */
 MacroFixtureBag::macro('astDocblockArrowFnTest', static fn(int $count) => \str_repeat('a', $count));
+
+// PR #994 fixtures — body-flow inference. None of the closures below have a
+// docblock @return OR a native return type, so storage-only and reflection
+// recovery both bottom out at `mixed`. The factory's new body-flow inference
+// is the only path that can produce a narrower return type.
+
+// Literal string: `fn () => 'hello'` should surface as `'hello'`.
+MacroFixtureBag::macro('astBodyInferLiteralStringTest', static fn() => 'hello');
+
+// Multi-return union: each branch is a literal, the result is their union.
+MacroFixtureBag::macro('astBodyInferUnionTest', static function () {
+    if (\random_int(0, 1) === 0) {
+        return 1;
+    }
+    return 'x';
+});
+
+// Unhandled node (`new` expression) — body inference bails. `Expr\New_` is
+// firmly outside the PR's rule table; adding it later would be a deliberate
+// spec change, not a sloppy refactor of `inferExpression()`. Without any
+// source of narrowing, the factory falls back to its null-return path and
+// the caller's reflection-only pseudo-method surfaces `mixed`.
+MacroFixtureBag::macro('astBodyInferBailsOnComplex', static fn() => new \stdClass());
+
+// Concat of two literal strings should fold to a single literal.
+MacroFixtureBag::macro('astBodyInferConcatTest', static fn() => 'a' . 'b');

--- a/tests/Type/macro-fixtures-vendor-style.php
+++ b/tests/Type/macro-fixtures-vendor-style.php
@@ -71,14 +71,13 @@ MacroFixtureBag::macro('astDocblockArrowFnTest', static fn(int $count) => \str_r
 // is the only path that can produce a narrower return type.
 
 // Literal string: `fn () => 'hello'` should surface as `'hello'`.
-MacroFixtureBag::macro('astBodyInferLiteralStringTest', static fn(): string => 'hello');
+MacroFixtureBag::macro('astBodyInferLiteralStringTest', static fn() => 'hello');
 
 // Multi-return union: each branch is a literal, the result is their union.
-MacroFixtureBag::macro('astBodyInferUnionTest', static function (): int|string {
+MacroFixtureBag::macro('astBodyInferUnionTest', static function () {
     if (\random_int(0, 1) === 0) {
         return 1;
     }
-
     return 'x';
 });
 
@@ -87,7 +86,11 @@ MacroFixtureBag::macro('astBodyInferUnionTest', static function (): int|string {
 // spec change, not a sloppy refactor of `inferExpression()`. Without any
 // source of narrowing, the factory falls back to its null-return path and
 // the caller's reflection-only pseudo-method surfaces `mixed`.
-MacroFixtureBag::macro('astBodyInferBailsOnComplex', static fn(): \stdClass => new \stdClass());
+MacroFixtureBag::macro('astBodyInferBailsOnComplex', static fn() => new \stdClass());
 
-// Concat of two literal strings should fold to a single literal.
-MacroFixtureBag::macro('astBodyInferConcatTest', static fn(): string => 'ab');
+// Concat of two literal strings should fold to a single literal. The fixture
+// MUST keep the `.` operator (not a pre-folded `'ab'`) — rector's
+// `typeDeclarations` set is configured to skip this file, but any future
+// constant-folding pass would defeat the test if it collapses the concat at
+// authoring time. See rector.php skip-path comment.
+MacroFixtureBag::macro('astBodyInferConcatTest', static fn() => 'a' . 'b');

--- a/tests/Type/macro-fixtures-vendor-style.php
+++ b/tests/Type/macro-fixtures-vendor-style.php
@@ -71,13 +71,14 @@ MacroFixtureBag::macro('astDocblockArrowFnTest', static fn(int $count) => \str_r
 // is the only path that can produce a narrower return type.
 
 // Literal string: `fn () => 'hello'` should surface as `'hello'`.
-MacroFixtureBag::macro('astBodyInferLiteralStringTest', static fn() => 'hello');
+MacroFixtureBag::macro('astBodyInferLiteralStringTest', static fn(): string => 'hello');
 
 // Multi-return union: each branch is a literal, the result is their union.
-MacroFixtureBag::macro('astBodyInferUnionTest', static function () {
+MacroFixtureBag::macro('astBodyInferUnionTest', static function (): int|string {
     if (\random_int(0, 1) === 0) {
         return 1;
     }
+
     return 'x';
 });
 
@@ -86,7 +87,7 @@ MacroFixtureBag::macro('astBodyInferUnionTest', static function () {
 // spec change, not a sloppy refactor of `inferExpression()`. Without any
 // source of narrowing, the factory falls back to its null-return path and
 // the caller's reflection-only pseudo-method surfaces `mixed`.
-MacroFixtureBag::macro('astBodyInferBailsOnComplex', static fn() => new \stdClass());
+MacroFixtureBag::macro('astBodyInferBailsOnComplex', static fn(): \stdClass => new \stdClass());
 
 // Concat of two literal strings should fold to a single literal.
-MacroFixtureBag::macro('astBodyInferConcatTest', static fn() => 'a' . 'b');
+MacroFixtureBag::macro('astBodyInferConcatTest', static fn(): string => 'ab');

--- a/tests/Type/tests/Macros/MacroAstBodyInferenceTest.phpt
+++ b/tests/Type/tests/Macros/MacroAstBodyInferenceTest.phpt
@@ -1,0 +1,54 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Tests\Psalm\LaravelPlugin\Type\Fixtures\MacroFixtureBag;
+
+/**
+ * AST body-flow inference — PR #994.
+ *
+ * Companion to `MacroAstScanVendorClosureTest.phpt`. Same vendor-style file
+ * (`macro-fixtures-vendor-style.php`), but the closures registered here have
+ * neither a docblock `@return` nor a native return type. The PR's body-flow
+ * inference is the only path that can produce a narrower return type than the
+ * pseudo-method fallback's `mixed`.
+ *
+ * Bring the inference back to PHPStan parity:
+ *
+ *   astBodyInferLiteralStringTest:  () => 'hello'
+ *   astBodyInferUnionTest:          () => 1|'x' (multi-return union)
+ *   astBodyInferConcatTest:         () => 'ab'  (literal-string folding)
+ *   astBodyInferBailsOnComplex:     () => mixed (unhandled expression bails)
+ *
+ * If body inference regresses, the call sites below will read back the wrong
+ * narrowed type and `@psalm-check-type-exact` will fail loud.
+ */
+
+function test_ast_body_infer_literal_string(): string
+{
+    $_ = (new MacroFixtureBag())->astBodyInferLiteralStringTest();
+    /** @psalm-check-type-exact $_ = 'hello' */
+    return $_;
+}
+
+function test_ast_body_infer_multi_return_union(): int|string
+{
+    $_ = (new MacroFixtureBag())->astBodyInferUnionTest();
+    /** @psalm-check-type-exact $_ = 1|'x' */
+    return $_;
+}
+
+function test_ast_body_infer_bails_on_complex(): mixed
+{
+    $_ = (new MacroFixtureBag())->astBodyInferBailsOnComplex();
+    /** @psalm-check-type-exact $_ = mixed */
+    return $_;
+}
+
+function test_ast_body_infer_concat_folds_to_literal(): string
+{
+    $_ = (new MacroFixtureBag())->astBodyInferConcatTest();
+    /** @psalm-check-type-exact $_ = 'ab' */
+    return $_;
+}
+?>
+--EXPECTF--

--- a/tests/Unit/Util/Ast/CachedClosureTypeFactoryTest.php
+++ b/tests/Unit/Util/Ast/CachedClosureTypeFactoryTest.php
@@ -8,6 +8,8 @@ use Closure;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Psalm\Config;
+use Psalm\Internal\EventDispatcher;
 use Psalm\LaravelPlugin\Util\Ast\CachedClosureTypeFactory;
 use Psalm\Type\Atomic\TClosure;
 use Psalm\Type\Union;
@@ -33,6 +35,25 @@ final class CachedClosureTypeFactoryTest extends TestCase
 {
     /** @var list<string> */
     private array $tempFiles = [];
+
+    public static function setUpBeforeClass(): void
+    {
+        // PR #994 body-flow inference (exercised by the body-flow test below)
+        // calls `TLiteralString::make()` which requires Psalm's singleton
+        // `Config`. Mirror the same minimal-bootstrap pattern as
+        // {@see ClosureTypeFactoryTest::setUpBeforeClass()} so the cached
+        // wrapper's coverage of that path doesn't depend on the un-cached
+        // factory test class running first.
+        $rc = new \ReflectionClass(Config::class);
+        $instance = $rc->newInstanceWithoutConstructor();
+        $rc->getProperty('instance')->setValue(null, $instance);
+        $rc->getProperty('eventDispatcher')->setValue($instance, new EventDispatcher());
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        (new \ReflectionClass(Config::class))->getProperty('instance')->setValue(null, null);
+    }
 
     #[\Override]
     protected function setUp(): void
@@ -183,6 +204,30 @@ PHP,
         $second = CachedClosureTypeFactory::fromClosureObject($this->loadClosureFromFile($file));
         $this->assertInstanceOf(TClosure::class, $second);
         $this->assertSame('literal-string', $second->return_type?->getId());
+    }
+
+    #[Test]
+    public function delegates_to_body_flow_inference_when_docblock_absent(): void
+    {
+        // PR #994: the cached wrapper must also reach the body-flow path.
+        // Without this test, an accidental "cache `null` results forever"
+        // bug in the wrapper could silently keep callers on `mixed` for
+        // closures that should now narrow via body inference. The
+        // un-cached factory has its own coverage for the rule table; this
+        // test only verifies the wrapper does not block the inference
+        // result from surfacing.
+        $file = $this->writeTempFile(
+            <<<'PHP'
+<?php
+$register(static fn () => 'cached-hello');
+PHP,
+        );
+
+        $closure = $this->loadClosureFromFile($file);
+        $result = CachedClosureTypeFactory::fromClosureObject($closure);
+
+        $this->assertInstanceOf(TClosure::class, $result);
+        $this->assertSame("'cached-hello'", $result->return_type?->getId());
     }
 
     private function writeTempFile(string $contents): string

--- a/tests/Unit/Util/Ast/CachedClosureTypeFactoryTest.php
+++ b/tests/Unit/Util/Ast/CachedClosureTypeFactoryTest.php
@@ -8,11 +8,10 @@ use Closure;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Psalm\Config;
-use Psalm\Internal\EventDispatcher;
 use Psalm\LaravelPlugin\Util\Ast\CachedClosureTypeFactory;
 use Psalm\Type\Atomic\TClosure;
 use Psalm\Type\Union;
+use Tests\Psalm\LaravelPlugin\Unit\Util\Ast\Concerns\InitializesPsalmConfigSingleton;
 
 /**
  * Targeted coverage for the memoizing decorator. The stateless build
@@ -33,27 +32,10 @@ use Psalm\Type\Union;
 #[CoversClass(CachedClosureTypeFactory::class)]
 final class CachedClosureTypeFactoryTest extends TestCase
 {
+    use InitializesPsalmConfigSingleton;
+
     /** @var list<string> */
     private array $tempFiles = [];
-
-    public static function setUpBeforeClass(): void
-    {
-        // PR #994 body-flow inference (exercised by the body-flow test below)
-        // calls `TLiteralString::make()` which requires Psalm's singleton
-        // `Config`. Mirror the same minimal-bootstrap pattern as
-        // {@see ClosureTypeFactoryTest::setUpBeforeClass()} so the cached
-        // wrapper's coverage of that path doesn't depend on the un-cached
-        // factory test class running first.
-        $rc = new \ReflectionClass(Config::class);
-        $instance = $rc->newInstanceWithoutConstructor();
-        $rc->getProperty('instance')->setValue(null, $instance);
-        $rc->getProperty('eventDispatcher')->setValue($instance, new EventDispatcher());
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        (new \ReflectionClass(Config::class))->getProperty('instance')->setValue(null, null);
-    }
 
     #[\Override]
     protected function setUp(): void

--- a/tests/Unit/Util/Ast/ClosureTypeFactoryTest.php
+++ b/tests/Unit/Util/Ast/ClosureTypeFactoryTest.php
@@ -424,6 +424,35 @@ PHP);
     }
 
     #[Test]
+    public function body_infer_bails_on_empty_body(): void
+    {
+        // PHPStan's own `ClosureTypeFactoryTest` returns `mixed` for an
+        // empty-body closure (`function () {}`). Our factory bails (the
+        // visitor finds no returns AND `bodyAlwaysTerminates([])` is false),
+        // so the caller falls back to its reflection-only pseudo-method
+        // which has no native return → surfaces as `mixed`. Same effective
+        // outcome on a different code path; lock both branches in.
+        $this->assertBailsForBody(<<<'PHP'
+<?php
+$register(static function () {});
+PHP);
+    }
+
+    #[Test]
+    public function body_infer_bails_on_non_literal_const_fetch(): void
+    {
+        // ConstFetch handling only resolves globally-namespaced `true`,
+        // `false`, `null`. Anything else (`PHP_EOL`, user-defined
+        // constants, `use const` aliases) bails — adding general constant
+        // resolution would require a constant resolver and is firmly out
+        // of the PR's scope.
+        $this->assertBailsForBody(<<<'PHP'
+<?php
+$register(static fn () => PHP_EOL);
+PHP);
+    }
+
+    #[Test]
     public function body_infer_bails_on_implicit_null_fallthrough(): void
     {
         // Conservatively bail when the body has a code path that reaches the

--- a/tests/Unit/Util/Ast/ClosureTypeFactoryTest.php
+++ b/tests/Unit/Util/Ast/ClosureTypeFactoryTest.php
@@ -8,12 +8,11 @@ use Closure;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Psalm\Config;
-use Psalm\Internal\EventDispatcher;
 use Psalm\LaravelPlugin\Util\Ast\ClosureDocblockIndexVisitor;
 use Psalm\LaravelPlugin\Util\Ast\ClosureTypeFactory;
 use Psalm\Type\Atomic\TClosure;
 use Psalm\Type\Union;
+use Tests\Psalm\LaravelPlugin\Unit\Util\Ast\Concerns\InitializesPsalmConfigSingleton;
 
 /**
  * Unit coverage for the stateless AST-scan path that recovers `@param` /
@@ -37,34 +36,10 @@ use Psalm\Type\Union;
 #[CoversClass(ClosureDocblockIndexVisitor::class)]
 final class ClosureTypeFactoryTest extends TestCase
 {
+    use InitializesPsalmConfigSingleton;
+
     /** @var list<string> */
     private array $tempFiles = [];
-
-    public static function setUpBeforeClass(): void
-    {
-        // PR #994 literal-string body inference constructs `TLiteralString`
-        // directly, which reads `max_string_length` from Psalm's singleton
-        // {@see Config}. Production callers always have a `Config` (the
-        // plugin runs inside Psalm), but the unit-test harness does not
-        // bootstrap one. Populate just enough to make the literal-string
-        // path succeed — heavier alternatives (loading `tests/Type/psalm.xml`
-        // through `Config::loadFromXMLFile`) pull in schema validation and
-        // composer-classmap warmups that aren't relevant here.
-        $rc = new \ReflectionClass(Config::class);
-        $instance = $rc->newInstanceWithoutConstructor();
-        $rc->getProperty('instance')->setValue(null, $instance);
-        $rc->getProperty('eventDispatcher')->setValue($instance, new EventDispatcher());
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        // Restore the "no Config initialized" precondition other unit tests
-        // (notably `NoEnvOutsideConfigHandlerTest`) rely on. Without this
-        // teardown the singleton planted in setUpBeforeClass leaks across
-        // test classes within one PHPUnit run, masking real "config not yet
-        // bootstrapped" guard tests.
-        (new \ReflectionClass(Config::class))->getProperty('instance')->setValue(null, null);
-    }
 
     #[\Override]
     protected function tearDown(): void
@@ -274,15 +249,10 @@ PHP,
         // `UnaryMinus`, so signed-literal closures bail. Lock that in so a
         // later "obvious" widening doesn't silently start producing `-1`
         // (or worse, `1`) for sloppy callers that wrote `fn() => -1`.
-        $file = $this->writeTempFile(
-            <<<'PHP'
+        $this->assertBailsForBody(<<<'PHP'
 <?php
 $register(static fn () => -1);
-PHP,
-        );
-        $closure = $this->loadClosureFromFile($file);
-
-        $this->assertNull(ClosureTypeFactory::fromClosureObject($closure));
+PHP);
     }
 
     #[Test]
@@ -292,15 +262,10 @@ PHP,
         // tail as terminating, but there is no `return` to feed the inference
         // engine — so we still bail to `null`, just on a different code path
         // than `bodyAlwaysTerminates() === false`. Lock both branches in.
-        $file = $this->writeTempFile(
-            <<<'PHP'
+        $this->assertBailsForBody(<<<'PHP'
 <?php
 $register(static function () { throw new \RuntimeException(); });
-PHP,
-        );
-        $closure = $this->loadClosureFromFile($file);
-
-        $this->assertNull(ClosureTypeFactory::fromClosureObject($closure));
+PHP);
     }
 
     #[Test]
@@ -313,17 +278,12 @@ PHP,
         // Documenting the limit here ensures a future relaxation (e.g.
         // teaching `bodyAlwaysTerminates()` to peek inside `try/catch`)
         // is a deliberate change, not a silent drift.
-        $file = $this->writeTempFile(
-            <<<'PHP'
+        $this->assertBailsForBody(<<<'PHP'
 <?php
 $register(static function () {
     try { return 1; } catch (\Throwable) { return 2; }
 });
-PHP,
-        );
-        $closure = $this->loadClosureFromFile($file);
-
-        $this->assertNull(ClosureTypeFactory::fromClosureObject($closure));
+PHP);
     }
 
     #[Test]
@@ -386,31 +346,21 @@ PHP;
         // Variable returns are out of scope (the spec explicitly excludes
         // variable type-flow). Without docblock and without a native return,
         // body inference bails and the factory returns `null`.
-        $file = $this->writeTempFile(
-            <<<'PHP'
+        $this->assertBailsForBody(<<<'PHP'
 <?php
 $register(static function () { $x = 1; return $x; });
-PHP,
-        );
-        $closure = $this->loadClosureFromFile($file);
-
-        $this->assertNull(ClosureTypeFactory::fromClosureObject($closure));
+PHP);
     }
 
     #[Test]
     public function body_infer_bails_on_unhandled_node(): void
     {
-        // Method call inside the return is outside the rule table — the
+        // Property fetch inside the return is outside the rule table — the
         // factory bails the entire inference rather than guess.
-        $file = $this->writeTempFile(
-            <<<'PHP'
+        $this->assertBailsForBody(<<<'PHP'
 <?php
 $register(static fn () => (new \stdClass())->foo);
-PHP,
-        );
-        $closure = $this->loadClosureFromFile($file);
-
-        $this->assertNull(ClosureTypeFactory::fromClosureObject($closure));
+PHP);
     }
 
     #[Test]
@@ -420,15 +370,10 @@ PHP,
         // native) wins. Body inference is suppressed, and since the closure
         // also has no docblock the factory falls back to `null` — caller
         // keeps its reflection-only pseudo-method path.
-        $file = $this->writeTempFile(
-            <<<'PHP'
+        $this->assertBailsForBody(<<<'PHP'
 <?php
 $register(static function (): int { return 7; });
-PHP,
-        );
-        $closure = $this->loadClosureFromFile($file);
-
-        $this->assertNull(ClosureTypeFactory::fromClosureObject($closure));
+PHP);
     }
 
     #[Test]
@@ -438,19 +383,14 @@ PHP,
         // closing brace without an explicit `return` — PHP returns `null` in
         // that case, and inferring just the explicit return value would
         // silently disagree with runtime.
-        $file = $this->writeTempFile(
-            <<<'PHP'
+        $this->assertBailsForBody(<<<'PHP'
 <?php
 $register(static function () {
     if (\random_int(0, 1) === 0) {
         return 1;
     }
 });
-PHP,
-        );
-        $closure = $this->loadClosureFromFile($file);
-
-        $this->assertNull(ClosureTypeFactory::fromClosureObject($closure));
+PHP);
     }
 
     #[Test]
@@ -490,6 +430,19 @@ PHP,
         $this->assertInstanceOf(TClosure::class, $result, 'Body inference should have produced a TClosure');
 
         return $result;
+    }
+
+    /**
+     * Companion to {@see self::buildInferredFromBody()} for the bail tests.
+     * Same fixture-load pipeline, but asserts the factory returned `null`
+     * (caller falls back to its reflection-only pseudo-method path).
+     */
+    private function assertBailsForBody(string $fixturePhp): void
+    {
+        $file = $this->writeTempFile($fixturePhp);
+        $closure = $this->loadClosureFromFile($file);
+
+        $this->assertNull(ClosureTypeFactory::fromClosureObject($closure));
     }
 
     #[Test]

--- a/tests/Unit/Util/Ast/ClosureTypeFactoryTest.php
+++ b/tests/Unit/Util/Ast/ClosureTypeFactoryTest.php
@@ -208,6 +208,39 @@ PHP,
     /**
      * @return iterable<string, array{string}>
      */
+    public static function mixedNumericOperands(): iterable
+    {
+        // `inferArithmetic()` accepts float-flavoured operands on either side
+        // and on both sides. All three shapes must still widen to `int|float`.
+        yield 'int + float' => ['1 + 2.5'];
+        yield 'float + int' => ['1.5 + 2'];
+        yield 'float * float' => ['1.5 * 2.5'];
+    }
+
+    #[Test]
+    #[\PHPUnit\Framework\Attributes\DataProvider('mixedNumericOperands')]
+    public function body_infer_arithmetic_accepts_mixed_numeric_operands(string $expression): void
+    {
+        $result = $this->buildInferredFromBody("static fn () => {$expression}");
+        $this->assertSame('float|int', $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_arithmetic_bails_on_non_numeric_operand(): void
+    {
+        // Without `isNumericUnion()` gate, `1 + 'x'` would widen to `int|float`
+        // — but runtime is a `TypeError`. The inferArithmetic docblock calls
+        // out the operand inference as the load-bearing numeric gate; this
+        // test locks it in so any "simplification" of that gate fails loud.
+        $this->assertBailsForBody(<<<'PHP'
+<?php
+$register(static fn () => 1 + 'x');
+PHP);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
     public static function arithmeticOperators(): iterable
     {
         // All six arithmetic operators share a single branch in
@@ -242,6 +275,20 @@ PHP,
     }
 
     #[Test]
+    public function body_infer_concat_bails_on_non_string_operand(): void
+    {
+        // PHP coerces `'a' . 1` to `'a1'` at runtime, but `inferConcat()`
+        // requires both operands to be single string literals — the gate
+        // exists so we don't accidentally fold types Psalm renders as
+        // `numeric-string` or `int`. Lock it in so future "obvious" relaxation
+        // doesn't silently produce wrong literals.
+        $this->assertBailsForBody(<<<'PHP'
+<?php
+$register(static fn () => 'a' . 1);
+PHP);
+    }
+
+    #[Test]
     public function body_infer_bails_on_unary_minus(): void
     {
         // PhpParser models `-1` as `UnaryMinus(Int_(1))` — not a literal
@@ -256,7 +303,7 @@ PHP);
     }
 
     #[Test]
-    public function body_infer_accepts_throw_only_terminator(): void
+    public function body_infer_bails_on_throw_only_terminator(): void
     {
         // `bodyAlwaysTerminates()` considers a `Stmt\Expression(Expr\Throw_)`
         // tail as terminating, but there is no `return` to feed the inference

--- a/tests/Unit/Util/Ast/ClosureTypeFactoryTest.php
+++ b/tests/Unit/Util/Ast/ClosureTypeFactoryTest.php
@@ -8,6 +8,8 @@ use Closure;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Psalm\Config;
+use Psalm\Internal\EventDispatcher;
 use Psalm\LaravelPlugin\Util\Ast\ClosureDocblockIndexVisitor;
 use Psalm\LaravelPlugin\Util\Ast\ClosureTypeFactory;
 use Psalm\Type\Atomic\TClosure;
@@ -37,6 +39,32 @@ final class ClosureTypeFactoryTest extends TestCase
 {
     /** @var list<string> */
     private array $tempFiles = [];
+
+    public static function setUpBeforeClass(): void
+    {
+        // PR #994 literal-string body inference constructs `TLiteralString`
+        // directly, which reads `max_string_length` from Psalm's singleton
+        // {@see Config}. Production callers always have a `Config` (the
+        // plugin runs inside Psalm), but the unit-test harness does not
+        // bootstrap one. Populate just enough to make the literal-string
+        // path succeed — heavier alternatives (loading `tests/Type/psalm.xml`
+        // through `Config::loadFromXMLFile`) pull in schema validation and
+        // composer-classmap warmups that aren't relevant here.
+        $rc = new \ReflectionClass(Config::class);
+        $instance = $rc->newInstanceWithoutConstructor();
+        $rc->getProperty('instance')->setValue(null, $instance);
+        $rc->getProperty('eventDispatcher')->setValue($instance, new EventDispatcher());
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        // Restore the "no Config initialized" precondition other unit tests
+        // (notably `NoEnvOutsideConfigHandlerTest`) rely on. Without this
+        // teardown the singleton planted in setUpBeforeClass leaks across
+        // test classes within one PHPUnit run, masking real "config not yet
+        // bootstrapped" guard tests.
+        (new \ReflectionClass(Config::class))->getProperty('instance')->setValue(null, null);
+    }
 
     #[\Override]
     protected function tearDown(): void
@@ -130,6 +158,338 @@ PHP,
         $closure = $this->loadClosureFromFile($file);
 
         $this->assertNull(ClosureTypeFactory::fromClosureObject($closure));
+    }
+
+    /**
+     * PR #994 body-flow inference fixtures. Each test installs a closure that
+     * has NO docblock and NO native return type, so the factory has nothing to
+     * fall back on except the body-flow inference path. The asserted `getId()`
+     * is what callers see as the closure's recovered return type.
+     */
+    #[Test]
+    public function body_infer_literal_string(): void
+    {
+        $result = $this->buildInferredFromBody("static fn () => 'hello'");
+        $this->assertSame("'hello'", $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_literal_int(): void
+    {
+        $result = $this->buildInferredFromBody('static fn () => 42');
+        $this->assertSame('42', $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_literal_float(): void
+    {
+        $result = $this->buildInferredFromBody('static fn () => 1.5');
+        // `getId(exact: true)` on TLiteralFloat renders as `float(<value>)` —
+        // distinct from TLiteralInt and TLiteralString, which render as bare
+        // numerals and quoted strings respectively. Lock the exact rendering
+        // so a Psalm-side change to literal-float formatting is caught.
+        $this->assertSame('float(1.5)', $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_const_true(): void
+    {
+        $result = $this->buildInferredFromBody('static fn () => true');
+        $this->assertSame('true', $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_const_false(): void
+    {
+        $result = $this->buildInferredFromBody('static fn () => false');
+        $this->assertSame('false', $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_const_null(): void
+    {
+        $result = $this->buildInferredFromBody('static fn () => null');
+        $this->assertSame('null', $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_concat_literal_strings(): void
+    {
+        $result = $this->buildInferredFromBody("static fn () => 'a' . 'b'");
+        $this->assertSame("'ab'", $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_arithmetic_returns_int_or_float(): void
+    {
+        // The spec deliberately widens arithmetic to `int|float` even when
+        // both operands are int literals: the same operator can produce a
+        // float at runtime (1/2, intdiv overflow on 32-bit, etc.), and
+        // modelling each case exactly would explode the rule table.
+        $result = $this->buildInferredFromBody('static fn () => 1 + 2');
+        $this->assertSame('float|int', $result->return_type?->getId());
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function arithmeticOperators(): iterable
+    {
+        // All six arithmetic operators share a single branch in
+        // {@see ClosureTypeFactory::inferExpression()}. If a future refactor
+        // splits the implementation per-operator (e.g. modeling `Mod` as
+        // int-only), the data provider catches the regression.
+        yield 'plus' => ['1 + 2'];
+        yield 'minus' => ['5 - 2'];
+        yield 'mul' => ['3 * 4'];
+        yield 'div' => ['8 / 2'];
+        yield 'mod' => ['7 % 3'];
+        yield 'pow' => ['2 ** 8'];
+    }
+
+    #[Test]
+    #[\PHPUnit\Framework\Attributes\DataProvider('arithmeticOperators')]
+    public function body_infer_arithmetic_widens_uniformly_for_every_operator(string $expression): void
+    {
+        $result = $this->buildInferredFromBody("static fn () => {$expression}");
+        $this->assertSame('float|int', $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_chained_concat_folds_to_literal(): void
+    {
+        // Left-associative parsing makes `'a' . 'b' . 'c'` a Concat of
+        // (Concat('a','b'), 'c'). The inner Concat must recurse through
+        // `inferExpression()` and surface its folded literal so the outer
+        // Concat sees a single-string-literal operand.
+        $result = $this->buildInferredFromBody("static fn () => 'a' . 'b' . 'c'");
+        $this->assertSame("'abc'", $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_bails_on_unary_minus(): void
+    {
+        // PhpParser models `-1` as `UnaryMinus(Int_(1))` — not a literal
+        // scalar. The spec's rule table covers `Scalar\Int_` but not
+        // `UnaryMinus`, so signed-literal closures bail. Lock that in so a
+        // later "obvious" widening doesn't silently start producing `-1`
+        // (or worse, `1`) for sloppy callers that wrote `fn() => -1`.
+        $file = $this->writeTempFile(
+            <<<'PHP'
+<?php
+$register(static fn () => -1);
+PHP,
+        );
+        $closure = $this->loadClosureFromFile($file);
+
+        $this->assertNull(ClosureTypeFactory::fromClosureObject($closure));
+    }
+
+    #[Test]
+    public function body_infer_accepts_throw_only_terminator(): void
+    {
+        // `bodyAlwaysTerminates()` considers a `Stmt\Expression(Expr\Throw_)`
+        // tail as terminating, but there is no `return` to feed the inference
+        // engine — so we still bail to `null`, just on a different code path
+        // than `bodyAlwaysTerminates() === false`. Lock both branches in.
+        $file = $this->writeTempFile(
+            <<<'PHP'
+<?php
+$register(static function () { throw new \RuntimeException(); });
+PHP,
+        );
+        $closure = $this->loadClosureFromFile($file);
+
+        $this->assertNull(ClosureTypeFactory::fromClosureObject($closure));
+    }
+
+    #[Test]
+    public function body_infer_bails_when_terminator_is_try_catch(): void
+    {
+        // `try { return 1; } catch { return 2; }` terminates in both arms,
+        // but `bodyAlwaysTerminates()` is intentionally conservative: it
+        // only accepts a plain `Return_` or `Throw_` as the last top-level
+        // statement. A `Stmt\TryCatch` fails the check, so inference bails.
+        // Documenting the limit here ensures a future relaxation (e.g.
+        // teaching `bodyAlwaysTerminates()` to peek inside `try/catch`)
+        // is a deliberate change, not a silent drift.
+        $file = $this->writeTempFile(
+            <<<'PHP'
+<?php
+$register(static function () {
+    try { return 1; } catch (\Throwable) { return 2; }
+});
+PHP,
+        );
+        $closure = $this->loadClosureFromFile($file);
+
+        $this->assertNull(ClosureTypeFactory::fromClosureObject($closure));
+    }
+
+    #[Test]
+    public function body_infer_nested_shaped_array(): void
+    {
+        // `inferArray()` recurses through `inferExpression()`, so nested
+        // arrays should compose into a nested shaped array. If someone
+        // "simplifies" the recursion to only accept literal scalars at the
+        // leaves, the per-rule tests still pass but this composition test
+        // fails — that's the regression-protection value.
+        $result = $this->buildInferredFromBody("static fn () => [[1, 2], 3]");
+        $this->assertSame('list{list{1, 2}, 3}', $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_mixed_key_array_drops_list_marker(): void
+    {
+        // Any explicit key flips `$isList` to false. Verifies the auto-index
+        // path interacts correctly with explicit keys in the same array.
+        $result = $this->buildInferredFromBody("static fn () => [1, 'k' => 2]");
+        $this->assertSame("array{0: 1, k: 2}", $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_shaped_list_array(): void
+    {
+        $result = $this->buildInferredFromBody("static fn () => [1, 'x']");
+        $this->assertSame("list{1, 'x'}", $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_shaped_keyed_array(): void
+    {
+        $result = $this->buildInferredFromBody("static fn () => ['k' => 1]");
+        $this->assertSame("array{k: 1}", $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_multi_return_unions_branches(): void
+    {
+        // `if/else`: both branches yield literal returns; the result should be
+        // their union. Locks in `combineUnionTypeArray()` wiring.
+        $closureSource = <<<'PHP'
+static function () {
+    if (\random_int(0, 1) === 0) {
+        return 1;
+    }
+    return 'x';
+}
+PHP;
+        $result = $this->buildInferredFromBody($closureSource);
+        // Union::getId() sorts atomics alphabetically — apostrophe (39) sorts
+        // before digit (49), so `'x'` precedes `1` in the rendered output.
+        $this->assertSame("'x'|1", $result->return_type?->getId());
+    }
+
+    #[Test]
+    public function body_infer_bails_on_variable_return(): void
+    {
+        // Variable returns are out of scope (the spec explicitly excludes
+        // variable type-flow). Without docblock and without a native return,
+        // body inference bails and the factory returns `null`.
+        $file = $this->writeTempFile(
+            <<<'PHP'
+<?php
+$register(static function () { $x = 1; return $x; });
+PHP,
+        );
+        $closure = $this->loadClosureFromFile($file);
+
+        $this->assertNull(ClosureTypeFactory::fromClosureObject($closure));
+    }
+
+    #[Test]
+    public function body_infer_bails_on_unhandled_node(): void
+    {
+        // Method call inside the return is outside the rule table — the
+        // factory bails the entire inference rather than guess.
+        $file = $this->writeTempFile(
+            <<<'PHP'
+<?php
+$register(static fn () => (new \stdClass())->foo);
+PHP,
+        );
+        $closure = $this->loadClosureFromFile($file);
+
+        $this->assertNull(ClosureTypeFactory::fromClosureObject($closure));
+    }
+
+    #[Test]
+    public function body_infer_does_not_run_when_native_return_present(): void
+    {
+        // Reflection sees `: int`, so the existing precedence (docblock then
+        // native) wins. Body inference is suppressed, and since the closure
+        // also has no docblock the factory falls back to `null` — caller
+        // keeps its reflection-only pseudo-method path.
+        $file = $this->writeTempFile(
+            <<<'PHP'
+<?php
+$register(static function (): int { return 7; });
+PHP,
+        );
+        $closure = $this->loadClosureFromFile($file);
+
+        $this->assertNull(ClosureTypeFactory::fromClosureObject($closure));
+    }
+
+    #[Test]
+    public function body_infer_bails_on_implicit_null_fallthrough(): void
+    {
+        // Conservatively bail when the body has a code path that reaches the
+        // closing brace without an explicit `return` — PHP returns `null` in
+        // that case, and inferring just the explicit return value would
+        // silently disagree with runtime.
+        $file = $this->writeTempFile(
+            <<<'PHP'
+<?php
+$register(static function () {
+    if (\random_int(0, 1) === 0) {
+        return 1;
+    }
+});
+PHP,
+        );
+        $closure = $this->loadClosureFromFile($file);
+
+        $this->assertNull(ClosureTypeFactory::fromClosureObject($closure));
+    }
+
+    #[Test]
+    public function body_infer_skips_nested_closure_returns(): void
+    {
+        // The outer closure's only `return` yields a literal; the inner
+        // closure also returns something, but its return belongs to the inner
+        // function and must NOT contaminate the outer inference.
+        $file = $this->writeTempFile(
+            <<<'PHP'
+<?php
+$register(static function () {
+    $cb = static function () { return 'inner'; };
+    return 'outer';
+});
+PHP,
+        );
+        $closure = $this->loadClosureFromFile($file);
+        $result = ClosureTypeFactory::fromClosureObject($closure);
+
+        $this->assertInstanceOf(TClosure::class, $result);
+        $this->assertSame("'outer'", $result->return_type?->getId());
+    }
+
+    /**
+     * Helper: write a fixture file whose only closure is `$closureSource`,
+     * load it, and assert the recovered TClosure exists. Body-only inference
+     * tests share this scaffolding because they all want a fresh single-closure
+     * file with no docblock and no native return type.
+     */
+    private function buildInferredFromBody(string $closureSource): TClosure
+    {
+        $file = $this->writeTempFile("<?php\n\$register({$closureSource});\n");
+        $closure = $this->loadClosureFromFile($file);
+        $result = ClosureTypeFactory::fromClosureObject($closure);
+
+        $this->assertInstanceOf(TClosure::class, $result, 'Body inference should have produced a TClosure');
+
+        return $result;
     }
 
     #[Test]

--- a/tests/Unit/Util/Ast/Concerns/InitializesPsalmConfigSingleton.php
+++ b/tests/Unit/Util/Ast/Concerns/InitializesPsalmConfigSingleton.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Util\Ast\Concerns;
+
+use Psalm\Config;
+use Psalm\Internal\EventDispatcher;
+
+/**
+ * Plants a minimal `Psalm\Config` singleton so test paths that touch
+ * `TLiteralString::make()` (reads `Config::getInstance()->max_string_length`)
+ * succeed without bootstrapping the full Psalm project analyser.
+ *
+ * Used by the body-flow inference tests in {@see ClosureTypeFactoryTest} and
+ * {@see CachedClosureTypeFactoryTest}. Heavier alternatives (loading
+ * `tests/Type/psalm.xml` through `Config::loadFromXMLFile()`) pull in schema
+ * validation and composer-classmap warmups that aren't relevant here.
+ *
+ * `tearDownAfterClass` MUST null the singleton: otherwise sibling test
+ * classes (notably `NoEnvOutsideConfigHandlerTest`) that rely on the
+ * "no Config initialized" precondition see a stale instance.
+ */
+trait InitializesPsalmConfigSingleton
+{
+    public static function setUpBeforeClass(): void
+    {
+        $rc = new \ReflectionClass(Config::class);
+        $instance = $rc->newInstanceWithoutConstructor();
+        $rc->getProperty('instance')->setValue(null, $instance);
+        $rc->getProperty('eventDispatcher')->setValue($instance, new EventDispatcher());
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        (new \ReflectionClass(Config::class))->getProperty('instance')->setValue(null, null);
+    }
+}


### PR DESCRIPTION
## Issue to Solve

Closures whose return type is implied by their body — `fn () => 'hello'`, `fn () => 1 + 2`, `function () { if (...) return 1; return 'x'; }` — currently surface as `mixed` from the macro recovery path when no docblock `@return` and no native return type are present. Reflection cannot peek inside the body; the docblock-based recovery shipped in #991 has nothing to read. PHPStan's `ClosureTypeFactory` infers from the body transparently in this case; psalm-plugin-laravel did not.

## Related

Continues #994 (base branch `worktree-991-macros-ast-scan-vendor`). Closes the "body-flow inference" follow-up gap noted in the #991 file-header docblock and #994 description.

## Solution Description

Extends `src/Util/Ast/ClosureTypeFactory.php` with a narrow body-flow inference path that fires only when both the docblock `@return` AND the native reflection return are absent. Anything more sophisticated (variable type-flow, generic template inference, `StatementsAnalyzer` re-entry) is explicitly out of scope; the rule table is small and conservative.

**Rule table** (anything outside it bails the entire inference, deliberately):

| AST node                                           | Inferred                                  |
|----------------------------------------------------|-------------------------------------------|
| `Scalar\String_`                                   | `TLiteralString` via `TLiteralString::make` |
| `Scalar\Int_`                                      | `Type::getInt(false, $value)`             |
| `Scalar\Float_`                                    | `Type::getFloat($value)`                  |
| `ConstFetch true / false / null`                   | matching constant `Union`                 |
| `Array_` (keys + values inferable)                 | shaped array via `TKeyedArray::make`      |
| `BinaryOp\Concat` of literal strings               | folded literal-string                     |
| `Plus/Minus/Mul/Div/Mod/Pow` of inferable numerics | `int\|float`                              |
| anything else                                      | bail (caller falls back to `mixed`)       |

**Multi-return closures:** the new `BodyReturnCollectorVisitor` walks the body collecting top-level returns while honouring `NodeVisitor::DONT_TRAVERSE_CHILDREN` for nested closures / arrow functions / function declarations / class methods (their returns belong to the inner function). The per-return unions are then `Type::combineUnionTypeArray`-folded.

**Implicit-`null` fall-through guard:** a conservative `bodyAlwaysTerminates()` check requires the last top-level statement to be a `return` or `throw`. Closures like `function () { if (cond) return 1; }` — which would silently return `null` at runtime — bail rather than produce a partial type that disagrees with PHP semantics.

**Memory hygiene:** `CachedClosureTypeFactory::reset()` now runs at the end of `MacroRegistry::init()`. The visitor's per-file index retains `Closure` / `ArrowFunction` AST subtrees so body inference can run without re-parsing; dropping the cache before Psalm's `pcntl_fork` phase avoids copy-on-write replication of those subtrees into every analysis worker.


## Verified by

- Type tests: `tests/Type/tests/Macros/MacroAstBodyInferenceTest.phpt` exercises literal-string, multi-return-union, concat-folding, and bail paths end-to-end through `MacroFixtureBag`.
- Unit tests: `tests/Unit/Util/Ast/ClosureTypeFactoryTest.php` adds one test per inference rule plus regression coverage for the implicit-`null` fall-through bail, nested-closure shielding, throw-only termination, try/catch bail, chained concat, mixed-key arrays, and a data-provided sweep over all six arithmetic operators.
- Cached layer: `tests/Unit/Util/Ast/CachedClosureTypeFactoryTest.php` adds a body-flow round-trip to verify the memoizing wrapper does not block inference results.
- Self-analysis: `composer psalm` exits 0, no new `psalm-baseline.xml` entries (none exists).

## Checklist

- [x] Tests cover the change (type test in `tests/Type/` and unit test in `tests/Unit/`)
- [x] Documentation is updated (class-level docblocks in `ClosureTypeFactory` and `BodyReturnCollectorVisitor`)

