### PR TITLE
Narrow Eloquent `Builder` aggregate returns using known column type

### DIFF
--- a/src/Handlers/Eloquent/BuilderAggregateHandler.php
+++ b/src/Handlers/Eloquent/BuilderAggregateHandler.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Eloquent;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Psalm\LaravelPlugin\Util\ModelPropertyResolver;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\Type;
+use Psalm\Type\Atomic\TFloat;
+use Psalm\Type\Atomic\TInt;
+use Psalm\Type\Atomic\TNull;
+use Psalm\Type\Union;
+
+/**
+ * Narrows Builder::sum/avg/average/min/max returns using the column's resolved
+ * Psalm type (user `@property` → cast → schema).
+ *
+ * Targets Eloquent Builder only (Query\Builder has no model template). Calls
+ * arriving via Eloquent's `@mixin Query\Builder` chain still surface the
+ * Eloquent template parameters on the event.
+ *
+ * Cast-aware min/max diverges from Laravel runtime: the query-level aggregate
+ * does NOT apply casts, but reporting the cast type matches the rest of the
+ * plugin's column-read view and the issue's stated request.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1004
+ * @internal
+ */
+final class BuilderAggregateHandler implements MethodReturnTypeProviderInterface
+{
+    /**
+     * Hash-lookup table for the method-name quick reject. Hoisted as a const so
+     * the array isn't reallocated on every Builder method call (this provider
+     * fires on the hot path).
+     */
+    private const AGGREGATE_METHODS = [
+        'sum' => true,
+        'avg' => true,
+        'average' => true,
+        'min' => true,
+        'max' => true,
+    ];
+
+    /**
+     * Registers both Builder classes because sum/avg/min/max are declared on
+     * Query\Builder and reached from Eloquent\Builder via `@mixin`. Psalm's
+     * {@see \Psalm\Internal\Analyzer\Statements\Expression\Call\Method\MethodCallReturnTypeFetcher}
+     * fires the provider for the premixin class first and the declaring class
+     * second — registering both ensures the call is resolved regardless of
+     * which leg picks up the model template.
+     *
+     * @return list<string>
+     * @psalm-pure
+     */
+    #[\Override]
+    public static function getClassLikeNames(): array
+    {
+        return [Builder::class, QueryBuilder::class];
+    }
+
+    #[\Override]
+    public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        $method = $event->getMethodNameLowercase();
+        if (!isset(self::AGGREGATE_METHODS[$method])) {
+            return null;
+        }
+
+        $args = $event->getCallArgs();
+        if ($args === []) {
+            return null;
+        }
+
+        $source = $event->getSource();
+        $argType = $source->getNodeTypeProvider()->getType($args[0]->value);
+        if (!$argType instanceof Union || !$argType->isSingleStringLiteral()) {
+            return null;
+        }
+        $columnName = $argType->getSingleStringLiteral()->value;
+
+        $modelClass = self::resolveModelClass($event);
+        if ($modelClass === null) {
+            return null;
+        }
+
+        $columnType = ModelPropertyHandler::resolveColumnType(
+            $source->getCodebase(),
+            $modelClass,
+            $columnName,
+        );
+        if (!$columnType instanceof Union) {
+            return null;
+        }
+
+        return match ($method) {
+            'sum' => self::narrowSum($columnType),
+            'avg', 'average' => self::narrowAvg($columnType),
+            'min', 'max' => self::narrowMinMax($columnType),
+        };
+    }
+
+    /**
+     * LHS fallback handles @mixin chains where event template params arrive
+     * unsubstituted (mirrors {@see ModelPropertyResolver::resolvePluckReturnType}).
+     *
+     * @return class-string<Model>|null
+     */
+    private static function resolveModelClass(MethodReturnTypeProviderEvent $event): ?string
+    {
+        $templateParams = $event->getTemplateTypeParameters();
+        $modelClass = ModelPropertyResolver::extractModelFromUnion($templateParams[0] ?? null);
+        if ($modelClass !== null) {
+            return $modelClass;
+        }
+
+        $stmt = $event->getStmt();
+        $lhsExpr = $stmt instanceof \PhpParser\Node\Expr\MethodCall ? $stmt->var : null;
+        if (!$lhsExpr instanceof \PhpParser\Node\Expr) {
+            return null;
+        }
+
+        $lhsType = $event->getSource()->getNodeTypeProvider()->getType($lhsExpr);
+        if (!$lhsType instanceof Union) {
+            return null;
+        }
+
+        foreach ($lhsType->getAtomicTypes() as $atomic) {
+            if (!$atomic instanceof Type\Atomic\TGenericObject) {
+                continue;
+            }
+            $model = ModelPropertyResolver::extractModelFromUnion($atomic->type_params[0] ?? null);
+            if ($model !== null) {
+                return $model;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * sum() upstream returns `$result ?: 0` so null is impossible. Pure int or pure float only.
+     *
+     * @psalm-mutation-free
+     */
+    private static function narrowSum(Union $columnType): ?Union
+    {
+        $shape = self::numericShape($columnType);
+        if ($shape === 'int') {
+            return Type::getInt();
+        }
+        if ($shape === 'float') {
+            return Type::getFloat();
+        }
+
+        return null;
+    }
+
+    /**
+     * avg() is null on empty table; numeric values land as float|int.
+     *
+     * @psalm-mutation-free
+     */
+    private static function narrowAvg(Union $columnType): ?Union
+    {
+        if (self::numericShape($columnType) === null) {
+            return null;
+        }
+
+        return new Union([new TInt(), new TFloat(), new TNull()]);
+    }
+
+    /**
+     * min()/max() return column type + null (empty table). Idempotent on already-nullable.
+     *
+     * @psalm-external-mutation-free
+     */
+    private static function narrowMinMax(Union $columnType): Union
+    {
+        if ($columnType->isNullable()) {
+            return $columnType;
+        }
+
+        return Type::combineUnionTypes($columnType, Type::getNull());
+    }
+
+    /**
+     * Returns `'int'` / `'float'` only when the column is one of those (optionally nullable).
+     * Mixed numerics, strings, numeric-string, TNumeric, objects → null (defer to stub).
+     *
+     * @psalm-mutation-free
+     */
+    private static function numericShape(Union $type): ?string
+    {
+        $hasInt = false;
+        $hasFloat = false;
+
+        foreach ($type->getAtomicTypes() as $atomic) {
+            if ($atomic instanceof TInt) {
+                $hasInt = true;
+                continue;
+            }
+            if ($atomic instanceof TFloat) {
+                $hasFloat = true;
+                continue;
+            }
+            if ($atomic instanceof TNull) {
+                continue;
+            }
+            return null;
+        }
+
+        if ($hasInt && !$hasFloat) {
+            return 'int';
+        }
+        if ($hasFloat && !$hasInt) {
+            return 'float';
+        }
+
+        return null;
+    }
+}

--- a/src/Handlers/Eloquent/BuilderAggregateHandler.php
+++ b/src/Handlers/Eloquent/BuilderAggregateHandler.php
@@ -81,6 +81,7 @@ final class BuilderAggregateHandler implements MethodReturnTypeProviderInterface
         if (!$argType instanceof Union || !$argType->isSingleStringLiteral()) {
             return null;
         }
+
         $columnName = $argType->getSingleStringLiteral()->value;
 
         $modelClass = self::resolveModelClass($event);
@@ -133,6 +134,7 @@ final class BuilderAggregateHandler implements MethodReturnTypeProviderInterface
             if (!$atomic instanceof Type\Atomic\TGenericObject) {
                 continue;
             }
+
             $model = ModelPropertyResolver::extractModelFromUnion($atomic->type_params[0] ?? null);
             if ($model !== null) {
                 return $model;
@@ -153,6 +155,7 @@ final class BuilderAggregateHandler implements MethodReturnTypeProviderInterface
         if ($shape === 'int') {
             return Type::getInt();
         }
+
         if ($shape === 'float') {
             return Type::getFloat();
         }
@@ -204,19 +207,23 @@ final class BuilderAggregateHandler implements MethodReturnTypeProviderInterface
                 $hasInt = true;
                 continue;
             }
+
             if ($atomic instanceof TFloat) {
                 $hasFloat = true;
                 continue;
             }
+
             if ($atomic instanceof TNull) {
                 continue;
             }
+
             return null;
         }
 
         if ($hasInt && !$hasFloat) {
             return 'int';
         }
+
         if ($hasFloat && !$hasInt) {
             return 'float';
         }

--- a/src/Handlers/Eloquent/ModelPropertyHandler.php
+++ b/src/Handlers/Eloquent/ModelPropertyHandler.php
@@ -138,6 +138,48 @@ final class ModelPropertyHandler
     }
 
     /**
+     * Public resolver mirroring {@see getPropertyType} (user `@property` → cast →
+     * schema), for handlers that need column types outside `PropertyTypeProviderEvent`
+     * (e.g. {@see \Psalm\LaravelPlugin\Handlers\Eloquent\BuilderAggregateHandler}).
+     *
+     * Slated to migrate behind `ModelMetadataRegistry::for($fqcn)` once the registry
+     * lands (see `.alies/docs/model-metadata-registry.md`); kept as a static here to
+     * minimize change surface for #1004.
+     *
+     * @param class-string<Model> $fqClasslikeName
+     */
+    public static function resolveColumnType(
+        \Psalm\Codebase $codebase,
+        string $fqClasslikeName,
+        string $columnName,
+    ): ?Union {
+        // Defensive vs. `getPropertyType`: the caller's FQCN can come from mixin
+        // template inference and may not be in the storage provider.
+        try {
+            $classStorage = $codebase->classlike_storage_provider->get($fqClasslikeName);
+        } catch (\InvalidArgumentException) {
+            return null;
+        }
+
+        $propertyType = $classStorage->pseudo_property_get_types['$' . $columnName] ?? null;
+        if ($propertyType instanceof Union) {
+            return $propertyType;
+        }
+
+        $column = self::resolveColumn($fqClasslikeName, $columnName);
+        if (!$column instanceof SchemaColumn) {
+            return null;
+        }
+
+        $casts = self::resolveCasts($codebase, $fqClasslikeName);
+        if (isset($casts[$columnName])) {
+            return CastResolver::resolve($casts[$columnName], $column->nullable);
+        }
+
+        return self::mapColumnType($column);
+    }
+
+    /**
      * Resolve all migration-inferred columns for a model.
      *
      * @return array<string, SchemaColumn>

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -106,8 +106,12 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Eloquent/FactoryCountTypeProvider.php';
         require_once __DIR__ . '/Handlers/Eloquent/ModelPropertyAccessorHandler.php';
         require_once __DIR__ . '/Handlers/Eloquent/ModelAttributeSubsetHandler.php';
+        // ModelPropertyHandler is loaded unconditionally because BuilderAggregateHandler
+        // calls ModelPropertyHandler::resolveColumnType() to narrow aggregate returns
+        // even when migrations are disabled (the @property branch still applies).
+        // Schema population (ModelRegistrationHandler::enableMigrations) stays gated.
+        require_once __DIR__ . '/Handlers/Eloquent/ModelPropertyHandler.php';
         if ($pluginConfig->shouldUseMigrations()) {
-            require_once __DIR__ . '/Handlers/Eloquent/ModelPropertyHandler.php';
             Handlers\Eloquent\ModelRegistrationHandler::enableMigrations();
         }
 
@@ -172,6 +176,8 @@ final class Plugin implements PluginEntryPointInterface
         $registration->registerHooksFromClass(Handlers\Eloquent\BuilderScopeHandler::class);
         require_once __DIR__ . '/Handlers/Eloquent/BuilderPluckHandler.php';
         $registration->registerHooksFromClass(Handlers\Eloquent\BuilderPluckHandler::class);
+        require_once __DIR__ . '/Handlers/Eloquent/BuilderAggregateHandler.php';
+        $registration->registerHooksFromClass(Handlers\Eloquent\BuilderAggregateHandler::class);
         $registration->registerHooksFromClass(Handlers\Eloquent\CustomCollectionHandler::class);
 
         require_once __DIR__ . '/Handlers/Collections/CollectionFilterHandler.php';

--- a/tests/Type/tests/Builder/BuilderAggregateTest.phpt
+++ b/tests/Type/tests/Builder/BuilderAggregateTest.phpt
@@ -1,0 +1,140 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use App\Models\Part;
+
+/**
+ * Builder::sum/avg/average/min/max should narrow the return type using the
+ * column's resolved Psalm type (user @property → cast → schema). The stub
+ * declares `numeric-string|int|float[|null]` for unknown columns; once we
+ * know the column is int / float / Carbon / etc, the operand types stop
+ * triggering InvalidOperand at every call site.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1004
+ */
+
+// --- sum() ---
+
+/** Customer has `@property int<0, max> $vehicles_count` → sum narrows to int. */
+function test_sum_on_int_column(): void
+{
+    $_result = Customer::query()->sum('vehicles_count');
+    /** @psalm-check-type-exact $_result = int */
+}
+
+/** Issue reproducer: summing across a chain in strict-operand mode. */
+function test_sum_chain_strict_operand(): void
+{
+    $_result = 100 + Customer::query()->where('active', true)->sum('vehicles_count');
+    /** @psalm-check-type-exact $_result = int */
+}
+
+/** Part has `@property float $unit_price` → sum narrows to float. */
+function test_sum_on_float_column(): void
+{
+    $_result = Part::query()->sum('unit_price');
+    /** @psalm-check-type-exact $_result = float */
+}
+
+/** Unknown column falls back to the stub's declared return. */
+function test_sum_on_unknown_column(): void
+{
+    $_result = Customer::query()->sum('unknown_column');
+    /** @psalm-check-type-exact $_result = float|int|numeric-string */
+}
+
+/** Dynamic column name → no literal → fall back to stub. */
+function test_sum_with_dynamic_column(string $column): void
+{
+    $_result = Customer::query()->sum($column);
+    /** @psalm-check-type-exact $_result = float|int|numeric-string */
+}
+
+// --- avg() / average() ---
+
+/** Numeric column → float|int|null (Laravel returns null on empty table). */
+function test_avg_on_int_column(): void
+{
+    $_result = Customer::query()->avg('vehicles_count');
+    /** @psalm-check-type-exact $_result = float|int|null */
+}
+
+/** average() is an alias for avg(). */
+function test_average_on_float_column(): void
+{
+    $_result = Part::query()->average('unit_price');
+    /** @psalm-check-type-exact $_result = float|int|null */
+}
+
+/** Non-numeric column (string id) → defer to stub. */
+function test_avg_on_non_numeric_column_defers(): void
+{
+    $_result = Customer::query()->avg('id');
+    /** @psalm-check-type-exact $_result = float|int|null|numeric-string */
+}
+
+// --- min() / max() ---
+
+/** Numeric column → column type | null (empty-table case). */
+function test_min_on_int_column(): void
+{
+    $_result = Customer::query()->min('vehicles_count');
+    /** @psalm-check-type-exact $_result = int<0, max>|null */
+}
+
+/** String column. */
+function test_max_on_string_column(): void
+{
+    $_result = Customer::query()->max('id');
+    /** @psalm-check-type-exact $_result = string|null */
+}
+
+/**
+ * Nullable column already includes null in @property — adding null is
+ * idempotent.
+ */
+function test_min_on_nullable_carbon_column(): void
+{
+    $_result = Customer::query()->min('email_verified_at');
+    /** @psalm-check-type-exact $_result = \Carbon\CarbonInterface|null */
+}
+
+/**
+ * Custom-cast / Carbon columns at the call site of a date aggregate produce
+ * the cast type plus null — matches the user-facing `@property` view, even
+ * though Laravel's query-level aggregate does not apply casts at runtime.
+ * Documented trade-off in BuilderAggregateHandler.
+ */
+function test_max_on_nullable_carbon_column(): void
+{
+    $_result = Customer::query()->max('email_verified_at');
+    /** @psalm-check-type-exact $_result = \Carbon\CarbonInterface|null */
+}
+
+// --- relation / static-call passthrough (matches BuilderPluckHandler coverage) ---
+
+/** Static call on model proxies through __callStatic to Builder<Customer>::sum(). */
+function test_sum_on_model_static(): void
+{
+    $_result = Customer::sum('vehicles_count');
+    /** @psalm-check-type-exact $_result = int */
+}
+
+/**
+ * Aggregate after a where() preserves the model template through the chain.
+ */
+function test_max_after_where(): void
+{
+    $_result = Customer::query()->where('active', true)->max('id');
+    /** @psalm-check-type-exact $_result = string|null */
+}
+
+/** Direct query on Vehicle (Vehicle has `@property string $make`). */
+function test_max_on_vehicle_query(): void
+{
+    $_result = \App\Models\Vehicle::query()->max('make');
+    /** @psalm-check-type-exact $_result = string|null */
+}
+?>
+--EXPECTF--

--- a/tests/Unit/Handlers/Eloquent/ResolveColumnTypeTest.php
+++ b/tests/Unit/Handlers/Eloquent/ResolveColumnTypeTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Eloquent;
+
+use App\Models\WorkOrder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\Codebase;
+use Psalm\Internal\Provider\ClassLikeStorageProvider;
+use Psalm\LaravelPlugin\Handlers\Eloquent\ModelPropertyHandler;
+use Psalm\Type;
+
+/**
+ * Covers the `@property` short-circuit path of {@see ModelPropertyHandler::resolveColumnType}
+ * (#1004), which {@see \Psalm\LaravelPlugin\Handlers\Eloquent\BuilderAggregateHandler} relies on
+ * for column-type narrowing.
+ *
+ * The schema and cast branches reach into `CastsMethodParser`, which dereferences
+ * `Codebase::$methods` — that property requires a fully-wired `Psalm\Internal\Codebase\Methods`
+ * instance (with `ClassLikes`, `FileReferenceProvider`, …) that cannot be cheaply faked in a
+ * unit test. Those branches are exercised end-to-end by the integration / app-test layer.
+ */
+#[CoversClass(ModelPropertyHandler::class)]
+final class ResolveColumnTypeTest extends TestCase
+{
+    private ClassLikeStorageProvider $classLikeStorageProvider;
+
+    private Codebase $codebase;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->classLikeStorageProvider = new ClassLikeStorageProvider();
+        $this->classLikeStorageProvider->create(WorkOrder::class);
+
+        $codebase = (new \ReflectionClass(Codebase::class))->newInstanceWithoutConstructor();
+        $codebase->classlike_storage_provider = $this->classLikeStorageProvider;
+        $this->codebase = $codebase;
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        $this->classLikeStorageProvider->remove(WorkOrder::class);
+        // Reset the schema set by `it_returns_null_when_no_property_and_no_schema`
+        // so later unit tests in the suite don't see a stray empty aggregator.
+        \Psalm\LaravelPlugin\Providers\SchemaStateProvider::setSchema(
+            new \Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaAggregator(),
+        );
+    }
+
+    #[Test]
+    public function it_returns_pseudo_property_get_type(): void
+    {
+        $storage = $this->classLikeStorageProvider->get(WorkOrder::class);
+        $storage->pseudo_property_get_types['$amount_cents'] = Type::getInt();
+
+        $type = ModelPropertyHandler::resolveColumnType($this->codebase, WorkOrder::class, 'amount_cents');
+
+        self::assertNotNull($type);
+        self::assertSame('int', (string) $type);
+    }
+
+    #[Test]
+    public function it_returns_user_property_with_object_type(): void
+    {
+        // Class-typed @property — proves resolveColumnType passes through non-scalar Unions
+        // (e.g. `@property CarbonInterface|null $created_at`) without rewriting them.
+        $storage = $this->classLikeStorageProvider->get(WorkOrder::class);
+        $storage->pseudo_property_get_types['$created_at'] = new \Psalm\Type\Union([
+            new \Psalm\Type\Atomic\TNamedObject(\Carbon\CarbonInterface::class),
+            new \Psalm\Type\Atomic\TNull(),
+        ]);
+
+        $type = ModelPropertyHandler::resolveColumnType($this->codebase, WorkOrder::class, 'created_at');
+
+        self::assertNotNull($type);
+        self::assertSame('Carbon\CarbonInterface|null', (string) $type);
+    }
+
+    #[Test]
+    public function it_returns_null_when_no_property_and_no_schema(): void
+    {
+        // No pseudo_property_get_types set; SchemaStateProvider has no schema for work_orders.
+        \Psalm\LaravelPlugin\Providers\SchemaStateProvider::setSchema(
+            new \Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaAggregator(),
+        );
+
+        $type = ModelPropertyHandler::resolveColumnType($this->codebase, WorkOrder::class, 'unknown_column');
+
+        self::assertNull($type);
+    }
+}

--- a/tests/Unit/Handlers/Eloquent/ResolveColumnTypeTest.php
+++ b/tests/Unit/Handlers/Eloquent/ResolveColumnTypeTest.php
@@ -60,8 +60,8 @@ final class ResolveColumnTypeTest extends TestCase
 
         $type = ModelPropertyHandler::resolveColumnType($this->codebase, WorkOrder::class, 'amount_cents');
 
-        self::assertNotNull($type);
-        self::assertSame('int', (string) $type);
+        $this->assertNotNull($type);
+        $this->assertSame('int', (string) $type);
     }
 
     #[Test]
@@ -77,8 +77,8 @@ final class ResolveColumnTypeTest extends TestCase
 
         $type = ModelPropertyHandler::resolveColumnType($this->codebase, WorkOrder::class, 'created_at');
 
-        self::assertNotNull($type);
-        self::assertSame('Carbon\CarbonInterface|null', (string) $type);
+        $this->assertNotNull($type);
+        $this->assertSame('Carbon\CarbonInterface|null', (string) $type);
     }
 
     #[Test]
@@ -91,6 +91,6 @@ final class ResolveColumnTypeTest extends TestCase
 
         $type = ModelPropertyHandler::resolveColumnType($this->codebase, WorkOrder::class, 'unknown_column');
 
-        self::assertNull($type);
+        $this->assertNull($type);
     }
 }


### PR DESCRIPTION
## Issue to Solve

`Illuminate\Database\Query\Builder::sum/avg/average/min/max` stubs declare `numeric-string|int|float[|null]` because PDO can return any of those for unknown columns. When the column type is known (user `@property`, `$casts`, or migration schema), the stub-wide union still trips `InvalidOperand` in strict-operand mode at every call site, e.g.:

```php
// `files.size` migration: $table->unsignedBigInteger('size')
$totalSizeInBytes = File::whereIn('vault_id', $vaultIds)->sum('size')
    + File::where('type', File::TYPE_AVATAR)->sum('size');
// → InvalidOperand: cannot process numeric types together in strict operands mode
```

## Related

Closes #1004

## Solution Description

New `BuilderAggregateHandler` (`MethodReturnTypeProviderInterface`) registered for `Illuminate\Database\Eloquent\Builder` and `Illuminate\Database\Query\Builder`. For each aggregate call it:

1. Extracts the column literal from the first argument.
2. Resolves the receiver model from the event's template parameters, falling back to the call's LHS type when `@mixin` chains leave templates unsubstituted (mirrors `BuilderPluckHandler`).
3. Calls a new public `ModelPropertyHandler::resolveColumnType(Codebase, class-string<Model>, string)` that walks `@property` → cast → schema, returning the resolved `Union` or `null`.
4. Narrows per method:
   - `sum()` → `int` or `float` (Laravel's `$result ?: 0` upstream rules out `null`).
   - `avg()` / `average()` → `float|int|null`.
   - `min()` / `max()` → column type + `null` (empty-table case, idempotent on already-nullable).
5. Defers to the stub when the column is decimal/numeric without a numeric cast, when the column name is dynamic, or when the model can't be resolved.

Doc trade-off noted in the handler: `min`/`max` on a `datetime`-cast column reports `CarbonInterface|null` to match the user's `@property` view, even though Laravel's query-level aggregate does not apply casts at runtime.

The `require_once` for `ModelPropertyHandler.php` is hoisted out of the `shouldUseMigrations()` gate because the `@property` branch of `resolveColumnType` works without schema data; hook registration of `ModelPropertyHandler`'s events remains gated.

## Verification

- New phpt: `tests/Type/tests/Builder/BuilderAggregateTest.phpt` (13 cases covering int/float/string/Carbon columns, unknown/dynamic column fallback, `avg`/`average` on non-numeric, static-call passthrough, chained `where()`, `Vehicle::query()->max('make')`).
- New unit test: `tests/Unit/Handlers/Eloquent/ResolveColumnTypeTest.php` covering the `@property` short-circuit. Schema/cast branches are reached only with a fully-wired `Codebase::$methods` (required by `CastsMethodParser`), which is impractical to fake at unit level — existing `ModelPropertyHandler::getPropertyType` has the same coverage shape.
- `composer test:type` (421 tests) — green.
- `composer test:unit` (685 tests) — green.
- `composer psalm` — clean.

## Known limitation

Aggregate calls on `Relation` receivers (e.g. `$customer->vehicles()->max('make')`) traverse a double `@mixin` chain (`Relation` → `Builder` → `Query\Builder`) that the LHS-type fallback in this PR doesn't unwind. Direct query forms (`Model::query()->sum(...)`), chained `where()`, and `Model::sum(...)` static-call forms are covered. Worth a separate issue.

## Checklist

- [x] Tests cover the change (phpt + unit)
