### PR TITLE
Document `Eloquent\Builder` closure-param typing trade-off

### DIFF
--- a/docs/contributing/decisions.md
+++ b/docs/contributing/decisions.md
@@ -146,6 +146,23 @@ Document every workaround with a comment linking to the upstream issue.
 
 **Why:** Workarounds accumulate tech debt and can mask the root cause. They also break silently when the upstream behavior changes. But waiting indefinitely for upstream fixes blocks real users.
 
+### Closure-parameter typing in `Eloquent\Builder` where-family stubs
+
+**Decision:** The `\Closure(self<TModel>): mixed` arm on `Builder::where`, `firstWhere`, `whereNot`, `orWhereNot` is intentionally non-`static`. Users subclassing `Builder` and writing `$this->where(static fn (self $q) => ...)` should type the closure parameter as base `\Illuminate\Database\Eloquent\Builder`, not `self`.
+
+**Why:** Psalm 7 does not specialize `static` inside closure-parameter positions against the receiver's generic binding. Every alternative shape regresses some real call pattern.
+
+| Stub form | `Customer::query()->where(fn ($q) => ...)` | `$this->where(fn (self $q) => ...)` in subclass | `$sub->where(fn (Builder $q) => ...)` from outside |
+|---|---|---|---|
+| `self<TModel>` (current) | works | rejected (#815) | works |
+| `static<TModel>` | $q collapses to `mixed` (#776) | works | works |
+| `self<TModel> \| static<TModel>` | `UndefinedClass` from union arms | partial | partial |
+| `self<TModel> & static` | works | works | rejected on subclass receivers |
+
+`self<TModel>` is the only stub shape that satisfies the canonical Laravel-docs idiom on subclass instances. The base-`Builder` typing in user code is also semantically honest. `Builder::where` calls `$this->model->newQueryWithoutRelationships()`, which returns base `Builder` unless the model overrides `newEloquentBuilder()`.
+
+**See:** [#815](https://github.com/psalm/psalm-plugin-laravel/issues/815), [#776](https://github.com/psalm/psalm-plugin-laravel/issues/776), [PR #784](https://github.com/psalm/psalm-plugin-laravel/pull/784), `tests/Type/tests/Builder/WhereClosureSubclassCoercionTest.phpt`.
+
 ## Taint Analysis
 
 ### Taint annotations: high confidence only

--- a/tests/Type/tests/Builder/WhereClosureSubclassCoercionTest.phpt
+++ b/tests/Type/tests/Builder/WhereClosureSubclassCoercionTest.phpt
@@ -2,12 +2,37 @@
 <?php declare(strict_types=1);
 
 /**
- * Eloquent\Builder subclass passing a closure to $this->where() must preserve
- * the subclass return type. PR #784 widened the stub closure return to :mixed,
- * which made Psalm reject closures whose parameter narrows to `self`. The
- * workaround below widens the closure parameter to base Builder.
+ * Eloquent\Builder subclass passing a closure to $this->where() inside the
+ * subclass must type the closure parameter as the BASE class
+ * `\Illuminate\Database\Eloquent\Builder` — not `self`.
+ *
+ * Why this is the recommended form (not a workaround):
+ *
+ * PR #784 fixed #776 by typing the stub closure as `\Closure(self<TModel>): mixed`.
+ * Psalm 7 does not specialize the closure-parameter `static` against the
+ * receiver's generic binding, so the stub uses `self<TModel>` to keep the
+ * (more common) untyped arrow-function form working:
+ *
+ *     Customer::query()->where(fn ($q) => $q->where('email', 'x'));   // works
+ *
+ * Issue #815 asks for `fn (self $q)` to also work inside subclass methods.
+ * This is intrinsically incompatible with the #776 fix under Psalm 7:
+ *
+ *   - `self<TModel>`                  → #776 works, `fn (self $q)` rejected.
+ *   - `static<TModel>`                → `fn (self $q)` works, #776 collapses to `mixed`.
+ *   - `self<TModel> | static<TModel>` → union arms produce `UndefinedClass`.
+ *   - `self<TModel> & static`         → `fn (self $q)` works inside subclass,
+ *                                       but `fn (Builder $q)` (the canonical
+ *                                       Laravel-docs form) is then rejected on
+ *                                       subclass instances from external code.
+ *
+ * Until Psalm 7 specializes `static` in closure-parameter positions, the only
+ * shape that satisfies every caller is the base `\Illuminate\Database\Eloquent\Builder`
+ * type — which is also what Laravel itself passes to the closure unless the
+ * model overrides `newEloquentBuilder()`.
  *
  * @see https://github.com/psalm/psalm-plugin-laravel/issues/815
+ * @see https://github.com/psalm/psalm-plugin-laravel/pull/784
  */
 
 use Illuminate\Database\Eloquent\Builder;
@@ -24,11 +49,20 @@ final class Issue815FooBuilder extends Builder
     /** @return self<TModel> */
     public function publishedOnly(): self
     {
-        // @todo https://github.com/psalm/psalm-plugin-laravel/issues/815
-        //   Once #815 is fixed, narrow the closure parameter back to `self $q`
-        //   (the natural form — `$this` in this context is the subclass).
         return $this->where(static fn (Builder $q) => $q->whereNotNull('published_at'));
     }
+}
+
+/**
+ * Same closure shape from an external caller against a subclass-typed receiver.
+ * Covers column 3 of the trade-off table in `docs/contributing/decisions.md`.
+ *
+ * @param Issue815FooBuilder<Issue815Foo> $b
+ * @return Issue815FooBuilder<Issue815Foo>
+ */
+function issue815_external_caller(Issue815FooBuilder $b): Issue815FooBuilder
+{
+    return $b->where(static fn (Builder $q) => $q->whereNotNull('published_at'));
 }
 ?>
 --EXPECTF--


### PR DESCRIPTION
## Issue to Solve

Refs #815. The reporter hits `ArgumentTypeCoercion` when typing the closure parameter as `self` (i.e. the custom subclass type) inside a Builder subclass:

```php
final class FooEloquentBuilder extends Builder
{
    public function publishedOnly(): self
    {
        return $this->where(static fn (self $q): self => $q->whereNotNull('published_at'));
    }
}
```

## Related

Refs #815, #776, #784.

## Solution Description

Investigation showed this is a forced trade-off, not a fixable bug at the stub layer. PR #784 deliberately chose `\Closure(self<TModel>): mixed` over the more natural `\Closure(static): mixed` because Psalm 7 does not specialize `static` inside closure-parameter positions against the receiver's generic binding. I probed every remaining stub variation:

| Stub form | `Customer::query()->where(fn ($q) => ...)` (#776) | `$this->where(fn (self $q) => ...)` in subclass (#815) | `$sub->where(fn (Builder $q) => ...)` external caller |
|---|---|---|---|
| `self<TModel>` (current) | works | rejected (#815) | works |
| `static<TModel>` | $q collapses to `mixed` | works | works |
| `self<TModel> \| static<TModel>` | `UndefinedClass` from union | partial | partial |
| `self<TModel> & static` | works | works | rejected on subclass receivers |

The intersection looked promising at first (all 427 type tests passed) but the laravel-expert reviewer flagged a subtle regression that an empirical probe confirmed: `$sub->where(static fn (Builder $q) => ...)` on a custom-Builder-typed receiver from external code, which is the canonical Laravel-docs idiom, is rejected with `ArgumentTypeCoercion` once `&static` is added. That regression is more common than the #815 case, so no stub-only fix is acceptable.

This PR therefore documents the constraint instead of pretending to fix it. The reporter (and anyone else hitting this) should type the closure parameter as base `\Illuminate\Database\Eloquent\Builder`, which is also semantically honest because `Builder::where` calls `$this->model->newQueryWithoutRelationships()` and that returns base `Builder` unless the model overrides `newEloquentBuilder()`.

Changes:

- `docs/contributing/decisions.md`: new "Closure-parameter typing in `Eloquent\Builder` where-family stubs" sub-section under "Upstream Workarounds", with the trade-off matrix above.
- `tests/Type/tests/Builder/WhereClosureSubclassCoercionTest.phpt`: docblock rewritten from "@todo, waiting on #815" to a permanent recommendation; the inline `@todo` removed; an external-caller assertion added so the matrix's third column is exercised, not just reasoned about.

A real fix requires either upstream Psalm 7 (specialize `static` in closure-parameter positions against the receiver's generic binding) or a `MethodParamsProvider` handler that computes the closure type per call site. Both are out of scope for this docs PR.

## Checklist

- [x] Tests cover the change (type test in `tests/Type/`)
- [x] Documentation is updated
