### PR TITLE
Resolve instance scope calls on base Builder

### DIFF
--- a/src/Handlers/Eloquent/BuilderScopeHandler.php
+++ b/src/Handlers/Eloquent/BuilderScopeHandler.php
@@ -213,7 +213,7 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
             $declaringId = $codebase->methods->getDeclaringMethodId(
                 new MethodIdentifier(\strtolower($modelClass), \strtolower($candidate)),
             );
-            if ($declaringId === null) {
+            if (!$declaringId instanceof \Psalm\Internal\MethodIdentifier) {
                 continue;
             }
 

--- a/src/Handlers/Eloquent/BuilderScopeHandler.php
+++ b/src/Handlers/Eloquent/BuilderScopeHandler.php
@@ -7,6 +7,7 @@ namespace Psalm\LaravelPlugin\Handlers\Eloquent;
 use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use Psalm\Codebase;
@@ -58,11 +59,20 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
      * immediately follows up with checkMethodArgs for the same call. Keyed by method
      * name only: the producer always runs right before the consumer within one
      * analysis thread, so the latest entry matches the call being checked even when
-     * two models declare a scope with the same name.
+     * two models declare a scope with the same name. Entries persist across files,
+     * so the consumer rejects names that are real Builder methods (see
+     * {@see isRealBuilderMethod}) to avoid shadowing genuine calls analyzed later.
      *
      * @var array<lowercase-string, list<FunctionLikeParameter>>
      */
-    private static array $scopeParams = [];
+    private static array $pendingScopeParams = [];
+
+    /**
+     * Memoization for {@see getScopeParams}: 'Model::method' -> params or null (not a scope).
+     *
+     * @var array<string, list<FunctionLikeParameter>|null>
+     */
+    private static array $scopeParamsCache = [];
 
     /**
      * Registry of trait-declared builder methods for the base Builder class.
@@ -148,12 +158,17 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
             ]),
         ]);
 
-        if (self::hasScopeMethod($codebase, $modelClass, $methodName)) {
-            // Hand the scope's declared params (minus the leading $query) to the params
+        // A non-null result implies the model declares the scope (detection is strict,
+        // see getScopeParams). On failure to resolve we decline entirely — falling back
+        // to mixed is honest, while returning a type with a fabricated zero-param
+        // signature would emit TooManyArguments on every scope call with args.
+        $scopeParams = self::getScopeParams($codebase, $modelClass, $methodName);
+        if ($scopeParams !== null) {
+            // Hand the scope's params (minus the leading $query) to the params
             // provider: Psalm follows this return type with checkMethodArgs for
             // Builder::<scope>, which has no real method storage and would otherwise
             // throw UnexpectedValueException in Codebase\Methods::getMethodParams.
-            self::$scopeParams[$methodName] = self::resolveScopeParams($codebase, $modelClass, $methodName);
+            self::$pendingScopeParams[$methodName] = $scopeParams;
 
             return $builderReturn;
         }
@@ -180,53 +195,89 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
      * doesn't exist as a real method, getMethodParams would throw UnexpectedValueException
      * unless we intercept it here with the params from the trait's @method static annotation.
      *
-     * Covers $baseBuilderTraitMethods (e.g., SoftDeletes methods) and instance scope
-     * calls via the {@see $scopeParams} hand-off populated by the return type provider.
+     * Covers instance scope calls via the {@see $pendingScopeParams} hand-off populated
+     * by the return type provider, then $baseBuilderTraitMethods (e.g., SoftDeletes
+     * methods) — mirroring the precedence in {@see getMethodReturnType} (scopes first).
      *
      * @return list<FunctionLikeParameter>|null
-     * @psalm-external-mutation-free
      */
     #[\Override]
     public static function getMethodParams(MethodParamsProviderEvent $event): ?array
     {
         /** @var lowercase-string $methodName */
         $methodName = $event->getMethodNameLowercase();
-        return self::$baseBuilderTraitMethods[$methodName] ?? self::$scopeParams[$methodName] ?? null;
+
+        $scopeParams = self::$pendingScopeParams[$methodName] ?? null;
+        if ($scopeParams !== null && !self::isRealBuilderMethod($event, $methodName)) {
+            return $scopeParams;
+        }
+
+        return self::$baseBuilderTraitMethods[$methodName] ?? null;
     }
 
     /**
-     * Resolve the params a caller passes to a scope: the scope method's declared
-     * params without the leading $query (Laravel injects it).
+     * Get the params a caller passes to a scope (its declared params minus the
+     * leading $query, which Laravel injects), or null when the model declares no
+     * such scope.
      *
-     * Reads the legacy scopeXxx() method first (mirroring hasScopeMethod's order),
-     * then the #[Scope]-attributed method of the same name.
+     * Dispatch mirrors Laravel's Model::callNamedScope: a #[Scope]-attributed
+     * method wins over a legacy scopeXxx() method of the same name. Detection is
+     * strict (bare methods require the attribute), so a non-null return implies
+     * the method is a real scope — callers don't need a separate hasScopeMethod()
+     * guard.
+     *
+     * Memoized: deterministic per model+method once the codebase is populated.
      *
      * @param class-string<Model> $modelClass
-     * @return list<FunctionLikeParameter>
+     * @return list<FunctionLikeParameter>|null
      */
-    private static function resolveScopeParams(Codebase $codebase, string $modelClass, string $methodName): array
+    public static function getScopeParams(Codebase $codebase, string $modelClass, string $methodName): ?array
     {
-        foreach (['scope' . $methodName, $methodName] as $candidate) {
-            // Scopes are often declared on an abstract parent model; resolve the
-            // declaring class before fetching storage (getStorage alone throws for
-            // inherited methods).
-            $declaringId = $codebase->methods->getDeclaringMethodId(
-                new MethodIdentifier(\strtolower($modelClass), \strtolower($candidate)),
-            );
-            if (!$declaringId instanceof \Psalm\Internal\MethodIdentifier) {
-                continue;
-            }
-
-            try {
-                $storage = $codebase->methods->getStorage($declaringId);
-            } catch (\InvalidArgumentException|\UnexpectedValueException) {
-                continue;
-            }
-
-            return \array_slice($storage->params, 1);
+        $key = $modelClass . '::' . $methodName;
+        if (\array_key_exists($key, self::$scopeParamsCache)) {
+            return self::$scopeParamsCache[$key];
         }
 
-        return [];
+        if ($codebase->methodExists($modelClass . '::' . $methodName)
+            && self::hasScopeAttribute($codebase, $modelClass, $methodName)
+        ) {
+            /** @var lowercase-string $methodName */
+            $scopeMethodId = new MethodIdentifier($modelClass, $methodName);
+        } elseif ($codebase->methodExists($modelClass . '::scope' . \ucfirst($methodName))) {
+            /** @var lowercase-string $legacyScopeLower */
+            $legacyScopeLower = 'scope' . $methodName;
+            $scopeMethodId = new MethodIdentifier($modelClass, $legacyScopeLower);
+        } else {
+            return self::$scopeParamsCache[$key] = null;
+        }
+
+        // Methods::getMethodParams resolves the declaring class internally, so scopes
+        // declared on abstract parent models or in traits keep their signatures.
+        return self::$scopeParamsCache[$key] = \array_slice(
+            $codebase->methods->getMethodParams($scopeMethodId),
+            1,
+        );
+    }
+
+    /**
+     * Whether the Builder (or the mixed-in Query\Builder) declares the method for real.
+     *
+     * Guards the scope hand-off in {@see getMethodParams}: $pendingScopeParams entries
+     * persist across files, so a model's scopeLatest() must not shadow a genuine
+     * Builder::latest() call on an unrelated model analyzed later — real methods keep
+     * their own storage-backed params.
+     */
+    private static function isRealBuilderMethod(MethodParamsProviderEvent $event, string $methodName): bool
+    {
+        $source = $event->getStatementsSource();
+        if (!$source instanceof StatementsSource) {
+            return false;
+        }
+
+        $codebase = $source->getCodebase();
+
+        return $codebase->methodExists(Builder::class . '::' . $methodName)
+            || $codebase->methodExists(QueryBuilder::class . '::' . $methodName);
     }
 
     /**

--- a/src/Handlers/Eloquent/BuilderScopeHandler.php
+++ b/src/Handlers/Eloquent/BuilderScopeHandler.php
@@ -51,6 +51,20 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
     private static array $traitBuilderCache = [];
 
     /**
+     * Scope params hand-off: lowercase scope name -> params (minus the leading $query).
+     *
+     * Populated by the return type provider when it resolves an instance scope call
+     * (Customer::query()->active()); consumed by {@see getMethodParams} when Psalm
+     * immediately follows up with checkMethodArgs for the same call. Keyed by method
+     * name only: the producer always runs right before the consumer within one
+     * analysis thread, so the latest entry matches the call being checked even when
+     * two models declare a scope with the same name.
+     *
+     * @var array<lowercase-string, list<FunctionLikeParameter>>
+     */
+    private static array $scopeParams = [];
+
+    /**
      * Registry of trait-declared builder methods for the base Builder class.
      *
      * Populated by {@see ModelRegistrationHandler} when processing base-Builder models
@@ -113,12 +127,12 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
         // without forwarding the LHS type params. We recover them from the LHS expression.
         $templateTypeParameters = $event->getTemplateTypeParameters();
 
-        // For trait-declared builder methods (e.g., withTrashed), extract from LHS when
-        // template params are missing. Scope methods are skipped here: providing a return
-        // type for scope methods via this path would cause Psalm to call checkMethodArgs
-        // for Builder::scopeMethod, which has no method params and would crash.
-        // Scope instance calls (Customer::query()->active()) remain a known limitation.
-        if ($templateTypeParameters === null && isset(self::$baseBuilderTraitMethods[$methodName])) {
+        // For scope and trait-declared builder methods (e.g., active(), withTrashed()),
+        // extract from LHS when template params are missing. Builder::methodName has no
+        // real method storage, so when Psalm follows up with checkMethodArgs, the params
+        // provider below must answer for the method (scope params come from the
+        // scope-params hand-off populated in the scope branch).
+        if ($templateTypeParameters === null) {
             $templateTypeParameters = self::extractTemplateParamsFromCallStmt($event->getStmt(), $source);
         }
 
@@ -135,6 +149,12 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
         ]);
 
         if (self::hasScopeMethod($codebase, $modelClass, $methodName)) {
+            // Hand the scope's declared params (minus the leading $query) to the params
+            // provider: Psalm follows this return type with checkMethodArgs for
+            // Builder::<scope>, which has no real method storage and would otherwise
+            // throw UnexpectedValueException in Codebase\Methods::getMethodParams.
+            self::$scopeParams[$methodName] = self::resolveScopeParams($codebase, $modelClass, $methodName);
+
             return $builderReturn;
         }
 
@@ -160,8 +180,8 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
      * doesn't exist as a real method, getMethodParams would throw UnexpectedValueException
      * unless we intercept it here with the params from the trait's @method static annotation.
      *
-     * Only covers $baseBuilderTraitMethods (e.g., SoftDeletes methods); scope methods are
-     * not in this registry so this provider returns null for them (Psalm skips arg checking).
+     * Covers $baseBuilderTraitMethods (e.g., SoftDeletes methods) and instance scope
+     * calls via the {@see $scopeParams} hand-off populated by the return type provider.
      *
      * @return list<FunctionLikeParameter>|null
      * @psalm-external-mutation-free
@@ -171,7 +191,42 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
     {
         /** @var lowercase-string $methodName */
         $methodName = $event->getMethodNameLowercase();
-        return self::$baseBuilderTraitMethods[$methodName] ?? null;
+        return self::$baseBuilderTraitMethods[$methodName] ?? self::$scopeParams[$methodName] ?? null;
+    }
+
+    /**
+     * Resolve the params a caller passes to a scope: the scope method's declared
+     * params without the leading $query (Laravel injects it).
+     *
+     * Reads the legacy scopeXxx() method first (mirroring hasScopeMethod's order),
+     * then the #[Scope]-attributed method of the same name.
+     *
+     * @param class-string<Model> $modelClass
+     * @return list<FunctionLikeParameter>
+     */
+    private static function resolveScopeParams(Codebase $codebase, string $modelClass, string $methodName): array
+    {
+        foreach (['scope' . $methodName, $methodName] as $candidate) {
+            // Scopes are often declared on an abstract parent model; resolve the
+            // declaring class before fetching storage (getStorage alone throws for
+            // inherited methods).
+            $declaringId = $codebase->methods->getDeclaringMethodId(
+                new MethodIdentifier(\strtolower($modelClass), \strtolower($candidate)),
+            );
+            if ($declaringId === null) {
+                continue;
+            }
+
+            try {
+                $storage = $codebase->methods->getStorage($declaringId);
+            } catch (\InvalidArgumentException|\UnexpectedValueException) {
+                continue;
+            }
+
+            return \array_slice($storage->params, 1);
+        }
+
+        return [];
     }
 
     /**

--- a/src/Handlers/Eloquent/CustomBuilderMethodHandler.php
+++ b/src/Handlers/Eloquent/CustomBuilderMethodHandler.php
@@ -263,14 +263,10 @@ final class CustomBuilderMethodHandler
         $codebase = $source->getCodebase();
         $methodName = $event->getMethodNameLowercase();
 
-        // Guard required: getScopeParams matches any model method in its #[Scope] branch
-        // (it checks methodExists but not the attribute). Without this, non-scope model methods
-        // like __construct would be matched, causing TooManyArguments on custom builder constructors.
-        if (!BuilderScopeHandler::hasScopeMethod($codebase, $modelClass, $methodName)) {
-            return null;
-        }
-
-        return ModelMethodHandler::getScopeParams($codebase, $modelClass, $methodName);
+        // getScopeParams detection is strict (bare methods require the #[Scope] attribute),
+        // so non-scope model methods like __construct return null and custom builder
+        // constructors keep their own params.
+        return BuilderScopeHandler::getScopeParams($codebase, $modelClass, $methodName);
     }
 
     /**

--- a/src/Handlers/Eloquent/ModelMethodHandler.php
+++ b/src/Handlers/Eloquent/ModelMethodHandler.php
@@ -273,7 +273,7 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
 
         // Scope method — params from the scope definition minus the first $query param.
         /** @var class-string<Model> $modelClass */
-        $scopeParams = self::getScopeParams($codebase, $modelClass, $methodName);
+        $scopeParams = BuilderScopeHandler::getScopeParams($codebase, $modelClass, $methodName);
         if ($scopeParams !== null) {
             return $scopeParams;
         }
@@ -538,41 +538,6 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
                 $event->getContext(),
                 $fakeProxy,
             );
-        }
-
-        return null;
-    }
-
-    /**
-     * Get params for a scope method on a model, minus the $query parameter.
-     *
-     * Handles both legacy scopeXxx() methods and modern #[Scope] attribute methods.
-     * Used by both the static model call handler ({@see getMethodParams}) and
-     * {@see CustomBuilderMethodHandler::getScopeMethodParamsOnBuilder}.
-     *
-     * @internal Used by {@see CustomBuilderMethodHandler}
-     * @param class-string<Model> $modelClass
-     * @return list<FunctionLikeParameter>|null
-     */
-    public static function getScopeParams(Codebase $codebase, string $modelClass, string $methodName): ?array
-    {
-        // Legacy: scopeActive(Builder $query, ...) → active(...)
-        $legacyScopeMethod = $modelClass . '::scope' . \ucfirst($methodName);
-        if ($codebase->methodExists($legacyScopeMethod)) {
-            /** @var lowercase-string $legacyScopeLower */
-            $legacyScopeLower = 'scope' . $methodName;
-
-            return \array_slice(
-                $codebase->methods->getMethodParams(new MethodIdentifier($modelClass, $legacyScopeLower)),
-                1,
-            );
-        }
-
-        // Modern #[Scope]: active(Builder $query, ...) → active(...)
-        $directMethod = $modelClass . '::' . $methodName;
-        if ($codebase->methodExists($directMethod)) {
-            /** @var lowercase-string $methodName */
-            return \array_slice($codebase->methods->getMethodParams(new MethodIdentifier($modelClass, $methodName)), 1);
         }
 
         return null;

--- a/src/Handlers/Magic/MethodForwardingHandler.php
+++ b/src/Handlers/Magic/MethodForwardingHandler.php
@@ -275,7 +275,7 @@ final class MethodForwardingHandler implements MethodReturnTypeProviderInterface
             // signature (same as the dynamic-where fallback) rather than returning [] (zero params),
             // which would emit misleading TooManyArguments for scopes that accept arguments.
             return (
-                ModelMethodHandler::getScopeParams(
+                BuilderScopeHandler::getScopeParams(
                     $codebase,
                     self::$scopeParamsCache[$scopeKey],
                     $methodName,

--- a/tests/Application/app/Models/AbstractDocument.php
+++ b/tests/Application/app/Models/AbstractDocument.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Abstract parent declaring scopes: instance scope calls on a child's builder
+ * must resolve params from the declaring (parent) class.
+ */
+abstract class AbstractDocument extends Model
+{
+    /**
+     * @param  Builder<self>  $query
+     */
+    public function scopeSignedBetween(Builder $query, CarbonInterface $from, CarbonInterface $to): void
+    {
+        $query->whereBetween('signed_at', [$from, $to]);
+    }
+}

--- a/tests/Application/app/Models/Concerns/HasFlaggedScope.php
+++ b/tests/Application/app/Models/Concerns/HasFlaggedScope.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Concerns;
+
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Trait-hosted scope: instance scope calls must resolve when the scope lives
+ * in a trait rather than on the model class itself.
+ *
+ * @psalm-require-extends \Illuminate\Database\Eloquent\Model
+ */
+trait HasFlaggedScope
+{
+    /** @param Builder<self> $query */
+    public function scopeFlagged(Builder $query): void
+    {
+        $query->where('flagged', true);
+    }
+}

--- a/tests/Application/app/Models/Contract.php
+++ b/tests/Application/app/Models/Contract.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Models\Concerns\HasFlaggedScope;
+
+/**
+ * Child of AbstractDocument: exercises inherited and trait-hosted scopes
+ * called on builder instances.
+ */
+final class Contract extends AbstractDocument
+{
+    use HasFlaggedScope;
+
+    protected $table = 'contracts';
+}

--- a/tests/Application/app/Models/Customer.php
+++ b/tests/Application/app/Models/Customer.php
@@ -110,6 +110,18 @@ class Customer extends Authenticatable
         $query->whereNotNull('email_verified_at');
     }
 
+    /**
+     * Legacy scope with a parameter: exercises the instance-call params hand-off
+     * (the caller passes everything after $query).
+     *
+     * @param  Builder<self>  $query
+     * @return Builder<self>
+     */
+    public function scopeOfName($query, string $name)
+    {
+        return $query->where('name', $name);
+    }
+
     public function getFirstNameUsingLegacyAccessorAttribute(): string
     {
         return $this->name;

--- a/tests/Application/app/Models/Customer.php
+++ b/tests/Application/app/Models/Customer.php
@@ -111,8 +111,8 @@ class Customer extends Authenticatable
     }
 
     /**
-     * Legacy scope with a parameter: exercises the instance-call params hand-off
-     * (the caller passes everything after $query).
+     * Legacy scope with a parameter: called as Customer::query()->ofName('Ada').
+     * Exercises the instance-call params hand-off (the caller passes everything after $query).
      *
      * @param  Builder<self>  $query
      * @return Builder<self>
@@ -120,6 +120,18 @@ class Customer extends Authenticatable
     public function scopeOfName($query, string $name)
     {
         return $query->where('name', $name);
+    }
+
+    /**
+     * Legacy scope with a defaulted parameter: called as Customer::query()->ofStatus().
+     * A zero-arg call must not emit TooFewArguments.
+     *
+     * @param  Builder<self>  $query
+     * @return Builder<self>
+     */
+    public function scopeOfStatus($query, string $status = 'active')
+    {
+        return $query->where('status', $status);
     }
 
     public function getFirstNameUsingLegacyAccessorAttribute(): string

--- a/tests/Type/tests/Builder/InstanceScopeCallTest.phpt
+++ b/tests/Type/tests/Builder/InstanceScopeCallTest.phpt
@@ -1,0 +1,51 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Contract;
+use App\Models\Customer;
+
+/**
+ * Instance scope calls on Builder (Customer::query()->active()) must resolve to
+ * Builder<Model> instead of mixed, so downstream chained calls (sum, where, get)
+ * keep their narrowed types.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1004
+ */
+
+$legacy = Customer::query()->active();
+/** @psalm-trace $legacy */
+
+$attribute = Customer::query()->verified();
+/** @psalm-trace $attribute */
+
+$chained = Customer::query()->active()->verified();
+/** @psalm-trace $chained */
+
+$sum = Customer::query()->active()->sum('vehicles_count');
+/** @psalm-trace $sum */
+
+$withArg = Customer::query()->ofName('Ada');
+/** @psalm-trace $withArg */
+
+// Args after $query are type-checked against the scope's declared params.
+$badArg = Customer::query()->ofName(123);
+
+// Scope declared on an abstract parent model: params resolve from the declaring class.
+$inherited = Contract::query()->signedBetween(now(), now());
+/** @psalm-trace $inherited */
+
+// Scope hosted in a trait used by the model.
+$fromTrait = Contract::query()->flagged();
+/** @psalm-trace $fromTrait */
+
+echo $legacy::class, $attribute::class, $chained::class, $withArg::class, $badArg::class, $inherited::class, $fromTrait::class, $sum;
+?>
+--EXPECTF--
+Trace on line %d: $legacy: Illuminate\Database\Eloquent\Builder<App\Models\Customer>
+Trace on line %d: $attribute: Illuminate\Database\Eloquent\Builder<App\Models\Customer>
+Trace on line %d: $chained: Illuminate\Database\Eloquent\Builder<App\Models\Customer>
+Trace on line %d: $sum: int
+Trace on line %d: $withArg: Illuminate\Database\Eloquent\Builder<App\Models\Customer>
+InvalidArgument on line %d: Argument 1 of Illuminate\Database\Eloquent\Builder::ofname expects string, but 123 provided
+Trace on line %d: $inherited: Illuminate\Database\Eloquent\Builder<App\Models\Contract>
+Trace on line %d: $fromTrait: Illuminate\Database\Eloquent\Builder<App\Models\Contract>

--- a/tests/Type/tests/Builder/InstanceScopeCallTest.phpt
+++ b/tests/Type/tests/Builder/InstanceScopeCallTest.phpt
@@ -3,49 +3,105 @@
 
 use App\Models\Contract;
 use App\Models\Customer;
+use Illuminate\Database\Eloquent\Builder;
 
 /**
- * Instance scope calls on Builder (Customer::query()->active()) must resolve to
- * Builder<Model> instead of mixed, so downstream chained calls (sum, where, get)
- * keep their narrowed types.
+ * Instance scope calls on the base Builder (Customer::query()->active()) must
+ * resolve to Builder<Model> instead of mixed, with the scope's params (minus
+ * the leading $query) used for argument checking.
  *
- * @see https://github.com/psalm/psalm-plugin-laravel/issues/1004
+ * @see https://github.com/psalm/psalm-plugin-laravel/pull/1032
  */
 
-$legacy = Customer::query()->active();
-/** @psalm-trace $legacy */
+/** Legacy scopeActive() called on a builder instance. */
+function test_legacy_scope_on_builder(): void
+{
+    $_result = Customer::query()->active();
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
 
-$attribute = Customer::query()->verified();
-/** @psalm-trace $attribute */
+/** Modern #[Scope] attribute method called on a builder instance. */
+function test_scope_attribute_on_builder(): void
+{
+    $_result = Customer::query()->verified();
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
 
-$chained = Customer::query()->active()->verified();
-/** @psalm-trace $chained */
+/** Chained scopes keep the model template. */
+function test_chained_scopes(): void
+{
+    $_result = Customer::query()->active()->verified();
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
 
-$sum = Customer::query()->active()->sum('vehicles_count');
-/** @psalm-trace $sum */
+/** Downstream aggregate narrowing works through a scope chain. */
+function test_scope_chain_to_sum(): void
+{
+    $_result = Customer::query()->active()->sum('vehicles_count');
+    /** @psalm-check-type-exact $_result = int */
+}
 
-$withArg = Customer::query()->ofName('Ada');
-/** @psalm-trace $withArg */
+/** Scope with a parameter: the arg after $query is accepted. */
+function test_scope_with_arg(): void
+{
+    $_result = Customer::query()->ofName('Ada');
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
 
-// Args after $query are type-checked against the scope's declared params.
-$badArg = Customer::query()->ofName(123);
+/** Scope args are type-checked against the scope's declared params. */
+function test_scope_wrong_arg_type(): void
+{
+    $_result = Customer::query()->ofName(123);
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
 
-// Scope declared on an abstract parent model: params resolve from the declaring class.
-$inherited = Contract::query()->signedBetween(now(), now());
-/** @psalm-trace $inherited */
+/** Extra args beyond the scope's params are rejected. */
+function test_scope_too_many_args(): void
+{
+    $_result = Customer::query()->ofName('Ada', 'extra');
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
 
-// Scope hosted in a trait used by the model.
-$fromTrait = Contract::query()->flagged();
-/** @psalm-trace $fromTrait */
+/** Missing required scope args are rejected. */
+function test_scope_too_few_args(): void
+{
+    $_result = Customer::query()->ofName();
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
 
-echo $legacy::class, $attribute::class, $chained::class, $withArg::class, $badArg::class, $inherited::class, $fromTrait::class, $sum;
+/** Scope param with a default value: a zero-arg call is fine. */
+function test_scope_default_param(): void
+{
+    $_result = Customer::query()->ofStatus();
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
+
+/** Scope declared on an abstract parent model resolves params from the declaring class. */
+function test_inherited_scope(): void
+{
+    $_result = Contract::query()->signedBetween(now(), now());
+    /** @psalm-check-type-exact $_result = Builder<Contract> */
+}
+
+/** Scope hosted in a trait used by the model. */
+function test_trait_scope(): void
+{
+    $_result = Contract::query()->flagged();
+    /** @psalm-check-type-exact $_result = Builder<Contract> */
+}
+
+/**
+ * Negative: a nonexistent method on a base Builder instance must not be typed by the
+ * widened provider. It still resolves to mixed via Builder::__call (Psalm doesn't
+ * report UndefinedMagicMethod here on master either).
+ */
+function test_nonexistent_method_on_builder(): void
+{
+    $_result = Customer::query()->completelyFakeMethod();
+    /** @psalm-check-type-exact $_result = mixed */
+}
 ?>
 --EXPECTF--
-Trace on line %d: $legacy: Illuminate\Database\Eloquent\Builder<App\Models\Customer>
-Trace on line %d: $attribute: Illuminate\Database\Eloquent\Builder<App\Models\Customer>
-Trace on line %d: $chained: Illuminate\Database\Eloquent\Builder<App\Models\Customer>
-Trace on line %d: $sum: int
-Trace on line %d: $withArg: Illuminate\Database\Eloquent\Builder<App\Models\Customer>
 InvalidArgument on line %d: Argument 1 of Illuminate\Database\Eloquent\Builder::ofname expects string, but 123 provided
-Trace on line %d: $inherited: Illuminate\Database\Eloquent\Builder<App\Models\Contract>
-Trace on line %d: $fromTrait: Illuminate\Database\Eloquent\Builder<App\Models\Contract>
+TooManyArguments on line %d: Too many arguments for Illuminate\Database\Eloquent\Builder::ofname - expecting 1 but saw 2
+TooFewArguments on line %d: Too few arguments for Illuminate\Database\Eloquent\Builder::ofname - expecting name to be passed

--- a/tests/Type/tests/Builder/StaticBuilderMethodsTest.phpt
+++ b/tests/Type/tests/Builder/StaticBuilderMethodsTest.phpt
@@ -63,13 +63,12 @@ function test_static_legacy_scope(): void
 }
 
 /**
- * Modern #[Scope] attribute: calling via the builder instance returns mixed.
+ * Modern #[Scope] attribute: calling via the builder instance returns Builder<Customer>.
  *
- * Known limitation: #[Scope] and legacy scopeXxx() methods on base-Builder models
- * return mixed when called on builder instances. Psalm routes through Builder::__call,
- * and BuilderScopeHandler cannot safely provide a return type here without also providing
- * params (which require knowing the model class — unavailable in the params provider event).
- * Custom-builder models don't have this limitation (CustomBuilderMethodHandler handles them).
+ * BuilderScopeHandler recovers the model from the LHS Builder type and hands the
+ * scope's params (minus $query) to the params provider, so Psalm routes through
+ * Builder::__call without crashing in checkMethodArgs.
+ * See InstanceScopeCallTest.phpt for the dedicated coverage.
  *
  * Calling Customer::verified() statically triggers InvalidStaticInvocation because
  * it's a real instance method — see test_scope_attribute_static_is_invalid below.
@@ -173,7 +172,6 @@ function test_nonexistent_method(): void
 }
 ?>
 --EXPECTF--
-MixedReturnStatement on line %d: Could not infer a return type
 InvalidStaticInvocation on line %d: Method App\Models\Customer::verified is not static, but is called statically
 MixedReturnStatement on line %d: Could not infer a return type
 UndefinedMagicMethod on line %d: Magic method App\Builders\VehicleBuilder::withtrashed does not exist


### PR DESCRIPTION
## Issue to Solve

Instance scope calls on the base Eloquent Builder returned `mixed`:

```php
Customer::query()->active();          // mixed (legacy scopeActive)
Customer::query()->verified();        // mixed (#[Scope] attribute)
Invoice::query()->notRefunded()->sum('total_minor'); // mixed → MixedOperand downstream
```

This was a documented known limitation in `BuilderScopeHandler`: Psalm routes these calls through `Builder::__call` without forwarding LHS template params, and returning a type for a scope made Psalm follow up with `checkMethodArgs` for `Builder::<scope>`, which has no real method storage and threw `UnexpectedValueException` in `Codebase\Methods::getMethodParams`.

## Related

Complements #1004 (column-aware `sum()`/`avg()`/`min()`/`max()` narrowing, which was unreachable through scope chains until now). The abstract-typed-LHS case from #901 is out of scope here.

## Solution Description

- `getMethodReturnType` now recovers the model from the LHS `Builder<TModel>` type for scope calls, not only for trait-declared builder methods.
- A scope-params hand-off (`$scopeParams`, mirroring the existing `$baseBuilderTraitMethods` mechanism) feeds the scope's declared params (minus the leading `$query`) to `getMethodParams`, so arg checking works instead of crashing. Scope arguments are now validated (wrong type → `InvalidArgument`, wrong arity → `TooManyArguments`).
- Params resolve via `getDeclaringMethodId`, so scopes declared on abstract parent models or in traits keep their signatures (plain `getStorage` throws for inherited methods).

Verified with a new type test covering legacy `scopeXxx`, `#[Scope]` attribute, chained scopes, scope-with-args (positive + negative), inherited scope, and trait-hosted scope; plus a real-world run on a large Laravel codebase where `Model::query()->someScope()->sum('int_column')` now infers `int` (previously `MixedOperand`) with no new false positives across the codebase.

`StaticBuilderMethodsTest.phpt` is updated: its pinned `MixedReturnStatement` limitation for `test_scope_attribute_via_builder` no longer occurs.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)