### PR TITLE
feat(taint): detect weak hashing of secrets via `md5()` / `sha1()` (CWE-328)

### DIFF
--- a/docs/contributing/taint-analysis.md
+++ b/docs/contributing/taint-analysis.md
@@ -100,8 +100,8 @@ All taint kind names are defined in [`Psalm\Type\TaintKind::TAINT_NAMES`](https:
 | `shell`         | Command injection                         | `Process::run()`                              | `escapeshellarg()`                            |
 | `ssrf`          | Server-side request forgery               | `Http::get($url)`                             | N/A                                           |
 | `file`          | Path traversal                            | `Filesystem::get()`, `response()->download()` | N/A                                           |
-| `user_secret`   | Password/token exposure in logs or output | `echo`, log sinks                             | `Hash::make()`, `Encrypter::encrypt()`        |
-| `system_secret` | Internal secret exposure                  | `echo`, log sinks                             | `Hash::make()`, `Encrypter::encrypt()`        |
+| `user_secret`   | Password/token exposure in logs or output | `echo`, log sinks, `md5()`, `sha1()`          | `Hash::make()`, `Encrypter::encrypt()`        |
+| `system_secret` | Internal secret exposure                  | `echo`, log sinks, `md5()`, `sha1()`          | `Hash::make()`, `Encrypter::encrypt()`        |
 
 ### All available kinds
 

--- a/stubs/common/Php/HashFunctions.phpstub
+++ b/stubs/common/Php/HashFunctions.phpstub
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Taint sinks for PHP's weak cryptographic hash functions.
+ *
+ * md5() and sha1() are unsuitable for hashing credentials or secrets
+ * (CWE-328: Use of Weak Hash). They remain valid for non-secret checksums,
+ * so the sinks are gated on the {user,system}_secret taint kinds —
+ * untainted inputs continue to type-check cleanly.
+ *
+ * Use Hash::make() / bcrypt() / Hash::check() for credentials; both
+ * functions escape user_secret and system_secret via their own stubs.
+ *
+ * Scope: only direct md5() / sha1() calls. `hash('md5', ...)` and
+ * `hash_hmac('md5', ...)` are not covered because the algorithm is
+ * carried as a runtime string argument that a docblock sink cannot
+ * inspect — that would need a dedicated function-call handler.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/673
+ */
+
+/**
+ * Mirrors Psalm's CallMap entry — the stub's @return shadows it, so it must
+ * keep `non-falsy-string` to avoid widening downstream type inference.
+ *
+ * @param string $string
+ * @param bool $binary
+ * @return non-falsy-string
+ *
+ * @psalm-taint-sink user_secret $string
+ * @psalm-taint-sink system_secret $string
+ */
+function md5($string, $binary = false) {}
+
+/**
+ * @param string $string
+ * @param bool $binary
+ * @return string
+ *
+ * @psalm-taint-sink user_secret $string
+ * @psalm-taint-sink system_secret $string
+ */
+function sha1($string, $binary = false) {}

--- a/tests/Type/tests/TaintAnalysis/SafeWeakHashUntaintedChecksum.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeWeakHashUntaintedChecksum.phpt
@@ -1,0 +1,32 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * md5()/sha1() on non-secret data (file checksums, ETags, cache keys) are
+ * legitimate non-cryptographic uses. The taint sinks are gated on the
+ * user_secret / system_secret labels, so even input carrying *other* taint
+ * kinds (html, sql, ...) must not trigger TaintedUserSecret or
+ * TaintedSystemSecret — only secret-class taint should be flagged.
+ *
+ * Request::input() carries the `html` (and other input-group) taint kind,
+ * so flowing it into md5()/sha1() exercises the label gate explicitly.
+ */
+function etagFromRequestBody(\Illuminate\Http\Request $request): string {
+    /** @var string $body */
+    $body = $request->input('body');
+
+    return md5($body) . ':' . sha1($body);
+}
+
+function checksumFileContents(string $path): string {
+    $contents = file_get_contents($path);
+    if ($contents === false) {
+        return '';
+    }
+
+    return md5($contents) . ':' . sha1($contents);
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/TaintedSystemSecretMd5ApiKey.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSystemSecretMd5ApiKey.phpt
@@ -1,0 +1,21 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Cross-coverage of the (kind, sink) matrix: system_secret flows into md5()
+ * (complements TaintedSystemSecretSha1ApiKey and TaintedUserSecretMd5Password).
+ *
+ * @psalm-taint-source system_secret
+ */
+function readSystemApiKey(): string {
+    return (string) getenv('API_KEY');
+}
+
+function legacyMd5ApiKey(): string {
+    return md5(readSystemApiKey());
+}
+?>
+--EXPECTF--
+%ATaintedSystemSecret on line %d: Detected tainted system secret leaking%A

--- a/tests/Type/tests/TaintAnalysis/TaintedSystemSecretSha1ApiKey.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSystemSecretSha1ApiKey.phpt
@@ -1,0 +1,22 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * sha1() is a broken hash (CWE-328). A system_secret source flowing into
+ * sha1() must trigger TaintedSystemSecret — sha1 cannot be used to mask
+ * server credentials.
+ *
+ * @psalm-taint-source system_secret
+ */
+function readApiKeyFromEnv(): string {
+    return (string) getenv('API_KEY');
+}
+
+function legacySha1ApiKey(): string {
+    return sha1(readApiKeyFromEnv());
+}
+?>
+--EXPECTF--
+%ATaintedSystemSecret on line %d: Detected tainted system secret leaking%A

--- a/tests/Type/tests/TaintAnalysis/TaintedUserSecretMd5BinaryMode.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedUserSecretMd5BinaryMode.phpt
@@ -1,0 +1,17 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Binary-mode regression guard: the sink targets the `$string` parameter
+ * by name. Calling md5($secret, true) for a 16-byte raw digest must still
+ * fire, otherwise a contributor could silently break the sink by moving
+ * the annotation off the named parameter.
+ */
+function legacyMd5PasswordBinary(\Illuminate\Foundation\Auth\User $user): string {
+    return md5($user->getAuthPassword(), true);
+}
+?>
+--EXPECTF--
+%ATaintedUserSecret on line %d: Detected tainted user secret leaking%A

--- a/tests/Type/tests/TaintAnalysis/TaintedUserSecretMd5IndirectFlow.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedUserSecretMd5IndirectFlow.phpt
@@ -1,0 +1,34 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis --threads=1
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Indirect-flow case: the user_secret taint is laundered through a local
+ * variable and a helper method before reaching md5(). Psalm must still
+ * trace the flow and emit TaintedUserSecret at the md5() call site.
+ *
+ * --threads=1 is required: when this test is batched with the rest of the
+ * --taint-analysis corpus under Psalm's default parallel workers, the
+ * cross-method taint edge does not survive the worker merge. Standalone
+ * runs detect it correctly. Same convention as the InlineValidate
+ * cross-procedural tests.
+ */
+final class LegacyPasswordHasher
+{
+    public function digest(string $password): string
+    {
+        $normalised = strtolower(trim($password));
+
+        return md5($normalised);
+    }
+}
+
+function hashViaHelper(\Illuminate\Foundation\Auth\User $user): string {
+    $password = $user->getAuthPassword();
+
+    return (new LegacyPasswordHasher())->digest($password);
+}
+?>
+--EXPECTF--
+%ATaintedUserSecret on line %d: Detected tainted user secret leaking%A

--- a/tests/Type/tests/TaintAnalysis/TaintedUserSecretMd5Password.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedUserSecretMd5Password.phpt
@@ -1,0 +1,16 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * md5() is a broken hash (CWE-328). Passing a user_secret source
+ * (Authenticatable::getAuthPassword()) into md5() must trigger
+ * TaintedUserSecret because the digest is feasible to brute force.
+ */
+function legacyMd5Password(\Illuminate\Foundation\Auth\User $user): string {
+    return md5($user->getAuthPassword());
+}
+?>
+--EXPECTF--
+%ATaintedUserSecret on line %d: Detected tainted user secret leaking%A

--- a/tests/Type/tests/TaintAnalysis/TaintedUserSecretSha1Password.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedUserSecretSha1Password.phpt
@@ -1,0 +1,16 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Cross-coverage of the (kind, sink) matrix: user_secret flows into sha1()
+ * (the user_secret/sha1 cell complements TaintedUserSecretMd5Password and
+ * TaintedSystemSecretSha1ApiKey).
+ */
+function legacySha1Password(\Illuminate\Foundation\Auth\User $user): string {
+    return sha1($user->getAuthPassword());
+}
+?>
+--EXPECTF--
+%ATaintedUserSecret on line %d: Detected tainted user secret leaking%A


### PR DESCRIPTION
## Issue to Solve

`md5()` and `sha1()` on credentials or secrets is CWE-328 (use of a broken/risky cryptographic algorithm). Until now the plugin did not flag this — `md5($user->getAuthPassword())` and `sha1((string) getenv('API_KEY'))` were silently accepted under `--taint-analysis`.

## Related

Closes #673

## Solution Description

Add a new stub `stubs/common/Php/HashFunctions.phpstub` that re-declares the global `md5()` / `sha1()` builtins with `@psalm-taint-sink user_secret $string` and `@psalm-taint-sink system_secret $string`. When a value tainted with either secret kind reaches `md5()` / `sha1()` under `--taint-analysis`, Psalm now emits `TaintedUserSecret` or `TaintedSystemSecret`.

### Before / After

Before:
```php
function legacy(\Illuminate\Foundation\Auth\User $user): string {
    return md5($user->getAuthPassword()); // silent
}
```

After (under `--taint-analysis`):
```
TaintedUserSecret: Detected tainted user secret leaking
  Illuminate\Foundation\Auth\User::getAuthPassword
  call to md5 — return md5($user->getAuthPassword());
```

### False-positive guard

The sinks are kind-gated. Only values carrying `user_secret` or `system_secret` taint trigger the issue. Legitimate non-cryptographic uses on untainted or differently-tainted data (`md5(file_get_contents($path))`, `md5($request->input('body'))` for ETag generation, cache-key construction, etc.) continue to type-check cleanly. Exercised by `SafeWeakHashUntaintedChecksum.phpt`, which routes both untainted input and `html`-tainted `Request::input()` into `md5()` / `sha1()` and asserts no secret-class issue fires.

### CallMap precision preserved

`md5()`'s stub `@return` is set to `non-falsy-string` to match Psalm's CallMap entry. Without this, the stub would shadow CallMap and widen the return type to `string` for every `md5()` call in user projects (since Psalm's `Functions::getStorage()` short-circuits to stub storage when present). `sha1()` keeps `@return string` because CallMap already returns `string`.

### Scope

This PR covers direct `md5()` / `sha1()` builtins only. The `hash($algo, ...)` / `hash_hmac($algo, ...)` family is intentionally out of scope: the weakness is conditional on the literal algorithm string, which a docblock sink cannot inspect. That would require a dedicated function-call handler and belongs in a follow-up.

### Verification

Test coverage added under `tests/Type/tests/TaintAnalysis/`:

- `TaintedUserSecretMd5Password.phpt` — `getAuthPassword()` → `md5()` flags `TaintedUserSecret`
- `TaintedUserSecretSha1Password.phpt` — `getAuthPassword()` → `sha1()` flags `TaintedUserSecret`
- `TaintedSystemSecretMd5ApiKey.phpt` — `system_secret`-tainted source → `md5()` flags `TaintedSystemSecret`
- `TaintedSystemSecretSha1ApiKey.phpt` — `system_secret`-tainted source → `sha1()` flags `TaintedSystemSecret`
- `TaintedUserSecretMd5IndirectFlow.phpt` — secret laundered through a local var and a separate class method before `md5()`; verifies indirect cross-method flow. Pinned to `--threads=1` (same convention as the existing `InlineValidate*` cross-procedural tests).
- `TaintedUserSecretMd5BinaryMode.phpt` — `md5($secret, true)` regression guard; ensures the sink stays bound to `$string` if the docblock is refactored.
- `SafeWeakHashUntaintedChecksum.phpt` — untainted `file_get_contents()` and `html`-tainted `Request::input()` flowing into `md5()` / `sha1()` must NOT raise a secret-class issue. Validates the kind gate.

Docs: `docs/contributing/taint-analysis.md` adds `md5()`, `sha1()` to the example-sink column for the `user_secret` and `system_secret` rows.

Local checks all green: `composer test:type` (431 tests), `composer test:unit`, `composer test:app`, `composer psalm` (100% inference), `composer cs`.

## Checklist

- [x] Tests cover the change (type tests in `tests/Type/tests/TaintAnalysis/`)
- [x] Documentation is updated (`docs/contributing/taint-analysis.md`)
