### PR TITLE
Resolve `Builder::find($mixed)` widening to `Collection|TModel|null`

### DIFF
--- a/src/Handlers/Eloquent/BuilderFindMixedHandler.php
+++ b/src/Handlers/Eloquent/BuilderFindMixedHandler.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Eloquent;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
+use Illuminate\Database\Eloquent\Relations\HasOneOrManyThrough;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use Psalm\NodeTypeProvider;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\Type;
+use Psalm\Type\Atomic\TCallableObject;
+use Psalm\Type\Atomic\TClosure;
+use Psalm\Type\Atomic\TIterable;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Atomic\TObjectWithProperties;
+use Psalm\Type\Atomic\TTemplateParam;
+use Psalm\Type\Union;
+
+/**
+ * Collapses `Builder::find($mixed)` (and `findOrFail` / `findOrNew` / `findOr`)
+ * to the scalar-id branch when the argument is `mixed`. Also covers the
+ * relation classes that re-declare these methods with their own conditionals
+ * (`BelongsToMany`, `HasManyThrough`, `HasOneOrManyThrough`, `HasOneOrMany`).
+ *
+ * The stub uses a template conditional:
+ *
+ *     @template T
+ *     @param T $id
+ *     @psalm-return (T is (array|Arrayable) ? Collection<int, TModel> : TModel|null)
+ *
+ * When the caller's `$id` is `mixed` (e.g., property access on `\stdClass`
+ * returned by `\DB::select()`), Psalm cannot prove `mixed is array|Arrayable`
+ * either way, so it widens the result to the union of both branches:
+ * `Collection<int, TModel>|TModel|null`. Downstream `$model->prop = ...` then
+ * surfaces as `UndefinedPropertyAssignment` on the Collection branch.
+ *
+ * Larastan ships an `@method` overload pair on the stub, but Psalm stores
+ * pseudo-methods in `$storage->pseudo_methods[$lc_method_name]` — a
+ * last-write-wins map, not an overload set — so the overload approach is not
+ * portable. This handler implements the same trade-off Larastan makes: when
+ * the argument is `mixed`, return the scalar-id branch (`TModel|null` /
+ * `TModel`), accepting that callers who pass a `mixed` that is actually an
+ * array get the wrong narrowing in exchange for the common case (DB-row id
+ * lookups) staying clean. See `tests/Type/tests/Builder/FindMixedTradeOffTest.phpt`
+ * for the pinned trade-off.
+ *
+ * For `BelongsToMany`, the scalar-id branch carries a pivot intersection
+ * (`TRelatedModel&object{pivot: TPivotModel}`); the handler reconstructs that
+ * shape from the relation's templates (TPivotModel is at index 2). The other
+ * covered relations do not carry pivot intersections.
+ *
+ * Non-mixed argument types are deferred to the stub, where the conditional
+ * resolves correctly.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/975
+ * @internal
+ */
+final class BuilderFindMixedHandler implements MethodReturnTypeProviderInterface
+{
+    private const METHOD_FIND = 'find';
+    private const METHOD_FIND_OR_FAIL = 'findorfail';
+    private const METHOD_FIND_OR_NEW = 'findornew';
+    private const METHOD_FIND_OR = 'findor';
+
+    /**
+     * @var array<string, true>
+     */
+    private const TARGET_METHODS = [
+        self::METHOD_FIND => true,
+        self::METHOD_FIND_OR_FAIL => true,
+        self::METHOD_FIND_OR_NEW => true,
+        self::METHOD_FIND_OR => true,
+    ];
+
+    /**
+     * Pivot template-parameter index per class. The class must be in
+     * `getClassLikeNames()` to reach the handler; `null` means the class has
+     * no pivot intersection (use bare TRelatedModel).
+     *
+     * @var array<class-string, int|null>
+     */
+    private const PIVOT_TEMPLATE_INDEX = [
+        Builder::class => null,
+        HasOneOrMany::class => null,
+        HasManyThrough::class => null,
+        HasOneOrManyThrough::class => null,
+        BelongsToMany::class => 2,
+    ];
+
+    /**
+     * Cache for the `null` Union combined with `TModel` in the scalar-id
+     * branch. `Type::getNull()` is not memoized inside Psalm — every call
+     * allocates a fresh `TNull` + `Union`. Caching saves an allocation pair on
+     * every reachable `find($mixed)` call site analyzed by the worker.
+     */
+    private static ?Union $nullUnion = null;
+
+    /**
+     * @return list<string>
+     * @psalm-pure
+     */
+    #[\Override]
+    public static function getClassLikeNames(): array
+    {
+        return [
+            Builder::class,
+            HasOneOrMany::class,
+            HasManyThrough::class,
+            HasOneOrManyThrough::class,
+            BelongsToMany::class,
+        ];
+    }
+
+    #[\Override]
+    public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        $methodName = $event->getMethodNameLowercase();
+        if (!isset(self::TARGET_METHODS[$methodName])) {
+            return null;
+        }
+
+        $stmt = $event->getStmt();
+        if (!$stmt instanceof MethodCall) {
+            return null;
+        }
+
+        $args = $event->getCallArgs();
+        if ($args === []) {
+            return null;
+        }
+
+        $nodeTypeProvider = $event->getSource()->getNodeTypeProvider();
+        $idType = $nodeTypeProvider->getType($args[0]->value);
+        if ($idType === null || !$idType->isMixed()) {
+            return null;
+        }
+
+        $templateParams = $event->getTemplateTypeParameters();
+        if ($templateParams === null || !isset($templateParams[0])) {
+            return null;
+        }
+
+        $tModel = self::applyPivotIntersection(
+            tModel: $templateParams[0],
+            templateParams: $templateParams,
+            fqClassName: $event->getFqClasslikeName(),
+        );
+
+        return match ($methodName) {
+            self::METHOD_FIND => Type::combineUnionTypes($tModel, self::nullUnion()),
+            self::METHOD_FIND_OR_FAIL, self::METHOD_FIND_OR_NEW => $tModel,
+            self::METHOD_FIND_OR => Type::combineUnionTypes(
+                $tModel,
+                self::extractFindOrTValue($args, $nodeTypeProvider) ?? self::nullUnion(),
+            ),
+            default => null,
+        };
+    }
+
+    /**
+     * Wraps `$tModel` with `&object{pivot: TPivotModel}` for `BelongsToMany`,
+     * matching the stub's scalar-id branch. Returns `$tModel` unchanged for
+     * classes without a pivot template.
+     *
+     * @param list<Union> $templateParams
+     *
+     * @psalm-mutation-free
+     */
+    private static function applyPivotIntersection(
+        Union $tModel,
+        array $templateParams,
+        string $fqClassName,
+    ): Union {
+        $pivotIndex = self::PIVOT_TEMPLATE_INDEX[$fqClassName] ?? null;
+        if ($pivotIndex === null || !isset($templateParams[$pivotIndex])) {
+            return $tModel;
+        }
+
+        $pivotIntersection = new TObjectWithProperties(['pivot' => $templateParams[$pivotIndex]]);
+        $intersectionKey = $pivotIntersection->getKey();
+
+        $newAtomics = [];
+        foreach ($tModel->getAtomicTypes() as $atomic) {
+            // Only atomics that use HasIntersectionTrait support
+            // setIntersectionTypes(). Others (e.g. TNull) are passed through —
+            // they cannot carry the pivot intersection and forcing one would
+            // crash.
+            if (
+                $atomic instanceof TNamedObject
+                || $atomic instanceof TTemplateParam
+                || $atomic instanceof TObjectWithProperties
+                || $atomic instanceof TIterable
+                || $atomic instanceof TCallableObject
+            ) {
+                $existing = $atomic->getIntersectionTypes();
+                $existing[$intersectionKey] = $pivotIntersection;
+                $newAtomics[] = $atomic->setIntersectionTypes($existing);
+            } else {
+                $newAtomics[] = $atomic;
+            }
+        }
+
+        return new Union($newAtomics);
+    }
+
+    /**
+     * Resolves the `TValue` template that `findOr` returns when the lookup
+     * misses. The callback can be either argument 2 (Laravel's documented
+     * shape) or argument 1 (the `findOr($id, $callback)` convenience form
+     * where Builder swaps `$columns` for `$callback` internally).
+     *
+     * @param list<Arg> $args
+     */
+    private static function extractFindOrTValue(array $args, NodeTypeProvider $nodeTypeProvider): ?Union
+    {
+        foreach ([2, 1] as $argIndex) {
+            if (!isset($args[$argIndex])) {
+                continue;
+            }
+
+            $argType = $nodeTypeProvider->getType($args[$argIndex]->value);
+            if ($argType === null) {
+                continue;
+            }
+
+            foreach ($argType->getAtomicTypes() as $atomic) {
+                if (!$atomic instanceof TClosure) {
+                    continue;
+                }
+                if ($atomic->return_type !== null) {
+                    return $atomic->return_type;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * `Type::getNull()` is not memoized inside Psalm — every call allocates a
+     * fresh `TNull` + `Union`. The cache here saves an allocation pair on
+     * every reachable mixed-id call site analyzed by the worker.
+     *
+     * @psalm-external-mutation-free
+     */
+    private static function nullUnion(): Union
+    {
+        return self::$nullUnion ??= Type::getNull();
+    }
+}

--- a/src/Handlers/Eloquent/BuilderFindMixedHandler.php
+++ b/src/Handlers/Eloquent/BuilderFindMixedHandler.php
@@ -65,8 +65,11 @@ use Psalm\Type\Union;
 final class BuilderFindMixedHandler implements MethodReturnTypeProviderInterface
 {
     private const METHOD_FIND = 'find';
+
     private const METHOD_FIND_OR_FAIL = 'findorfail';
+
     private const METHOD_FIND_OR_NEW = 'findornew';
+
     private const METHOD_FIND_OR = 'findor';
 
     /**
@@ -138,7 +141,7 @@ final class BuilderFindMixedHandler implements MethodReturnTypeProviderInterface
 
         $nodeTypeProvider = $event->getSource()->getNodeTypeProvider();
         $idType = $nodeTypeProvider->getType($args[0]->value);
-        if ($idType === null || !$idType->isMixed()) {
+        if (!$idType instanceof \Psalm\Type\Union || !$idType->isMixed()) {
             return null;
         }
 
@@ -226,7 +229,7 @@ final class BuilderFindMixedHandler implements MethodReturnTypeProviderInterface
             }
 
             $argType = $nodeTypeProvider->getType($args[$argIndex]->value);
-            if ($argType === null) {
+            if (!$argType instanceof \Psalm\Type\Union) {
                 continue;
             }
 
@@ -234,7 +237,8 @@ final class BuilderFindMixedHandler implements MethodReturnTypeProviderInterface
                 if (!$atomic instanceof TClosure) {
                     continue;
                 }
-                if ($atomic->return_type !== null) {
+
+                if ($atomic->return_type instanceof \Psalm\Type\Union) {
                     return $atomic->return_type;
                 }
             }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -170,6 +170,8 @@ final class Plugin implements PluginEntryPointInterface
         $registration->registerHooksFromClass(Handlers\Eloquent\BuilderScopeHandler::class);
         require_once __DIR__ . '/Handlers/Eloquent/BuilderPluckHandler.php';
         $registration->registerHooksFromClass(Handlers\Eloquent\BuilderPluckHandler::class);
+        require_once __DIR__ . '/Handlers/Eloquent/BuilderFindMixedHandler.php';
+        $registration->registerHooksFromClass(Handlers\Eloquent\BuilderFindMixedHandler::class);
         $registration->registerHooksFromClass(Handlers\Eloquent\CustomCollectionHandler::class);
 
         require_once __DIR__ . '/Handlers/Collections/CollectionFilterHandler.php';

--- a/tests/Type/tests/Builder/FindMixedNarrowingTest.phpt
+++ b/tests/Type/tests/Builder/FindMixedNarrowingTest.phpt
@@ -1,0 +1,88 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use Illuminate\Database\Eloquent\Collection;
+
+/**
+ * Regression for #975. `Builder::find($mixed)` (and `findOrFail` / `findOrNew`)
+ * previously widened to `Collection<int, TModel>|TModel|null` because the
+ * stub uses a template conditional:
+ *
+ *   `psalm-return (T is (array|Arrayable) ? Collection<int, TModel> : TModel|null)`
+ *
+ * When the caller passes `mixed` (e.g., `$_client->client_id` where `$_client`
+ * is `\stdClass` from `\DB::select()`), Psalm cannot prove the negative branch
+ * and combines both, so chained `$client->prop = ...` surfaces as
+ * `UndefinedPropertyAssignment` on the spurious Collection branch.
+ *
+ * `BuilderFindMixedHandler` collapses the mixed case to the scalar-id branch
+ * (`TModel|null` / `TModel`), matching Larastan's overload trade-off. Concrete
+ * scalar/array arguments still narrow through the stub conditional.
+ * The `findOr` companion, the relation-class re-declarations (BelongsToMany
+ * pivot intersection, HasManyThrough/HasOneOrManyThrough/HasOneOrMany), and
+ * the accepted soundness trade-off (mixed-but-actually-array) are covered in
+ * sibling tests: FindOrMixedNarrowingTest, RelationFindMixedNarrowingTest,
+ * FindMixedTradeOffTest.
+ *
+ * From invoiceninja's app/Console/Commands/CheckData.php:
+ *
+ *   $client = Client::withTrashed()->find($_client->client_id);
+ *   $client->paid_to_date = $total_paid_to_date;
+ */
+function test_find_mixed_narrows_to_model_or_null(mixed $id): void
+{
+    $_r = Customer::find($id);
+    /** @psalm-check-type-exact $_r = Customer&static|null */
+}
+
+// The exact invoiceninja chain shape: SoftDeletes scope before find($mixed).
+// If withTrashed() ever drops the TModel template, this assertion regresses
+// before any downstream property access does.
+function test_find_mixed_via_with_trashed_narrows(mixed $id): void
+{
+    $_r = Customer::withTrashed()->find($id);
+    /** @psalm-check-type-exact $_r = Customer&static|null */
+}
+
+// Bare query() path. Note `Customer|null` (no `&static`): the Model::query()
+// stub returns `Builder<static>`, and Psalm strips the `&static` intersection
+// when binding through the explicit call. The handler returns whatever the
+// template parameter resolves to, so it matches the stub's pre-existing
+// behavior on this path (both literal and mixed args).
+function test_find_mixed_via_query_narrows(mixed $id): void
+{
+    $_r = Customer::query()->find($id);
+    /** @psalm-check-type-exact $_r = Customer|null */
+}
+
+function test_find_or_fail_mixed_narrows_to_model(mixed $id): void
+{
+    $_r = Customer::findOrFail($id);
+    /** @psalm-check-type-exact $_r = Customer&static */
+}
+
+function test_find_or_new_mixed_narrows_to_model(mixed $id): void
+{
+    $_r = Customer::findOrNew($id);
+    /** @psalm-check-type-exact $_r = Customer&static */
+}
+
+// Positive control: a literal int still narrows through the stub conditional.
+function test_find_int_narrows_to_model_or_null(): void
+{
+    $_r = Customer::find(123);
+    /** @psalm-check-type-exact $_r = Customer&static|null */
+}
+
+// Positive control: an array argument still narrows through the stub conditional.
+// Guards against the handler over-collapsing or a stub regression that drops
+// the conditional altogether.
+function test_find_array_narrows_to_collection(): void
+{
+    $_r = Customer::find([1, 2, 3]);
+    /** @psalm-check-type-exact $_r = Collection<int, Customer&static> */
+}
+
+?>
+--EXPECTF--

--- a/tests/Type/tests/Builder/FindMixedTradeOffTest.phpt
+++ b/tests/Type/tests/Builder/FindMixedTradeOffTest.phpt
@@ -1,0 +1,39 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use Illuminate\Database\Eloquent\Collection;
+
+/**
+ * Pins the accepted soundness trade-off in `BuilderFindMixedHandler` (#975).
+ *
+ * When the caller's `$id` is typed `mixed` but at runtime happens to be an
+ * `array` or `Arrayable`, Laravel returns a `Collection<int, TModel>`. The
+ * handler still narrows the static type to `TModel|null`, so subsequent
+ * property access on what is actually a Collection passes Psalm but fails at
+ * runtime. This is the same trade-off Larastan accepts via its `@method`
+ * overload pair; it is preferable to keeping the wider `Collection|TModel|null`
+ * union because that wider union breaks the vastly more common case (DB-row
+ * id lookup, e.g., `\DB::select()` returning `list<\stdClass>` whose property
+ * reads are `mixed` even though every value is scalar).
+ *
+ * If this test ever needs updating because the handler is refined to detect
+ * the mixed-but-array case (e.g., by inspecting the source expression for an
+ * obvious array narrowing), update both the assertion below and the inline
+ * docblock on `BuilderFindMixedHandler` to reflect the new behavior.
+ */
+function trade_off_mixed_that_is_actually_array(array $ids): void
+{
+    /** @var mixed $erased At runtime $erased is `array<int>`; declared as mixed to mimic stdClass property reads. */
+    $erased = $ids;
+
+    // Customer::find($erased) at runtime returns Collection<int, Customer>,
+    // not Customer|null. The handler reports the scalar branch anyway —
+    // that's the accepted trade-off. Pinning the inferred type makes the
+    // soundness gap visible to anyone reading these tests.
+    $_r = Customer::find($erased);
+    /** @psalm-check-type-exact $_r = Customer&static|null */
+}
+
+?>
+--EXPECTF--

--- a/tests/Type/tests/Builder/FindOrMixedNarrowingTest.phpt
+++ b/tests/Type/tests/Builder/FindOrMixedNarrowingTest.phpt
@@ -1,0 +1,37 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use Illuminate\Database\Eloquent\Collection;
+
+/**
+ * Companion to FindMixedNarrowingTest for #975. `Builder::findOr($mixed, fn)`
+ * has the same conditional widening as `find()` plus an extra `TValue` template
+ * from the callback. The handler collapses the mixed case to `TModel|TValue`,
+ * with TValue resolved from the closure's return type.
+ *
+ * Laravel accepts the callback at arg position 1 (`findOr($id, $callback)`) or
+ * arg position 2 (`findOr($id, $columns, $callback)`); the handler probes both.
+ */
+function test_find_or_mixed_with_callback_at_arg2(mixed $id): void
+{
+    $_r = Customer::query()->findOr($id, ['id'], fn() => 'fallback');
+    /** @psalm-check-type-exact $_r = Customer|'fallback' */
+}
+
+function test_find_or_mixed_with_callback_at_arg1(mixed $id): void
+{
+    $_r = Customer::query()->findOr($id, fn() => 'fallback');
+    /** @psalm-check-type-exact $_r = Customer|'fallback' */
+}
+
+function test_find_or_mixed_no_callback_falls_back_to_null(mixed $id): void
+{
+    // Default callback is null at runtime — the handler returns TModel|null
+    // when no closure is found in the arg list.
+    $_r = Customer::query()->findOr($id);
+    /** @psalm-check-type-exact $_r = Customer|null */
+}
+
+?>
+--EXPECTF--

--- a/tests/Type/tests/Builder/RelationFindMixedNarrowingTest.phpt
+++ b/tests/Type/tests/Builder/RelationFindMixedNarrowingTest.phpt
@@ -1,0 +1,74 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use App\Models\Mechanic;
+use App\Models\MechanicSpecialization;
+use App\Models\WorkOrder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+/**
+ * Companion to FindMixedNarrowingTest for #975. The relation classes
+ * `BelongsToMany`, `HasManyThrough`, `HasOneOrManyThrough`, and `HasOneOrMany`
+ * re-declare find/findOrFail/findOrNew with their own conditionals, so they
+ * widen the same way when `$id` is `mixed`. The handler collapses each to the
+ * scalar-id branch.
+ *
+ * For `BelongsToMany`, the scalar-id branch carries the
+ * `&object{pivot: TPivotModel}` intersection from the stub. The handler
+ * reconstructs that shape from the relation's TPivotModel template (index 2);
+ * stripping it would break callers that rely on `$model->pivot` afterwards.
+ */
+function test_belongs_to_many_find_mixed_narrows_with_pivot(Mechanic $mechanic, mixed $id): void
+{
+    $_r = $mechanic->specializations()->find($id);
+    /** @psalm-check-type-exact $_r = MechanicSpecialization&object{pivot: Pivot}|null */
+}
+
+function test_belongs_to_many_find_or_fail_mixed_narrows_with_pivot(Mechanic $mechanic, mixed $id): void
+{
+    $_r = $mechanic->specializations()->findOrFail($id);
+    /** @psalm-check-type-exact $_r = MechanicSpecialization&object{pivot: Pivot} */
+}
+
+function test_belongs_to_many_find_or_new_mixed_narrows_with_pivot(Mechanic $mechanic, mixed $id): void
+{
+    $_r = $mechanic->specializations()->findOrNew($id);
+    /** @psalm-check-type-exact $_r = MechanicSpecialization&object{pivot: Pivot} */
+}
+
+function test_belongs_to_many_find_or_mixed_narrows_with_pivot(Mechanic $mechanic, mixed $id): void
+{
+    $_r = $mechanic->specializations()->findOr($id, fn() => 'fallback');
+    /** @psalm-check-type-exact $_r = MechanicSpecialization&object{pivot: Pivot}|'fallback' */
+}
+
+function test_has_many_through_find_mixed_narrows(Customer $customer, mixed $id): void
+{
+    $_r = $customer->workOrders()->find($id);
+    /** @psalm-check-type-exact $_r = WorkOrder|null */
+}
+
+function test_has_many_through_find_or_fail_mixed_narrows(Customer $customer, mixed $id): void
+{
+    $_r = $customer->workOrders()->findOrFail($id);
+    /** @psalm-check-type-exact $_r = WorkOrder */
+}
+
+// Positive controls — concrete int + array args still resolve through the
+// stub conditional, even on relation paths where the handler is registered.
+function test_belongs_to_many_find_int_still_narrows_to_model(Mechanic $mechanic): void
+{
+    $_r = $mechanic->specializations()->find(123);
+    /** @psalm-check-type-exact $_r = MechanicSpecialization&object{pivot: Pivot}|null */
+}
+
+function test_belongs_to_many_find_array_still_narrows_to_collection(Mechanic $mechanic): void
+{
+    $_r = $mechanic->specializations()->find([1, 2, 3]);
+    /** @psalm-check-type-exact $_r = Collection<int, MechanicSpecialization&object{pivot: Pivot}>|null */
+}
+
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeSsrfEloquentFetch.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeSsrfEloquentFetch.phpt
@@ -31,8 +31,10 @@ class StatusModel extends \Illuminate\Database\Eloquent\Model
     }
 }
 
-// find/findOrFail pass mixed $id into a typed template parameter → MixedArgument needed
-/** @psalm-suppress MixedAssignment, MixedArgument */
+// BuilderFindMixedHandler (#975) collapses find/findOrFail($mixed) to TModel|null / TModel,
+// so the call site no longer raises MixedArgument; only the $id = $request->input('id')
+// assignment needs suppressing.
+/** @psalm-suppress MixedAssignment */
 function noSsrfViaFindOrFail(\Illuminate\Http\Request $request): void
 {
     $id = $request->input('id');
@@ -40,7 +42,7 @@ function noSsrfViaFindOrFail(\Illuminate\Http\Request $request): void
     redirect($status->getRedirectUrl());
 }
 
-/** @psalm-suppress MixedAssignment, MixedArgument */
+/** @psalm-suppress MixedAssignment */
 function noSsrfViaFind(\Illuminate\Http\Request $request): void
 {
     $id = $request->input('id');


### PR DESCRIPTION
## Issue to Solve

`Builder::find/findOrFail/findOrNew/findOr` widen to `Collection<int, TModel>|TModel|null` when the argument is `mixed`. Psalm's `TemplateInferredTypeReplacer` cannot place `mixed` in either branch of the stub's `T is (array|Arrayable)` conditional, so it combines both. Downstream `$model->prop = ...` then surfaces as `UndefinedPropertyAssignment` on the spurious Collection branch.

The motivating real-world case is invoiceninja's `Client::withTrashed()->find($_client->client_id)` where `$_client` is a `\stdClass` from `\DB::select()` — every property read is `mixed` even though the runtime value is scalar.

## Related

Closes #975

## Solution Description

Larastan ships an `@method` overload pair on the stub. Psalm stores pseudo-methods last-write-wins in `$storage->pseudo_methods`, so the overload approach is not portable. New `BuilderFindMixedHandler` (`MethodReturnTypeProviderInterface`) collapses the mixed case to the scalar-id branch via the same trade-off:

- `find` → `TModel|null`
- `findOrFail` / `findOrNew` → `TModel`
- `findOr` → `TModel|TValue` (TValue from the callback closure at arg 1 or 2)

Concrete scalar/array arguments still narrow through the stub conditional.

Covers `Builder` and the four relation classes that re-declare the methods. `BelongsToMany`'s `&object{pivot: TPivotModel}` intersection is reconstructed from template index 2; other relations have no pivot.

The accepted soundness gap (mixed-truly-array → wrong narrowing) is pinned in `FindMixedTradeOffTest.phpt` so future readers see it.

Verification: 423/423 type tests, 632 unit, app exit 0, psalm self-check clean, cs clean.

## Checklist

- [x] Tests cover the change (4 new `.phpt` files under `tests/Type/tests/Builder/`)
- [x] Documentation: handler docblock + test header docs describe the trade-off
