### PR TITLE
Suppress `PossiblyUnusedMethod` for `#[Scope]`-attributed Eloquent methods

### DIFF
--- a/src/Handlers/SuppressHandler.php
+++ b/src/Handlers/SuppressHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Handlers;
 
+use Illuminate\Database\Eloquent\Attributes\Scope;
 use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
 use Psalm\Internal\Provider\ClassLikeStorageProvider;
 use Psalm\Plugin\EventHandler\AfterClassLikeVisitInterface;
@@ -381,6 +382,7 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
 
         if (\in_array('Illuminate\Database\Eloquent\Model', $parents, true)) {
             self::suppressEloquentAccessorMethods($classStorage);
+            self::suppressEloquentScopeMethods($classStorage);
         }
 
         if (\in_array('Illuminate\Notifications\Notification', $parents, true)) {
@@ -447,6 +449,45 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
                 self::suppressInternalDispatchMethod('PossiblyUnusedMethod', $methodStorage);
             }
         }
+    }
+
+    /**
+     * Suppress PossiblyUnusedMethod / UnusedMethod for methods annotated with #[Scope].
+     *
+     * Eloquent dispatches modern scopes through `Builder::callNamedScope()` / `Builder::__call()`
+     * (which routes via `Model::__call()` and reflection). The call site `$builder->published()`
+     * never references the model method directly, so Psalm cannot link it back to the declaration
+     * and reports `PossiblyUnusedMethod` (or `UnusedMethod` under `findUnusedCode=true`). The plugin
+     * already covers the type/visibility side via `BuilderScopeHandler` / `ModelMethodHandler` —
+     * this fixes the suppression side. See psalm/psalm-plugin-laravel#874.
+     *
+     * Visibility: routed through `suppressInternalDispatchMethod()` so `public` and `protected`
+     * stay silenced, but `private` stays flagged. At runtime Eloquent invokes the scope on the
+     * model instance from `Builder`'s foreign scope — a `private` scope is unreachable from that
+     * dispatch site and would fatal, so leaving it reported surfaces the real bug.
+     */
+    private static function suppressEloquentScopeMethods(ClassLikeStorage $classStorage): void
+    {
+        foreach ($classStorage->methods as $methodStorage) {
+            if (!self::hasScopeAttribute($methodStorage)) {
+                continue;
+            }
+
+            self::suppressInternalDispatchMethod('PossiblyUnusedMethod', $methodStorage);
+            self::suppressInternalDispatchMethod('UnusedMethod', $methodStorage);
+        }
+    }
+
+    /** @psalm-mutation-free */
+    private static function hasScopeAttribute(MethodStorage $methodStorage): bool
+    {
+        foreach ($methodStorage->attributes as $attribute) {
+            if ($attribute->fq_class_name === Scope::class) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Type/tests/Model/ScopeAttributeUnusedMethodTest.phpt
+++ b/tests/Type/tests/Model/ScopeAttributeUnusedMethodTest.phpt
@@ -1,0 +1,49 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Sandbox;
+
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Regression fixture for psalm/psalm-plugin-laravel#874.
+ *
+ * Eloquent dispatches modern scopes through Builder::callNamedScope() / Builder::__call()
+ * via reflection, so Psalm cannot link the `$builder->published()` call site back to the
+ * model method declaration. Without SuppressHandler::suppressEloquentScopeMethods(), every
+ * #[Scope] method on a user model would surface as PossiblyUnusedMethod (or UnusedMethod
+ * under findUnusedCode=true).
+ *
+ * The type-test config has `findUnusedCode` off, so this fixture exercises only the plugin
+ * code path today; it becomes a real regression guard once #869's findUnusedCode lock-in
+ * lands. Smoke pattern matches NotificationTest.phpt / MailableTest.phpt.
+ *
+ * Private negative case is omitted: Psalm's ClassLikes::checkMethodReferences() skips
+ * unused-method emission entirely for private methods on classes whose declaring class
+ * has __call (see vendor/vimeo/psalm/src/Psalm/Internal/Codebase/ClassLikes.php:1994).
+ * Eloquent\Model declares __call, so a private #[Scope] is structurally unflaggable —
+ * the handler still routes private through suppressInternalDispatchMethod() defensively
+ * (it would fatal at runtime, so silencing it would mask the bug).
+ */
+final class ScopeAttributeModel extends Model
+{
+    /** @param Builder<self> $query */
+    #[Scope]
+    public function publicPublished(Builder $query): void
+    {
+        $query->where('published_at', '<=', 'now');
+    }
+
+    /** @param Builder<self> $query */
+    #[Scope]
+    protected function protectedArchived(Builder $query): void
+    {
+        $query->whereNotNull('archived_at');
+    }
+}
+
+new ScopeAttributeModel();
+?>
+--EXPECT--


### PR DESCRIPTION
## Issue to Solve

A model query scope declared with the modern `#[Scope]` attribute is reported as `PossiblyUnusedMethod` (and `UnusedMethod` under `findUnusedCode=true`). Eloquent dispatches scopes through `Builder::callNamedScope()` / `Builder::__call()` via reflection, so Psalm cannot link `$builder->published()` back to the model method declaration. The plugin already handles the type/visibility side (`BuilderScopeHandler`, `ModelMethodHandler`, `CustomBuilderMethodHandler`), but not the unused-method side.

## Related

Closes #874.

Follow-ups:
- Legacy `scopeXxx()` methods (deferred per #874, same root cause).
- Lock-in regression test under `findUnusedCode=true` is gated on #869's shared config; this PR ships the smoke fixture in the meantime, matching the precedent set by `NotificationTest.phpt` / `MailableTest.phpt`.

## Solution Description

Extends `SuppressHandler` with `suppressEloquentScopeMethods()`, called from the existing Eloquent\Model branch of `suppressByParentClass()` next to `suppressEloquentAccessorMethods()`. It walks `$classStorage->methods`, checks `MethodStorage->attributes` for the `Illuminate\Database\Eloquent\Attributes\Scope` FQCN (using the same `attributes[]->fq_class_name === Scope::class` lookup pattern as `BuilderScopeHandler::hasScopeAttribute()`), and routes both `PossiblyUnusedMethod` and `UnusedMethod` through `suppressInternalDispatchMethod()`. Public + protected are silenced; private stays flagged because Eloquent invokes the scope on the model instance from `Builder`'s foreign scope (a private override would fatal), matching Laravel's own `! $reflectionClass->isPrivate()` filter in `Model::isScopeMethodWithAttribute()`.

A new PHPT in `tests/Type/tests/Model/ScopeAttributeUnusedMethodTest.phpt` exercises a final model with public + protected `#[Scope]` methods. The fixture follows the existing smoke pattern (default type-test config has `findUnusedCode` off); turning this into a real regression guard depends on #869's `psalm-find-unused.xml` config. The private negative case is omitted with a comment explaining the structural blocker: `ClassLikes::checkMethodReferences()` at line 1994 skips unused-method emission on private methods when the class has `__call`, and `Eloquent\Model` declares `__call`, so a private `#[Scope]` is unflaggable today regardless of suppression.

Verified with `composer test:type`, `composer test:unit`, `composer psalm`, `composer cs`.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
