### PR TITLE
Suppress `PossiblyUnusedMethod` for legacy `scopeXxx()` Eloquent methods

### DIFF
--- a/src/Handlers/SuppressHandler.php
+++ b/src/Handlers/SuppressHandler.php
@@ -383,6 +383,7 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
         if (\in_array('Illuminate\Database\Eloquent\Model', $parents, true)) {
             self::suppressEloquentAccessorMethods($classStorage);
             self::suppressEloquentScopeMethods($classStorage);
+            self::suppressLegacyEloquentScopeMethods($classStorage);
         }
 
         if (\in_array('Illuminate\Notifications\Notification', $parents, true)) {
@@ -488,6 +489,55 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
         }
 
         return false;
+    }
+
+    /**
+     * Suppress PossiblyUnusedMethod / UnusedMethod for legacy `scopeXxx()` Eloquent methods.
+     *
+     * Same dispatch problem as `#[Scope]` (see `suppressEloquentScopeMethods()` above), only
+     * older: `$builder->active()` resolves to `$model->scopeActive(...)` via
+     * `Model::callNamedScope()` (`{'scope'.ucfirst($scope)}(...)`). The call site never
+     * references the model method directly, so Psalm reports the scope method as unused.
+     * Sibling of psalm/psalm-plugin-laravel#874, deferred there to keep the diff focused.
+     *
+     * Detection: lowercase method key starts with `scope` AND the original-cased name has an
+     * uppercase ASCII letter directly after `scope` (matches Laravel's `ucfirst()` resolution
+     * at `Model.php:1981`). The cased-name check prevents misclassifying methods like
+     * `scopeactive` (which Laravel cannot dispatch — `ucfirst()` produces `scopeActive`) or
+     * a literal `scope()` method.
+     *
+     * Visibility: same routing as the modern variant — `private` stays flagged because the
+     * dispatch lives on `$this` in `Model::callNamedScope()` and a `private` override on a
+     * subclass would not be resolvable from the parent scope (PHP private scoping).
+     */
+    private static function suppressLegacyEloquentScopeMethods(ClassLikeStorage $classStorage): void
+    {
+        foreach ($classStorage->methods as $methodName => $methodStorage) {
+            if (!self::isLegacyScopeMethodName($methodName, $methodStorage->cased_name)) {
+                continue;
+            }
+
+            self::suppressInternalDispatchMethod('PossiblyUnusedMethod', $methodStorage);
+            self::suppressInternalDispatchMethod('UnusedMethod', $methodStorage);
+        }
+    }
+
+    /** @psalm-pure */
+    private static function isLegacyScopeMethodName(string $lowercaseName, ?string $casedName): bool
+    {
+        if ($casedName === null || \strlen($casedName) < 6) {
+            return false;
+        }
+
+        if (!\str_starts_with($lowercaseName, 'scope')) {
+            return false;
+        }
+
+        // Laravel resolves $builder->active() via `scope` . ucfirst('active') => `scopeActive`.
+        // A `scopeactive()` method is dispatch-unreachable, so don't suppress it.
+        $firstNameChar = $casedName[5];
+
+        return $firstNameChar >= 'A' && $firstNameChar <= 'Z';
     }
 
     /**

--- a/tests/Type/tests/Model/LegacyScopeUnusedMethodTest.phpt
+++ b/tests/Type/tests/Model/LegacyScopeUnusedMethodTest.phpt
@@ -1,0 +1,46 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Sandbox;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Regression fixture for the legacy follow-up of psalm/psalm-plugin-laravel#874.
+ *
+ * Eloquent dispatches `$builder->active()` through `Model::callNamedScope()` which calls
+ * `$this->{'scope'.ucfirst($scope)}(...)` (see vendor/laravel/framework/.../Model.php:1981).
+ * Psalm cannot link the call site back to `scopeActive()` and reports PossiblyUnusedMethod
+ * (UnusedMethod under findUnusedCode=true). SuppressHandler::suppressLegacyEloquentScopeMethods()
+ * silences the public+protected variants Eloquent can actually dispatch on.
+ *
+ * Same caveats as the modern #[Scope] sibling test:
+ *  - Lock-in under findUnusedCode is deferred to #869 (default type-test config has it off).
+ *  - Private negative case is structurally unflaggable in Psalm 7: ClassLikes.php:1994 skips
+ *    unused-method emission on private methods of classes with __call, and Model declares __call.
+ */
+final class LegacyScopeModel extends Model
+{
+    /**
+     * @param  Builder<self>  $query
+     * @return Builder<self>
+     */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('active', true);
+    }
+
+    /**
+     * @param  Builder<self>  $query
+     * @return Builder<self>
+     */
+    protected function scopeArchived(Builder $query): Builder
+    {
+        return $query->whereNotNull('archived_at');
+    }
+}
+
+new LegacyScopeModel();
+?>
+--EXPECT--


### PR DESCRIPTION
## Issue to Solve

Legacy Eloquent scopes (`scopeXxx()` methods) are reported as `PossiblyUnusedMethod` (and `UnusedMethod` under `findUnusedCode=true`). `$builder->active()` resolves to `$model->scopeActive(...)` via `Model::callNamedScope()` (`$this->{'scope'.ucfirst($scope)}(...)`) — Psalm cannot link the call site back to the method declaration.

## Related

Follow-up to #874 / #998, which covered the modern `#[Scope]` attribute. The legacy variant was explicitly deferred there ("worth a separate issue/PR so the diff and the test additions stay focused").

Lock-in regression test under `findUnusedCode=true` remains gated on #869, same as the modern sibling.

## Solution Description

Adds `suppressLegacyEloquentScopeMethods()` to `SuppressHandler`, called from the Eloquent\Model branch of `suppressByParentClass()` next to `suppressEloquentScopeMethods()`. Detection uses both:

- lowercase-keyed name starts with `scope`,
- AND `cased_name[5]` is uppercase A-Z.

The cased-name check mirrors Laravel's `ucfirst()` resolution at `Model.php:1981` and prevents false positives on `scopeactive` (dispatch-unreachable) or a literal `scope()` method. Both `PossiblyUnusedMethod` and `UnusedMethod` are pushed via `suppressInternalDispatchMethod()`, so public + protected are silenced while `private` stays flagged (a private subclass override is unreachable from `Model::callNamedScope()` in the parent's scope and would fatal).

New PHPT in `tests/Type/tests/Model/LegacyScopeUnusedMethodTest.phpt` exercises public + protected `scopeXxx()` methods on a final model. The fixture follows the smoke pattern of `ScopeAttributeUnusedMethodTest.phpt`; the private negative case stays untestable for the same `Model::__call` structural reason documented there (`ClassLikes::checkMethodReferences()` skips unused-method emission on private methods of classes with `__call`).

Verified with `composer test:type`, `composer test:unit`, `composer psalm`, `composer cs`.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
