### PR TITLE
Narrow `config()` and `Repository::get()` return types

### DIFF
--- a/src/Handlers/Config/ConfigRepositoryMethodHandler.php
+++ b/src/Handlers/Config/ConfigRepositoryMethodHandler.php
@@ -14,28 +14,21 @@ use Psalm\Storage\FunctionLikeParameter;
 use Psalm\Type;
 
 /**
- * Narrows `Repository::get('some.key', $default)` (and the equivalent call on the
- * `\Illuminate\Contracts\Config\Repository` contract) to the runtime type of
- * `some.key`. Cross-receiver consistency with `Config::get(...)` is handled by
- * Psalm's facade pipeline — the facade resolves to the concrete Repository and
- * triggers this handler.
+ * Narrows `Repository::get()` (concrete + contract) and `Config::get()` (facade)
+ * to the runtime type reflected from the booted Laravel app.
  *
- * Other typed accessors (`string`, `integer`, `float`, `boolean`, `array`,
- * `collection`) are intentionally not handled here: their stub return types in
- * `stubs/common/Config/Repository.phpstub` are already precise (the stub even
- * tightens `$default` to reject scalars that would crash at runtime).
+ * Typed accessors (`string`, `integer`, `float`, `boolean`, `array`,
+ * `collection`) are not handled here — their stub return types in
+ * `stubs/common/Config/Repository.phpstub` are already precise.
  *
- * Solution 3 of https://github.com/psalm/psalm-plugin-laravel/issues/752.
+ * See https://github.com/psalm/psalm-plugin-laravel/issues/752.
  */
 final class ConfigRepositoryMethodHandler implements MethodReturnTypeProviderInterface, MethodParamsProviderInterface
 {
     /**
-     * Register for the concrete Repository, the contract, the Config facade,
-     * and any root-namespace alias resolving to the Repository binding.
-     * Psalm dispatches MethodReturnTypeProvider hooks by exact class name, so
-     * `Config::get(...)` (which uses `__callStatic` on the facade) needs the
-     * facade FQCN listed here — otherwise the facade pipeline falls through
-     * to the stub and the call site stays at `mixed`.
+     * Psalm dispatches `MethodReturnTypeProvider` by exact class name, so the
+     * facade FQCN (and any root-namespace alias) must be registered alongside
+     * the concrete/contract — otherwise `Config::get()` falls back to the stub.
      *
      * @inheritDoc
      * @return list<string>
@@ -60,10 +53,6 @@ final class ConfigRepositoryMethodHandler implements MethodReturnTypeProviderInt
             return null;
         }
 
-        // resolveFromCallArgs returns null for shapes the stub handles:
-        //   - 0 args
-        //   - array first arg (multi-key getMany form)
-        //   - dynamic first arg → mixed
         return ConfigKeyResolver::resolveFromCallArgs(
             $event->getCallArgs(),
             $event->getSource()->getNodeTypeProvider(),
@@ -71,19 +60,11 @@ final class ConfigRepositoryMethodHandler implements MethodReturnTypeProviderInt
     }
 
     /**
-     * Provide explicit `get()` params for the Config facade FQCN and any
-     * root-namespace alias that proxies to it.
-     *
-     * In Psalm 7, registering a class for a MethodReturnTypeProviderInterface
-     * and then returning null from getMethodParams for a method that only
-     * exists as a `@method` annotation on that class causes an
-     * UnexpectedValueException: Cannot get method params for ...::get crash.
-     * The same crash hit AuthMethodHandler — see #454 and #854.
-     *
-     * For the concrete Repository and the contract, defer to Psalm by returning
-     * null: get() is a real method on both, and letting Psalm derive params
-     * from the source keeps the signature in sync with future Laravel
-     * versions automatically.
+     * Synthesise `get()` params for the Facade FQCN (`@method`-declared only).
+     * Without this, Psalm 7 crashes with
+     * `Cannot get method params for ...::get` — same crash class as #454/#854.
+     * Defers to source for the real Repository + contract so future Laravel
+     * signature changes are picked up automatically.
      *
      * @inheritDoc
      * @psalm-mutation-free
@@ -103,6 +84,7 @@ final class ConfigRepositoryMethodHandler implements MethodReturnTypeProviderInt
             return null;
         }
 
+        // `@method static mixed get(array|string $key, mixed $default = null)`
         $stringOrArray = new Type\Union([
             new Type\Atomic\TString(),
             new Type\Atomic\TArray([Type::getArrayKey(), Type::getMixed()]),

--- a/src/Handlers/Config/ConfigRepositoryMethodHandler.php
+++ b/src/Handlers/Config/ConfigRepositoryMethodHandler.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Config;
+
+use Psalm\LaravelPlugin\Providers\FacadeMapProvider;
+use Psalm\LaravelPlugin\Util\ConfigKeyResolver;
+use Psalm\Plugin\EventHandler\Event\MethodParamsProviderEvent;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\MethodParamsProviderInterface;
+use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\Storage\FunctionLikeParameter;
+use Psalm\Type;
+
+/**
+ * Narrows `Repository::get('some.key', $default)` (and the equivalent call on the
+ * `\Illuminate\Contracts\Config\Repository` contract) to the runtime type of
+ * `some.key`. Cross-receiver consistency with `Config::get(...)` is handled by
+ * Psalm's facade pipeline — the facade resolves to the concrete Repository and
+ * triggers this handler.
+ *
+ * Other typed accessors (`string`, `integer`, `float`, `boolean`, `array`,
+ * `collection`) are intentionally not handled here: their stub return types in
+ * `stubs/common/Config/Repository.phpstub` are already precise (the stub even
+ * tightens `$default` to reject scalars that would crash at runtime).
+ *
+ * Solution 3 of https://github.com/psalm/psalm-plugin-laravel/issues/752.
+ */
+final class ConfigRepositoryMethodHandler implements MethodReturnTypeProviderInterface, MethodParamsProviderInterface
+{
+    /**
+     * Register for the concrete Repository, the contract, the Config facade,
+     * and any root-namespace alias resolving to the Repository binding.
+     * Psalm dispatches MethodReturnTypeProvider hooks by exact class name, so
+     * `Config::get(...)` (which uses `__callStatic` on the facade) needs the
+     * facade FQCN listed here — otherwise the facade pipeline falls through
+     * to the stub and the call site stays at `mixed`.
+     *
+     * @inheritDoc
+     * @return list<string>
+     * @psalm-external-mutation-free
+     */
+    #[\Override]
+    public static function getClassLikeNames(): array
+    {
+        return [
+            \Illuminate\Config\Repository::class,
+            \Illuminate\Contracts\Config\Repository::class,
+            \Illuminate\Support\Facades\Config::class,
+            ...FacadeMapProvider::getFacadeClasses(\Illuminate\Config\Repository::class),
+        ];
+    }
+
+    /** @inheritDoc */
+    #[\Override]
+    public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Type\Union
+    {
+        if ($event->getMethodNameLowercase() !== 'get') {
+            return null;
+        }
+
+        // resolveFromCallArgs returns null for shapes the stub handles:
+        //   - 0 args
+        //   - array first arg (multi-key getMany form)
+        //   - dynamic first arg → mixed
+        return ConfigKeyResolver::resolveFromCallArgs(
+            $event->getCallArgs(),
+            $event->getSource()->getNodeTypeProvider(),
+        );
+    }
+
+    /**
+     * Provide explicit `get()` params for the Config facade FQCN and any
+     * root-namespace alias that proxies to it.
+     *
+     * In Psalm 7, registering a class for a MethodReturnTypeProviderInterface
+     * and then returning null from getMethodParams for a method that only
+     * exists as a `@method` annotation on that class causes an
+     * UnexpectedValueException: Cannot get method params for ...::get crash.
+     * The same crash hit AuthMethodHandler — see #454 and #854.
+     *
+     * For the concrete Repository and the contract, defer to Psalm by returning
+     * null: get() is a real method on both, and letting Psalm derive params
+     * from the source keeps the signature in sync with future Laravel
+     * versions automatically.
+     *
+     * @inheritDoc
+     * @psalm-mutation-free
+     */
+    #[\Override]
+    public static function getMethodParams(MethodParamsProviderEvent $event): ?array
+    {
+        if ($event->getMethodNameLowercase() !== 'get') {
+            return null;
+        }
+
+        $fqcn = $event->getFqClasslikeName();
+
+        if ($fqcn === \Illuminate\Config\Repository::class
+            || $fqcn === \Illuminate\Contracts\Config\Repository::class
+        ) {
+            return null;
+        }
+
+        $stringOrArray = new Type\Union([
+            new Type\Atomic\TString(),
+            new Type\Atomic\TArray([Type::getArrayKey(), Type::getMixed()]),
+        ]);
+
+        return [
+            new FunctionLikeParameter('key', false, $stringOrArray, $stringOrArray, is_optional: false),
+            new FunctionLikeParameter(
+                'default',
+                false,
+                Type::getMixed(),
+                Type::getMixed(),
+                is_optional: true,
+                default_type: Type::getNull(),
+            ),
+        ];
+    }
+}

--- a/src/Handlers/Helpers/ConfigHelperHandler.php
+++ b/src/Handlers/Helpers/ConfigHelperHandler.php
@@ -10,18 +10,13 @@ use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
 use Psalm\Type;
 
 /**
- * Narrows `config('some.key', $default)` to the runtime type of `some.key` from
- * the booted Laravel app, generalized so env-driven scalars don't collapse to
- * their observed-default literal (see {@see \Psalm\LaravelPlugin\Util\ConfigValueReflector}).
+ * Narrows `config('some.key', $default)` to the runtime value from the booted
+ * Laravel app (generalized — see {@see \Psalm\LaravelPlugin\Util\ConfigValueReflector}).
  *
- * Defers to the existing helpers stub when the call shape is incompatible with
- * key-based reflection:
+ * Defers to the helpers stub on non-narrowable shapes (no args → Repository;
+ * array first arg → null setter form; dynamic key → mixed).
  *
- *  - `config()`           → stub returns Repository
- *  - `config(['k' => v])` → stub returns null (setter form)
- *  - `config($dynamicKey)` → stub returns mixed (key cannot be statically resolved)
- *
- * Solution 3 of https://github.com/psalm/psalm-plugin-laravel/issues/752.
+ * See https://github.com/psalm/psalm-plugin-laravel/issues/752.
  */
 final class ConfigHelperHandler implements FunctionReturnTypeProviderInterface
 {
@@ -39,10 +34,6 @@ final class ConfigHelperHandler implements FunctionReturnTypeProviderInterface
     #[\Override]
     public static function getFunctionReturnType(FunctionReturnTypeProviderEvent $event): ?Type\Union
     {
-        // resolveFromCallArgs returns null for shapes the stub handles:
-        //   - 0 args → Repository
-        //   - array first arg → null (setter form)
-        //   - dynamic first arg → mixed
         return ConfigKeyResolver::resolveFromCallArgs(
             $event->getCallArgs(),
             $event->getStatementsSource()->getNodeTypeProvider(),

--- a/src/Handlers/Helpers/ConfigHelperHandler.php
+++ b/src/Handlers/Helpers/ConfigHelperHandler.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Helpers;
+
+use Psalm\LaravelPlugin\Util\ConfigKeyResolver;
+use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
+use Psalm\Type;
+
+/**
+ * Narrows `config('some.key', $default)` to the runtime type of `some.key` from
+ * the booted Laravel app, generalized so env-driven scalars don't collapse to
+ * their observed-default literal (see {@see \Psalm\LaravelPlugin\Util\ConfigValueReflector}).
+ *
+ * Defers to the existing helpers stub when the call shape is incompatible with
+ * key-based reflection:
+ *
+ *  - `config()`           → stub returns Repository
+ *  - `config(['k' => v])` → stub returns null (setter form)
+ *  - `config($dynamicKey)` → stub returns mixed (key cannot be statically resolved)
+ *
+ * Solution 3 of https://github.com/psalm/psalm-plugin-laravel/issues/752.
+ */
+final class ConfigHelperHandler implements FunctionReturnTypeProviderInterface
+{
+    /**
+     * @inheritDoc
+     * @psalm-pure
+     */
+    #[\Override]
+    public static function getFunctionIds(): array
+    {
+        return ['config'];
+    }
+
+    /** @inheritDoc */
+    #[\Override]
+    public static function getFunctionReturnType(FunctionReturnTypeProviderEvent $event): ?Type\Union
+    {
+        // resolveFromCallArgs returns null for shapes the stub handles:
+        //   - 0 args → Repository
+        //   - array first arg → null (setter form)
+        //   - dynamic first arg → mixed
+        return ConfigKeyResolver::resolveFromCallArgs(
+            $event->getCallArgs(),
+            $event->getStatementsSource()->getNodeTypeProvider(),
+        );
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -231,6 +231,7 @@ final class Plugin implements PluginEntryPointInterface
             require_once __DIR__ . '/Handlers/Config/ConfigRepositoryMethodHandler.php';
             $registration->registerHooksFromClass(Handlers\Config\ConfigRepositoryMethodHandler::class);
         }
+
         require_once __DIR__ . '/Handlers/Translations/TranslationKeyHandler.php';
         $registration->registerHooksFromClass(Handlers\Translations\TranslationKeyHandler::class);
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -218,13 +218,19 @@ final class Plugin implements PluginEntryPointInterface
         // config() helper + Repository::get() narrowing — reflect runtime config
         // values from the booted Laravel app. See
         // https://github.com/psalm/psalm-plugin-laravel/issues/752.
-        require_once __DIR__ . '/Util/ConfigValueReflector.php';
-        require_once __DIR__ . '/Util/ThrowingConfigRepository.php';
-        require_once __DIR__ . '/Util/ConfigKeyResolver.php';
-        require_once __DIR__ . '/Handlers/Helpers/ConfigHelperHandler.php';
-        $registration->registerHooksFromClass(Handlers\Helpers\ConfigHelperHandler::class);
-        require_once __DIR__ . '/Handlers/Config/ConfigRepositoryMethodHandler.php';
-        $registration->registerHooksFromClass(Handlers\Config\ConfigRepositoryMethodHandler::class);
+        // Opt-out via `<resolveConfigReturnTypes value="false" />` for apps that
+        // construct ad-hoc Repository instances (false positives possible — the
+        // handler can't tell a fresh `new Repository([])` apart from the booted
+        // singleton at analysis time).
+        if ($pluginConfig->resolveConfigReturnTypes) {
+            require_once __DIR__ . '/Util/ConfigValueReflector.php';
+            require_once __DIR__ . '/Util/ThrowingConfigRepository.php';
+            require_once __DIR__ . '/Util/ConfigKeyResolver.php';
+            require_once __DIR__ . '/Handlers/Helpers/ConfigHelperHandler.php';
+            $registration->registerHooksFromClass(Handlers\Helpers\ConfigHelperHandler::class);
+            require_once __DIR__ . '/Handlers/Config/ConfigRepositoryMethodHandler.php';
+            $registration->registerHooksFromClass(Handlers\Config\ConfigRepositoryMethodHandler::class);
+        }
         require_once __DIR__ . '/Handlers/Translations/TranslationKeyHandler.php';
         $registration->registerHooksFromClass(Handlers\Translations\TranslationKeyHandler::class);
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -214,6 +214,17 @@ final class Plugin implements PluginEntryPointInterface
         $registration->registerHooksFromClass(Handlers\Helpers\NowTodayHandler::class);
         require_once __DIR__ . '/Handlers/Helpers/PathHandler.php';
         $registration->registerHooksFromClass(Handlers\Helpers\PathHandler::class);
+
+        // config() helper + Repository::get() narrowing — reflect runtime config
+        // values from the booted Laravel app. See
+        // https://github.com/psalm/psalm-plugin-laravel/issues/752.
+        require_once __DIR__ . '/Util/ConfigValueReflector.php';
+        require_once __DIR__ . '/Util/ThrowingConfigRepository.php';
+        require_once __DIR__ . '/Util/ConfigKeyResolver.php';
+        require_once __DIR__ . '/Handlers/Helpers/ConfigHelperHandler.php';
+        $registration->registerHooksFromClass(Handlers\Helpers\ConfigHelperHandler::class);
+        require_once __DIR__ . '/Handlers/Config/ConfigRepositoryMethodHandler.php';
+        $registration->registerHooksFromClass(Handlers\Config\ConfigRepositoryMethodHandler::class);
         require_once __DIR__ . '/Handlers/Translations/TranslationKeyHandler.php';
         $registration->registerHooksFromClass(Handlers\Translations\TranslationKeyHandler::class);
 

--- a/src/PluginConfig.php
+++ b/src/PluginConfig.php
@@ -25,6 +25,7 @@ final readonly class PluginConfig
         public ColumnFallback $modelPropertiesColumnFallback,
         public array $configDirectories,
         public bool $resolveDynamicWhereClauses,
+        public bool $resolveConfigReturnTypes,
         public bool $findMissingTranslations,
         public bool $findMissingViews,
         /**
@@ -60,12 +61,14 @@ final readonly class PluginConfig
         $findMissingViews = self::xmlBoolAttr($config?->findMissingViews, 'findMissingViews');
         $findOctaneIncompatibleBinding = self::xmlOptionalBoolAttr($config?->findOctaneIncompatibleBinding, 'findOctaneIncompatibleBinding');
         $resolveDynamicWhereClauses = self::xmlBoolAttr($config?->resolveDynamicWhereClauses, 'resolveDynamicWhereClauses', true);
+        $resolveConfigReturnTypes = self::xmlBoolAttr($config?->resolveConfigReturnTypes, 'resolveConfigReturnTypes', true);
         $configDirectories = self::xmlNameList($config, 'configDirectory');
 
         return new self(
             modelPropertiesColumnFallback: $columnFallback,
             configDirectories: $configDirectories,
             resolveDynamicWhereClauses: $resolveDynamicWhereClauses,
+            resolveConfigReturnTypes: $resolveConfigReturnTypes,
             findMissingTranslations: $findMissingTranslations,
             findMissingViews: $findMissingViews,
             findOctaneIncompatibleBinding: $findOctaneIncompatibleBinding,

--- a/src/Util/ConfigKeyResolver.php
+++ b/src/Util/ConfigKeyResolver.php
@@ -55,7 +55,7 @@ final class ConfigKeyResolver
      */
     public static function instance(): self
     {
-        if (self::$instance !== null) {
+        if (self::$instance instanceof \Psalm\LaravelPlugin\Util\ConfigKeyResolver) {
             return self::$instance;
         }
 
@@ -189,7 +189,7 @@ final class ConfigKeyResolver
         $expr = $call_args[$index]->value;
 
         $literal = self::inferLiteralFromAst($expr);
-        if ($literal !== null) {
+        if ($literal instanceof \Psalm\Type\Union) {
             return $literal;
         }
 
@@ -257,7 +257,7 @@ final class ConfigKeyResolver
         }
 
         foreach ($closureReturnTypes as $returnType) {
-            if ($returnType === null) {
+            if (!$returnType instanceof \Psalm\Type\Union) {
                 // Untyped closure body — contribute mixed without discarding
                 // siblings already collected.
                 $atomics[] = new TMixed();

--- a/src/Util/ConfigKeyResolver.php
+++ b/src/Util/ConfigKeyResolver.php
@@ -81,9 +81,11 @@ final class ConfigKeyResolver
     /**
      * Mirrors `Arr::get` runtime semantics:
      *
-     *   - key absent      → generalized default
-     *   - present non-null → reflected (default ignored)
-     *   - present null     → null | generalized default
+     *   - key absent → generalized default
+     *   - key present → reflected value (default ignored, even if null)
+     *
+     * The default fires only when {@see Arr::exists()} returns false. A
+     * stored null with `array_key_exists` === true is returned verbatim.
      */
     public function resolveCallReturnType(string $key, Union $defaultType): Union
     {
@@ -97,11 +99,7 @@ final class ConfigKeyResolver
             return self::generalizeDefault($defaultType);
         }
 
-        if (!$reflected->isNullable()) {
-            return $reflected;
-        }
-
-        return Type::combineUnionTypes($reflected, self::generalizeDefault($defaultType));
+        return $reflected;
     }
 
     /**
@@ -141,6 +139,14 @@ final class ConfigKeyResolver
     {
         if ($call_args === []) {
             return null;
+        }
+
+        // Named args (`config(default: 'x', key: 'app.debug')`) — positional
+        // extraction would treat the wrong slot as the key. Bail to the stub.
+        foreach ($call_args as $arg) {
+            if ($arg->name !== null) {
+                return null;
+            }
         }
 
         $expr = $call_args[0]->value;
@@ -273,17 +279,23 @@ final class ConfigKeyResolver
             return;
         }
 
+        // Only wrap Repository calls — has() / get() can blow up on partial
+        // bootstrap or exploding service providers. Reflector failures are
+        // plugin bugs and must surface, not silently cache mixed.
         try {
-            if (!$this->config->has($key)) {
-                $this->cache[$key] = null;
-                return;
-            }
-
-            $this->cache[$key] = ConfigValueReflector::reflect($this->config->get($key));
+            $present = $this->config->has($key);
+            /** @psalm-var mixed $value */
+            $value = $present ? $this->config->get($key) : null;
         } catch (\Throwable) {
-            // Cache mixed so retries stay cheap. Silent by design — matches
-            // the pre-PR stub ceiling at the call site.
             $this->cache[$key] = Type::getMixed();
+            return;
         }
+
+        if (!$present) {
+            $this->cache[$key] = null;
+            return;
+        }
+
+        $this->cache[$key] = ConfigValueReflector::reflect($value);
     }
 }

--- a/src/Util/ConfigKeyResolver.php
+++ b/src/Util/ConfigKeyResolver.php
@@ -21,32 +21,17 @@ use Psalm\Type\Atomic\TTrue;
 use Psalm\Type\Union;
 
 /**
- * Resolves dot-notation config keys against the booted Laravel app and returns a
- * Psalm Union describing the value's runtime type (generalized — see
- * {@see ConfigValueReflector}).
+ * Resolves dot-notation config keys against the booted Laravel app to a Psalm
+ * Union describing the runtime value (generalized — see {@see ConfigValueReflector}).
  *
- * Instance-based with a process-wide singleton to mirror
- * {@see \Psalm\LaravelPlugin\Handlers\Auth\AuthConfigAnalyzer}: callers in the
- * analysis hot path go through {@see instance()}, while unit tests construct
- * directly against a fake {@see ConfigRepository}.
+ * Cache trichotomy via `array_key_exists`:
+ *   - missing entry  → not yet computed
+ *   - `null` value   → key absent from config (Repository::has() === false)
+ *   - `Union` value  → key present (may be `Union<TNull>` if value is literally null)
  *
- * The cache distinguishes three states via `array_key_exists`:
- *   - key absent from the cache → not yet computed
- *   - cached value `null`       → known absent from config (Repository::has() === false)
- *   - cached value `Union`      → present (may be a Union of `null` if the config
- *                                 value is literally null)
- *
- * Throwing lookups (Repository binding unbound, partial bootstrap, exploding
- * service provider during has()/get()) are swallowed and cached as
- * {@see Type::getMixed()} so subsequent call-sites short-circuit and stay at a
- * hashmap lookup.
- *
- * **Repository immutability assumption.** The cache trusts that the booted
- * Repository's contents are stable for the lifetime of the Psalm process.
- * Laravel's package boot calls `mergeConfigFrom` once before analysis starts;
- * `Repository::set` / `prepend` / `push` are not invoked by user code between
- * the plugin's boot and the analysis run, so per-key reflection is safe to
- * memoise. Re-warm only via {@see reset()} (tests only).
+ * Singleton mirrors {@see \Psalm\LaravelPlugin\Handlers\Auth\AuthConfigAnalyzer}:
+ * production goes through {@see instance()}, unit tests construct directly
+ * against a fake repository.
  *
  * @internal
  */
@@ -63,14 +48,10 @@ final class ConfigKeyResolver
     public function __construct(private readonly ConfigRepository $config) {}
 
     /**
-     * Singleton accessor. Swallows {@see ConfigRepositoryProvider::get()} throws
-     * the same way {@see warm()} does — if the container binding is missing or
-     * a service provider explodes during plugin boot, the resolver caches a
-     * no-op repository so subsequent call-sites short-circuit to `mixed` via
-     * the cache miss → throw path. Letting the exception propagate would crash
-     * Psalm at every `config()` / `Repository::get()` site, since plugin hook
-     * handlers run outside {@see \Psalm\LaravelPlugin\Plugin::__invoke}'s
-     * try/catch.
+     * Swallows `ConfigRepositoryProvider::get()` failures with a
+     * {@see ThrowingConfigRepository} sentinel. Hook handlers run outside
+     * {@see \Psalm\LaravelPlugin\Plugin::__invoke}'s try/catch, so a propagated
+     * throw would crash analysis at every `config()` callsite.
      */
     public static function instance(): self
     {
@@ -86,8 +67,8 @@ final class ConfigKeyResolver
     }
 
     /**
-     * Drops the singleton. Test-only — production analysis never invalidates
-     * because the booted Repository is immutable for the Psalm process lifetime.
+     * Test-only. The booted Repository is immutable for the Psalm process
+     * lifetime, so production never invalidates.
      *
      * @psalm-api
      * @psalm-external-mutation-free
@@ -98,17 +79,11 @@ final class ConfigKeyResolver
     }
 
     /**
-     * Resolve the full call-site return type for `config($key, $default)` or
-     * `Repository::get($key, $default)`. Combines reflection with default-arg
-     * merge logic:
+     * Mirrors `Arr::get` runtime semantics:
      *
-     *  - Key absent from config       → generalized default (no null union)
-     *  - Key present, value not null  → reflected value (default ignored)
-     *  - Key present, value is null   → null | generalized default
-     *
-     * Pass `$defaultType` = `Type::getNull()` when no default arg is supplied
-     * (Laravel's signature defaults to null). Pass `Type::getMixed()` when the
-     * default arg's type cannot be read from the call site.
+     *   - key absent      → generalized default
+     *   - present non-null → reflected (default ignored)
+     *   - present null     → null | generalized default
      */
     public function resolveCallReturnType(string $key, Union $defaultType): Union
     {
@@ -117,8 +92,8 @@ final class ConfigKeyResolver
         $reflected = $this->cache[$key];
 
         if ($reflected === null) {
-            // Key absent: Laravel returns the default verbatim. Generalize so
-            // `'fallback'` literals don't trigger spurious `===` warnings later.
+            // Generalize so `'fallback'` literals don't trigger spurious `===`
+            // warnings at the call site.
             return self::generalizeDefault($defaultType);
         }
 
@@ -126,19 +101,13 @@ final class ConfigKeyResolver
             return $reflected;
         }
 
-        // Reflected type carries TNull — merge with the generalized default so
-        // callers that pass a default see `null | T` where T is the default's
-        // generalized form.
         return Type::combineUnionTypes($reflected, self::generalizeDefault($defaultType));
     }
 
     /**
-     * Single entry point used by both `config()` and `Repository::get()`
-     * handlers. Extracts a literal string key from the first arg, reads the
-     * default arg's type from the second slot, and routes through
-     * {@see resolveCallReturnType}. Returns null when the call shape is not
-     * narrowable (no args, dynamic key, array first-arg) so the caller defers
-     * to the stub.
+     * Shared entry point for both `config()` and `Repository::get()` handlers.
+     * Returns null on non-narrowable shapes (no args, dynamic key, array
+     * first-arg) so the caller defers to the stub.
      *
      * @param list<\PhpParser\Node\Arg> $call_args
      */
@@ -157,20 +126,14 @@ final class ConfigKeyResolver
     }
 
     /**
-     * Extract a literal string key from the first argument of a `config()` /
-     * `Repository::get()` call. Inspects the raw AST first ({@see String_})
-     * because {@see \Psalm\NodeTypeProvider} returns null inside Psalm's
-     * `__callStatic` dispatch for Facade methods — the analyzer fires the
-     * return-type-provider hook before resolving argument types. Falls back to
-     * NodeTypeProvider for non-literal expressions where the type system has
-     * already inferred a single-string-literal union.
+     * AST-first because Psalm's NodeTypeProvider returns null inside the Facade
+     * `__callStatic` dispatch (hook fires before arg types resolve). Falls back
+     * to the type provider for resolvable non-literal expressions.
      *
-     * Returns:
-     *   - the literal string when the key is statically resolvable
-     *   - `false` when the first arg is an array literal (setter / multi-key
-     *     form — caller must defer to the stub)
-     *   - `null` when the key cannot be resolved (dynamic input or unknown
-     *     type — caller must defer to mixed)
+     * Return contract:
+     *   - string → key resolved
+     *   - false  → array first arg (setter / multi-key form, defer to stub)
+     *   - null   → dynamic / unresolvable (defer to mixed)
      *
      * @param list<\PhpParser\Node\Arg> $call_args
      */
@@ -190,10 +153,7 @@ final class ConfigKeyResolver
             return $expr->value;
         }
 
-        // Fall back to inferred type — handles variables holding string literals
-        // (`const KEY = 'app.name'; config(self::KEY)`) where Psalm has already
-        // resolved the expression. Returns null when the NodeTypeProvider has
-        // no entry (typical inside the facade __callStatic dispatch).
+        // Handles `config(self::KEY)` where Psalm has resolved the expression.
         $type = $nodeTypeProvider->getType($expr);
 
         if (!$type instanceof Union || !$type->isSingleStringLiteral()) {
@@ -204,16 +164,13 @@ final class ConfigKeyResolver
     }
 
     /**
-     * Read the effective default-arg type from a `config()` / `Repository::get()`
-     * call site. Returns `Type::getNull()` when no default is supplied (Laravel's
-     * signature default) and `Type::getMixed()` when the default arg is present
-     * but its type cannot be read — preserves the "default may be anything"
-     * possibility instead of collapsing to null.
+     * Sentinels:
+     *   - no default arg → `Type::getNull()` (Laravel's signature default)
+     *   - present but unresolvable → `Type::getMixed()` (preserve "default may
+     *     be anything" rather than collapse to null)
      *
-     * Inspects the raw AST first for literal expressions. Psalm's
-     * {@see \Psalm\NodeTypeProvider} returns null for argument nodes inside the
-     * facade `__callStatic` dispatch, so a literal `'fallback'` would otherwise
-     * fall back to `mixed` and lose narrowing precision.
+     * AST-first for literal expressions — Psalm's NodeTypeProvider returns
+     * null inside the Facade `__callStatic` dispatch.
      *
      * @param list<\PhpParser\Node\Arg> $call_args
      */
@@ -233,11 +190,7 @@ final class ConfigKeyResolver
         return $nodeTypeProvider->getType($expr) ?? Type::getMixed();
     }
 
-    /**
-     * Best-effort inference of a default-arg type from the raw AST. Covers the
-     * literal forms that Psalm's NodeTypeProvider cannot resolve inside the
-     * Facade `__callStatic` dispatch.
-     */
+    /** Literal forms Psalm's NodeTypeProvider can't resolve in `__callStatic`. */
     private static function inferLiteralFromAst(\PhpParser\Node\Expr $expr): ?Union
     {
         if ($expr instanceof \PhpParser\Node\Scalar\String_) {
@@ -269,16 +222,10 @@ final class ConfigKeyResolver
     }
 
     /**
-     * Walk a default-arg Union and downgrade literal scalar atomics to their
-     * general form. Mirrors Larastan's `GeneralizePrecision::lessSpecific()` —
-     * Psalm has no direct equivalent. Closures (`fn() => 'bar'`) collapse to
-     * their generalized return type; closures without a declared return type
-     * contribute `mixed` to the result (so `string | Closure(): void` becomes
-     * `string | mixed`, not just `mixed`).
-     *
-     * Atomics left untouched: TNonEmptyString, named objects, arrays, mixed.
-     * Their precision is already useful and the caller almost always benefits
-     * from preserving them.
+     * Downgrade literal scalar atomics to their general form. Mirrors Larastan's
+     * `GeneralizePrecision::lessSpecific()`. Closures resolve to their
+     * generalized return type; untyped closures contribute `mixed` without
+     * dropping union siblings (`string | Closure(): void` → `string | mixed`).
      *
      * @psalm-mutation-free
      */
@@ -288,10 +235,7 @@ final class ConfigKeyResolver
         $closureReturnTypes = [];
 
         foreach ($defaultType->getAtomicTypes() as $atomic) {
-            // Closure default — `config('foo', fn () => 'bar')` resolves the
-            // closure via value(). Defer to the recursively generalized return
-            // type. TClosure must be checked BEFORE TNamedObject parent class
-            // wins a default arm.
+            // Must match before TNamedObject's default arm — TClosure extends it.
             if ($atomic instanceof TClosure) {
                 $closureReturnTypes[] = $atomic->return_type;
                 continue;
@@ -308,9 +252,8 @@ final class ConfigKeyResolver
 
         foreach ($closureReturnTypes as $returnType) {
             if ($returnType === null) {
-                // Closure with no declared return → static analysis cannot
-                // follow the body. Contribute TMixed without discarding atomics
-                // already collected from other union members.
+                // Untyped closure body — contribute mixed without discarding
+                // siblings already collected.
                 $atomics[] = new TMixed();
                 continue;
             }
@@ -320,13 +263,8 @@ final class ConfigKeyResolver
             }
         }
 
-        if ($atomics === []) {
-            // Defensive fallback — every Union must carry at least one atomic.
-            // Reaches here only if the input itself was somehow empty.
-            return Type::getMixed();
-        }
-
-        return new Union($atomics);
+        // Every Union needs at least one atomic; empty input is defensive only.
+        return $atomics === [] ? Type::getMixed() : new Union($atomics);
     }
 
     private function warm(string $key): void
@@ -343,8 +281,8 @@ final class ConfigKeyResolver
 
             $this->cache[$key] = ConfigValueReflector::reflect($this->config->get($key));
         } catch (\Throwable) {
-            // Cache mixed so retries are cheap. The stub's mixed return still
-            // applies at the call site; failure here is silent by design.
+            // Cache mixed so retries stay cheap. Silent by design — matches
+            // the pre-PR stub ceiling at the call site.
             $this->cache[$key] = Type::getMixed();
         }
     }

--- a/src/Util/ConfigKeyResolver.php
+++ b/src/Util/ConfigKeyResolver.php
@@ -1,0 +1,351 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Util;
+
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Psalm\LaravelPlugin\Providers\ConfigRepositoryProvider;
+use Psalm\Type;
+use Psalm\Type\Atomic\TBool;
+use Psalm\Type\Atomic\TClosure;
+use Psalm\Type\Atomic\TFalse;
+use Psalm\Type\Atomic\TFloat;
+use Psalm\Type\Atomic\TInt;
+use Psalm\Type\Atomic\TLiteralFloat;
+use Psalm\Type\Atomic\TLiteralInt;
+use Psalm\Type\Atomic\TLiteralString;
+use Psalm\Type\Atomic\TMixed;
+use Psalm\Type\Atomic\TString;
+use Psalm\Type\Atomic\TTrue;
+use Psalm\Type\Union;
+
+/**
+ * Resolves dot-notation config keys against the booted Laravel app and returns a
+ * Psalm Union describing the value's runtime type (generalized — see
+ * {@see ConfigValueReflector}).
+ *
+ * Instance-based with a process-wide singleton to mirror
+ * {@see \Psalm\LaravelPlugin\Handlers\Auth\AuthConfigAnalyzer}: callers in the
+ * analysis hot path go through {@see instance()}, while unit tests construct
+ * directly against a fake {@see ConfigRepository}.
+ *
+ * The cache distinguishes three states via `array_key_exists`:
+ *   - key absent from the cache → not yet computed
+ *   - cached value `null`       → known absent from config (Repository::has() === false)
+ *   - cached value `Union`      → present (may be a Union of `null` if the config
+ *                                 value is literally null)
+ *
+ * Throwing lookups (Repository binding unbound, partial bootstrap, exploding
+ * service provider during has()/get()) are swallowed and cached as
+ * {@see Type::getMixed()} so subsequent call-sites short-circuit and stay at a
+ * hashmap lookup.
+ *
+ * **Repository immutability assumption.** The cache trusts that the booted
+ * Repository's contents are stable for the lifetime of the Psalm process.
+ * Laravel's package boot calls `mergeConfigFrom` once before analysis starts;
+ * `Repository::set` / `prepend` / `push` are not invoked by user code between
+ * the plugin's boot and the analysis run, so per-key reflection is safe to
+ * memoise. Re-warm only via {@see reset()} (tests only).
+ *
+ * @internal
+ */
+final class ConfigKeyResolver
+{
+    private static ?ConfigKeyResolver $instance = null;
+
+    /**
+     * @var array<string, Union|null>
+     */
+    private array $cache = [];
+
+    /** @psalm-mutation-free */
+    public function __construct(private readonly ConfigRepository $config) {}
+
+    /**
+     * Singleton accessor. Swallows {@see ConfigRepositoryProvider::get()} throws
+     * the same way {@see warm()} does — if the container binding is missing or
+     * a service provider explodes during plugin boot, the resolver caches a
+     * no-op repository so subsequent call-sites short-circuit to `mixed` via
+     * the cache miss → throw path. Letting the exception propagate would crash
+     * Psalm at every `config()` / `Repository::get()` site, since plugin hook
+     * handlers run outside {@see \Psalm\LaravelPlugin\Plugin::__invoke}'s
+     * try/catch.
+     */
+    public static function instance(): self
+    {
+        if (self::$instance !== null) {
+            return self::$instance;
+        }
+
+        try {
+            return self::$instance = new self(ConfigRepositoryProvider::get());
+        } catch (\Throwable) {
+            return self::$instance = new self(new ThrowingConfigRepository());
+        }
+    }
+
+    /**
+     * Drops the singleton. Test-only — production analysis never invalidates
+     * because the booted Repository is immutable for the Psalm process lifetime.
+     *
+     * @psalm-api
+     * @psalm-external-mutation-free
+     */
+    public static function reset(): void
+    {
+        self::$instance = null;
+    }
+
+    /**
+     * Resolve the full call-site return type for `config($key, $default)` or
+     * `Repository::get($key, $default)`. Combines reflection with default-arg
+     * merge logic:
+     *
+     *  - Key absent from config       → generalized default (no null union)
+     *  - Key present, value not null  → reflected value (default ignored)
+     *  - Key present, value is null   → null | generalized default
+     *
+     * Pass `$defaultType` = `Type::getNull()` when no default arg is supplied
+     * (Laravel's signature defaults to null). Pass `Type::getMixed()` when the
+     * default arg's type cannot be read from the call site.
+     */
+    public function resolveCallReturnType(string $key, Union $defaultType): Union
+    {
+        $this->warm($key);
+
+        $reflected = $this->cache[$key];
+
+        if ($reflected === null) {
+            // Key absent: Laravel returns the default verbatim. Generalize so
+            // `'fallback'` literals don't trigger spurious `===` warnings later.
+            return self::generalizeDefault($defaultType);
+        }
+
+        if (!$reflected->isNullable()) {
+            return $reflected;
+        }
+
+        // Reflected type carries TNull — merge with the generalized default so
+        // callers that pass a default see `null | T` where T is the default's
+        // generalized form.
+        return Type::combineUnionTypes($reflected, self::generalizeDefault($defaultType));
+    }
+
+    /**
+     * Single entry point used by both `config()` and `Repository::get()`
+     * handlers. Extracts a literal string key from the first arg, reads the
+     * default arg's type from the second slot, and routes through
+     * {@see resolveCallReturnType}. Returns null when the call shape is not
+     * narrowable (no args, dynamic key, array first-arg) so the caller defers
+     * to the stub.
+     *
+     * @param list<\PhpParser\Node\Arg> $call_args
+     */
+    public static function resolveFromCallArgs(array $call_args, \Psalm\NodeTypeProvider $nodeTypeProvider): ?Union
+    {
+        $key = self::extractLiteralKey($call_args, $nodeTypeProvider);
+
+        if ($key === null || $key === false) {
+            return null;
+        }
+
+        return self::instance()->resolveCallReturnType(
+            $key,
+            self::readDefaultTypeAt($call_args, 1, $nodeTypeProvider),
+        );
+    }
+
+    /**
+     * Extract a literal string key from the first argument of a `config()` /
+     * `Repository::get()` call. Inspects the raw AST first ({@see String_})
+     * because {@see \Psalm\NodeTypeProvider} returns null inside Psalm's
+     * `__callStatic` dispatch for Facade methods — the analyzer fires the
+     * return-type-provider hook before resolving argument types. Falls back to
+     * NodeTypeProvider for non-literal expressions where the type system has
+     * already inferred a single-string-literal union.
+     *
+     * Returns:
+     *   - the literal string when the key is statically resolvable
+     *   - `false` when the first arg is an array literal (setter / multi-key
+     *     form — caller must defer to the stub)
+     *   - `null` when the key cannot be resolved (dynamic input or unknown
+     *     type — caller must defer to mixed)
+     *
+     * @param list<\PhpParser\Node\Arg> $call_args
+     */
+    private static function extractLiteralKey(array $call_args, \Psalm\NodeTypeProvider $nodeTypeProvider): string|false|null
+    {
+        if ($call_args === []) {
+            return null;
+        }
+
+        $expr = $call_args[0]->value;
+
+        if ($expr instanceof \PhpParser\Node\Expr\Array_) {
+            return false;
+        }
+
+        if ($expr instanceof \PhpParser\Node\Scalar\String_) {
+            return $expr->value;
+        }
+
+        // Fall back to inferred type — handles variables holding string literals
+        // (`const KEY = 'app.name'; config(self::KEY)`) where Psalm has already
+        // resolved the expression. Returns null when the NodeTypeProvider has
+        // no entry (typical inside the facade __callStatic dispatch).
+        $type = $nodeTypeProvider->getType($expr);
+
+        if (!$type instanceof Union || !$type->isSingleStringLiteral()) {
+            return null;
+        }
+
+        return $type->getSingleStringLiteral()->value;
+    }
+
+    /**
+     * Read the effective default-arg type from a `config()` / `Repository::get()`
+     * call site. Returns `Type::getNull()` when no default is supplied (Laravel's
+     * signature default) and `Type::getMixed()` when the default arg is present
+     * but its type cannot be read — preserves the "default may be anything"
+     * possibility instead of collapsing to null.
+     *
+     * Inspects the raw AST first for literal expressions. Psalm's
+     * {@see \Psalm\NodeTypeProvider} returns null for argument nodes inside the
+     * facade `__callStatic` dispatch, so a literal `'fallback'` would otherwise
+     * fall back to `mixed` and lose narrowing precision.
+     *
+     * @param list<\PhpParser\Node\Arg> $call_args
+     */
+    private static function readDefaultTypeAt(array $call_args, int $index, \Psalm\NodeTypeProvider $nodeTypeProvider): Union
+    {
+        if (!isset($call_args[$index])) {
+            return Type::getNull();
+        }
+
+        $expr = $call_args[$index]->value;
+
+        $literal = self::inferLiteralFromAst($expr);
+        if ($literal !== null) {
+            return $literal;
+        }
+
+        return $nodeTypeProvider->getType($expr) ?? Type::getMixed();
+    }
+
+    /**
+     * Best-effort inference of a default-arg type from the raw AST. Covers the
+     * literal forms that Psalm's NodeTypeProvider cannot resolve inside the
+     * Facade `__callStatic` dispatch.
+     */
+    private static function inferLiteralFromAst(\PhpParser\Node\Expr $expr): ?Union
+    {
+        if ($expr instanceof \PhpParser\Node\Scalar\String_) {
+            return Type::getString();
+        }
+
+        if ($expr instanceof \PhpParser\Node\Scalar\Int_) {
+            return Type::getInt();
+        }
+
+        if ($expr instanceof \PhpParser\Node\Scalar\Float_) {
+            return Type::getFloat();
+        }
+
+        if ($expr instanceof \PhpParser\Node\Expr\ConstFetch) {
+            $name = $expr->name->toLowerString();
+            return match ($name) {
+                'true', 'false' => Type::getBool(),
+                'null' => Type::getNull(),
+                default => null,
+            };
+        }
+
+        if ($expr instanceof \PhpParser\Node\Expr\Array_) {
+            return Type::getArray();
+        }
+
+        return null;
+    }
+
+    /**
+     * Walk a default-arg Union and downgrade literal scalar atomics to their
+     * general form. Mirrors Larastan's `GeneralizePrecision::lessSpecific()` —
+     * Psalm has no direct equivalent. Closures (`fn() => 'bar'`) collapse to
+     * their generalized return type; closures without a declared return type
+     * contribute `mixed` to the result (so `string | Closure(): void` becomes
+     * `string | mixed`, not just `mixed`).
+     *
+     * Atomics left untouched: TNonEmptyString, named objects, arrays, mixed.
+     * Their precision is already useful and the caller almost always benefits
+     * from preserving them.
+     *
+     * @psalm-mutation-free
+     */
+    public static function generalizeDefault(Union $defaultType): Union
+    {
+        $atomics = [];
+        $closureReturnTypes = [];
+
+        foreach ($defaultType->getAtomicTypes() as $atomic) {
+            // Closure default — `config('foo', fn () => 'bar')` resolves the
+            // closure via value(). Defer to the recursively generalized return
+            // type. TClosure must be checked BEFORE TNamedObject parent class
+            // wins a default arm.
+            if ($atomic instanceof TClosure) {
+                $closureReturnTypes[] = $atomic->return_type;
+                continue;
+            }
+
+            $atomics[] = match (true) {
+                $atomic instanceof TLiteralString => new TString(),
+                $atomic instanceof TLiteralInt => new TInt(),
+                $atomic instanceof TLiteralFloat => new TFloat(),
+                $atomic instanceof TTrue, $atomic instanceof TFalse => new TBool(),
+                default => $atomic,
+            };
+        }
+
+        foreach ($closureReturnTypes as $returnType) {
+            if ($returnType === null) {
+                // Closure with no declared return → static analysis cannot
+                // follow the body. Contribute TMixed without discarding atomics
+                // already collected from other union members.
+                $atomics[] = new TMixed();
+                continue;
+            }
+
+            foreach (self::generalizeDefault($returnType)->getAtomicTypes() as $returnAtomic) {
+                $atomics[] = $returnAtomic;
+            }
+        }
+
+        if ($atomics === []) {
+            // Defensive fallback — every Union must carry at least one atomic.
+            // Reaches here only if the input itself was somehow empty.
+            return Type::getMixed();
+        }
+
+        return new Union($atomics);
+    }
+
+    private function warm(string $key): void
+    {
+        if (\array_key_exists($key, $this->cache)) {
+            return;
+        }
+
+        try {
+            if (!$this->config->has($key)) {
+                $this->cache[$key] = null;
+                return;
+            }
+
+            $this->cache[$key] = ConfigValueReflector::reflect($this->config->get($key));
+        } catch (\Throwable) {
+            // Cache mixed so retries are cheap. The stub's mixed return still
+            // applies at the call site; failure here is silent by design.
+            $this->cache[$key] = Type::getMixed();
+        }
+    }
+}

--- a/src/Util/ConfigValueReflector.php
+++ b/src/Util/ConfigValueReflector.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Util;
+
+use Psalm\Type;
+use Psalm\Type\Atomic\TKeyedArray;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Union;
+
+/**
+ * Translates a runtime config value (resolved from the booted Laravel app) into a
+ * Psalm Union type.
+ *
+ * Scalars are intentionally generalized to their non-literal form. Booted Laravel
+ * resolves env-driven values to a single concrete observation at analysis time;
+ * narrowing `config('app.debug')` to `false` (its observed default) would surface
+ * spurious `TypeDoesNotContainType` issues on every `if (config('app.debug'))`.
+ * Returning `bool`/`string`/`int` keeps the call site flexible to runtime overrides.
+ *
+ * Arrays preserve shape up to {@see self::MAX_DEPTH} levels deep and
+ * {@see self::MAX_KEYS_PER_LEVEL} keys per level. Beyond that, the reflector
+ * degrades to `array<array-key, mixed>` rather than emitting megabyte-scale type
+ * strings.
+ *
+ * Closures, resources, and unknown values fall back to `mixed`.
+ *
+ * @internal
+ */
+final class ConfigValueReflector
+{
+    public const MAX_DEPTH = 5;
+
+    public const MAX_KEYS_PER_LEVEL = 64;
+
+    public static function reflect(mixed $value, int $depth = 0): Union
+    {
+        if ($value === null) {
+            return Type::getNull();
+        }
+
+        if (\is_bool($value)) {
+            return Type::getBool();
+        }
+
+        if (\is_int($value)) {
+            return Type::getInt();
+        }
+
+        if (\is_float($value)) {
+            return Type::getFloat();
+        }
+
+        if (\is_string($value)) {
+            return Type::getString();
+        }
+
+        if (\is_array($value)) {
+            return self::reflectArray($value, $depth);
+        }
+
+        if ($value instanceof \Closure) {
+            // value() (used by Repository::get) invokes closures lazily — static
+            // analysis cannot follow the body without an explicit return type.
+            return Type::getMixed();
+        }
+
+        if (\is_object($value)) {
+            return new Union([new TNamedObject($value::class)]);
+        }
+
+        // Resources and any other unsupported value kinds.
+        return Type::getMixed();
+    }
+
+    /**
+     * @param array<array-key, mixed> $value
+     */
+    private static function reflectArray(array $value, int $depth): Union
+    {
+        if ($value === []) {
+            return Type::getEmptyArray();
+        }
+
+        if ($depth >= self::MAX_DEPTH || \count($value) > self::MAX_KEYS_PER_LEVEL) {
+            return Type::getArray();
+        }
+
+        $is_list = \array_is_list($value);
+
+        $properties = [];
+        /** @psalm-var mixed $sub_value */
+        foreach ($value as $key => $sub_value) {
+            $properties[$key] = self::reflect($sub_value, $depth + 1);
+        }
+
+        // TKeyedArray::make requires non-empty-array; the empty branch is handled
+        // above. Make returns TKeyedArray|TArray (TArray only when properties
+        // collapse to never, which cannot happen here).
+        return new Union([TKeyedArray::make($properties, null, null, is_list: $is_list)]);
+    }
+}

--- a/src/Util/ConfigValueReflector.php
+++ b/src/Util/ConfigValueReflector.php
@@ -17,9 +17,12 @@ use Psalm\Type\Union;
  * `config('app.debug')` to `false` would trigger `TypeDoesNotContainType` on
  * every `if (config('app.debug'))` callsite that overrides via env.
  *
- * Arrays preserve shape up to {@see MAX_DEPTH}/{@see MAX_KEYS_PER_LEVEL};
- * beyond that, degrade to `array<array-key, mixed>`. Closures, resources, and
- * unknown values fall back to `mixed`.
+ * Arrays preserve shape up to {@see MAX_DEPTH}/{@see MAX_KEYS_PER_LEVEL}; a
+ * per-tree {@see MAX_TOTAL_PROPERTIES} budget guards against a branching
+ * shallow array building a megabyte-scale type string before the depth cap
+ * fires. Beyond any cap, degrade to `array<array-key, mixed>`.
+ *
+ * Resources and unknown values fall back to `mixed`.
  *
  * @internal
  */
@@ -29,7 +32,24 @@ final class ConfigValueReflector
 
     public const MAX_KEYS_PER_LEVEL = 64;
 
-    public static function reflect(mixed $value, int $depth = 0): Union
+    /**
+     * Total keyed-array properties allowed across one top-level reflection.
+     * 512 covers Filament-scale configs (~hundreds of keyed leaves) without
+     * letting a branching shape produce multi-MB type identifiers.
+     */
+    public const MAX_TOTAL_PROPERTIES = 512;
+
+    public static function reflect(mixed $value): Union
+    {
+        $remainingBudget = self::MAX_TOTAL_PROPERTIES;
+
+        return self::reflectInternal($value, 0, $remainingBudget);
+    }
+
+    /**
+     * @param int<0, max> $depth
+     */
+    private static function reflectInternal(mixed $value, int $depth, int &$remainingBudget): Union
     {
         if ($value === null) {
             return Type::getNull();
@@ -52,16 +72,13 @@ final class ConfigValueReflector
         }
 
         if (\is_array($value)) {
-            return self::reflectArray($value, $depth);
-        }
-
-        if ($value instanceof \Closure) {
-            // value() (used by Repository::get) invokes closures lazily — static
-            // analysis cannot follow the body without an explicit return type.
-            return Type::getMixed();
+            return self::reflectArray($value, $depth, $remainingBudget);
         }
 
         if (\is_object($value)) {
+            // Stored closures: `Repository::get` does NOT auto-invoke them
+            // (`value()` only runs on the $default branch inside `Arr::get`).
+            // Return Closure as a plain named object so callers can $closure().
             return new Union([new TNamedObject($value::class)]);
         }
 
@@ -71,23 +88,30 @@ final class ConfigValueReflector
 
     /**
      * @param array<array-key, mixed> $value
+     * @param int<0, max> $depth
      */
-    private static function reflectArray(array $value, int $depth): Union
+    private static function reflectArray(array $value, int $depth, int &$remainingBudget): Union
     {
         if ($value === []) {
             return Type::getEmptyArray();
         }
 
-        if ($depth >= self::MAX_DEPTH || \count($value) > self::MAX_KEYS_PER_LEVEL) {
+        $count = \count($value);
+
+        if ($depth >= self::MAX_DEPTH
+            || $count > self::MAX_KEYS_PER_LEVEL
+            || $count > $remainingBudget
+        ) {
             return Type::getArray();
         }
 
+        $remainingBudget -= $count;
         $is_list = \array_is_list($value);
 
         $properties = [];
         /** @psalm-var mixed $sub_value */
         foreach ($value as $key => $sub_value) {
-            $properties[$key] = self::reflect($sub_value, $depth + 1);
+            $properties[$key] = self::reflectInternal($sub_value, $depth + 1, $remainingBudget);
         }
 
         // TKeyedArray::make requires non-empty-array; the empty branch is handled

--- a/src/Util/ConfigValueReflector.php
+++ b/src/Util/ConfigValueReflector.php
@@ -10,21 +10,16 @@ use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Union;
 
 /**
- * Translates a runtime config value (resolved from the booted Laravel app) into a
- * Psalm Union type.
+ * Translates a runtime config value into a Psalm Union.
  *
- * Scalars are intentionally generalized to their non-literal form. Booted Laravel
- * resolves env-driven values to a single concrete observation at analysis time;
- * narrowing `config('app.debug')` to `false` (its observed default) would surface
- * spurious `TypeDoesNotContainType` issues on every `if (config('app.debug'))`.
- * Returning `bool`/`string`/`int` keeps the call site flexible to runtime overrides.
+ * Scalars are generalized (not literal) because booted Laravel collapses
+ * env-driven values to a single observation at analysis time. Narrowing
+ * `config('app.debug')` to `false` would trigger `TypeDoesNotContainType` on
+ * every `if (config('app.debug'))` callsite that overrides via env.
  *
- * Arrays preserve shape up to {@see self::MAX_DEPTH} levels deep and
- * {@see self::MAX_KEYS_PER_LEVEL} keys per level. Beyond that, the reflector
- * degrades to `array<array-key, mixed>` rather than emitting megabyte-scale type
- * strings.
- *
- * Closures, resources, and unknown values fall back to `mixed`.
+ * Arrays preserve shape up to {@see MAX_DEPTH}/{@see MAX_KEYS_PER_LEVEL};
+ * beyond that, degrade to `array<array-key, mixed>`. Closures, resources, and
+ * unknown values fall back to `mixed`.
  *
  * @internal
  */

--- a/src/Util/IssueUrlGenerator.php
+++ b/src/Util/IssueUrlGenerator.php
@@ -85,6 +85,7 @@ final class IssueUrlGenerator
         return [
             "- modelPropertiesColumnFallback: {$pluginConfig->modelPropertiesColumnFallback->value}",
             '- resolveDynamicWhereClauses: ' . self::formatBool($pluginConfig->resolveDynamicWhereClauses),
+            '- resolveConfigReturnTypes: ' . self::formatBool($pluginConfig->resolveConfigReturnTypes),
             '- findMissingTranslations: ' . self::formatBool($pluginConfig->findMissingTranslations),
             '- findMissingViews: ' . self::formatBool($pluginConfig->findMissingViews),
             '- findOctaneIncompatibleBinding: ' . self::formatOctaneFlag($pluginConfig->findOctaneIncompatibleBinding),

--- a/src/Util/ThrowingConfigRepository.php
+++ b/src/Util/ThrowingConfigRepository.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Util;
+
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+
+/**
+ * Sentinel ConfigRepository used by {@see ConfigKeyResolver::instance()} when
+ * the booted Laravel app cannot supply a real Repository (binding unbound,
+ * partial bootstrap, exploding service provider during plugin init).
+ *
+ * Every method throws so {@see ConfigKeyResolver::warm()}'s catch arm fires
+ * and caches `Type::getMixed()` for the key — the stub's pre-PR ceiling.
+ * Without this sentinel, the throw would propagate from a Psalm hook handler
+ * and crash analysis on every `config()` / `Repository::get()` call site.
+ *
+ * @internal
+ */
+final class ThrowingConfigRepository implements ConfigRepository
+{
+    private const MESSAGE = 'ConfigRepository unavailable: plugin booted without a usable Laravel app.';
+
+    /** @psalm-pure */
+    #[\Override]
+    public function has($key): bool
+    {
+        throw new \LogicException(self::MESSAGE);
+    }
+
+    /** @psalm-pure */
+    #[\Override]
+    public function get($key, $default = null): mixed
+    {
+        throw new \LogicException(self::MESSAGE);
+    }
+
+    /**
+     * @return array<string, mixed>
+     * @psalm-pure
+     */
+    #[\Override]
+    public function all(): array
+    {
+        throw new \LogicException(self::MESSAGE);
+    }
+
+    /** @psalm-pure */
+    #[\Override]
+    public function set($key, $value = null): void
+    {
+        throw new \LogicException(self::MESSAGE);
+    }
+
+    /** @psalm-pure */
+    #[\Override]
+    public function prepend($key, $value): void
+    {
+        throw new \LogicException(self::MESSAGE);
+    }
+
+    /** @psalm-pure */
+    #[\Override]
+    public function push($key, $value): void
+    {
+        throw new \LogicException(self::MESSAGE);
+    }
+}

--- a/tests/Type/tests/ConfigRepositoryGetTest.phpt
+++ b/tests/Type/tests/ConfigRepositoryGetTest.phpt
@@ -1,0 +1,63 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Config\Repository;
+use Illuminate\Contracts\Config\Repository as ConfigContract;
+
+/**
+ * Repository::get() return type narrowing — same dot-notation resolution as
+ * config() helper. The Config facade routes here via Psalm's facade pipeline.
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/752
+ */
+
+function repo_get_string_key(Repository $config): void
+{
+    $_result = $config->get('app.name');
+    /** @psalm-check-type-exact $_result = string */
+}
+
+function repo_get_bool_key(Repository $config): void
+{
+    $_result = $config->get('app.debug');
+    /** @psalm-check-type-exact $_result = bool */
+}
+
+function repo_get_missing_key_no_default(Repository $config): void
+{
+    $_result = $config->get('foo.bar.nonexistent');
+    /** @psalm-check-type-exact $_result = null */
+}
+
+function repo_get_missing_key_string_default(Repository $config): void
+{
+    $_result = $config->get('foo.bar.nonexistent', 'fallback');
+    /** @psalm-check-type-exact $_result = string */
+}
+
+function repo_get_missing_key_int_default(Repository $config): void
+{
+    $_result = $config->get('foo.bar.nonexistent', 42);
+    /** @psalm-check-type-exact $_result = int */
+}
+
+function repo_get_dynamic_key_remains_mixed(Repository $config, string $key): void
+{
+    $_result = $config->get($key);
+    /** @psalm-check-type-exact $_result = mixed */
+}
+
+function repo_get_via_contract(ConfigContract $config): void
+{
+    $_result = $config->get('app.name');
+    /** @psalm-check-type-exact $_result = string */
+}
+
+function repo_get_array_first_arg_defers_to_stub(Repository $config): void
+{
+    // Repository::get(array) is the multi-key form (getMany). The handler
+    // returns null on array first-arg so the stub's signature wins.
+    $_result = $config->get(['app.name', 'app.debug']);
+    /** @psalm-check-type-exact $_result = mixed */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Facades/ConfigFacadeGetTest.phpt
+++ b/tests/Type/tests/Facades/ConfigFacadeGetTest.phpt
@@ -1,0 +1,42 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Facades\Config;
+
+/**
+ * Config::get() through the facade — should route through the Repository
+ * method provider via Psalm's facade pipeline.
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/752
+ */
+
+function facade_get_string_key(): void
+{
+    $_result = Config::get('app.name');
+    /** @psalm-check-type-exact $_result = string */
+}
+
+function facade_get_bool_key(): void
+{
+    $_result = Config::get('app.debug');
+    /** @psalm-check-type-exact $_result = bool */
+}
+
+function facade_get_missing_key_string_default(): void
+{
+    $_result = Config::get('foo.bar.nonexistent', 'fallback');
+    /** @psalm-check-type-exact $_result = string */
+}
+
+function facade_get_missing_key_no_default(): void
+{
+    $_result = Config::get('foo.bar.nonexistent');
+    /** @psalm-check-type-exact $_result = null */
+}
+
+function facade_get_dynamic_key_remains_mixed(string $key): void
+{
+    $_result = Config::get($key);
+    /** @psalm-check-type-exact $_result = mixed */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Support/helpers/config.phpt
+++ b/tests/Type/tests/Support/helpers/config.phpt
@@ -1,19 +1,70 @@
 --FILE--
 <?php declare(strict_types=1);
 
-function config_with_one_argument(): mixed
+/**
+ * config() return type narrowing based on dot-notation key resolution
+ * against the booted Laravel app, with default-arg merge logic.
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/752
+ */
+
+function config_string_key(): void
 {
-    return config('app.name');
+    $_result = config('app.name');
+    /** @psalm-check-type-exact $_result = string */
 }
 
-function config_with_first_null_argument_and_second_argument_provided(): mixed
+function config_bool_key(): void
 {
-    return config('app.non-existent', false);
+    $_result = config('app.debug');
+    /** @psalm-check-type-exact $_result = bool */
 }
 
-function config_setting_at_runtime(): null
+function config_string_timezone(): void
 {
-    return config(['app.non-existent' => false]);
+    $_result = config('app.timezone');
+    /** @psalm-check-type-exact $_result = string */
+}
+
+function config_missing_key_with_string_default(): void
+{
+    $_result = config('foo.bar.nonexistent', 'fallback');
+    /** @psalm-check-type-exact $_result = string */
+}
+
+function config_missing_key_with_int_default(): void
+{
+    $_result = config('foo.bar.nonexistent', 42);
+    /** @psalm-check-type-exact $_result = int */
+}
+
+function config_missing_key_no_default(): void
+{
+    $_result = config('foo.bar.nonexistent');
+    /** @psalm-check-type-exact $_result = null */
+}
+
+function config_missing_key_with_typed_closure_default(): void
+{
+    $_result = config('foo.bar.nonexistent', fn (): string => 'fallback');
+    /** @psalm-check-type-exact $_result = string */
+}
+
+function config_no_args_returns_repository(): void
+{
+    $_result = config();
+    /** @psalm-check-type-exact $_result = Illuminate\Config\Repository */
+}
+
+function config_setter_form_returns_null(): void
+{
+    $_result = config(['app.name' => 'Custom']);
+    /** @psalm-check-type-exact $_result = null */
+}
+
+function config_dynamic_key_remains_mixed(string $key): void
+{
+    $_result = config($key);
+    /** @psalm-check-type-exact $_result = mixed */
 }
 ?>
 --EXPECTF--

--- a/tests/Type/tests/Support/helpers/config.phpt
+++ b/tests/Type/tests/Support/helpers/config.phpt
@@ -66,5 +66,13 @@ function config_dynamic_key_remains_mixed(string $key): void
     $_result = config($key);
     /** @psalm-check-type-exact $_result = mixed */
 }
+
+function config_with_named_args_defers_to_stub(): void
+{
+    // Named args could let `default:` masquerade as the key in a positional
+    // scan. The handler bails and the stub's mixed return stands.
+    $_result = config(default: 'x', key: 'app.debug');
+    /** @psalm-check-type-exact $_result = mixed */
+}
 ?>
 --EXPECTF--

--- a/tests/Unit/PluginConfigTest.php
+++ b/tests/Unit/PluginConfigTest.php
@@ -47,6 +47,7 @@ final class PluginConfigTest extends TestCase
         // explicit true/false in XML overrides the auto-detection.
         $this->assertNull($config->findOctaneIncompatibleBinding);
         $this->assertTrue($config->resolveDynamicWhereClauses);
+        $this->assertTrue($config->resolveConfigReturnTypes);
         $this->assertSame([], $config->configDirectories);
     }
 
@@ -314,6 +315,37 @@ final class PluginConfigTest extends TestCase
     }
 
     #[Test]
+    public function resolve_config_return_types_true(): void
+    {
+        $xml = new \SimpleXMLElement('<pluginClass><resolveConfigReturnTypes value="true" /></pluginClass>');
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertTrue($config->resolveConfigReturnTypes);
+    }
+
+    #[Test]
+    public function resolve_config_return_types_false(): void
+    {
+        $xml = new \SimpleXMLElement('<pluginClass><resolveConfigReturnTypes value="false" /></pluginClass>');
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertFalse($config->resolveConfigReturnTypes);
+    }
+
+    #[Test]
+    public function invalid_resolve_config_return_types_throws(): void
+    {
+        $xml = new \SimpleXMLElement('<pluginClass><resolveConfigReturnTypes value="yes" /></pluginClass>');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid resolveConfigReturnTypes value 'yes'");
+
+        PluginConfig::fromXml($xml);
+    }
+
+    #[Test]
     #[IgnoreDeprecations]
     public function cache_path_uses_env_var(): void
     {
@@ -391,6 +423,7 @@ final class PluginConfigTest extends TestCase
             '<pluginClass>'
             . '<modelProperties columnFallback="none" />'
             . '<resolveDynamicWhereClauses value="false" />'
+            . '<resolveConfigReturnTypes value="false" />'
             . '<failOnInternalError value="true" />'
             . '<findMissingTranslations value="true" />'
             . '<findMissingViews value="true" />'
@@ -403,6 +436,7 @@ final class PluginConfigTest extends TestCase
 
         $this->assertSame(ColumnFallback::None, $config->modelPropertiesColumnFallback);
         $this->assertFalse($config->resolveDynamicWhereClauses);
+        $this->assertFalse($config->resolveConfigReturnTypes);
         $this->assertTrue($config->findMissingTranslations);
         $this->assertTrue($config->findMissingViews);
         $this->assertSame('/tmp/psalm-test', $config->cachePath);

--- a/tests/Unit/Util/ConfigKeyResolverTest.php
+++ b/tests/Unit/Util/ConfigKeyResolverTest.php
@@ -178,7 +178,7 @@ final class ConfigKeyResolverTest extends TestCase
     }
 
     #[Test]
-    public function resolveCallReturnType_unions_null_with_default_when_value_is_null(): void
+    public function resolveCallReturnType_returns_null_when_value_is_null_ignoring_default(): void
     {
         $repo = $this->fakeRepository(['app.providers' => null]);
         $resolver = new ConfigKeyResolver($repo);
@@ -188,9 +188,9 @@ final class ConfigKeyResolverTest extends TestCase
             new \Psalm\Type\Union([\Psalm\Type\Atomic\TLiteralString::make('fallback')]),
         );
 
-        // null | string
-        $this->assertTrue($type->isNullable());
-        $this->assertTrue($type->hasString());
+        // Laravel's Arr::get returns the stored null when the key exists
+        // (array_key_exists === true) — the default is NOT applied.
+        $this->assertTrue($type->isNull());
     }
 
     #[Test]

--- a/tests/Unit/Util/ConfigKeyResolverTest.php
+++ b/tests/Unit/Util/ConfigKeyResolverTest.php
@@ -1,0 +1,284 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Util;
+
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Util\ConfigKeyResolver;
+use Psalm\Type;
+use Tests\Psalm\LaravelPlugin\Unit\Util\Ast\Concerns\InitializesPsalmConfigSingleton;
+
+#[CoversClass(ConfigKeyResolver::class)]
+final class ConfigKeyResolverTest extends TestCase
+{
+    // `TLiteralString::make()` and friends read `Config::getInstance()`.
+    // Tests that exercise generalizeDefault need the singleton planted.
+    use InitializesPsalmConfigSingleton;
+
+    protected function tearDown(): void
+    {
+        ConfigKeyResolver::reset();
+    }
+
+    #[Test]
+    public function resolveCallReturnType_returns_null_when_key_absent_and_no_default(): void
+    {
+        $repo = $this->fakeRepository(['app.name' => 'Laravel']);
+        $resolver = new ConfigKeyResolver($repo);
+
+        // Missing key + no-default sentinel (Type::getNull()) → generalized null
+        $type = $resolver->resolveCallReturnType('app.missing', Type::getNull());
+        $this->assertTrue($type->isNull());
+    }
+
+    #[Test]
+    public function resolveCallReturnType_returns_generalized_string_for_string_value(): void
+    {
+        $repo = $this->fakeRepository(['app.name' => 'Laravel']);
+        $resolver = new ConfigKeyResolver($repo);
+
+        $type = $resolver->resolveCallReturnType('app.name', Type::getNull());
+        // Generalized — not 'Laravel' literal.
+        $this->assertSame('string', $type->getId());
+    }
+
+    #[Test]
+    public function resolveCallReturnType_keeps_null_when_value_is_literally_null_and_no_default(): void
+    {
+        $repo = $this->fakeRepository(['app.providers' => null]);
+        $resolver = new ConfigKeyResolver($repo);
+
+        // Reflected value is null; default sentinel is null too → result is null.
+        $type = $resolver->resolveCallReturnType('app.providers', Type::getNull());
+        $this->assertTrue($type->isNull());
+    }
+
+    #[Test]
+    public function resolveCallReturnType_returns_mixed_when_repository_throws(): void
+    {
+        $repo = new class implements ConfigRepository {
+            #[\Override]
+            public function has($key): bool
+            {
+                throw new \RuntimeException('config exploded');
+            }
+
+            #[\Override]
+            public function get($key, $default = null)
+            {
+                throw new \RuntimeException('config exploded');
+            }
+
+            #[\Override]
+            public function all(): array
+            {
+                return [];
+            }
+
+            #[\Override]
+            public function set($key, $value = null): void {}
+
+            #[\Override]
+            public function prepend($key, $value): void {}
+
+            #[\Override]
+            public function push($key, $value): void {}
+        };
+
+        $resolver = new ConfigKeyResolver($repo);
+        $type = $resolver->resolveCallReturnType('any.key', Type::getNull());
+
+        $this->assertTrue($type->isMixed());
+    }
+
+    #[Test]
+    public function resolveCallReturnType_returns_mixed_when_default_is_mixed(): void
+    {
+        $repo = $this->fakeRepository(['app.name' => 'Laravel']);
+        $resolver = new ConfigKeyResolver($repo);
+
+        // Key absent + default of unknown type → caller passes Type::getMixed()
+        // (readDefaultTypeAt sentinel). Result must stay mixed, not collapse.
+        $type = $resolver->resolveCallReturnType('app.missing', Type::getMixed());
+        $this->assertTrue($type->isMixed());
+    }
+
+    #[Test]
+    public function cache_hit_avoids_second_repository_call(): void
+    {
+        $callCount = 0;
+        $repo = new class ($callCount) implements ConfigRepository {
+            public function __construct(private int &$callCount) {}
+
+            #[\Override]
+            public function has($key): bool
+            {
+                $this->callCount++;
+                return true;
+            }
+
+            #[\Override]
+            public function get($key, $default = null): string
+            {
+                return 'Laravel';
+            }
+
+            #[\Override]
+            public function all(): array
+            {
+                return [];
+            }
+
+            #[\Override]
+            public function set($key, $value = null): void {}
+
+            #[\Override]
+            public function prepend($key, $value): void {}
+
+            #[\Override]
+            public function push($key, $value): void {}
+        };
+
+        $resolver = new ConfigKeyResolver($repo);
+        $resolver->resolveCallReturnType('app.name', Type::getNull());
+        $resolver->resolveCallReturnType('app.name', Type::getNull());
+        $resolver->resolveCallReturnType('app.name', Type::getString());
+
+        $this->assertSame(1, $callCount, 'Cache must coalesce repeated lookups to a single has() call.');
+    }
+
+    #[Test]
+    public function resolveCallReturnType_returns_reflected_when_value_not_null(): void
+    {
+        $repo = $this->fakeRepository(['app.debug' => true]);
+        $resolver = new ConfigKeyResolver($repo);
+
+        $type = $resolver->resolveCallReturnType('app.debug', Type::getString());
+        // Reflected wins over default — `bool`, not `bool|string`
+        $this->assertSame('bool', $type->getId());
+    }
+
+    #[Test]
+    public function resolveCallReturnType_returns_generalized_default_when_key_absent(): void
+    {
+        $repo = $this->fakeRepository(['app.name' => 'Laravel']);
+        $resolver = new ConfigKeyResolver($repo);
+
+        // Literal 'fallback' default → generalize to string (not literal).
+        $type = $resolver->resolveCallReturnType(
+            'app.missing',
+            new \Psalm\Type\Union([\Psalm\Type\Atomic\TLiteralString::make('fallback')]),
+        );
+
+        $this->assertSame('string', $type->getId());
+    }
+
+    #[Test]
+    public function resolveCallReturnType_unions_null_with_default_when_value_is_null(): void
+    {
+        $repo = $this->fakeRepository(['app.providers' => null]);
+        $resolver = new ConfigKeyResolver($repo);
+
+        $type = $resolver->resolveCallReturnType(
+            'app.providers',
+            new \Psalm\Type\Union([\Psalm\Type\Atomic\TLiteralString::make('fallback')]),
+        );
+
+        // null | string
+        $this->assertTrue($type->isNullable());
+        $this->assertTrue($type->hasString());
+    }
+
+    #[Test]
+    public function generalizeDefault_downgrades_literal_scalars(): void
+    {
+        $input = new \Psalm\Type\Union([
+            \Psalm\Type\Atomic\TLiteralString::make('x'),
+            new \Psalm\Type\Atomic\TLiteralInt(42),
+            new \Psalm\Type\Atomic\TTrue(),
+        ]);
+
+        $generalized = ConfigKeyResolver::generalizeDefault($input);
+
+        $this->assertTrue($generalized->hasString());
+        $this->assertTrue($generalized->hasInt());
+        $this->assertTrue($generalized->hasBool());
+        $this->assertFalse($generalized->isSingleStringLiteral());
+        $this->assertFalse($generalized->isSingleIntLiteral());
+    }
+
+    #[Test]
+    public function generalizeDefault_resolves_typed_closure_to_return_type(): void
+    {
+        $closure = new \Psalm\Type\Atomic\TClosure(
+            params: [],
+            return_type: new \Psalm\Type\Union([\Psalm\Type\Atomic\TLiteralString::make('bar')]),
+        );
+
+        $generalized = ConfigKeyResolver::generalizeDefault(new \Psalm\Type\Union([$closure]));
+
+        $this->assertSame('string', $generalized->getId());
+    }
+
+    #[Test]
+    public function generalizeDefault_resolves_untyped_closure_to_mixed(): void
+    {
+        $closure = new \Psalm\Type\Atomic\TClosure();
+
+        $generalized = ConfigKeyResolver::generalizeDefault(new \Psalm\Type\Union([$closure]));
+
+        $this->assertTrue($generalized->isMixed());
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     */
+    private function fakeRepository(array $values): ConfigRepository
+    {
+        return new class ($values) implements ConfigRepository {
+            /** @param array<string, mixed> $values */
+            public function __construct(private array $values) {}
+
+            #[\Override]
+            public function has($key): bool
+            {
+                return \array_key_exists($key, $this->values);
+            }
+
+            #[\Override]
+            public function get($key, $default = null): mixed
+            {
+                return $this->values[$key] ?? $default;
+            }
+
+            #[\Override]
+            public function all(): array
+            {
+                return $this->values;
+            }
+
+            #[\Override]
+            public function set($key, $value = null): void
+            {
+                if (\is_array($key)) {
+                    foreach ($key as $k => $v) {
+                        $this->values[$k] = $v;
+                    }
+                    return;
+                }
+
+                $this->values[$key] = $value;
+            }
+
+            #[\Override]
+            public function prepend($key, $value): void {}
+
+            #[\Override]
+            public function push($key, $value): void {}
+        };
+    }
+}

--- a/tests/Unit/Util/ConfigKeyResolverTest.php
+++ b/tests/Unit/Util/ConfigKeyResolverTest.php
@@ -68,7 +68,7 @@ final class ConfigKeyResolverTest extends TestCase
             }
 
             #[\Override]
-            public function get($key, $default = null)
+            public function get($key, $default = null): void
             {
                 throw new \RuntimeException('config exploded');
             }
@@ -268,6 +268,7 @@ final class ConfigKeyResolverTest extends TestCase
                     foreach ($key as $k => $v) {
                         $this->values[$k] = $v;
                     }
+
                     return;
                 }
 

--- a/tests/Unit/Util/ConfigValueReflectorTest.php
+++ b/tests/Unit/Util/ConfigValueReflectorTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Util;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Util\ConfigValueReflector;
+use Psalm\Type;
+use Psalm\Type\Atomic\TKeyedArray;
+use Psalm\Type\Atomic\TNamedObject;
+
+#[CoversClass(ConfigValueReflector::class)]
+final class ConfigValueReflectorTest extends TestCase
+{
+    #[Test]
+    public function reflects_null_to_TNull(): void
+    {
+        $this->assertTrue(ConfigValueReflector::reflect(null)->isNull());
+    }
+
+    #[Test]
+    public function reflects_bool_to_general_bool_not_literal(): void
+    {
+        $type = ConfigValueReflector::reflect(false);
+        $this->assertSame('bool', $type->getId());
+    }
+
+    #[Test]
+    public function reflects_int_to_general_int_not_literal(): void
+    {
+        $type = ConfigValueReflector::reflect(42);
+        $this->assertSame('int', $type->getId());
+    }
+
+    #[Test]
+    public function reflects_float_to_general_float(): void
+    {
+        $type = ConfigValueReflector::reflect(3.14);
+        $this->assertSame('float', $type->getId());
+    }
+
+    #[Test]
+    public function reflects_string_to_general_string_not_literal(): void
+    {
+        $type = ConfigValueReflector::reflect('Laravel');
+        $this->assertSame('string', $type->getId());
+    }
+
+    #[Test]
+    public function reflects_empty_array_to_empty_array_atomic(): void
+    {
+        $type = ConfigValueReflector::reflect([]);
+        $this->assertTrue($type->equals(Type::getEmptyArray()));
+    }
+
+    #[Test]
+    public function reflects_list_to_keyed_array_is_list(): void
+    {
+        $type = ConfigValueReflector::reflect(['a', 'b']);
+        $atomic = $type->getSingleAtomic();
+
+        $this->assertInstanceOf(TKeyedArray::class, $atomic);
+        $this->assertTrue($atomic->is_list);
+        $this->assertCount(2, $atomic->properties);
+    }
+
+    #[Test]
+    public function reflects_keyed_array_preserves_string_keys(): void
+    {
+        $type = ConfigValueReflector::reflect(['name' => 'Laravel', 'debug' => true]);
+        $atomic = $type->getSingleAtomic();
+
+        $this->assertInstanceOf(TKeyedArray::class, $atomic);
+        $this->assertFalse($atomic->is_list);
+        $this->assertArrayHasKey('name', $atomic->properties);
+        $this->assertArrayHasKey('debug', $atomic->properties);
+    }
+
+    #[Test]
+    public function reflects_object_to_named_object_atomic(): void
+    {
+        $type = ConfigValueReflector::reflect(new \stdClass());
+        $atomic = $type->getSingleAtomic();
+
+        $this->assertInstanceOf(TNamedObject::class, $atomic);
+        $this->assertSame(\stdClass::class, $atomic->value);
+    }
+
+    #[Test]
+    public function reflects_closure_to_mixed(): void
+    {
+        // The reflector cannot follow a closure body without execution. value()
+        // resolves it at runtime — analysis must keep mixed at the call site.
+        $type = ConfigValueReflector::reflect(static fn(): string => 'x');
+        $this->assertTrue($type->isMixed());
+    }
+
+    #[Test]
+    public function degrades_to_mixed_array_at_max_depth(): void
+    {
+        // Build a tree deeper than MAX_DEPTH so the deepest level hits the
+        // degradation arm. The outer levels remain TKeyedArray; only the leaf
+        // beyond MAX_DEPTH collapses to array<array-key, mixed>.
+        $leaf = ['leaf' => 'value'];
+        $tree = $leaf;
+        for ($i = 0; $i < ConfigValueReflector::MAX_DEPTH + 1; $i++) {
+            $tree = ['n' => $tree];
+        }
+        $type = ConfigValueReflector::reflect($tree);
+
+        // Walk the keyed arrays until we hit the degraded floor. Assert exact
+        // id at the floor — the sibling key-cap test uses the same shape.
+        $current = $type->getSingleAtomic();
+        while ($current instanceof \Psalm\Type\Atomic\TKeyedArray) {
+            $current = $current->properties['n']?->getSingleAtomic() ?? $current->properties['leaf']->getSingleAtomic();
+        }
+        $this->assertInstanceOf(\Psalm\Type\Atomic\TArray::class, $current);
+        $this->assertSame('array<array-key, mixed>', (new \Psalm\Type\Union([$current]))->getId());
+    }
+
+    #[Test]
+    public function degrades_to_mixed_array_when_keys_exceed_cap(): void
+    {
+        $wide = [];
+        for ($i = 0; $i <= ConfigValueReflector::MAX_KEYS_PER_LEVEL; $i++) {
+            $wide["key_{$i}"] = $i;
+        }
+
+        $type = ConfigValueReflector::reflect($wide);
+        $this->assertSame('array<array-key, mixed>', $type->getId());
+    }
+
+    #[Test]
+    public function nested_arrays_recurse_within_depth_cap(): void
+    {
+        $shallow = ['outer' => ['inner' => 'leaf']];
+        $type = ConfigValueReflector::reflect($shallow);
+        $atomic = $type->getSingleAtomic();
+
+        $this->assertInstanceOf(TKeyedArray::class, $atomic);
+        $inner = $atomic->properties['outer'];
+        $innerAtomic = $inner->getSingleAtomic();
+        $this->assertInstanceOf(TKeyedArray::class, $innerAtomic);
+    }
+}

--- a/tests/Unit/Util/ConfigValueReflectorTest.php
+++ b/tests/Unit/Util/ConfigValueReflectorTest.php
@@ -90,12 +90,16 @@ final class ConfigValueReflectorTest extends TestCase
     }
 
     #[Test]
-    public function reflects_closure_to_mixed(): void
+    public function reflects_closure_value_to_Closure_named_object(): void
     {
-        // The reflector cannot follow a closure body without execution. value()
-        // resolves it at runtime — analysis must keep mixed at the call site.
-        $type = ConfigValueReflector::reflect(static fn(): string => 'x');
-        $this->assertTrue($type->isMixed());
+        // Repository::get returns the closure object verbatim — `value()` only
+        // runs on the $default branch inside Arr::get, never on stored values.
+        $closure = static fn(): string => 'x';
+        $type = ConfigValueReflector::reflect($closure);
+        $atomic = $type->getSingleAtomic();
+
+        $this->assertInstanceOf(TNamedObject::class, $atomic);
+        $this->assertSame(\Closure::class, $atomic->value);
     }
 
     #[Test]
@@ -131,6 +135,30 @@ final class ConfigValueReflectorTest extends TestCase
 
         $type = ConfigValueReflector::reflect($wide);
         $this->assertSame('array<array-key, mixed>', $type->getId());
+    }
+
+    #[Test]
+    public function degrades_when_total_property_budget_exhausted(): void
+    {
+        // Branching shape that fits within MAX_DEPTH and the per-level cap, but
+        // explodes total atomic count without the cross-level budget. Each
+        // top-level entry holds a smaller keyed array; together they cross
+        // MAX_TOTAL_PROPERTIES.
+        $branch = [];
+        for ($i = 0; $i < 32; $i++) {
+            $branch["k_{$i}"] = $i;
+        }
+        $tree = [];
+        for ($i = 0; $i < 32; $i++) {
+            // 32 branches × 32 leaves each = 1024 > MAX_TOTAL_PROPERTIES (512).
+            $tree["b_{$i}"] = $branch;
+        }
+        $type = ConfigValueReflector::reflect($tree);
+
+        // The top-level shape is still keyed (within budget for level 0),
+        // but at least one sub-tree degrades to array<array-key, mixed>.
+        $id = $type->getId();
+        $this->assertStringContainsString('array<array-key, mixed>', $id, 'Budget exhaustion must surface as array<array-key, mixed> somewhere in the tree.');
     }
 
     #[Test]

--- a/tests/Unit/Util/ConfigValueReflectorTest.php
+++ b/tests/Unit/Util/ConfigValueReflectorTest.php
@@ -113,6 +113,7 @@ final class ConfigValueReflectorTest extends TestCase
         for ($i = 0; $i < ConfigValueReflector::MAX_DEPTH + 1; $i++) {
             $tree = ['n' => $tree];
         }
+
         $type = ConfigValueReflector::reflect($tree);
 
         // Walk the keyed arrays until we hit the degraded floor. Assert exact
@@ -121,6 +122,7 @@ final class ConfigValueReflectorTest extends TestCase
         while ($current instanceof \Psalm\Type\Atomic\TKeyedArray) {
             $current = $current->properties['n']?->getSingleAtomic() ?? $current->properties['leaf']->getSingleAtomic();
         }
+
         $this->assertInstanceOf(\Psalm\Type\Atomic\TArray::class, $current);
         $this->assertSame('array<array-key, mixed>', (new \Psalm\Type\Union([$current]))->getId());
     }
@@ -148,11 +150,13 @@ final class ConfigValueReflectorTest extends TestCase
         for ($i = 0; $i < 32; $i++) {
             $branch["k_{$i}"] = $i;
         }
+
         $tree = [];
         for ($i = 0; $i < 32; $i++) {
             // 32 branches × 32 leaves each = 1024 > MAX_TOTAL_PROPERTIES (512).
             $tree["b_{$i}"] = $branch;
         }
+
         $type = ConfigValueReflector::reflect($tree);
 
         // The top-level shape is still keyed (within budget for level 0),


### PR DESCRIPTION
## Issue to Solve

`config('some.key')`, `\Illuminate\Config\Repository::get('some.key')`, and `Config::get('some.key')` all return `mixed`. Every callsite then triggers `MixedAssignment`/`MixedArgument`/`MixedOperand` issues, which is the headline of #752 and a major source of noise in real-world Laravel apps (Filament, Bagisto, etc.).

## Related

Closes #752.

## Solution Description

A Psalm type provider (`ConfigHelperHandler` + `ConfigRepositoryMethodHandler`) routes the three call shapes through a singleton `ConfigKeyResolver`. The resolver reads the value from the booted Laravel app via the existing `ConfigRepositoryProvider`, reflects it into a Psalm `Union` (`ConfigValueReflector`), and merges that with the default-arg type to produce a narrowed return.

**Why scalars stay general.** Booted Laravel resolves env-driven defaults to a single concrete observation at analysis time. Narrowing `config('app.debug')` to `false` (its boot-time value) would surface spurious `TypeDoesNotContainType` errors on every `if (config('app.debug'))` callsite; narrowing `config('app.name')` to `'Laravel'` would break every `===` against a production override. The reflector therefore generalizes literals: `bool`/`int`/`string`/`float` rather than `TLiteralBool`/`TLiteralInt`/etc. Arrays preserve their shape up to depth 5 with a 64-key cap per level; beyond that the type degrades to `array<array-key, mixed>` to avoid pathological recursion (cyclic refs, megabyte-scale type strings).

**Default-arg merge mirrors `Arr::get` runtime semantics.**

| key state                 | default arg | returned type                       |
|---------------------------|-------------|--------------------------------------|
| absent                    | any         | generalized default                  |
| present, value not null   | any         | reflected value (default ignored)    |
| present, value is null    | any         | `null \| generalized default`        |

Closure defaults follow through to their declared return type via recursive generalization. Untyped closures contribute `mixed` without discarding atomics already collected from other union members (so `string | Closure(): void` resolves to `string | mixed`, not just `mixed`).

**Literal AST inspection.** Psalm's `NodeTypeProvider` returns `null` for argument nodes inside the facade `__callStatic` dispatch — `Config::get('app.name')` would otherwise drop to `mixed` because the second arg's type is unknown at handler time. Both `extractLiteralKey` and `readDefaultTypeAt` inspect the raw AST (`String_`, `Int_`, `Float_`, `ConstFetch`, `Array_`) first and fall back to the type provider only when the expression is not a literal.

**`Config` facade routing.** Listing `\Illuminate\Support\Facades\Config::class` (plus `FacadeMapProvider::getFacadeClasses(\Illuminate\Config\Repository::class)`) in `getClassLikeNames` makes the handler fire for the facade. `MethodParamsProviderInterface` is implemented alongside the return-type hook because Psalm 7 throws `Cannot get method params for Illuminate\Support\Facades\Config::get` when the registered method only exists as a `@method` annotation (same crash class as #454 / #854). The provider synthesises params for the facade FQCN and defers to source for the real `Repository`/contract.

**Failure-safe resolver bootstrap.** `ConfigKeyResolver::instance()` wraps `ConfigRepositoryProvider::get()` in a try/catch and falls back to a `ThrowingConfigRepository` sentinel. Without that, an unbound binding (or an exploding service provider during plugin init) would propagate from a Psalm hook handler and crash analysis on every `config()` call site. The sentinel's methods all throw, so `ConfigKeyResolver::warm()`'s existing catch arm caches `mixed` (matching the pre-PR stub ceiling).

**Out of scope (follow-up PR).** Reading `@return` PHPDoc on `config/*.php` files (Larastan PR #2445 equivalent). Different source of truth (static AST vs runtime), different fixtures, different review surface — shipped separately to keep this PR reviewable.

## Verification

- `composer test:type` (423 tests) — type tests cover all narrowing branches across `config()`, `Repository::get`, and `Config::get`.
- `composer test:unit` (707 tests) — unit tests for the reflector (granularity table, depth/key caps) and resolver (cache trichotomy, generalization, closure handling, throwing repo).
- `composer psalm` — clean.
- `composer test:app` — clean.

## Checklist

- [x] Tests cover the change (type tests in `tests/Type/` + unit tests in `tests/Unit/`)
