### PR TITLE
Narrow `when()`/`unless()` callback return types

### DIFF
--- a/src/Handlers/Support/ConditionableWhenHandler.php
+++ b/src/Handlers/Support/ConditionableWhenHandler.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Support;
+
+use Illuminate\Support\Traits\Conditionable;
+use PhpParser\Node\Expr\MethodCall;
+use Psalm\Codebase;
+use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\Internal\Type\Comparator\UnionTypeComparator;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\Type\Atomic;
+use Psalm\Type\Atomic\TCallable;
+use Psalm\Type\Atomic\TClosure;
+use Psalm\Type\Atomic\TMixed;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Atomic\TNever;
+use Psalm\Type\Atomic\TNull;
+use Psalm\Type\Atomic\TVoid;
+use Psalm\Type\Union;
+
+/**
+ * Narrows {@see Conditionable::when()} / {@see Conditionable::unless()} to the callback's
+ * return type when it carries information the receiver does not — the Option B follow-up
+ * to the `@return $this` stub (#993).
+ *
+ * The stub alone already types the common case: a callback returning void / null / the
+ * receiver type collapses to `$this` via Laravel's `$callback($this, $value) ?? $this`.
+ * This handler adds only the remaining gap — a callback returning a genuinely different
+ * type (e.g. `when($v, fn(): int => ...)`) — producing `<receiver>&static | <callback-return>`.
+ *
+ * That union is a deliberate, sound over-approximation: a falsy `$value` (or a `null`
+ * callback result) still yields `$this` at runtime, so the receiver always belongs in the
+ * result. {@see self::narrowsBeyondReceiver()} defines what counts as a genuine narrowing.
+ * Only the two-argument `when($value, $callback)` form is inspected; the 0/1-arg
+ * `HigherOrderWhenProxy` branch and the `$default` argument defer to the stub's `$this`.
+ *
+ * Registered on the `Conditionable` trait: Psalm dispatches a method return-type provider on
+ * the declaring class, which for a trait method is the trait, so one registration covers every
+ * host (Builder, Collection, Stringable, Request, user classes). The precise receiver type
+ * (with template params) is read from the call's left-hand side via the node type provider.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/993
+ */
+final class ConditionableWhenHandler implements MethodReturnTypeProviderInterface
+{
+    /**
+     * @return list<string>
+     * @psalm-pure
+     */
+    #[\Override]
+    public static function getClassLikeNames(): array
+    {
+        // The declaring class of a trait method is the trait, and Psalm dispatches on it,
+        // so this single entry covers every class that uses Conditionable.
+        return [Conditionable::class];
+    }
+
+    #[\Override]
+    public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        $method = $event->getMethodNameLowercase();
+        if ($method !== 'when' && $method !== 'unless') {
+            return null;
+        }
+
+        // Need at least the callback ($args[1]); the 0/1-arg proxy branch defers to the stub.
+        $args = $event->getCallArgs();
+        if (\count($args) < 2) {
+            return null;
+        }
+
+        $source = $event->getSource();
+        if (! $source instanceof StatementsAnalyzer) {
+            return null;
+        }
+
+        $stmt = $event->getStmt();
+        if (! $stmt instanceof MethodCall) {
+            return null;
+        }
+
+        $receiver = $source->getNodeTypeProvider()->getType($stmt->var);
+        if (! $receiver instanceof Union) {
+            return null;
+        }
+
+        $callbackReturn = self::callableReturn($source, $args[1]->value);
+        if (! $callbackReturn instanceof Union) {
+            return null; // callback return undeterminable (e.g. string callable) — defer to stub
+        }
+
+        $receiverClasses = self::classNames($receiver);
+        $codebase = $source->getCodebase();
+
+        $extra = [];
+        foreach ($callbackReturn->getAtomicTypes() as $atomic) {
+            if (self::narrowsBeyondReceiver($atomic, $receiver, $receiverClasses, $codebase)) {
+                $extra[] = $atomic;
+            }
+        }
+
+        // Nothing new beyond the receiver → let the stub's `@return $this` (rendered as
+        // `<receiver>&static`) stand, keeping every receiver-only call byte-identical.
+        if ($extra === []) {
+            return null;
+        }
+
+        $receiverStatic = [];
+        foreach ($receiver->getAtomicTypes() as $atomic) {
+            $receiverStatic[] = $atomic instanceof TNamedObject ? $atomic->setIsStatic(true) : $atomic;
+        }
+
+        return new Union([...$receiverStatic, ...$extra]);
+    }
+
+    /**
+     * Does this callback-return atomic carry information the receiver does not?
+     *
+     * Everything excluded here collapses to `$this` at runtime or would pollute the type:
+     *  - null / void / never — `$callback(...) ?? $this` yields `$this`;
+     *  - mixed — an untyped callback; unioning it discards the stub's `$this` and reintroduces
+     *    the mixed leak #704 fixed;
+     *  - the same class as the receiver, regardless of template args — the fluent case; unioning
+     *    a sibling generic (`Builder<Model>` beside `Builder<Customer>`) only widens the type and
+     *    breaks variance against a declared return;
+     *  - anything already contained by the receiver type.
+     *
+     * @param array<string, true> $receiverClasses lowercased receiver class names
+     */
+    private static function narrowsBeyondReceiver(
+        Atomic $atomic,
+        Union $receiver,
+        array $receiverClasses,
+        Codebase $codebase,
+    ): bool {
+        if ($atomic instanceof TNull || $atomic instanceof TVoid || $atomic instanceof TNever || $atomic instanceof TMixed) {
+            return false;
+        }
+
+        if ($atomic instanceof TNamedObject && isset($receiverClasses[\strtolower($atomic->value)])) {
+            return false;
+        }
+
+        return ! UnionTypeComparator::isContainedBy($codebase, new Union([$atomic]), $receiver);
+    }
+
+    /**
+     * Lowercased class names of the receiver's object atomics, as a set.
+     *
+     * @return array<string, true>
+     * @psalm-mutation-free
+     */
+    private static function classNames(Union $receiver): array
+    {
+        $names = [];
+        foreach ($receiver->getAtomicTypes() as $atomic) {
+            if ($atomic instanceof TNamedObject) {
+                $names[\strtolower($atomic->value)] = true;
+            }
+        }
+
+        return $names;
+    }
+
+    /**
+     * Extract the return type of a callable argument from its inferred type.
+     *
+     * Returns null when any atomic is a callable without a known return type (or the arg
+     * is not callable at all) — the caller then defers to the stub rather than guess.
+     */
+    private static function callableReturn(StatementsAnalyzer $source, \PhpParser\Node\Expr $expr): ?Union
+    {
+        $type = $source->getNodeTypeProvider()->getType($expr);
+        if (! $type instanceof Union) {
+            return null;
+        }
+
+        $returns = [];
+        foreach ($type->getAtomicTypes() as $atomic) {
+            // A passed closure literal infers as TClosure (extends TNamedObject); a `callable`
+            // type infers as TCallable. Both carry their inferred return type via CallableTrait.
+            if (! $atomic instanceof TClosure && ! $atomic instanceof TCallable) {
+                return null;
+            }
+
+            if (! $atomic->return_type instanceof Union) {
+                return null;
+            }
+
+            foreach ($atomic->return_type->getAtomicTypes() as $returnAtomic) {
+                $returns[] = $returnAtomic;
+            }
+        }
+
+        return new Union($returns);
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -196,6 +196,9 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Collections/HigherOrderCollectionProxyHandler.php';
         $registration->registerHooksFromClass(Handlers\Collections\HigherOrderCollectionProxyHandler::class);
 
+        require_once __DIR__ . '/Handlers/Support/ConditionableWhenHandler.php';
+        $registration->registerHooksFromClass(Handlers\Support\ConditionableWhenHandler::class);
+
         require_once __DIR__ . '/Handlers/Console/CommandArgumentHandler.php';
         $registration->registerHooksFromClass(Handlers\Console\CommandArgumentHandler::class);
 

--- a/stubs/common/Support/Traits/Conditionable.phpstub
+++ b/stubs/common/Support/Traits/Conditionable.phpstub
@@ -6,9 +6,9 @@ namespace Illuminate\Support\Traits;
  * Simplify return types for Conditionable methods.
  *
  * Laravel's PHPDoc uses `@return $this|TWhenReturnType` with template inference,
- * but Psalm 7 resolves callable return types to `mixed`, breaking fluent chains.
- * Stubbing as `@return $this` makes ->when() and ->unless() chainable on
- * Builder, Collection, Stringable, and any other class using this trait.
+ * but Psalm 7 resolves the callable return type to `mixed`, breaking fluent chains.
+ * We stub as `@return $this` to keep the chain. A callback returning a different type
+ * is narrowed by {@see \Psalm\LaravelPlugin\Handlers\Support\ConditionableWhenHandler}.
  */
 trait Conditionable
 {

--- a/tests/Type/tests/ConditionableTappableTest.phpt
+++ b/tests/Type/tests/ConditionableTappableTest.phpt
@@ -92,6 +92,34 @@ function test_eloquent_builder_unless_with_real_callback(Builder $query): void
     /** @psalm-check-type-exact $_result = Builder<Customer>&static */
 }
 
+/**
+ * Issue #993 reproducer: when() at the tail of a function returning the parameterized
+ * Builder. A same-type callback must stay `Builder<Customer>` — no mixed collapse, no
+ * LessSpecificReturnStatement against the declared return.
+ *
+ * @param Builder<Customer> $query
+ * @return Builder<Customer>
+ */
+function test_eloquent_builder_when_returned_directly(Builder $query, ?string $search): Builder
+{
+    return $query->when($search, function (Builder $q, string $term): Builder {
+        return $q->where('name', 'like', "%{$term}%");
+    });
+}
+
+/**
+ * Mirror of the #993 reproducer for unless().
+ *
+ * @param Builder<Customer> $query
+ * @return Builder<Customer>
+ */
+function test_eloquent_builder_unless_returned_directly(Builder $query, bool $skip): Builder
+{
+    return $query->unless($skip, function (Builder $q, bool $_v): Builder {
+        return $q->where('active', true);
+    });
+}
+
 // --- Query\Builder (via BuildsQueries trait) ---
 
 /**
@@ -132,6 +160,45 @@ function test_stringable_when_fluent_chain(): void
 {
     $_result = (new Stringable('hello'))->when(false, null, null);
     /** @psalm-check-type-exact $_result = Stringable&static */
+}
+
+// --- Callback-return shapes (ConditionableWhenHandler, #993) ---
+
+/** Callback returns void → stays on the calling class. */
+function test_when_callback_void(): void
+{
+    $_result = (new Stringable('hello'))->when(true, static function (Stringable $_s): void {
+        // no-op
+    });
+    /** @psalm-check-type-exact $_result = Stringable&static */
+}
+
+/** Callback returns null → stays on the calling class (Laravel collapses null via ?? $this). */
+function test_when_callback_returns_null(): void
+{
+    $_result = (new Stringable('hello'))->when(true, static function (Stringable $_s) { return null; });
+    /** @psalm-check-type-exact $_result = Stringable&static */
+}
+
+/** Callback returns a type the receiver is NOT → narrows to `$this | <callback-return>`. */
+function test_when_callback_returns_int(): void
+{
+    $_result = (new Stringable('hello'))->when(true, static function (Stringable $_s): int { return random_int(0, 10); });
+    /** @psalm-check-type-exact $_result = Stringable&static|int<0, 10> */
+}
+
+/**
+ * Callback returns the same class as the receiver → defers to `$this` (stays Builder<Customer>),
+ * not widened to `Builder<Customer>|Builder<Model>`.
+ *
+ * @param Builder<Customer> $query
+ */
+function test_when_builder_callback_returns_builder(Builder $query): void
+{
+    $_result = $query->when(true, static function (Builder $q): Builder {
+        return $q->whereNull('name');
+    });
+    /** @psalm-check-type-exact $_result = Builder<Customer>&static */
 }
 
 // --- Tappable::tap() ---


### PR DESCRIPTION
## Issue to Solve

`Conditionable::when()` / `unless()` (Builder, Collection, Stringable, Request, every facade-backed service) only typed as `$this` via the existing stub (#704). That keeps fluent chains working but cannot narrow to a value the callback returns when it differs from the receiver. Closes #993.

## Solution

Keep the stub at `@return $this` (Laravel's own signature). Psalm 7 renders `$this` as `<Class>&static` at every call site, so it is observationally identical to `static` here while staying faithful to the framework. The CLAUDE.md "prefer `static`" rule targets template-parameter positions that collapse to `mixed` when chained; this is a plain self-return, so `$this` is correct.

Add `ConditionableWhenHandler` (`MethodReturnTypeProvider`, Option B from #993) to recover the gap: when a `when()`/`unless()` callback returns a type the receiver is not, the result narrows to `$this | <callback-return>`. This is sound because a falsy `$value` (or a `null` callback result) still yields `$this` at runtime via `$callback($this, $value) ?? $this`.

Deferred to the stub's `$this` (handler returns null), so existing typing is byte-identical:

- no callback / 0-1 arg (`HigherOrderWhenProxy` branch),
- callback returns `void` / `null` / `mixed` (untyped closures),
- callback returns the **same class** as the receiver (the common fluent case; avoids widening `Builder<Customer>` to `Builder<Customer>|Builder<Model>` and breaking variance).

The handler registers on the `Conditionable` **trait**, so Psalm's declaring-class dispatch covers every host (concrete and user classes) without enumerating them.