### PR TITLE
Specialize `Js::from()` and `Js::encode()` taint per callsite (reduce false-positive reports)

### DIFF
--- a/docs/contributing/taint-analysis.md
+++ b/docs/contributing/taint-analysis.md
@@ -286,7 +286,15 @@ When a function has `@psalm-flow ($param) -> return` without `@psalm-taint-speci
 public static function of($string) {}
 ```
 
-This differs from **escape functions** like `e()`, where `@psalm-taint-specialize` is not needed because the escape annotation removes the dangerous taint kind regardless of call site. Pure flow-through functions (no escape/unescape) must always pair `@psalm-taint-specialize` with `@psalm-flow`.
+**Escape functions still need `@psalm-taint-specialize`** when the stub returns a `mixed`-or-wider value that can pool. `@psalm-taint-escape` only strips the listed kind(s) (e.g. `html`, `has_quotes`); every other taint that flows through `@psalm-flow` (`sql`, `shell`, `user_secret`, `system_secret`, etc.) continues to pool into the single global return node and re-emerges at every other callsite (issue #1007). For `Js::from()` / `Js::encode()` adding `@psalm-taint-specialize` cleanly isolates per-callsite flow and is verified by `SafeJsEncodeSpecializePerCallsite.phpt`.
+
+**Empirical verification is mandatory.** Adding `@psalm-taint-specialize` to a `@psalm-flow` + `@psalm-taint-escape` (or `@psalm-taint-unescape`) stub is NOT mechanically safe in Psalm 7. Spot-checking issue #1007's follow-up list showed that the same triple breaks within-callsite taint propagation on `Connection::escape()`, `SessionGuard::hashPasswordForCookie()`, and `Encrypter::*String` — the `TaintedHtml*` tests for those methods stopped firing after `@psalm-taint-specialize` was added, even though `Js::encode()` with the same triple keeps propagating SQL taint correctly in `TaintedSqlJsEncodePreservesTaint.phpt`. The asymmetry is not localized yet (likely a Psalm-7 interaction between `@psalm-taint-specialize` and the `input` group alias on narrow parameter types). Before adding `@psalm-taint-specialize` to any other escape/unescape stub:
+
+1. Identify the existing test that asserts within-callsite non-escaped-kind flow through the stub. If no such test exists, write one.
+2. Add `@psalm-taint-specialize` and re-run the test. If it now reports zero errors, the stub falls into the broken-asymmetry class — revert the annotation and open a Psalm 7 bug report with a minimal repro.
+3. Add a per-callsite regression test under `tests/Type/tests/TaintAnalysis/Safe<Stub><Method>SpecializePerCallsite.phpt` modeled on `SafeJsEncodeSpecializePerCallsite.phpt`.
+
+The known-broken candidates (`e()`, `encrypt()` / `decrypt()` and `*String` variants, `SessionGuard::hashPasswordForCookie()`, `Connection::escape()`, `DB::escape()`) are tracked as follow-ups to #1007. Do not blanket-apply the annotation; treat every site as its own bisect.
 
 ## Per-rule escape on Rule objects
 
@@ -363,7 +371,7 @@ final class EmailWithDnsRule implements ValidationRule
 2. **For database methods, check whether values are PDO-bound or raw SQL**. See [PDO parameterized queries](#pdo-parameterized-queries). Column names go into SQL identifiers (sink); values go into bindings (escape).
 3. **Choose the correct annotation type**: source, sink, escape, or flow
 4. **If using `@psalm-taint-escape` or `@psalm-taint-unescape`**: always add `@psalm-flow` to preserve other taint kinds (unless the return value's other taints are truly irrelevant)
-5. **If using `@psalm-flow` on a method returning a concrete value (model, scalar, or collection)**: add `@psalm-taint-specialize` to prevent cross-call-site taint pollution. This applies whether or not `@psalm-taint-escape` is also present
+5. **If using `@psalm-flow` on a method returning a concrete value (model, scalar, or collection)**: add `@psalm-taint-specialize` to prevent cross-call-site taint pollution, then run the existing `Tainted<NonEscapedKind>*` test for the stub to confirm within-callsite flow still propagates. The combination is not mechanically safe on every stub shape in Psalm 7 — see [Flow-through factories need `@psalm-taint-specialize`](#flow-through-factories-need-psalm-taint-specialize) for the empirical-verification protocol
 6. **Match parameter types exactly** to Laravel's signatures. Do not narrow types.
 7. **Place in `stubs/common/`** under a path matching the Laravel namespace
 8. **Keep taint and type annotations together**. If a method already has type stubs, add taint annotations to the same file (see [Stub merging](README.md#stub-merging-how-psalm-combines-annotations))

--- a/stubs/common/Support/Js.phpstub
+++ b/stubs/common/Support/Js.phpstub
@@ -23,6 +23,7 @@ class Js implements Htmlable, Stringable
      * @psalm-taint-escape html
      * @psalm-taint-escape has_quotes
      * @psalm-flow ($data) -> return
+     * @psalm-taint-specialize
      */
     public static function from($data, $flags = 0, $depth = 512) {}
 
@@ -41,6 +42,7 @@ class Js implements Htmlable, Stringable
      * @psalm-taint-escape html
      * @psalm-taint-escape has_quotes
      * @psalm-flow ($data) -> return
+     * @psalm-taint-specialize
      */
     public static function encode($data, $flags = 0, $depth = 512) {}
 }

--- a/tests/Type/tests/TaintAnalysis/SafeJsEncodeSpecializePerCallsite.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeJsEncodeSpecializePerCallsite.phpt
@@ -1,0 +1,31 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Js::encode() and Js::from() are @psalm-taint-specialize: taint flowing in at
+ * one callsite must not pool into the return value at every other callsite
+ * (issue #1007). Js::from() shares the same stub annotation and is covered by
+ * this same regression because the fix is identical; it cannot be asserted
+ * with a `Js::from()->toHtml()` flow because Psalm does not propagate taint
+ * through the intermediate `Js` object property access.
+ *
+ * Without specialization, the SQL taint introduced in siteA() would pollute
+ * Js::encode()'s global return node and falsely poison siteB()'s call, firing
+ * a TaintedSql error at the unprepared() sink even though siteB's argument is
+ * a hardcoded literal.
+ */
+function siteA(\Illuminate\Http\Request $request): void {
+    /** @var string $sql */
+    $sql = $request->input('sql');
+    echo \Illuminate\Support\Js::encode($sql);
+}
+
+function siteB(): void {
+    $encoded = \Illuminate\Support\Js::encode('static-payload');
+    $conn = new \Illuminate\Database\Connection(new \PDO('sqlite::memory:'));
+    $conn->unprepared($encoded);
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

`Illuminate\Support\Js::from()` and `Js::encode()` declare `@psalm-flow ($data) -> return` without `@psalm-taint-specialize`. Psalm then pools every callsite into one global taint node: a tainted argument at any single caller poisons the return value at every other caller, producing cascades of false-positive `TaintedUserSecret` / `TaintedSystemSecret` errors at unrelated `<?= Js::from(...) ?>` sinks. Reproduced on `filamentphp/filament@4.x` where one genuine `decrypt() -> implode() -> Js::from()` flow surfaces ~60 false positives.

## Related

Closes #1007

## Solution Description

- `stubs/common/Support/Js.phpstub` — add `@psalm-taint-specialize` to both `from()` and `encode()` so taint is tracked per callsite. `@psalm-taint-escape html` only strips `html` / `has_quotes`; every other taint kind continues to pool through `@psalm-flow` unless the function is specialized.
- `tests/Type/tests/TaintAnalysis/SafeJsEncodeSpecializePerCallsite.phpt` — new regression test. A tainted SQL source at one callsite must not poison `Connection::unprepared()` at an unrelated callsite whose argument is a hardcoded literal. Verified that the test fails without the stub change and passes with it. `Js::from()` shares the same stub annotation; the test docblock spells out why it cannot be exercised in isolation (`Js::toHtml()` reads `$this->js` without an explicit flow annotation, so taint does not propagate through the intermediate `Js` object).
- `docs/contributing/taint-analysis.md` — rewrite the paragraph that previously claimed escape functions can omit specialization (the root cause of #1007). State the correct rule, mark empirical verification as mandatory, and note that the triple is not mechanically safe on every stub shape in Psalm 7. A spot-check on the issue's follow-up candidates (`Connection::escape`, `SessionGuard::hashPasswordForCookie`, `Encrypter::*String`) showed that adding `@psalm-taint-specialize` silently breaks within-callsite flow on those methods, even though `Js::encode` with the identical triple keeps propagating SQL taint correctly. That asymmetry is left for a follow-up Psalm 7 bisect; the doc lists the known-broken candidates so contributors do not blanket-apply the annotation.

Existing tests for the orthogonal escape/preserve behavior (`SafeJsEncodeEscapesHtml.phpt`, `SafeJsFromEscapesHtml.phpt`, `TaintedSqlJsEncodePreservesTaint.phpt`) continue to pass, confirming the change does not regress the per-kind escape or the within-callsite SQL passthrough.

## Checklist

- [x] Tests cover the change (`tests/Type/tests/TaintAnalysis/SafeJsEncodeSpecializePerCallsite.phpt`)
- [x] Documentation is updated (`docs/contributing/taint-analysis.md`)
