### PR TITLE
CI: dedupe push/PR runs and add concurrency cancel

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -11,6 +11,11 @@ on:
       - '**.php'
       - 'composer.json'
 
+# Cancel superseded runs on the same branch/PR to save CI minutes on fast pushes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   fix:
     name: Auto-fix code style

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -2,6 +2,7 @@ name: Psalm
 
 on:
   push:
+    branches: [master]
     paths:
       - '**.php'
       - 'psalm*'
@@ -13,6 +14,11 @@ on:
       - 'psalm*'
       - 'composer.json'
       - '.github/workflows/psalm.yml'
+
+# Cancel superseded runs on the same branch/PR to save CI minutes on fast pushes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   psalm:

--- a/.github/workflows/test-laravel-app.yml
+++ b/.github/workflows/test-laravel-app.yml
@@ -3,6 +3,7 @@ name: Test Laravel app
 on:
   workflow_dispatch:
   push:
+    branches: [master]
     paths:
       - '**.php'
       - '**.phpstub'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,12 +3,13 @@ name: Tests
 on:
   workflow_dispatch:
   push:
+    branches: [master]
     paths:
       - '**.php'
       - '**.phpstub'
       - '**.phpt'
-      - '**.yml'
       - 'composer.json'
+      - '.github/workflows/tests.yml'
   pull_request:
     paths:
       - '**.php'


### PR DESCRIPTION
## Issue to Solve

Internal-branch PR commits triggered both `push` and `pull_request` events on Psalm/Tests/Laravel-app workflows, doubling every job. Forced re-pushes also left stale in-progress runs spinning instead of being canceled.

PR #971 was the trigger: identical "Psalm" check ran twice (runs [26126157845](https://github.com/psalm/psalm-plugin-laravel/actions/runs/26126157845) and [26126138147](https://github.com/psalm/psalm-plugin-laravel/actions/runs/26126138147)) for the same SHA `f514f979`, each burning a runner.

## Related

Related to duplicate runs observed on #971. No issue ref.

## Solution Description

Four workflow tweaks:

1. **Scope `push` to `branches: [master]`** in `psalm.yml`, `tests.yml`, `test-laravel-app.yml`. Pre-merge runs come solely from `pull_request`. Forks already only emit `pull_request`. `code-style.yml` was already scoped.

2. **Add `concurrency` block** to `psalm.yml` and `code-style.yml`. Matches the existing pattern in `tests.yml` / `test-laravel-app.yml`. Force-pushes mid-CI now cancel the stale run.

3. **`tests.yml` path symmetry**: drop over-broad `'**.yml'` from push paths; add `.github/workflows/tests.yml` to both push and pull_request lists so workflow-only edits get validated on PR.

4. Will be self-validated on this PR. After merge, future PRs will run each workflow once per push instead of twice.

## Checklist

- ~~Tests cover the change~~ — CI config, no production code.
- ~~Documentation is updated~~ — no doc impact.
