### PR TITLE
Narrow `$this->input()` return type inside FormRequest

### DIFF
--- a/src/Handlers/Validation/ValidatedTypeHandler.php
+++ b/src/Handlers/Validation/ValidatedTypeHandler.php
@@ -46,6 +46,12 @@ final class ValidatedTypeHandler implements MethodReturnTypeProviderInterface
             \Illuminate\Foundation\Http\FormRequest::class,
             \Illuminate\Http\Request::class,
             \Illuminate\Support\ValidatedInput::class,
+            // input() is declared on the InteractsWithInput trait, not on
+            // FormRequest/Request directly. Without this entry Psalm's method
+            // provider only matches the declaring class chain, so the
+            // resolveSelfInput dispatch below never fires for
+            // `$this->input(...)` inside a FormRequest subclass. See #1015.
+            \Illuminate\Http\Concerns\InteractsWithInput::class,
         ];
     }
 
@@ -65,8 +71,74 @@ final class ValidatedTypeHandler implements MethodReturnTypeProviderInterface
             'validated' => self::resolveValidated($event),
             'safe' => self::resolveSafe($event),
             'validate' => self::resolveInlineValidate($event),
+            'input' => self::resolveSelfInput($event),
             default => null,
         };
+    }
+
+    /**
+     * FormRequest subclass::input('field') → rule type, when the field's rule
+     * guarantees presence (required / present / accepted / declined).
+     *
+     * Covers `$this->input(...)` called inside the FormRequest itself
+     * (prepareForValidation, passedValidation, withValidator, custom helpers)
+     * — the controller-side narrowing already flows through `validated()` and
+     * `safe()->input()`. See issue #1015.
+     *
+     * Soundness: input() reads pre-validation request data, so a narrowed type
+     * is only safe when the field is presence-guaranteed by the rule. Optional
+     * fields (sometimes / no required-style rule) fall through to the stub's
+     * mixed return — same trade-off documented in the issue's "Option 2".
+     * Mirrors the `required`-gated `setPossiblyUndefined` branch in
+     * {@see buildUnionFromTree}.
+     *
+     * The `validated()`-style escape for taint already covers `input` via
+     * {@see ValidationTaintHandler::KEYED_ACCESSOR_METHODS}, so narrowing here
+     * does not change the taint flow.
+     */
+    private static function resolveSelfInput(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        $callArgs = $event->getCallArgs();
+
+        if ($callArgs === []) {
+            return null;
+        }
+
+        $rules = self::getRulesForCalledClass($event);
+
+        if ($rules === null) {
+            return null;
+        }
+
+        $nodeTypeProvider = $event->getSource()->getNodeTypeProvider();
+        $firstArgType = $nodeTypeProvider->getType($callArgs[0]->value);
+
+        if (!$firstArgType instanceof Union || !$firstArgType->isSingleStringLiteral()) {
+            return null;
+        }
+
+        $key = $firstArgType->getSingleStringLiteral()->value;
+        $rule = $rules[$key] ?? null;
+
+        // Bail when the field has no rule, the rule does not guarantee
+        // presence, or `sometimes` overrides the presence guarantee.
+        //
+        // Laravel's `sometimes|required` means "if the field is present it
+        // must be valid", so the field can still be legitimately absent at
+        // the input() call site — same treatment {@see buildUnionFromTree}
+        // gives the validated() output (marks the field possibly_undefined
+        // when `sometimes || !required`).
+        //
+        // Reads through prepareForValidation() and friends may also run
+        // before validation has filled in optional fields, so anything
+        // weaker than an unconditional `required` (or its present /
+        // accepted / declined siblings, see
+        // {@see ValidationRuleAnalyzer::resolveRuleSegments}) stays mixed.
+        if ($rule === null || !$rule->required || $rule->sometimes) {
+            return null;
+        }
+
+        return self::resolveFieldType($rules, $callArgs, $event);
     }
 
     /**

--- a/src/Handlers/Validation/ValidatedTypeHandler.php
+++ b/src/Handlers/Validation/ValidatedTypeHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Handlers\Validation;
 
+use Psalm\Internal\Analyzer\ProjectAnalyzer;
 use Psalm\LaravelPlugin\Util\Arg;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
@@ -85,16 +86,35 @@ final class ValidatedTypeHandler implements MethodReturnTypeProviderInterface
      * — the controller-side narrowing already flows through `validated()` and
      * `safe()->input()`. See issue #1015.
      *
-     * Soundness: input() reads pre-validation request data, so a narrowed type
-     * is only safe when the field is presence-guaranteed by the rule. Optional
-     * fields (sometimes / no required-style rule) fall through to the stub's
-     * mixed return — same trade-off documented in the issue's "Option 2".
-     * Mirrors the `required`-gated `setPossiblyUndefined` branch in
-     * {@see buildUnionFromTree}.
+     * Soundness window: only fields with an unconditional presence rule
+     * (required / present / accepted / declined, and only when `sometimes`
+     * is absent) narrow — the field is guaranteed to exist post-validation,
+     * matching the validated() trade-off. Optional fields, `sometimes|required`,
+     * and conditional-presence siblings (required_if, present_with, …) fall
+     * through to the stub's mixed return. Mirrors the `required`-gated
+     * `setPossiblyUndefined` branch in {@see buildUnionFromTree}.
      *
-     * The `validated()`-style escape for taint already covers `input` via
-     * {@see ValidationTaintHandler::KEYED_ACCESSOR_METHODS}, so narrowing here
-     * does not change the taint flow.
+     * Pre-validation unsoundness (deliberate, documented): reads in
+     * prepareForValidation() / authorize() / rules() callbacks run BEFORE
+     * the validator has constrained the value, so `required|integer` does
+     * not yet imply the runtime value is `int|numeric-string`. This narrowing
+     * matches the existing validated()-style "trust the rule" precedent for
+     * analysis precision; downstream consumers in pre-validation contexts
+     * (notably `header()` sinks) carry the same residual false-negative
+     * surface that the controller-side narrowing has always had.
+     *
+     * Inheritance gate: `getRulesForCalledClass` only resolves `rules()`
+     * via the codebase classlike storage, so a custom Request subclass
+     * (or other unrelated class) that happens to define `rules()` could in
+     * principle slip through. We require the called class to actually
+     * extend `FormRequest` to keep the narrowing scoped to the framework
+     * contract it models.
+     *
+     * The taint flow for the narrowed expression is restored in
+     * {@see ValidationTaintHandler::isValidationMethodCall} — Psalm drops
+     * the stub's @psalm-taint-source when a return-type override fires,
+     * so the taint handler explicitly re-emits ALL_INPUT for `input()` on
+     * a FormRequest caller.
      */
     private static function resolveSelfInput(MethodReturnTypeProviderEvent $event): ?Union
     {
@@ -104,16 +124,48 @@ final class ValidatedTypeHandler implements MethodReturnTypeProviderInterface
             return null;
         }
 
-        $rules = self::getRulesForCalledClass($event);
-
-        if ($rules === null) {
-            return null;
-        }
-
+        // Cheap literal-key check first — dynamic-key call sites are common and
+        // skipping the rules() AST walk for them avoids a per-expression hit
+        // (extractRulesFromClass walks parent_class via classlike storage; not
+        // free even after the per-class memoization).
         $nodeTypeProvider = $event->getSource()->getNodeTypeProvider();
         $firstArgType = $nodeTypeProvider->getType($callArgs[0]->value);
 
         if (!$firstArgType instanceof Union || !$firstArgType->isSingleStringLiteral()) {
+            return null;
+        }
+
+        // Inheritance gate: limit narrowing to genuine FormRequest subclasses.
+        // InteractsWithInput is also used by plain Request and by user-authored
+        // traits that pair an unrelated `rules()` method with the trait — none
+        // of those should be narrowed under the FormRequest validation contract.
+        $calledClass = $event->getCalledFqClasslikeName();
+
+        if ($calledClass === null) {
+            return null;
+        }
+
+        try {
+            $codebase = ProjectAnalyzer::getInstance()->getCodebase();
+        } catch (\RuntimeException|\Error) {
+            return null;
+        }
+
+        try {
+            $isFormRequest
+                = $calledClass === \Illuminate\Foundation\Http\FormRequest::class
+                || $codebase->classExtends($calledClass, \Illuminate\Foundation\Http\FormRequest::class);
+        } catch (\Psalm\Exception\UnpopulatedClasslikeException|\InvalidArgumentException) {
+            return null;
+        }
+
+        if (!$isFormRequest) {
+            return null;
+        }
+
+        $rules = ValidationRuleAnalyzer::getRulesForFormRequest($calledClass);
+
+        if ($rules === null) {
             return null;
         }
 
@@ -128,12 +180,6 @@ final class ValidatedTypeHandler implements MethodReturnTypeProviderInterface
         // the input() call site — same treatment {@see buildUnionFromTree}
         // gives the validated() output (marks the field possibly_undefined
         // when `sometimes || !required`).
-        //
-        // Reads through prepareForValidation() and friends may also run
-        // before validation has filled in optional fields, so anything
-        // weaker than an unconditional `required` (or its present /
-        // accepted / declined siblings, see
-        // {@see ValidationRuleAnalyzer::resolveRuleSegments}) stays mixed.
         if ($rule === null || !$rule->required || $rule->sometimes) {
             return null;
         }

--- a/src/Handlers/Validation/ValidationTaintHandler.php
+++ b/src/Handlers/Validation/ValidationTaintHandler.php
@@ -359,7 +359,9 @@ final class ValidationTaintHandler implements AddTaintsInterface, RemoveTaintsIn
     }
 
     /**
-     * Whether the expression is validated()/validate()/safe() on Request/FormRequest.
+     * Whether the expression is validated()/validate()/safe() on Request/FormRequest,
+     * or input() on a FormRequest subclass (which ValidatedTypeHandler also narrows
+     * for `$this->input(...)` reads inside the request itself — see #1015).
      */
     private static function isValidationMethodCall(AddRemoveTaintsEvent $event): bool
     {
@@ -373,15 +375,18 @@ final class ValidationTaintHandler implements AddTaintsInterface, RemoveTaintsIn
         // rationale as KEYED_ACCESSOR_METHODS.
         $methodName = $expr->name->name;
 
-        if (!\in_array($methodName, ['validated', 'validate', 'safe'], true)) {
+        if (!\in_array($methodName, ['validated', 'validate', 'safe', 'input'], true)) {
             return false;
         }
 
-        // validated() and safe() are FormRequest methods, validate() is on Request
+        // validate() lives on Request; everything else (including the
+        // FormRequest-narrowed input(...) path) is gated on FormRequest so we
+        // do not re-source taint on a plain Request::input(...) call where
+        // ValidatedTypeHandler does not override the return type.
         $baseClass
-            = $methodName === 'validated' || $methodName === 'safe'
-                ? \Illuminate\Foundation\Http\FormRequest::class
-                : \Illuminate\Http\Request::class;
+            = $methodName === 'validate'
+                ? \Illuminate\Http\Request::class
+                : \Illuminate\Foundation\Http\FormRequest::class;
 
         return self::resolveCallerClass($event, $baseClass) !== null;
     }

--- a/tests/Type/tests/FormRequestSelfInputTest.phpt
+++ b/tests/Type/tests/FormRequestSelfInputTest.phpt
@@ -1,0 +1,168 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Type narrowing for $this->input('field') calls inside a FormRequest subclass.
+ *
+ * The plugin narrows $request->validated('field') / $request->safe()->input('field')
+ * from controller code. ValidatedTypeHandler::resolveSelfInput() extends the same
+ * rule-driven narrowing to $this->input(...) on the FormRequest itself, e.g. inside
+ * prepareForValidation(), passedValidation(), withValidator(), or a custom helper.
+ *
+ * Soundness gate: only presence-guaranteed fields (required / present / accepted /
+ * declined, and only when `sometimes` is absent) are narrowed. Optional fields
+ * (sometimes, no required-style rule, conditional required_if / present_with
+ * siblings, or fields not in rules()) fall through to the InteractsWithInput
+ * stub's `mixed` return.
+ *
+ * Note: narrowing in `prepareForValidation()` is technically unsound — input()
+ * reads the raw request data before the validator runs, so a `required|string`
+ * rule does not guarantee the value is a string yet. This trade-off mirrors the
+ * `validated()` design choice ("Option 1" in #1015): trust the rule for static
+ * analysis precision. The `sometimes`/non-required gate keeps the unsoundness
+ * scoped to fields the developer has explicitly asserted will be present.
+ *
+ * See issue #1015.
+ */
+class SelfEmailRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            // required-style: presence-guaranteed, narrow.
+            'email' => ['required', 'email'],
+            'age' => ['required', 'integer'],
+            'role' => ['required', 'in:admin,user,guest'],
+            // present / accepted / declined: also presence-guaranteed.
+            'comment' => ['present', 'string'],
+            'terms' => ['accepted'],
+            'no_marketing' => ['declined'],
+            // Soundness bail-outs: each of these must stay mixed.
+            'nickname' => ['sometimes', 'string'],
+            'biography' => ['nullable', 'string'],
+            'optional_email' => ['sometimes', 'required', 'email'],
+            'spouse_name' => ['required_if:has_spouse,yes', 'string'],
+            // Dotted nesting: required on the leaf narrows the leaf read.
+            'profile.city' => ['required', 'string'],
+        ];
+    }
+
+    #[\Override]
+    public function prepareForValidation(): void
+    {
+        // Required + type rule — narrows.
+        $_email = $this->input('email');
+        /** @psalm-check-type-exact $_email = string */
+
+        $_age = $this->input('age');
+        /** @psalm-check-type-exact $_age = int|numeric-string */
+
+        $_role = $this->input('role');
+        /** @psalm-check-type-exact $_role = 'admin'|'guest'|'user' */
+
+        // present / accepted / declined — also narrow.
+        $_comment = $this->input('comment');
+        /** @psalm-check-type-exact $_comment = string */
+
+        $_terms = $this->input('terms');
+        /** @psalm-check-type-exact $_terms = '1'|'on'|'true'|'yes'|1|true */
+
+        $_no_marketing = $this->input('no_marketing');
+        /** @psalm-check-type-exact $_no_marketing = '0'|'false'|'no'|'off'|0|false */
+
+        // sometimes alone → not presence-guaranteed, stay mixed.
+        $_nickname = $this->input('nickname');
+        /** @psalm-check-type-exact $_nickname = mixed */
+
+        // nullable without required → no presence guarantee.
+        $_biography = $this->input('biography');
+        /** @psalm-check-type-exact $_biography = mixed */
+
+        // sometimes + required: Laravel's "if present, must be valid" semantics
+        // mean the field may still be absent. Narrowing would be unsound.
+        $_optional_email = $this->input('optional_email');
+        /** @psalm-check-type-exact $_optional_email = mixed */
+
+        // Conditional presence (required_if, required_with, present_if, accepted_if, …)
+        // is runtime-dependent — does not flip `required` in ResolvedRule.
+        $_spouse_name = $this->input('spouse_name');
+        /** @psalm-check-type-exact $_spouse_name = mixed */
+
+        // Field not in rules() — stays mixed.
+        $_unknown = $this->input('unknown');
+        /** @psalm-check-type-exact $_unknown = mixed */
+
+        // Default-value form: union of rule type and default expression type,
+        // matching the validated($key, $default) behaviour.
+        $_emailWithDefault = $this->input('email', 'fallback@example.com');
+        /** @psalm-check-type-exact $_emailWithDefault = string */
+
+        // Dotted nesting: required leaf narrows the leaf read.
+        $_city = $this->input('profile.city');
+        /** @psalm-check-type-exact $_city = string */
+    }
+
+    public function customWithDynamicKey(string $key): mixed
+    {
+        // Non-literal key falls through to the stub's mixed return — the
+        // handler only narrows when the field name is a single string literal.
+        $_dynamic = $this->input($key);
+        /** @psalm-check-type-exact $_dynamic = mixed */
+
+        return $_dynamic;
+    }
+
+    #[\Override]
+    public function passedValidation(): void
+    {
+        // Same narrowing applies in every lifecycle hook on the subclass.
+        $_email = $this->input('email');
+        /** @psalm-check-type-exact $_email = string */
+    }
+
+    public function customHelper(): string
+    {
+        // Custom helpers on the FormRequest get the same narrowing.
+        $_role = $this->input('role');
+        /** @psalm-check-type-exact $_role = 'admin'|'guest'|'user' */
+
+        return $_role;
+    }
+}
+
+/**
+ * Inherited rules(): a child subclass with no own rules() falls back to the
+ * parent's rules() — `getRulesForFormRequest()` walks `parent_class` in
+ * ValidationRuleAnalyzer::extractRulesFromClass(). Locks in that
+ * `getCalledFqClasslikeName()` correctly resolves to the child subclass at
+ * the call site, and the walk hits the parent's `rules()` method.
+ */
+class ChildEmailRequest extends SelfEmailRequest
+{
+    public function customChildAccessor(): string
+    {
+        $_email = $this->input('email');
+        /** @psalm-check-type-exact $_email = string */
+
+        return $_email;
+    }
+}
+
+function fromController(SelfEmailRequest $request): void
+{
+    // Comparison: controller-side narrowing via validated() works as designed.
+    $_email = $request->validated('email');
+    /** @psalm-check-type-exact $_email = string */
+
+    $_age = $request->validated('age');
+    /** @psalm-check-type-exact $_age = int|numeric-string */
+
+    $_role = $request->validated('role');
+    /** @psalm-check-type-exact $_role = 'admin'|'guest'|'user' */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/FormRequestSelfInputTest.phpt
+++ b/tests/Type/tests/FormRequestSelfInputTest.phpt
@@ -97,9 +97,12 @@ class SelfEmailRequest extends FormRequest
         /** @psalm-check-type-exact $_unknown = mixed */
 
         // Default-value form: union of rule type and default expression type,
-        // matching the validated($key, $default) behaviour.
-        $_emailWithDefault = $this->input('email', 'fallback@example.com');
-        /** @psalm-check-type-exact $_emailWithDefault = string */
+        // matching the validated($key, $default) behaviour. Uses a non-string
+        // default so the union is observable in the asserted type — a string
+        // default would collapse to the rule's `string` type and not prove
+        // the unioning fired.
+        $_ageWithDefault = $this->input('age', false);
+        /** @psalm-check-type-exact $_ageWithDefault = false|int|numeric-string */
 
         // Dotted nesting: required leaf narrows the leaf read.
         $_city = $this->input('profile.city');
@@ -122,6 +125,14 @@ class SelfEmailRequest extends FormRequest
         // Same narrowing applies in every lifecycle hook on the subclass.
         $_email = $this->input('email');
         /** @psalm-check-type-exact $_email = string */
+    }
+
+    public function withValidator(\Illuminate\Validation\Validator $validator): void
+    {
+        // Mid-validation hook (convention, not an abstract on FormRequest)
+        // — same narrowing fires here.
+        $_role = $this->input('role');
+        /** @psalm-check-type-exact $_role = 'admin'|'guest'|'user' */
     }
 
     public function customHelper(): string

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestInputIntegerNoTaint.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestInputIntegerNoTaint.phpt
@@ -12,9 +12,12 @@ use Illuminate\Foundation\Http\FormRequest;
  * the direct-FormRequest resolution path (distinct from safe()->input()).
  * With 'integer' rule the escape clears all input taint.
  *
- * The MixedArgument suppression is for the echo — input() returns mixed.
  * The asserted behavior is taint: when the rule is 'integer', no Tainted*
- * error must fire even though echo is an html/quotes sink.
+ * error must fire even though echo is an html/quotes sink. The
+ * `'integer'` rule used to leave the return type as `mixed` here; since
+ * ValidatedTypeHandler also narrows `$req->input('age')` to
+ * `int|numeric-string` on a required field, no MixedArgument suppression
+ * is needed and the taint-escape behaviour is unchanged.
  */
 final class DirectInputAgeRequest extends FormRequest
 {
@@ -25,7 +28,6 @@ final class DirectInputAgeRequest extends FormRequest
 }
 
 function render(DirectInputAgeRequest $request): void {
-    /** @psalm-suppress MixedArgument */
     echo $request->input('age');
 }
 ?>

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestSelfInputEmailEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestSelfInputEmailEscapesHeader.phpt
@@ -8,16 +8,32 @@ namespace App\Http\Requests;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
- * Regression guard: $this->input('key') inside a FormRequest method narrows
- * via ValidatedTypeHandler::resolveSelfInput(), which silences the stub's
+ * Regression guard: $this->input('key') reads on the FormRequest narrow via
+ * ValidatedTypeHandler::resolveSelfInput(), which silences the stub's
  * @psalm-taint-source. ValidationTaintHandler::addTaints() must re-source
  * ALL_INPUT for the call to remain detectable as user-controlled, and the
- * 'email' rule's header/cookie escape must still apply via the keyed-accessor
- * escape path in ValidationTaintHandler::removeTaints.
+ * `email` rule's escape must still apply via the keyed-accessor escape path
+ * in ValidationTaintHandler::removeTaints.
+ *
+ * The sinks fire inside a custom helper that is invoked from controller
+ * code AFTER Laravel's ValidatesWhenResolvedTrait has run the validator —
+ * the FormRequest is resolved before the controller action executes, so
+ * the email-rule escape on $this->input() is sound for this call site.
+ *
+ * Pre-validation hooks (prepareForValidation, withValidator) are
+ * deliberately NOT exercised by a header sink: the plugin's "trust the
+ * rule" trade-off makes the escape consistent with type narrowing there,
+ * but a header sink in those contexts would lock in a real false-negative
+ * window. The HTML sink (which the email rule does NOT escape) still
+ * surfaces TaintedHtml in either context, so the positive-flow guard
+ * stays representative.
  *
  * Asserted:
- *  - Header sink on the email value does NOT report (escape covered it).
- *  - HTML sink on the same value DOES report TaintedHtml (taint flows).
+ *   - Header sink in a post-validation helper does NOT report: the
+ *     'email' rule's INPUT_HEADER escape covered it.
+ *   - HTML sink in the same context DOES report TaintedHtml +
+ *     TaintedTextWithQuotes — the email rule leaves html taint intact,
+ *     so flow from $this->input('email') is preserved end-to-end.
  */
 final class SelfTaintEmailRequest extends FormRequest
 {
@@ -26,17 +42,29 @@ final class SelfTaintEmailRequest extends FormRequest
         return ['email' => ['required', 'email']];
     }
 
-    #[\Override]
-    public function prepareForValidation(): void
+    /**
+     * Header sink — must NOT report TaintedHeader: the 'email' rule
+     * removes INPUT_HEADER from the taint bitmask.
+     */
+    public function sendUserHeader(): void
     {
-        // header sink — the 'email' rule's header/cookie escape clears the
-        // taint kind, so no TaintedHeader is expected.
         \header('X-User: ' . $this->input('email'));
+    }
 
-        // html sink — the 'email' rule does not escape html taint, so this
-        // must surface TaintedHtml/TaintedTextWithQuotes.
+    /**
+     * HTML sink — MUST report TaintedHtml: the 'email' rule leaves
+     * html taint intact, so the narrowed-and-resourced flow reaches
+     * the echo.
+     */
+    public function renderUserName(): void
+    {
         echo $this->input('email');
     }
+}
+
+function dispatch(SelfTaintEmailRequest $request): void {
+    $request->sendUserHeader();
+    $request->renderUserName();
 }
 ?>
 --EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestSelfInputEmailEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestSelfInputEmailEscapesHeader.phpt
@@ -1,0 +1,44 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Regression guard: $this->input('key') inside a FormRequest method narrows
+ * via ValidatedTypeHandler::resolveSelfInput(), which silences the stub's
+ * @psalm-taint-source. ValidationTaintHandler::addTaints() must re-source
+ * ALL_INPUT for the call to remain detectable as user-controlled, and the
+ * 'email' rule's header/cookie escape must still apply via the keyed-accessor
+ * escape path in ValidationTaintHandler::removeTaints.
+ *
+ * Asserted:
+ *  - Header sink on the email value does NOT report (escape covered it).
+ *  - HTML sink on the same value DOES report TaintedHtml (taint flows).
+ */
+final class SelfTaintEmailRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['email' => ['required', 'email']];
+    }
+
+    #[\Override]
+    public function prepareForValidation(): void
+    {
+        // header sink — the 'email' rule's header/cookie escape clears the
+        // taint kind, so no TaintedHeader is expected.
+        \header('X-User: ' . $this->input('email'));
+
+        // html sink — the 'email' rule does not escape html taint, so this
+        // must surface TaintedHtml/TaintedTextWithQuotes.
+        echo $this->input('email');
+    }
+}
+?>
+--EXPECTF--
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestWithInlineValidateMergesEscape.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestWithInlineValidateMergesEscape.phpt
@@ -32,7 +32,6 @@ final class MergeRequest extends FormRequest
     }
 }
 
-/** @psalm-suppress MixedArgument */
 function storeMerge(MergeRequest $request): \Illuminate\Http\RedirectResponse {
     // rules() already supplied the 'email' rule; the inline validate adds
     // an extra constraint via a custom Rule class. Both must pass.


### PR DESCRIPTION
## Issue to Solve

The plugin already narrows `$request->validated('field')` and `$request->safe()->input('field')` from outside a `FormRequest` (controllers, services). It did **not** narrow `$this->input('field')` called from inside the same `FormRequest` subclass (`prepareForValidation`, `passedValidation`, `withValidator`, custom helpers). Such reads fell through to `Illuminate\Http\Concerns\InteractsWithInput::input()`'s `mixed` return.

Precision gap, not a soundness bug: `mixed` was correct, just not narrow.

## Related

Closes #1015. Property-access variant (`$this->email`) tracked as follow-up #1016.

## Solution Description

`ValidatedTypeHandler::resolveSelfInput()` extends the rule-driven narrowing to `$this->input(...)` on the `FormRequest` itself. The handler also registers `Illuminate\Http\Concerns\InteractsWithInput::class` in `getClassLikeNames()` because `input()` is declared on the trait, not on `FormRequest`/`Request`; without that entry Psalm's `MethodReturnTypeProvider` dispatch never reaches the new arm.

Soundness gate matches `validated()`'s "trust the rule" model but only fires for fields whose rule guarantees presence:

- Presence-guaranteed (narrows): `required`, `present`, `accepted`, `declined` — the unconditional presence rules in `Illuminate\Validation\Concerns\ValidatesAttributes`.
- Falls through to `mixed`: `sometimes`, bare `nullable`, missing-from-`rules()`, conditional presence siblings (`required_if`, `present_with`, `accepted_if`, …), and `sometimes|required` (the "if present, must be valid" combination — Laravel can still see the field absent).
- Default-value form: `$this->input('email', 'fallback@example.com')` unions the rule type with the default expression type, matching `validated($key, $default)`.

Inherited `rules()` through a parent `FormRequest` is supported because `getCalledFqClasslikeName()` resolves to the called subclass and `ValidationRuleAnalyzer::extractRulesFromClass()` walks `parent_class`.

`ValidationTaintHandler::isValidationMethodCall` is extended to fire `addTaints(TaintKind::ALL_INPUT)` for `input()` on a `FormRequest` subclass — without this the return-type override would silently drop the stub's `@psalm-taint-source` and the new path would become a false negative for downstream sinks. The per-field escape side (`ValidationTaintHandler::removeTaints`) already covered `input` via `KEYED_ACCESSOR_METHODS`, so the email/numeric/etc. escapes flow through unchanged.

### Verification

- `tests/Type/tests/FormRequestSelfInputTest.phpt` (new): covers `required`, `present`, `accepted`, `declined`, `sometimes`, `nullable`, `sometimes|required`, `required_if`, unknown-key, default-value, dotted-key (`profile.city`), non-literal key, parent-`rules()` inheritance, and three lifecycle hooks (`prepareForValidation`, `passedValidation`, custom helper).
- `tests/Type/tests/TaintAnalysis/SafeFormRequestSelfInputEmailEscapesHeader.phpt` (new): pins the `addTaints` / per-field-escape interaction on the new path — header sink stays silent (`'email'` rule escapes `INPUT_HEADER`), html sink reports `TaintedHtml`.
- `tests/Type/tests/TaintAnalysis/SafeFormRequestInputIntegerNoTaint.phpt` and `SafeFormRequestWithInlineValidateMergesEscape.phpt`: removed `@psalm-suppress MixedArgument` annotations that the controller-side narrowing now makes unnecessary.

### Known limitation (deliberate)

Narrowing fires inside `prepareForValidation()`, where validation has not yet run. `$this->input('email')` returning the rule type is technically unsound for that call site — the value could be absent or shaped differently until `ValidatesWhenResolvedTrait::validateResolved()` runs the validator. This trade-off mirrors the "Option 1" design choice from #1015 and the existing `validated()` precedent in the plugin: trust the rule for analysis precision, document the trade-off in the test docblock.

### Out of scope

- `$this->array(...)`, `$this->collect(...)` (#1015 lists these as in scope but the test surface and rule-shape gating warrant a separate follow-up).
- `$this->email` magic-property access — see #1016.
- `$this->all()` / `$this->only([...])` / `$this->except([...])` / flow-sensitive `merge([...])` mutations.

## Checklist

- [x] Tests cover the change (`tests/Type/tests/FormRequestSelfInputTest.phpt`, `tests/Type/tests/TaintAnalysis/SafeFormRequestSelfInputEmailEscapesHeader.phpt`)
