### PR TITLE
Resolve dynamic `where{Column}` on Model direct calls

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -53,9 +53,9 @@ If a property is not declared via PHPDoc, this setting instructs the plugin how 
 
 **default**: `true`
 
-When enabled, the plugin resolves Laravel's [dynamic where methods](https://laravel.com/docs/queries#dynamic-where-clauses) (e.g. `whereTitle('foo')`, `whereFirstName('John')`) on Eloquent relation chains, preserving the relation's generic type instead of returning `mixed`.
+When enabled, the plugin resolves Laravel's [dynamic where methods](https://laravel.com/docs/queries#dynamic-where-clauses) (e.g. `whereTitle('foo')`, `whereFirstName('John')`) on both Eloquent relation chains and direct Model static / instance calls (`User::whereEmail('a@b')`, `$user->whereEmail('a@b')`), preserving the relation or `Builder<TModel>` generic type instead of returning `mixed` or raising `UndefinedMagicMethod`.
 
-Column names are validated against the model's `@property` annotations. Unmatched columns fall through to `mixed` without an error, so partial annotation is safe.
+Column names are validated against the model's `@property` annotations. Unmatched columns fall through to `mixed` (relations) or `UndefinedMagicMethod` (direct Model calls) without altering Psalm's default behaviour, so partial annotation is safe.
 
 Disable if dynamic where resolution conflicts with your codebase.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -55,7 +55,7 @@ If a property is not declared via PHPDoc, this setting instructs the plugin how 
 
 When enabled, the plugin resolves Laravel's [dynamic where methods](https://laravel.com/docs/queries#dynamic-where-clauses) (e.g. `whereTitle('foo')`, `whereFirstName('John')`) on both Eloquent relation chains and direct Model static / instance calls (`User::whereEmail('a@b')`, `$user->whereEmail('a@b')`), preserving the relation or `Builder<TModel>` generic type instead of returning `mixed` or raising `UndefinedMagicMethod`.
 
-Column names are validated against the model's `@property` annotations. Unmatched columns fall through to `mixed` (relations) or `UndefinedMagicMethod` (direct Model calls) without altering Psalm's default behaviour, so partial annotation is safe.
+Column names are validated against the model's `@property` annotations. Columns with no matching declaration are not claimed by the plugin: relation chains fall through to `mixed`, and direct Model calls fall through to `UndefinedMagicMethod`. Custom Eloquent builder methods that happen to start with `where` (e.g. `whereByMake(string)`) are also left to Psalm's normal resolution so their declared return types win. Partial `@property` annotation is therefore safe.
 
 Disable if dynamic where resolution conflicts with your codebase.
 

--- a/src/Handlers/Eloquent/ModelMethodHandler.php
+++ b/src/Handlers/Eloquent/ModelMethodHandler.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Expr\Variable;
 use Psalm\Codebase;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Internal\MethodIdentifier;
+use Psalm\LaravelPlugin\Util\DynamicWhereResolver;
 use Psalm\LaravelPlugin\Util\ProxyMethodReturnTypeProvider;
 use Psalm\Plugin\EventHandler\Event\MethodExistenceProviderEvent;
 use Psalm\Plugin\EventHandler\Event\MethodParamsProviderEvent;
@@ -248,7 +249,25 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
 
         // Scope method — params from the scope definition minus the first $query param.
         /** @var class-string<Model> $modelClass */
-        return self::getScopeParams($codebase, $modelClass, $methodName);
+        $scopeParams = self::getScopeParams($codebase, $modelClass, $methodName);
+        if ($scopeParams !== null) {
+            return $scopeParams;
+        }
+
+        // Dynamic where{Column}: gated on resolveDynamicWhereClauses (issue #1000).
+        // Mirrors the relation-chain fallback: typed single param when the return-type
+        // provider resolved a scalar column (issue #928 hand-off), variadic mixed
+        // otherwise so Psalm doesn't raise TooManyArguments on multi-segment forms
+        // like whereFirstNameAndLastName($a, $b).
+        if (
+            DynamicWhereResolver::isEnabled()
+            && DynamicWhereResolver::isDynamicWhereMethod($methodName)
+        ) {
+            return DynamicWhereResolver::consumeTypedParams($methodName, $event->getCallArgs())
+                ?? DynamicWhereResolver::variadicMixedParams();
+        }
+
+        return null;
     }
 
     /**
@@ -294,6 +313,39 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
 
         // Trait-declared builder methods (e.g., SoftDeletes::withTrashed): return custom builder type.
         if (CustomBuilderMethodHandler::hasTraitMethod($modelClass, $methodName)) {
+            return new Union([self::builderType($builderClass, $calledClass, $codebase)]);
+        }
+
+        // Dynamic where{Column}: gated on resolveDynamicWhereClauses (issue #1000).
+        // doesMethodExist has already confirmed via DynamicWhereResolver::methodMatchesColumns
+        // that the lowercase suffix matches columns. Here we run the strict camel-cased
+        // validation against the ORIGINAL method name to (a) decide whether to queue the
+        // typed-param hand-off for #928 and (b) keep behaviour aligned with the
+        // relation-chain path. Either way the return is Builder<calledClass> — existence
+        // has already been confirmed, so even when the strict validation rejects (e.g.
+        // the camel-cased segments don't all map to columns) we return the builder type
+        // rather than letting it fall through to mixed.
+        if (
+            DynamicWhereResolver::isEnabled()
+            && DynamicWhereResolver::isDynamicWhereMethod($methodName)
+            && !$codebase->methodExists(new MethodIdentifier(QueryBuilder::class, $methodName))
+        ) {
+            $stmt = $event->getStmt();
+            $originalMethodName = DynamicWhereResolver::originalMethodName($stmt, $methodName);
+            $columnType = DynamicWhereResolver::resolveColumnType($codebase, $modelClass, $originalMethodName);
+
+            // Queue typed param hand-off when the call is single-segment + scalar + 1-arg.
+            // Path stays close to MethodForwardingHandler::resolveDynamicWhereOnRelation
+            // for the Path-2 (direct __call) gating: only enqueue on instance/static call
+            // forms that the params provider will reach, with exactly one argument.
+            if ($columnType instanceof Union) {
+                $args = $stmt->getArgs();
+
+                if (\count($args) === 1) {
+                    DynamicWhereResolver::storePendingColumnType($methodName, $args[0], $columnType);
+                }
+            }
+
             return new Union([self::builderType($builderClass, $calledClass, $codebase)]);
         }
 
@@ -368,7 +420,28 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
         // Scope methods (e.g., scopeActive → active, #[Scope] verified → verified).
         // These are defined on the model and forwarded via __callStatic → Builder.
         /** @var class-string<Model> $modelClass */
-        return self::$unresolvedCache[$key] = BuilderScopeHandler::hasScopeMethod($codebase, $modelClass, $methodName);
+        if (BuilderScopeHandler::hasScopeMethod($codebase, $modelClass, $methodName)) {
+            return self::$unresolvedCache[$key] = true;
+        }
+
+        // Dynamic where{Column} methods (e.g., whereUuid, whereFirstNameAndLastName).
+        // Laravel's `Builder::dynamicWhere` resolves these at runtime when the suffix
+        // segments match column names. When `<resolveDynamicWhereClauses value="true" />`
+        // is set (default), confirm existence so a direct Model::whereCol(...) call
+        // doesn't raise UndefinedMagicMethod (issue #1000).
+        //
+        // The match is lowercase-only because the existence hook receives no AST node
+        // (so we can't reconstruct the original camel-cased suffix here). The return-
+        // type and params providers still run the strict camel-cased validation via
+        // DynamicWhereResolver::resolveColumnType when they fire on the confirmed call.
+        if (
+            DynamicWhereResolver::isEnabled()
+            && DynamicWhereResolver::methodMatchesColumns($codebase, $modelClass, $methodName)
+        ) {
+            return self::$unresolvedCache[$key] = true;
+        }
+
+        return self::$unresolvedCache[$key] = false;
     }
 
     /** @inheritDoc */

--- a/src/Handlers/Eloquent/ModelMethodHandler.php
+++ b/src/Handlers/Eloquent/ModelMethodHandler.php
@@ -57,6 +57,12 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
      * This method is called up to 4 times per static method call (existence, visibility,
      * params, return type), so caching avoids redundant methodExists lookups.
      *
+     * The dynamic-where branch of isUnresolvedBuilderMethod consults
+     * {@see DynamicWhereResolver::isEnabled}, so a stale entry produced under a
+     * previous "enabled" configuration could leak into a subsequent "disabled"
+     * bootstrap in the same process. Plugin re-bootstrap clears this cache via
+     * {@see init} to keep the cached verdict consistent with the active config.
+     *
      * @var array<string, bool>
      */
     private static array $unresolvedCache = [];
@@ -71,6 +77,21 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
      * @var array<class-string<Model>, class-string<Builder>>
      */
     private static array $customBuilderMap = [];
+
+    /**
+     * Reset per-process caches. Called once per Plugin::__construct so a re-bootstrap
+     * doesn't carry stale verdicts across analysis runs. In particular, the
+     * dynamic-where branch of {@see isUnresolvedBuilderMethod} depends on the
+     * runtime-mutable {@see DynamicWhereResolver::isEnabled} flag; clearing the cache
+     * here ensures a `resolveDynamicWhereClauses` flip is honoured on the next run.
+     *
+     * @psalm-external-mutation-free
+     */
+    public static function init(): void
+    {
+        self::$unresolvedCache = [];
+        self::$customBuilderMap = [];
+    }
 
     /**
      * Register a custom Eloquent builder class for a model.

--- a/src/Handlers/Eloquent/ModelMethodHandler.php
+++ b/src/Handlers/Eloquent/ModelMethodHandler.php
@@ -318,21 +318,33 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
 
         // Dynamic where{Column}: gated on resolveDynamicWhereClauses (issue #1000).
         // doesMethodExist has already confirmed via DynamicWhereResolver::methodMatchesColumns
-        // that the lowercase suffix matches columns. Here we run the strict camel-cased
-        // validation against the ORIGINAL method name to (a) decide whether to queue the
-        // typed-param hand-off for #928 and (b) keep behaviour aligned with the
-        // relation-chain path. Either way the return is Builder<calledClass> — existence
-        // has already been confirmed, so even when the strict validation rejects (e.g.
-        // the camel-cased segments don't all map to columns) we return the builder type
-        // rather than letting it fall through to mixed.
+        // that the lowercase suffix matches columns. The gate excludes both Query\Builder
+        // methods (handled by the fake-call branch below) AND methods declared on the
+        // registered builder class itself — for a custom builder that defines `whereFoo()`
+        // directly, the fake-call path resolves it with the method's actual return type
+        // instead of unconditionally substituting Builder<TModel>.
+        //
+        // Strict camel-cased validation (`resolveColumnType`) decides whether to queue the
+        // typed-param hand-off for #928 and gates the final return: a `false` result means
+        // the lowercase backtracker over-accepted (e.g. `wherefoobar` with @property `foo`
+        // and `bar` only matches via lowercase, not the camel-cased And/Or split that
+        // Laravel's runtime requires). Returning null in that case avoids claiming
+        // Builder<TModel> for a call Laravel would parse differently — existence remains
+        // confirmed so Psalm doesn't raise UndefinedMagicMethod, but the return type stays
+        // Psalm's default rather than a fabricated builder.
         if (
             DynamicWhereResolver::isEnabled()
             && DynamicWhereResolver::isDynamicWhereMethod($methodName)
             && !$codebase->methodExists(new MethodIdentifier(QueryBuilder::class, $methodName))
+            && !$codebase->methodExists(new MethodIdentifier($builderClass, $methodName))
         ) {
             $stmt = $event->getStmt();
             $originalMethodName = DynamicWhereResolver::originalMethodName($stmt, $methodName);
             $columnType = DynamicWhereResolver::resolveColumnType($codebase, $modelClass, $originalMethodName);
+
+            if ($columnType === false) {
+                return null;
+            }
 
             // Queue typed param hand-off (issue #928) only when the producer/consumer
             // contract holds: single-segment scalar column + exactly one argument. Mirrors

--- a/src/Handlers/Eloquent/ModelMethodHandler.php
+++ b/src/Handlers/Eloquent/ModelMethodHandler.php
@@ -334,10 +334,9 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
             $originalMethodName = DynamicWhereResolver::originalMethodName($stmt, $methodName);
             $columnType = DynamicWhereResolver::resolveColumnType($codebase, $modelClass, $originalMethodName);
 
-            // Queue typed param hand-off when the call is single-segment + scalar + 1-arg.
-            // Path stays close to MethodForwardingHandler::resolveDynamicWhereOnRelation
-            // for the Path-2 (direct __call) gating: only enqueue on instance/static call
-            // forms that the params provider will reach, with exactly one argument.
+            // Queue typed param hand-off (issue #928) only when the producer/consumer
+            // contract holds: single-segment scalar column + exactly one argument. Mirrors
+            // {@see \Psalm\LaravelPlugin\Handlers\Magic\MethodForwardingHandler::resolveDynamicWhereOnRelation}.
             if ($columnType instanceof Union) {
                 $args = $stmt->getArgs();
 

--- a/src/Handlers/Magic/MethodForwardingHandler.php
+++ b/src/Handlers/Magic/MethodForwardingHandler.php
@@ -83,8 +83,9 @@ final class MethodForwardingHandler implements
      * the {@see DynamicWhereResolver} hand-off cache, where a stale entry could be
      * consumed by a future call whose first Arg happens to share an spl_object_id.
      *
-     * The DynamicWhereResolver enable flag is owned by `Plugin::registerHandlers()` and
-     * is intentionally NOT reset here (init may run after enable() in tests).
+     * The DynamicWhereResolver enable flag is also cleared by the reset; Plugin
+     * re-applies it from XML config after init() returns, so a true→false config flip
+     * across re-bootstraps takes effect instead of inheriting the previous state.
      *
      * @psalm-external-mutation-free
      */
@@ -479,10 +480,10 @@ final class MethodForwardingHandler implements
      *   - whereFirstNameAndLastName → ['FirstName', 'LastName']        → both @property
      *   - whereTitleOrSlug        → ['Title', 'Slug']                  → both @property
      *
-     * For SINGLE-segment scalar-typed columns, the column type is queued in
-     * {@see $pendingDynamicWhereColumnType} so {@see getMethodParams} can return
-     * typed params for argument validation (issue #928). Multi-segment calls have
-     * one argument per segment with different types, which doesn't fit the
+     * For SINGLE-segment scalar-typed columns, the column type is queued via
+     * {@see DynamicWhereResolver::storePendingColumnType} so {@see getMethodParams}
+     * can return typed params for argument validation (issue #928). Multi-segment
+     * calls have one argument per segment with different types, which doesn't fit the
      * single-typed-param hand-off; they get the variadic-mixed fallback.
      *
      * @param non-empty-list<Union>|list<Union>|null $templateParams Relation's template type parameters

--- a/src/Handlers/Magic/MethodForwardingHandler.php
+++ b/src/Handlers/Magic/MethodForwardingHandler.php
@@ -9,13 +9,13 @@ use Psalm\Codebase;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\LaravelPlugin\Handlers\Eloquent\BuilderScopeHandler;
 use Psalm\LaravelPlugin\Handlers\Eloquent\ModelMethodHandler;
+use Psalm\LaravelPlugin\Util\DynamicWhereResolver;
 use Psalm\LaravelPlugin\Util\ModelPropertyResolver;
 use Psalm\Plugin\EventHandler\Event\MethodParamsProviderEvent;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\MethodParamsProviderInterface;
 use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
 use Psalm\Storage\FunctionLikeParameter;
-use Psalm\Type;
 use Psalm\Type\Atomic\TGenericObject;
 use Psalm\Type\Union;
 
@@ -37,7 +37,11 @@ use Psalm\Type\Union;
  * Also resolves Laravel's dynamic where{Column} magic methods on relation chains
  * (e.g., $user->posts()->whereTitle('foo')) when resolveDynamicWhereClauses is enabled (default: true).
  * Column names are validated against the model's declared @property annotations;
- * unmatched columns fall through to mixed without an error.
+ * unmatched columns fall through to mixed without an error. The dynamic-where helpers
+ * (validation, segment splitting, typed-param hand-off cache) live in
+ * {@see \Psalm\LaravelPlugin\Util\DynamicWhereResolver}; this handler invokes them on the
+ * relation-chain path while {@see \Psalm\LaravelPlugin\Handlers\Eloquent\ModelMethodHandler}
+ * uses the same util for direct Model static/instance calls (issue #1000).
  * Disable via <resolveDynamicWhereClauses value="false" /> in psalm.xml.
  *
  * Also resolves model scope methods called on relation chains
@@ -48,13 +52,6 @@ final class MethodForwardingHandler implements
     MethodReturnTypeProviderInterface,
     MethodParamsProviderInterface
 {
-    /**
-     * Larastan parity: split a where{Column} suffix on And/Or boundaries followed by an
-     * uppercase letter. Mirrors `Illuminate\Database\Query\Builder::dynamicWhere`'s
-     * `(And|Or)(?=[A-Z])`; we use a non-capturing group since we don't need the connector.
-     */
-    private const SEGMENT_SPLIT_PATTERN = '/(?:And|Or)(?=[A-Z])/';
-
     private static ?ForwardingRule $rule = null;
 
     /** @var array<lowercase-string, bool> Indexed source classes for O(1) lookup */
@@ -62,36 +59,6 @@ final class MethodForwardingHandler implements
 
     /** @var array<lowercase-string, bool> Indexed search classes for O(1) lookup in mixin interception */
     private static array $searchClassIndex = [];
-
-    /**
-     * Whether dynamic where{Column} method resolution is enabled.
-     *
-     * When enabled, methods matching the pattern where{Column} (e.g. whereTitle, whereEmail)
-     * are resolved on relation chains when the column exists in the model's declared property annotations.
-     */
-    private static bool $enableDynamicWhere = false;
-
-    /**
-     * Cache: "ModelClass:originalMethodName" → three-state validation result.
-     *
-     * Keyed by model class + ORIGINAL-CASE method name (not lowercase). The original case
-     * is needed because Laravel's runtime `Builder::dynamicWhere` splits the suffix on
-     * `(?:And|Or)(?=[A-Z])`, which only fires on properly camel-cased boundaries. The same
-     * lowercase name can therefore come from a splittable call (`whereFooAndBar`) or a
-     * non-splittable one (`wherefooandbar`), and they validate differently.
-     *
-     * Values:
-     *   - `false`: validation failed (one or more segments don't match a declared
-     *     pseudo property). Caller falls through to mixed.
-     *   - `null`: validation passed but no scalar column type can be handed off to the
-     *     typed-parameter checker (multi-segment call, or single-segment whose type is
-     *     object/array — Carbon, BackedEnum, json casts).
-     *   - `Union`: validation passed AND the call is single-segment with a scalar column
-     *     type. The typed-param hand-off path (issue #928) consumes this.
-     *
-     * @var array<string, false|null|Union>
-     */
-    private static array $dynamicWhereCache = [];
 
     /**
      * Cache: "lowercase-relation-class::method" → related model class.
@@ -110,40 +77,14 @@ final class MethodForwardingHandler implements
     private static array $scopeParamsCache = [];
 
     /**
-     * Hand-off cache: spl_object_id of the call's first {@see \PhpParser\Node\Arg} → column type.
-     *
-     * Populated by {@see resolveDynamicWhereOnRelation} during return-type resolution and
-     * consumed by {@see getMethodParams} immediately after.
-     *
-     * Lifecycle (verified against vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/
-     * Statements/Expression/Call/Method/MissingMethodCallHandler.php):
-     *   1. `handleMagicMethod` line 70 invokes the return-type provider — we store.
-     *   2. Line 94 invokes `CallAnalyzer::checkMethodArgs` synchronously in the same
-     *      worker; this routes through `Methods::getMethodParams` and fires our params
-     *      provider, which consumes and `unset()`s the entry.
-     *
-     * The key is `methodName . ':' . spl_object_id($firstArg)`. Both events read args
-     * from the same `$stmt->getArgs()` array, so the {@see \PhpParser\Node\Arg} nodes
-     * are object-identical and the id matches across the producer/consumer pair. The
-     * method-name prefix defends against PHP recycling an spl_object_id from a freed Arg
-     * node into an unrelated later call — without it, the consumer could pick up a stale
-     * column type from a different where{Column} method whose Arg node had the same id.
-     *
-     * Issue #928: the variadic-mixed signature previously returned by getMethodParams()
-     * accepted any value type. With this hand-off, getMethodParams returns typed params
-     * derived from the resolved column type and lets Psalm's standard argument checker
-     * emit InvalidArgument / InvalidScalarArgument on type mismatch.
-     *
-     * @var array<string, Union>
-     */
-    private static array $pendingDynamicWhereColumnType = [];
-
-    /**
      * Reset all static state. Called once per Plugin::__construct in production, plus
      * by test fixtures that re-bootstrap the handler. Every cache MUST be cleared so
      * leftover entries from a previous run can't leak across boundaries — in particular
-     * $pendingDynamicWhereColumnType, where a stale entry could be consumed by a future
-     * call whose first Arg happens to share an spl_object_id.
+     * the {@see DynamicWhereResolver} hand-off cache, where a stale entry could be
+     * consumed by a future call whose first Arg happens to share an spl_object_id.
+     *
+     * The DynamicWhereResolver enable flag is owned by `Plugin::registerHandlers()` and
+     * is intentionally NOT reset here (init may run after enable() in tests).
      *
      * @psalm-external-mutation-free
      */
@@ -153,8 +94,7 @@ final class MethodForwardingHandler implements
         self::$sourceClassIndex = [];
         self::$searchClassIndex = [];
         self::$scopeParamsCache = [];
-        self::$dynamicWhereCache = [];
-        self::$pendingDynamicWhereColumnType = [];
+        DynamicWhereResolver::reset();
 
         foreach ($rule->allSourceClasses() as $class) {
             self::$sourceClassIndex[\strtolower($class)] = true;
@@ -165,19 +105,6 @@ final class MethodForwardingHandler implements
         }
 
         ReturnTypeResolver::initForRule($rule);
-    }
-
-    /**
-     * Enable resolution of dynamic where{Column} methods on relation chains.
-     *
-     * Called from Plugin::registerHandlers() when <resolveDynamicWhereClauses value="true" /> is set.
-     * Must be called after init() if called at all.
-     *
-     * @psalm-external-mutation-free
-     */
-    public static function enableDynamicWhere(): void
-    {
-        self::$enableDynamicWhere = true;
     }
 
     /**
@@ -266,7 +193,7 @@ final class MethodForwardingHandler implements
 
         // Dynamic where{Column} fallback for Path 2 (opt-in).
         // This handles the case where the method arrives via __call rather than @mixin.
-        if (self::$enableDynamicWhere && $templateParams !== null && self::isDynamicWhereMethod($methodName)) {
+        if (DynamicWhereResolver::isEnabled() && $templateParams !== null && DynamicWhereResolver::isDynamicWhereMethod($methodName)) {
             return self::resolveDynamicWhereOnRelation($event, $codebase, $methodName, $fqClassName, $templateParams);
         }
 
@@ -347,7 +274,7 @@ final class MethodForwardingHandler implements
             // signature (same as the dynamic-where fallback) rather than returning [] (zero params),
             // which would emit misleading TooManyArguments for scopes that accept arguments.
             return ModelMethodHandler::getScopeParams($codebase, self::$scopeParamsCache[$scopeKey], $methodName)
-                ?? [new FunctionLikeParameter('args', by_ref: false, type: Type::getMixed(), is_variadic: true)];
+                ?? DynamicWhereResolver::variadicMixedParams();
         }
 
         // Dynamic where{Column}: provide a variadic mixed signature so Psalm's magic-method
@@ -355,20 +282,15 @@ final class MethodForwardingHandler implements
         // __call; these params only govern argument arity checking.
         // A variadic signature accepts both single-column (whereTitle($v)) and multi-column
         // (whereFirstNameAndLastName($a, $b)) patterns without raising TooManyArguments.
-        if (self::$enableDynamicWhere && self::isDynamicWhereMethod($methodName)) {
+        if (DynamicWhereResolver::isEnabled() && DynamicWhereResolver::isDynamicWhereMethod($methodName)) {
             // Issue #928: when the return-type provider resolved a scalar column on the
             // related model and the call has exactly one argument, return a typed param
             // so Psalm's argument checker can emit InvalidArgument / InvalidScalarArgument
             // on type mismatch. Everything else (multi-segment, unknown column, non-scalar
             // column, 0 or 2+ args) falls through to the permissive variadic-mixed
-            // signature. {@see consumeDynamicWhereTypedParams} for the full rationale.
-            $typedParams = self::consumeDynamicWhereTypedParams($methodName, $event->getCallArgs());
-
-            if ($typedParams !== null) {
-                return $typedParams;
-            }
-
-            return [new FunctionLikeParameter('args', by_ref: false, type: Type::getMixed(), is_variadic: true)];
+            // signature. {@see DynamicWhereResolver::consumeTypedParams} for the rationale.
+            return DynamicWhereResolver::consumeTypedParams($methodName, $event->getCallArgs())
+                ?? DynamicWhereResolver::variadicMixedParams();
         }
 
         return null;
@@ -460,7 +382,7 @@ final class MethodForwardingHandler implements
             // when the method is a valid dynamic where for the related model's column.
             // Pre-check the pattern here (mirrors Path 2 guard) to avoid entering the function
             // for non-where* methods (orderBy, limit, etc.) when dynamic where is enabled.
-            if (self::$enableDynamicWhere && self::isDynamicWhereMethod($methodName)) {
+            if (DynamicWhereResolver::isEnabled() && DynamicWhereResolver::isDynamicWhereMethod($methodName)) {
                 return self::resolveDynamicWhereOnRelation(
                     $event,
                     $codebase,
@@ -585,17 +507,17 @@ final class MethodForwardingHandler implements
 
         $stmt = $event->getStmt();
 
-        $originalMethodName = self::originalMethodName($stmt, $methodName);
+        $originalMethodName = DynamicWhereResolver::originalMethodName($stmt, $methodName);
 
-        $columnType = self::resolveDynamicWhereColumnType($codebase, $modelClass, $originalMethodName);
+        $columnType = DynamicWhereResolver::resolveColumnType($codebase, $modelClass, $originalMethodName);
 
         if ($columnType === false) {
             return null;
         }
 
         // Hand off the scalar column type to getMethodParams() so it can build a typed
-        // parameter list and let Psalm validate arguments. See $pendingDynamicWhereColumnType
-        // for the lifecycle and rationale. Issue #928.
+        // parameter list and let Psalm validate arguments. See
+        // {@see DynamicWhereResolver::storePendingColumnType} for the lifecycle. Issue #928.
         //
         // Gates on the store:
         //   (a) Path 1 (mixin interception) writes are unconsumable — Builder is in
@@ -605,10 +527,10 @@ final class MethodForwardingHandler implements
         //   (b) Only single-segment scalar columns produce a Union here; multi-segment
         //       and non-scalar single-segment results were cached as `null` upstream.
         //   (c) Only enqueue when the call has exactly one argument — the only shape
-        //       consumeDynamicWhereTypedParams() actually consumes. Without this gate,
-        //       2+ arg calls would deposit entries that the consumer skips, leaking
-        //       across the analysis run (and risking a wrong-type lookup later if PHP
-        //       reuses the spl_object_id of a freed Arg node).
+        //       DynamicWhereResolver::consumeTypedParams() actually consumes. Without
+        //       this gate, 2+ arg calls would deposit entries that the consumer skips,
+        //       leaking across the analysis run (and risking a wrong-type lookup later
+        //       if PHP reuses the spl_object_id of a freed Arg node).
         if (
             $columnType instanceof Union
             && \strtolower($event->getFqClasslikeName()) === \strtolower($relationClass)
@@ -617,7 +539,7 @@ final class MethodForwardingHandler implements
             $args = $stmt->getArgs();
 
             if (\count($args) === 1) {
-                self::$pendingDynamicWhereColumnType[$methodName . ':' . \spl_object_id($args[0])] = $columnType;
+                DynamicWhereResolver::storePendingColumnType($methodName, $args[0], $columnType);
             }
         }
 
@@ -625,44 +547,6 @@ final class MethodForwardingHandler implements
         return new Union([
             new TGenericObject($relationClass, $templateParams),
         ]);
-    }
-
-    /**
-     * Read and remove the column type queued by {@see resolveDynamicWhereOnRelation},
-     * returning a typed single-parameter list when the call has exactly one argument.
-     * Returns null otherwise so the caller falls back to the permissive variadic-mixed
-     * signature.
-     *
-     * Only the 1-argument value form is type-checked. Laravel's runtime
-     * `Builder::dynamicWhere` always uses `=` as the operator and silently drops every
-     * argument past the first (see `Query\Builder::addDynamic`), so the 2-arg "operator
-     * form" (`whereTitle('=', 'foo')`) is a runtime bug. Rather than blessing it (which
-     * would over-accept invalid types in the value position) or rejecting it (which
-     * would surface as TooManyArguments on legacy code patterns that issue #928's
-     * caveats explicitly ask us to tolerate), we leave 2+ arg calls to the variadic
-     * fallback. Larastan does the same via a single-optional-mixed-variadic
-     * `DynamicWhereParameterReflection`.
-     *
-     * @param list<\PhpParser\Node\Arg>|null $callArgs
-     * @return list<FunctionLikeParameter>|null
-     * @psalm-external-mutation-free
-     */
-    private static function consumeDynamicWhereTypedParams(string $methodName, ?array $callArgs): ?array
-    {
-        if ($callArgs === null || \count($callArgs) !== 1) {
-            return null;
-        }
-
-        $key = $methodName . ':' . \spl_object_id($callArgs[0]);
-
-        if (!isset(self::$pendingDynamicWhereColumnType[$key])) {
-            return null;
-        }
-
-        $columnType = self::$pendingDynamicWhereColumnType[$key];
-        unset(self::$pendingDynamicWhereColumnType[$key]);
-
-        return [new FunctionLikeParameter('value', by_ref: false, type: $columnType, is_optional: false)];
     }
 
     /**
@@ -705,146 +589,6 @@ final class MethodForwardingHandler implements
         return new Union([
             new TGenericObject($relationClass, $templateParams),
         ]);
-    }
-
-    /**
-     * Check whether a method name looks like a Laravel dynamic where{Column} call.
-     *
-     * Method names are always lowercased by Psalm. The pattern requires the method
-     * to start with "where" and have at least one more character (e.g. "wheretitle").
-     * Methods that exactly equal "where" are skipped — they are declared on Builder.
-     *
-     * @psalm-pure
-     */
-    private static function isDynamicWhereMethod(string $methodName): bool
-    {
-        return \strlen($methodName) > 5 && \str_starts_with($methodName, 'where');
-    }
-
-    /**
-     * Pull the original camel-cased method name from the AST, falling back to the
-     * already-lowercased event method name when the call uses a dynamic name
-     * (e.g. `$x->{$var}()`) or is a StaticCall. The camel case matters because
-     * the And/Or segment split requires uppercase boundaries that Psalm strips
-     * from getMethodNameLowercase().
-     *
-     * Psalm's MethodCallAnalyzer short-circuits dynamic-name MethodCalls before
-     * invoking return-type providers, so the fallback branch is effectively dead
-     * for the MethodCall case; kept for StaticCall and future Psalm versions.
-     *
-     * @psalm-mutation-free
-     */
-    private static function originalMethodName(
-        \PhpParser\Node\Expr\MethodCall|\PhpParser\Node\Expr\StaticCall $stmt,
-        string $lowercaseFallback,
-    ): string {
-        return $stmt instanceof MethodCall && $stmt->name instanceof \PhpParser\Node\Identifier
-            ? $stmt->name->name
-            : $lowercaseFallback;
-    }
-
-    /**
-     * Validate a dynamic where{Column} method call against the model's declared @property
-     * entries and return the column type when (and only when) a single scalar column was
-     * matched.
-     *
-     * Mirrors Larastan's `BuilderHelper::dynamicWhere` (split on And/Or capitalised boundaries,
-     * every segment must correspond to a declared column). The suffix after "where" is split
-     * by `(?:And|Or)(?=[A-Z])`, so the ORIGINAL camel-cased method name from the AST is
-     * required — see the caller for why we pull it from $stmt->name rather than the
-     * lowercased event method name.
-     *
-     * @property entries are normalised by stripping `$` and underscores and lowercasing
-     * (so `$email_address` collapses to `emailaddress`); each segment goes through the
-     * same normalisation and the call is rejected on the first mismatch.
-     *
-     * Return values:
-     *   - `false`: at least one segment doesn't match a declared property. Caller skips
-     *     the dynamic where resolution entirely.
-     *   - `null`: every segment matched but no scalar column type is suitable for the
-     *     typed-parameter hand-off (multi-segment, or single-segment whose type contains
-     *     an object/array — Carbon, BackedEnum, json casts). Caller returns the Relation
-     *     type without populating the hand-off cache.
-     *   - `Union`: every segment matched, the call is single-segment, and the column
-     *     type is scalar. Caller queues this type for {@see getMethodParams} (issue #928).
-     *
-     * @param class-string<\Illuminate\Database\Eloquent\Model> $modelClass
-     * @psalm-external-mutation-free
-     */
-    private static function resolveDynamicWhereColumnType(
-        Codebase $codebase,
-        string $modelClass,
-        string $originalMethodName,
-    ): false|Union|null {
-        $key = $modelClass . ':' . $originalMethodName;
-
-        if (\array_key_exists($key, self::$dynamicWhereCache)) {
-            return self::$dynamicWhereCache[$key];
-        }
-
-        // Strip "where" / "WHERE" prefix — original-case may be anything from "Where" to "WHERE",
-        // but our isDynamicWhereMethod gate ran on the lowercase form so the first 5 chars are
-        // always "where" in some casing. substr is byte-safe for that ASCII prefix.
-        $suffix = \substr($originalMethodName, 5);
-
-        $segments = \preg_split(self::SEGMENT_SPLIT_PATTERN, $suffix);
-
-        // preg_split with this literal pattern cannot fail at runtime; the guard is
-        // a Psalm narrowing concession (return type is non-empty-list<string>|false).
-        if ($segments === false) {
-            return self::$dynamicWhereCache[$key] = false;
-        }
-
-        try {
-            $storage = $codebase->classlike_storage_provider->get(\strtolower($modelClass));
-        } catch (\InvalidArgumentException) {
-            return self::$dynamicWhereCache[$key] = false;
-        }
-
-        // Build a normalised property map once per (model, method) pair. Cheaper than
-        // re-running str_replace+strtolower over every property for every segment.
-        // The map is not memoized across calls: Psalm may populate pseudo_property_get_types
-        // lazily as it parses the class, and a stale snapshot could miss properties added
-        // after first invocation.
-        //
-        // pseudo_property_get_types is sourced from @property/@property-read — readable
-        // columns. @property-write entries (password hashing etc.) don't correspond to
-        // filterable columns and are intentionally excluded.
-        $normalizedProperties = [];
-        foreach ($storage->pseudo_property_get_types as $propName => $propType) {
-            $normalizedProperties[\strtolower(\str_replace(['$', '_'], '', $propName))] = $propType;
-        }
-
-        // Validate every segment and stash the matching column type. An empty segment
-        // (e.g. `whereAndFoo` splitting to ['', 'Foo']) or any unmatched column rejects
-        // the whole call.
-        $matchedColumnTypes = [];
-        foreach ($segments as $segment) {
-            $segmentKey = \strtolower($segment);
-
-            if ($segmentKey === '' || !isset($normalizedProperties[$segmentKey])) {
-                return self::$dynamicWhereCache[$key] = false;
-            }
-
-            $matchedColumnTypes[] = $normalizedProperties[$segmentKey];
-        }
-
-        // Multi-segment calls take one argument per segment with potentially different
-        // column types — no single Union can stand in for the typed-param hand-off.
-        if (\count($matchedColumnTypes) !== 1) {
-            return self::$dynamicWhereCache[$key] = null;
-        }
-
-        $columnType = $matchedColumnTypes[0];
-
-        // Object/array column types (Carbon, BackedEnum, json casts) skip the typed-param
-        // hand-off — Laravel coerces strings/ints to these at the query layer, so narrowing
-        // to the property type would mass-regress real codebases.
-        if ($columnType->hasObjectType() || $columnType->hasArray()) {
-            return self::$dynamicWhereCache[$key] = null;
-        }
-
-        return self::$dynamicWhereCache[$key] = $columnType;
     }
 
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -119,6 +119,7 @@ final class Plugin implements PluginEntryPointInterface
         // Must be registered BEFORE BuilderScopeHandler, BuilderPluckHandler, and
         // CustomCollectionHandler — the handler returns null for non-Relation callers
         // (fast O(1) check), so downstream handlers fire unaffected.
+        require_once __DIR__ . '/Util/DynamicWhereResolver.php';
         require_once __DIR__ . '/Handlers/Magic/ForwardingRule.php';
         require_once __DIR__ . '/Handlers/Magic/ReturnTypeResolver.php';
         require_once __DIR__ . '/Handlers/Magic/MethodForwardingHandler.php';
@@ -154,7 +155,7 @@ final class Plugin implements PluginEntryPointInterface
             interceptMixin: true,
         ));
         if ($pluginConfig->resolveDynamicWhereClauses) {
-            Handlers\Magic\MethodForwardingHandler::enableDynamicWhere();
+            Util\DynamicWhereResolver::enable();
         }
 
         // Eloquent's Model -> Builder @mixin host correction is intentionally separate

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -126,6 +126,7 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Magic/MacroHandler.php';
         $registration->registerHooksFromClass(Handlers\Magic\MacroHandler::class);
         require_once __DIR__ . '/Handlers/Eloquent/ModelMethodHandler.php';
+        Handlers\Eloquent\ModelMethodHandler::init();
         require_once __DIR__ . '/Handlers/Eloquent/ModelBuilderMixinHandler.php';
         Handlers\Magic\MethodForwardingHandler::init(new Handlers\Magic\ForwardingRule(
             sourceClass: \Illuminate\Database\Eloquent\Relations\Relation::class,

--- a/src/Util/DynamicWhereResolver.php
+++ b/src/Util/DynamicWhereResolver.php
@@ -125,14 +125,20 @@ final class DynamicWhereResolver
     }
 
     /**
-     * Reset all state. Called by handler init() pathways so a re-bootstrap doesn't leak
-     * caches across analysis runs. The {@see $enabled} flag is preserved it's owned by
-     * Plugin config, not by any single handler's init().
+     * Reset all state, including the enable flag. Called by handler init() pathways so a
+     * re-bootstrap doesn't leak caches OR a previously-enabled flag across analysis runs.
+     *
+     * Plugin::registerHandlers() re-runs enable() after init() when the config still has
+     * `<resolveDynamicWhereClauses value="true" />`, so a config flip true->false in a
+     * second bootstrap correctly leaves the resolver disabled. Without resetting the flag,
+     * the second bootstrap would inherit "enabled" from the first run and silently ignore
+     * the new config value.
      *
      * @psalm-external-mutation-free
      */
     public static function reset(): void
     {
+        self::$enabled = false;
         self::$columnTypeCache = [];
         self::$pendingColumnType = [];
         self::$normalizedPropertiesCache = [];

--- a/src/Util/DynamicWhereResolver.php
+++ b/src/Util/DynamicWhereResolver.php
@@ -50,7 +50,7 @@ final class DynamicWhereResolver
      * uppercase letter. Mirrors `Illuminate\Database\Query\Builder::dynamicWhere`'s
      * `(And|Or)(?=[A-Z])`; we use a non-capturing group since we don't need the connector.
      */
-    public const SEGMENT_SPLIT_PATTERN = '/(?:And|Or)(?=[A-Z])/';
+    private const SEGMENT_SPLIT_PATTERN = '/(?:And|Or)(?=[A-Z])/';
 
     private static bool $enabled = false;
 
@@ -214,7 +214,7 @@ final class DynamicWhereResolver
             return false;
         }
 
-        return self::backtrackMatch(\substr($methodNameLower, 5), \array_keys($normalized), expectingConnector: false);
+        return self::partitionExists(\substr($methodNameLower, 5), \array_keys($normalized));
     }
 
     /**
@@ -386,39 +386,62 @@ final class DynamicWhereResolver
     }
 
     /**
-     * Recursive backtracking matcher: try to consume the remaining suffix as a chain of
-     * normalised property names joined by `and`/`or` connectors.
+     * Iterative DP partition check: can the suffix be consumed as `prop( (and|or) prop )*`?
+     *
+     * `$reachable[$offset]` is a 2-bit mask:
+     *   - bit 0 = offset reached in "expecting property" state
+     *   - bit 1 = offset reached in "expecting connector" state
+     *
+     * Equivalent to the recursive backtracker but with O(n * |props|) worst case instead
+     * of exponential — guards against adversarial property sets with overlapping prefixes
+     * (e.g. `a`, `aa`, `aaa`) feeding a long `where{...}` call.
      *
      * @param list<string> $normalizedProps
      * @psalm-pure
      */
-    private static function backtrackMatch(
-        string $suffix,
-        array $normalizedProps,
-        bool $expectingConnector,
-    ): bool {
-        if ($suffix === '') {
-            return $expectingConnector;
+    private static function partitionExists(string $suffix, array $normalizedProps): bool
+    {
+        $n = \strlen($suffix);
+
+        if ($n === 0) {
+            return false;
         }
 
-        if ($expectingConnector) {
-            if (\str_starts_with($suffix, 'and') && self::backtrackMatch(\substr($suffix, 3), $normalizedProps, expectingConnector: false)) {
-                return true;
-            }
+        $reachable = \array_fill(0, $n + 1, 0);
+        $reachable[0] = 1; // start: expecting a property at offset 0
 
-            return \str_starts_with($suffix, 'or') && self::backtrackMatch(\substr($suffix, 2), $normalizedProps, expectingConnector: false);
-        }
+        for ($i = 0; $i <= $n; $i++) {
+            $state = $reachable[$i];
 
-        foreach ($normalizedProps as $prop) {
-            if ($prop === '' || !\str_starts_with($suffix, $prop)) {
+            if ($state === 0) {
                 continue;
             }
 
-            if (self::backtrackMatch(\substr($suffix, \strlen($prop)), $normalizedProps, expectingConnector: true)) {
-                return true;
+            if (($state & 1) !== 0) {
+                foreach ($normalizedProps as $prop) {
+                    $len = \strlen($prop);
+
+                    if ($len === 0 || $i + $len > $n) {
+                        continue;
+                    }
+
+                    if (\substr_compare($suffix, $prop, $i, $len) === 0) {
+                        $reachable[$i + $len] |= 2;
+                    }
+                }
+            }
+
+            if (($state & 2) !== 0) {
+                if ($i + 3 <= $n && \substr_compare($suffix, 'and', $i, 3) === 0) {
+                    $reachable[$i + 3] |= 1;
+                }
+
+                if ($i + 2 <= $n && \substr_compare($suffix, 'or', $i, 2) === 0) {
+                    $reachable[$i + 2] |= 1;
+                }
             }
         }
 
-        return false;
+        return ($reachable[$n] & 2) !== 0;
     }
 }

--- a/src/Util/DynamicWhereResolver.php
+++ b/src/Util/DynamicWhereResolver.php
@@ -1,0 +1,424 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Util;
+
+use Illuminate\Database\Eloquent\Model;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use Psalm\Codebase;
+use Psalm\Storage\FunctionLikeParameter;
+use Psalm\Type;
+use Psalm\Type\Union;
+
+/**
+ * Shared helpers for Laravel's dynamic where{Column} magic method resolution.
+ *
+ * Owns the runtime enable flag, the validation cache, the typed-param hand-off cache,
+ * and the column-matching primitives used by both:
+ *
+ * - {@see \Psalm\LaravelPlugin\Handlers\Magic\MethodForwardingHandler} relation chains
+ *   (e.g. `$user->posts()->whereTitle('foo')`).
+ * - {@see \Psalm\LaravelPlugin\Handlers\Eloquent\ModelMethodHandler} direct static and
+ *   instance calls on Model subclasses (e.g. `Server::whereUuid($u)`,
+ *   `$server->whereUuid($u)`). See https://github.com/psalm/psalm-plugin-laravel/issues/1000.
+ *
+ * Two complementary validation entry points exist because the relevant Psalm hooks expose
+ * different inputs:
+ *
+ * - {@see resolveColumnType} precise validation that requires the ORIGINAL camel-cased
+ *   method name from the AST. Splits the suffix on `(?:And|Or)(?=[A-Z])` boundaries.
+ *   Used by `MethodReturnTypeProvider` and `MethodParamsProvider` hooks (both expose the
+ *   AST via `getStmt()` / `getCallArgs()`).
+ * - {@see methodMatchesColumns} best-effort validation from a lowercase-only method
+ *   name. Used by `MethodExistenceProvider`, which doesn't receive an AST node. Performs
+ *   a bounded backtracking match against normalised property names with `and`/`or`
+ *   connectors. Slightly looser than the precise split (the lowercase form can't
+ *   distinguish `wherefooandbar` as `[Foo, Bar]` vs an unsplittable `[FooAndBar]` column),
+ *   but that only widens existence to extra true-positives; the return-type and params
+ *   providers still call {@see resolveColumnType} for the strict camel-cased check.
+ *
+ * @psalm-external-mutation-free
+ */
+final class DynamicWhereResolver
+{
+    /**
+     * Larastan parity: split a where{Column} suffix on And/Or boundaries followed by an
+     * uppercase letter. Mirrors `Illuminate\Database\Query\Builder::dynamicWhere`'s
+     * `(And|Or)(?=[A-Z])`; we use a non-capturing group since we don't need the connector.
+     */
+    public const SEGMENT_SPLIT_PATTERN = '/(?:And|Or)(?=[A-Z])/';
+
+    private static bool $enabled = false;
+
+    /**
+     * Cache: "ModelClass:originalMethodName" -> three-state validation result.
+     *
+     * Keyed by model class + ORIGINAL-CASE method name (not lowercase). The original case
+     * is needed because Laravel's runtime `Builder::dynamicWhere` splits the suffix on
+     * `(?:And|Or)(?=[A-Z])`, which only fires on properly camel-cased boundaries. The same
+     * lowercase name can therefore come from a splittable call (`whereFooAndBar`) or a
+     * non-splittable one (`wherefooandbar`), and they validate differently.
+     *
+     * Values:
+     *   - `false`: validation failed (one or more segments don't match a declared
+     *     pseudo property). Caller falls through to mixed.
+     *   - `null`: validation passed but no scalar column type can be handed off to the
+     *     typed-parameter checker (multi-segment call, or single-segment whose type is
+     *     object/array Carbon, BackedEnum, json casts).
+     *   - `Union`: validation passed AND the call is single-segment with a scalar column
+     *     type. The typed-param hand-off path (issue #928) consumes this.
+     *
+     * @var array<string, false|null|Union>
+     */
+    private static array $columnTypeCache = [];
+
+    /**
+     * Hand-off cache: `methodName . ':' . spl_object_id($firstArg)` -> column type.
+     *
+     * Populated during return-type resolution; consumed immediately after by the params
+     * provider (issue #928). Both hooks read args from the same `$stmt->getArgs()` array,
+     * so the `Arg` node identity is stable across the producer/consumer pair.
+     *
+     * The method-name prefix defends against PHP recycling an `spl_object_id` from a
+     * freed `Arg` node into an unrelated later call without it, the consumer could
+     * pick up a stale column type from a different where{Column} method whose Arg node
+     * had the same id.
+     *
+     * @var array<string, Union>
+     */
+    private static array $pendingColumnType = [];
+
+    /**
+     * Cache: lowercase model FQCN -> normalised property name -> property type.
+     *
+     * `pseudo_property_get_types` is populated by Psalm's `Populator` during the scan
+     * phase and frozen before any method-existence / return-type / params provider
+     * fires (Populator runs to completion before AfterCodebasePopulated). Memoising
+     * the normalised map per model removes one `str_replace` + `strtolower` over
+     * every property for every distinct camel-case where{Column} call. A null entry
+     * encodes "storage was missing or had no pseudo-property entries" so the negative
+     * lookup short-circuits identically.
+     *
+     * @var array<lowercase-string, array<string, Union>|null>
+     */
+    private static array $normalizedPropertiesCache = [];
+
+    /**
+     * Enable dynamic where{Column} resolution. Wired from `Plugin::registerHandlers()`
+     * when `<resolveDynamicWhereClauses value="true" />` is set (default true).
+     *
+     * @psalm-external-mutation-free
+     */
+    public static function enable(): void
+    {
+        self::$enabled = true;
+    }
+
+    /** @psalm-external-mutation-free */
+    public static function isEnabled(): bool
+    {
+        return self::$enabled;
+    }
+
+    /**
+     * Reset all state. Called by handler init() pathways so a re-bootstrap doesn't leak
+     * caches across analysis runs. The {@see $enabled} flag is preserved it's owned by
+     * Plugin config, not by any single handler's init().
+     *
+     * @psalm-external-mutation-free
+     */
+    public static function reset(): void
+    {
+        self::$columnTypeCache = [];
+        self::$pendingColumnType = [];
+        self::$normalizedPropertiesCache = [];
+    }
+
+    /**
+     * Check whether a method name looks like a Laravel dynamic where{Column} call.
+     *
+     * The pattern requires the method to start with "where" and have at least one more
+     * character (e.g. "wheretitle"). Methods that exactly equal "where" are excluded
+     * they are declared on Builder.
+     *
+     * @psalm-pure
+     */
+    public static function isDynamicWhereMethod(string $methodName): bool
+    {
+        return \strlen($methodName) > 5 && \str_starts_with($methodName, 'where');
+    }
+
+    /**
+     * Pull the original camel-cased method name from the AST, falling back to the
+     * already-lowercased event method name when the call uses a dynamic name
+     * (e.g. `$x->{$var}()`). The camel case matters because the And/Or segment split
+     * requires uppercase boundaries that Psalm strips from getMethodNameLowercase().
+     *
+     * Both MethodCall and StaticCall expose `$stmt->name` as `Identifier|Expr` the
+     * Identifier branch carries the original spelling; non-Identifier names go through
+     * the fallback. Psalm's analyzer short-circuits dynamic-name MethodCalls before
+     * invoking return-type providers, so the fallback branch is effectively dead for
+     * the MethodCall case; kept for StaticCall and future Psalm versions.
+     *
+     * @psalm-mutation-free
+     */
+    public static function originalMethodName(
+        MethodCall|StaticCall $stmt,
+        string $lowercaseFallback,
+    ): string {
+        $name = $stmt->name;
+
+        return $name instanceof Identifier ? $name->name : $lowercaseFallback;
+    }
+
+    /**
+     * Lowercase-only match: does the given lowercase where{Column} method name
+     * correspond to one or more columns on the model?
+     *
+     * Used by the method-existence provider where the AST isn't available. Performs a
+     * bounded backtracking match: try to consume the suffix as `prop( (and|or) prop )*`
+     * for any combination of declared @property entries on the model.
+     *
+     * Returns `true` iff at least one partition validates. False positives are bounded
+     * by the property set (a `where<X>` call only matches when every lowercase
+     * substring lines up with a real property), so this widens existence but cannot
+     * confirm a column that isn't declared.
+     *
+     * Multi-segment behaviour: with no uppercase boundaries to anchor against, the
+     * match could in principle find multiple valid partitions for ambiguous property
+     * sets (e.g. properties `foo`, `bar`, `foobar` vs method `wherefooorbar` the
+     * "or" might be a connector or part of a column name). The function does not
+     * disambiguate; any valid partition is sufficient to confirm existence. The
+     * return-type and params providers still run the strict camel-cased validation
+     * via {@see resolveColumnType}.
+     *
+     * @param class-string<Model> $modelClass
+     * @psalm-external-mutation-free
+     */
+    public static function methodMatchesColumns(
+        Codebase $codebase,
+        string $modelClass,
+        string $methodNameLower,
+    ): bool {
+        if (!self::isDynamicWhereMethod($methodNameLower)) {
+            return false;
+        }
+
+        $normalized = self::getNormalizedProperties($codebase, $modelClass);
+
+        if ($normalized === null || $normalized === []) {
+            return false;
+        }
+
+        return self::backtrackMatch(\substr($methodNameLower, 5), \array_keys($normalized), expectingConnector: false);
+    }
+
+    /**
+     * Validate a dynamic where{Column} method call against the model's declared @property
+     * entries and return the column type when (and only when) a single scalar column was
+     * matched.
+     *
+     * Mirrors Larastan's `BuilderHelper::dynamicWhere` (split on And/Or capitalised boundaries,
+     * every segment must correspond to a declared column). The suffix after "where" is split
+     * by `(?:And|Or)(?=[A-Z])`, so the ORIGINAL camel-cased method name from the AST is
+     * required pull it from `$stmt->name` rather than the lowercased event method name.
+     *
+     * Pseudo-property entries are normalised by stripping `$` and underscores and
+     * lowercasing (so `$email_address` collapses to `emailaddress`); each segment goes
+     * through the same normalisation and the call is rejected on the first mismatch.
+     *
+     * Return values:
+     *   - `false`: at least one segment doesn't match a declared property. Caller skips
+     *     the dynamic where resolution entirely.
+     *   - `null`: every segment matched but no scalar column type is suitable for the
+     *     typed-parameter hand-off (multi-segment, or single-segment whose type contains
+     *     an object/array Carbon, BackedEnum, json casts). Caller returns the chain
+     *     type without populating the hand-off cache.
+     *   - `Union`: every segment matched, the call is single-segment, and the column
+     *     type is scalar. Caller queues this type for the params provider (issue #928).
+     *
+     * @param class-string<Model> $modelClass
+     * @psalm-external-mutation-free
+     */
+    public static function resolveColumnType(
+        Codebase $codebase,
+        string $modelClass,
+        string $originalMethodName,
+    ): false|Union|null {
+        $key = $modelClass . ':' . $originalMethodName;
+
+        if (\array_key_exists($key, self::$columnTypeCache)) {
+            return self::$columnTypeCache[$key];
+        }
+
+        $suffix = \substr($originalMethodName, 5);
+
+        $segments = \preg_split(self::SEGMENT_SPLIT_PATTERN, $suffix);
+
+        // preg_split with this literal pattern cannot fail at runtime; the guard is a
+        // Psalm narrowing concession (return type is non-empty-list<string>|false).
+        if ($segments === false) {
+            return self::$columnTypeCache[$key] = false;
+        }
+
+        $normalized = self::getNormalizedProperties($codebase, $modelClass);
+
+        if ($normalized === null) {
+            return self::$columnTypeCache[$key] = false;
+        }
+
+        $matchedColumnTypes = [];
+        foreach ($segments as $segment) {
+            $segmentKey = \strtolower($segment);
+
+            if ($segmentKey === '' || !isset($normalized[$segmentKey])) {
+                return self::$columnTypeCache[$key] = false;
+            }
+
+            $matchedColumnTypes[] = $normalized[$segmentKey];
+        }
+
+        if (\count($matchedColumnTypes) !== 1) {
+            return self::$columnTypeCache[$key] = null;
+        }
+
+        $columnType = $matchedColumnTypes[0];
+
+        // Object/array column types (Carbon, BackedEnum, json casts) skip the typed-param
+        // hand-off Laravel coerces strings/ints to these at the query layer, so narrowing
+        // to the property type would mass-regress real codebases.
+        if ($columnType->hasObjectType() || $columnType->hasArray()) {
+            return self::$columnTypeCache[$key] = null;
+        }
+
+        return self::$columnTypeCache[$key] = $columnType;
+    }
+
+    /**
+     * Queue a column type for the params provider to consume on the matching call.
+     *
+     * @psalm-external-mutation-free
+     */
+    public static function storePendingColumnType(string $methodName, Arg $firstArg, Union $type): void
+    {
+        self::$pendingColumnType[$methodName . ':' . \spl_object_id($firstArg)] = $type;
+    }
+
+    /**
+     * Read and remove the column type queued by the matching return-type provider,
+     * returning a typed single-parameter list when the call has exactly one argument.
+     * Returns null otherwise so the caller falls back to a permissive variadic-mixed
+     * signature.
+     *
+     * Only the 1-argument value form is type-checked. Laravel's runtime
+     * `Builder::dynamicWhere` always uses `=` as the operator and silently drops every
+     * argument past the first (see `Query\Builder::addDynamic`), so the 2-arg "operator
+     * form" (`whereTitle('=', 'foo')`) is a runtime bug. Rather than blessing it (which
+     * would over-accept invalid types in the value position) or rejecting it (which
+     * would surface as TooManyArguments on legacy code patterns that issue #928's
+     * caveats explicitly ask us to tolerate), 2+ arg calls fall through to the variadic
+     * fallback. Larastan does the same via a single-optional-mixed-variadic
+     * `DynamicWhereParameterReflection`.
+     *
+     * @param list<Arg>|null $callArgs
+     * @return list<FunctionLikeParameter>|null
+     * @psalm-external-mutation-free
+     */
+    public static function consumeTypedParams(string $methodName, ?array $callArgs): ?array
+    {
+        if ($callArgs === null || \count($callArgs) !== 1) {
+            return null;
+        }
+
+        $key = $methodName . ':' . \spl_object_id($callArgs[0]);
+
+        if (!isset(self::$pendingColumnType[$key])) {
+            return null;
+        }
+
+        $columnType = self::$pendingColumnType[$key];
+        unset(self::$pendingColumnType[$key]);
+
+        return [new FunctionLikeParameter('value', by_ref: false, type: $columnType, is_optional: false)];
+    }
+
+    /**
+     * Variadic mixed signature shared by relation-chain and Model-direct dynamic-where
+     * fallbacks when the typed-param hand-off doesn't apply.
+     *
+     * @return list<FunctionLikeParameter>
+     * @psalm-pure
+     */
+    public static function variadicMixedParams(): array
+    {
+        return [new FunctionLikeParameter('args', by_ref: false, type: Type::getMixed(), is_variadic: true)];
+    }
+
+    /**
+     * @param class-string<Model> $modelClass
+     * @return array<string, Union>|null Normalised property name -> property type. Null when storage is missing.
+     * @psalm-external-mutation-free
+     */
+    private static function getNormalizedProperties(Codebase $codebase, string $modelClass): ?array
+    {
+        $cacheKey = \strtolower($modelClass);
+
+        if (\array_key_exists($cacheKey, self::$normalizedPropertiesCache)) {
+            return self::$normalizedPropertiesCache[$cacheKey];
+        }
+
+        try {
+            $storage = $codebase->classlike_storage_provider->get($cacheKey);
+        } catch (\InvalidArgumentException) {
+            return self::$normalizedPropertiesCache[$cacheKey] = null;
+        }
+
+        $normalized = [];
+        foreach ($storage->pseudo_property_get_types as $propName => $propType) {
+            $normalized[\strtolower(\str_replace(['$', '_'], '', $propName))] = $propType;
+        }
+
+        return self::$normalizedPropertiesCache[$cacheKey] = $normalized;
+    }
+
+    /**
+     * Recursive backtracking matcher: try to consume the remaining suffix as a chain of
+     * normalised property names joined by `and`/`or` connectors.
+     *
+     * @param list<string> $normalizedProps
+     * @psalm-pure
+     */
+    private static function backtrackMatch(
+        string $suffix,
+        array $normalizedProps,
+        bool $expectingConnector,
+    ): bool {
+        if ($suffix === '') {
+            return $expectingConnector;
+        }
+
+        if ($expectingConnector) {
+            if (\str_starts_with($suffix, 'and') && self::backtrackMatch(\substr($suffix, 3), $normalizedProps, expectingConnector: false)) {
+                return true;
+            }
+
+            return \str_starts_with($suffix, 'or') && self::backtrackMatch(\substr($suffix, 2), $normalizedProps, expectingConnector: false);
+        }
+
+        foreach ($normalizedProps as $prop) {
+            if ($prop === '' || !\str_starts_with($suffix, $prop)) {
+                continue;
+            }
+
+            if (self::backtrackMatch(\substr($suffix, \strlen($prop)), $normalizedProps, expectingConnector: true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Type/tests/Model/DynamicWhereOnModelTest.phpt
+++ b/tests/Type/tests/Model/DynamicWhereOnModelTest.phpt
@@ -1,0 +1,104 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use App\Models\Invoice;
+use App\Models\Part;
+use App\Models\Vehicle;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Tests for dynamic where{Column} resolution on direct Model static / instance calls.
+ *
+ * Before #1000 the plugin resolved dynamic where{Column} only on Relation chains
+ * (HasMany, BelongsTo, ...). Calls directly on a Model raised UndefinedMagicMethod
+ * even when the column existed as @property. ModelMethodHandler now reuses
+ * DynamicWhereResolver to confirm existence and return Builder<TModel>.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1000
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/647
+ */
+
+// Static call on a bare-Builder Model — Customer has @property string $id.
+function test_static_dynamic_where_single_column(): void {
+    $_ = Customer::whereId('cust-1');
+    /** @psalm-check-type-exact $_ = Builder<Customer> */
+}
+
+// Instance call — same path via __call rather than __callStatic.
+function test_instance_dynamic_where_single_column(): void {
+    $_ = (new Part())->whereName('Brake Pads');
+    /** @psalm-check-type-exact $_ = Builder<Part> */
+}
+
+// Chained call — the returned Builder<TModel> must terminate with the model type.
+function test_static_dynamic_where_chain_first(): void {
+    $_ = Part::wherePartNumber('BP-1234')->first();
+    /** @psalm-check-type-exact $_ = Part|null */
+}
+
+// Multi-segment And — Part has @property string $part_number and @property string $name.
+function test_static_dynamic_where_multi_segment_and(): void {
+    $_ = Part::wherePartNumberAndName('BP-1234', 'Brake Pads');
+    /** @psalm-check-type-exact $_ = Builder<Part> */
+}
+
+// Multi-segment Or — same coverage as And.
+function test_static_dynamic_where_multi_segment_or(): void {
+    $_ = Part::wherePartNumberOrName('BP-1234', 'Brake Pads');
+    /** @psalm-check-type-exact $_ = Builder<Part> */
+}
+
+// Custom builder via attribute — Invoice declares InvoiceBuilder via #[UseEloquentBuilder].
+// The dynamic-where path must return the custom builder type, not Builder<Invoice>.
+function test_static_dynamic_where_uses_attribute_custom_builder(): void {
+    $_ = Invoice::whereStatus('paid');
+    /** @psalm-check-type-exact $_ = App\Builders\InvoiceBuilder */
+}
+
+// Custom builder via newEloquentBuilder() override — Vehicle declares VehicleBuilder
+// through the pre-attribute override path. The two custom-builder resolution routes
+// run through different branches in ModelMethodHandler::builderType, so both need
+// independent coverage.
+function test_static_dynamic_where_uses_newEloquentBuilder_custom_builder(): void {
+    $_ = Vehicle::whereMake('Toyota');
+    /** @psalm-check-type-exact $_ = App\Builders\VehicleBuilder<Vehicle> */
+}
+
+// Underscored multi-word column — Customer has @property non-empty-string
+// $first_name_using_legacy_accessor. "whereFirstNameUsingLegacyAccessor" normalises
+// to "firstnameusinglegacyaccessor" and must still resolve.
+function test_static_dynamic_where_underscored_multi_word_column(): void {
+    $_ = Customer::whereFirstNameUsingLegacyAccessor('Alice');
+    /** @psalm-check-type-exact $_ = Builder<Customer> */
+}
+
+// Typed-param hand-off (#928): scalar single-segment + 1 arg must reject wrong type.
+function test_static_dynamic_where_rejects_wrong_scalar_type(): void {
+    Part::whereName(123);
+}
+
+// Non-scalar (CarbonInterface|null) column falls through to variadic mixed.
+function test_static_dynamic_where_skips_non_scalar_column(): void {
+    Customer::whereEmailVerifiedAt('2024-01-01');
+    Customer::whereEmailVerifiedAt(null);
+}
+
+// Multi-segment falls through to variadic mixed — wrong types in either position
+// are tolerated (multi-segment intentionally skips typed-param hand-off, mirroring
+// the relation-chain behaviour and Larastan's DynamicWhereParameterReflection).
+function test_static_dynamic_where_multi_segment_falls_back_to_variadic(): void {
+    Part::wherePartNumberAndName(123, 456);
+}
+
+// Unknown column on a Model with no matching @property: existence remains unconfirmed,
+// Psalm continues to raise UndefinedMagicMethod. Without this guarantee, the looser
+// lowercase backtrack matcher could over-accept arbitrary method names.
+function test_static_dynamic_where_unknown_column_still_undefined(): void {
+    Part::whereNonExistentColumn('x');
+}
+
+?>
+--EXPECTF--
+InvalidArgument on line %d: Argument 1 of App\Models\Part::wherename expects string, but 123 provided
+UndefinedMagicMethod on line %d: Magic method App\Models\Part::wherenonexistentcolumn does not exist

--- a/tests/Type/tests/Model/DynamicWhereOnModelTest.phpt
+++ b/tests/Type/tests/Model/DynamicWhereOnModelTest.phpt
@@ -98,6 +98,23 @@ function test_static_dynamic_where_unknown_column_still_undefined(): void {
     Part::whereNonExistentColumn('x');
 }
 
+// Custom builder declares a where* method directly (VehicleBuilder::whereByMake).
+// The dynamic-where path must NOT shadow the declared method — the fake-call branch
+// resolves it from the custom builder's actual signature. Without the
+// `!methodExists($builderClass, ...)` gate this would return Builder<Vehicle> generically.
+function test_static_custom_builder_where_method_not_shadowed(): void {
+    $_ = Vehicle::whereByMake('Toyota');
+    /** @psalm-check-type-exact $_ = App\Builders\VehicleBuilder<Vehicle> */
+}
+
+// Lowercase non-splittable spelling (`whereid` vs `whereId`) still resolves to
+// Builder<Customer> — Laravel's runtime lowercases method names too and treats
+// `whereid` as the single-segment column `id`.
+function test_static_dynamic_where_lowercase_spelling(): void {
+    $_ = Customer::whereid('cust-1');
+    /** @psalm-check-type-exact $_ = Builder<Customer> */
+}
+
 ?>
 --EXPECTF--
 InvalidArgument on line %d: Argument 1 of App\Models\Part::wherename expects string, but 123 provided

--- a/tests/Type/tests/Model/StaticBuilderForwardingTest.phpt
+++ b/tests/Type/tests/Model/StaticBuilderForwardingTest.phpt
@@ -30,15 +30,13 @@ function test_static_cursor(): void
 }
 
 // Dynamic where{Column}: Customer has @property string $id, so whereId() must resolve
-// via Model::__callStatic forwarding to Builder::__call.
-//
-// Known limitation on bare static (no relation chain): MethodForwardingHandler enables
-// dynamic where{Column} only on relation chains. The static-on-Model form raises
-// UndefinedMagicMethod — see issue #647 follow-up.
+// via Model::__callStatic forwarding to Builder::__call. With resolveDynamicWhereClauses
+// enabled (default), ModelMethodHandler confirms existence via DynamicWhereResolver and
+// returns Builder<Customer>. See https://github.com/psalm/psalm-plugin-laravel/issues/1000.
 function test_static_dynamic_where_column(): void
 {
     $_result = Customer::whereId('cust-1');
-    /** @psalm-check-type-exact $_result = mixed */
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
 }
 
 // QueriesRelationships::whereDoesntHave called statically. Maps to Builder::whereDoesntHave.
@@ -80,4 +78,3 @@ function test_static_cursor_chain_each(): void
 
 ?>
 --EXPECTF--
-UndefinedMagicMethod on line %d: Magic method App\Models\Customer::whereid does not exist

--- a/tests/Type/tests/Relation/DynamicWhereDisabledTest.phpt
+++ b/tests/Type/tests/Relation/DynamicWhereDisabledTest.phpt
@@ -3,7 +3,9 @@
 --FILE--
 <?php declare(strict_types=1);
 
+use App\Models\Customer;
 use App\Models\Invoice;
+use App\Models\Part;
 use App\Models\WorkOrder;
 
 /**
@@ -11,7 +13,12 @@ use App\Models\WorkOrder;
  * dynamic where{Column} methods must NOT be resolved even for valid @property columns.
  * The call falls through to __call on the Relation and returns mixed.
  *
+ * The same gating applies to direct Model static/instance calls (issue #1000) — without
+ * the flag, ModelMethodHandler must continue to raise UndefinedMagicMethod for
+ * `Customer::whereId(...)` etc. so users can opt out.
+ *
  * @see https://github.com/psalm/psalm-plugin-laravel/issues/647
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1000
  */
 
 function test_dynamic_where_not_resolved_when_disabled(): void {
@@ -23,12 +30,25 @@ function test_dynamic_where_not_resolved_when_disabled(): void {
 }
 
 // Multi-segment dynamic where (issue #927) must respect the disabled flag too.
-// A regression that wired the segment-split path outside the $enableDynamicWhere
-// gate would still resolve here; verify the call collapses to mixed.
+// A regression that wired the segment-split path outside the enable gate would
+// still resolve here; verify the call collapses to mixed.
 function test_dynamic_where_multi_segment_not_resolved_when_disabled(): void {
     $r = (new WorkOrder())->invoice();
     $_ = $r->whereInvoiceNumberAndStatus('INV-2024-001', 'paid');
     /** @psalm-check-type-exact $_ = mixed */
 }
+
+// Issue #1000: a direct Model static call MUST raise UndefinedMagicMethod when the
+// resolveDynamicWhereClauses flag is off — the feature is opt-out gated.
+function test_static_dynamic_where_on_model_disabled(): void {
+    Customer::whereId('cust-1');
+}
+
+// Same gating for instance calls.
+function test_instance_dynamic_where_on_model_disabled(): void {
+    (new Part())->whereName('Brake Pads');
+}
 ?>
 --EXPECTF--
+UndefinedMagicMethod on line %d: Magic method App\Models\Customer::whereid does not exist
+UndefinedMagicMethod on line %d: Magic method App\Models\Part::wherename does not exist

--- a/tests/Unit/Handlers/Eloquent/ModelMethodHandlerInitTest.php
+++ b/tests/Unit/Handlers/Eloquent/ModelMethodHandlerInitTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Eloquent;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Handlers\Eloquent\ModelMethodHandler;
+
+#[CoversClass(ModelMethodHandler::class)]
+final class ModelMethodHandlerInitTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        ModelMethodHandler::init();
+    }
+
+    /**
+     * Regression: $unresolvedCache stores the dynamic-where existence verdict, which
+     * depends on the runtime-mutable DynamicWhereResolver::isEnabled() flag. If a
+     * previous "enabled" bootstrap cached `true` for a Model::where{Column} call, a
+     * subsequent "disabled" bootstrap in the same process must not inherit it — Plugin
+     * re-bootstrap calls ModelMethodHandler::init() to clear the cache alongside
+     * DynamicWhereResolver::reset().
+     */
+    #[Test]
+    public function init_clears_unresolved_cache_so_dynamic_where_verdict_does_not_leak_across_bootstraps(): void
+    {
+        ModelMethodHandler::registerCustomBuilder(StubModelForInit::class, StubBuilderForInit::class);
+
+        ModelMethodHandler::init();
+
+        // After init() the custom-builder map must be empty; otherwise a re-bootstrap
+        // would inherit registrations that the new run hasn't repopulated yet.
+        $reflection = new \ReflectionClass(ModelMethodHandler::class);
+        $prop = $reflection->getProperty('customBuilderMap');
+        $prop->setAccessible(true);
+        $this->assertSame([], $prop->getValue(), 'init() must clear the custom-builder map.');
+
+        $unresolved = $reflection->getProperty('unresolvedCache');
+        $unresolved->setAccessible(true);
+        $this->assertSame([], $unresolved->getValue(), 'init() must clear the unresolved-method cache so a config flip is honoured.');
+    }
+}
+
+/**
+ * @internal
+ */
+final class StubModelForInit extends Model {}
+
+/**
+ * @internal
+ * @extends Builder<StubModelForInit>
+ */
+final class StubBuilderForInit extends Builder {}

--- a/tests/Unit/Util/DynamicWhereResolverTest.php
+++ b/tests/Unit/Util/DynamicWhereResolverTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Util;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Util\DynamicWhereResolver;
+
+#[CoversClass(DynamicWhereResolver::class)]
+final class DynamicWhereResolverTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        DynamicWhereResolver::reset();
+    }
+
+    #[Test]
+    public function isDynamicWhereMethod_recognises_prefixed_methods(): void
+    {
+        $this->assertTrue(DynamicWhereResolver::isDynamicWhereMethod('whereid'));
+        $this->assertTrue(DynamicWhereResolver::isDynamicWhereMethod('wherefirstnameandlastname'));
+
+        $this->assertFalse(DynamicWhereResolver::isDynamicWhereMethod('where'));
+        $this->assertFalse(DynamicWhereResolver::isDynamicWhereMethod('wher'));
+        $this->assertFalse(DynamicWhereResolver::isDynamicWhereMethod('orWhereTitle'));
+    }
+
+    #[Test]
+    public function reset_clears_enable_flag_so_config_flip_takes_effect(): void
+    {
+        DynamicWhereResolver::enable();
+        $this->assertTrue(DynamicWhereResolver::isEnabled());
+
+        DynamicWhereResolver::reset();
+
+        // A subsequent bootstrap that does NOT re-call enable() must observe the flag
+        // back at its default state. Without this, a previously-enabled run would leak
+        // into a `<resolveDynamicWhereClauses value="false" />` configuration in the
+        // same process.
+        $this->assertFalse(
+            DynamicWhereResolver::isEnabled(),
+            'reset() must clear the enable flag so a true->false config flip is honoured on the next bootstrap.',
+        );
+    }
+
+    #[Test]
+    public function variadicMixedParams_returns_single_variadic_mixed_param(): void
+    {
+        $params = DynamicWhereResolver::variadicMixedParams();
+
+        $this->assertCount(1, $params);
+        $this->assertSame('args', $params[0]->name);
+        $this->assertTrue($params[0]->is_variadic);
+        $this->assertNotNull($params[0]->type);
+        $this->assertTrue($params[0]->type->isMixed());
+    }
+}


### PR DESCRIPTION
## Issue to Solve

`Model::whereColumn(...)` and `(new Model())->whereColumn(...)` raised `UndefinedMagicMethod` even when `column` matched an `@property` declaration on the model. The plugin only resolved dynamic `where{Column}` magic methods on Eloquent Relation chains; the same call directly on a Model fell through.

Observed in real-world apps (e.g. `coolify`, `invoiceninja`).

## Related

Closes #1000.
Related: #647 (original relation-chain support), #927 (multi-segment), #928 (typed-param hand-off).

## Solution Description

Extracted the dynamic-where validation cache, segment splitter, column-type lookup, and typed-param hand-off cache from `MethodForwardingHandler` into a shared `Util\DynamicWhereResolver`. Both consumers now go through the util:

- `MethodForwardingHandler` (Relation paths, unchanged behaviour).
- `ModelMethodHandler` (new: direct Model static / instance calls).

`ModelMethodHandler` extends its existing existence / params / return-type providers (already registered per concrete model by `ModelRegistrationHandler`) with dynamic-where branches:

- **Existence** uses a bounded lowercase backtracking matcher (`DynamicWhereResolver::methodMatchesColumns`) because `MethodExistenceProviderEvent` has no AST. False positives are bounded by the declared `@property` set.
- **Return type** uses the strict camel-cased validator (`resolveColumnType`) on `$event->getStmt()` and returns `Builder<TModel>` (or the registered custom builder).
- **Params** consume the `#928` typed-param hand-off for single-segment scalar columns, falling back to variadic mixed otherwise (mirrors Larastan's `DynamicWhereParameterReflection`).

Gated on the existing `<resolveDynamicWhereClauses value="..." />` config flag; the flag now lives on the util and is enabled from `Plugin::registerHandlers()`.

Verified producer/consumer ordering against `AtomicStaticCallAnalyzer.php:593-637` (static path: return-type provider fires before `CallAnalyzer::checkMethodArgs`) and `AtomicMethodCallAnalyzer.php:399` → `MissingMethodCallHandler::handleMagicMethod` (instance path: same order as relation chains). The `spl_object_id`-keyed hand-off cache is safe across both branches.

Coverage:

- New `tests/Type/tests/Model/DynamicWhereOnModelTest.phpt` covers static + instance calls, chained `->first()`, multi-segment `And`/`Or`, underscored multi-word columns, scalar-mismatch error, non-scalar (Carbon) column accepted, multi-segment variadic fallback, unknown column still `UndefinedMagicMethod`, and both custom-builder routes (`#[UseEloquentBuilder]` via `Invoice`, `newEloquentBuilder()` override via `Vehicle`).
- `tests/Type/tests/Relation/DynamicWhereDisabledTest.phpt` extended with Model-direct disabled-flag coverage.
- `tests/Type/tests/Model/StaticBuilderForwardingTest.phpt` flipped from the documented `UndefinedMagicMethod` expectation to `Builder<Customer>`.

`docs/config.md` updated to describe the new direct-Model behaviour.

## Checklist

- [x] Tests cover the change (type tests in `tests/Type/tests/Model/` and `tests/Type/tests/Relation/`)
- [x] Documentation is updated (`docs/config.md`, `MethodForwardingHandler` class docblock, `DynamicWhereResolver` docblocks)
