### PR TITLE
Resolve `self`/`static` scope parameters to the model on custom builders

### DIFF
--- a/src/Handlers/Eloquent/BuilderScopeHandler.php
+++ b/src/Handlers/Eloquent/BuilderScopeHandler.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use Psalm\Codebase;
 use Psalm\Internal\MethodIdentifier;
+use Psalm\Internal\Type\TypeExpander;
 use Psalm\LaravelPlugin\Util\ModelPropertyResolver;
 use Psalm\Plugin\EventHandler\Event\MethodParamsProviderEvent;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
@@ -252,10 +253,77 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
         }
 
         // Methods::getMethodParams resolves the declaring class internally, so scopes
-        // declared on abstract parent models or in traits keep their signatures.
-        return self::$scopeParamsCache[$key] = \array_slice(
-            $codebase->methods->getMethodParams($scopeMethodId),
-            1,
+        // declared on abstract parent models or in traits keep their signatures. Drop the
+        // leading $query param; the caller passes everything after it.
+        $callerParams = \array_slice($codebase->methods->getMethodParams($scopeMethodId), 1);
+
+        // expandScopeParamSelfReferences() pins self/static to the model (see its docblock).
+        // Memoized, so it runs once per model+method.
+        return self::$scopeParamsCache[$key] = self::expandScopeParamSelfReferences($codebase, $modelClass, $callerParams);
+    }
+
+    /**
+     * Pin `self`/`static`/`$this` (and nested generics like `list<self>`) in scope
+     * parameter types to the model class.
+     *
+     * A scope declared in a trait keeps its `self`/`static` parameter typehints
+     * unresolved: Psalm expands them at argument-check time against whatever class the
+     * params provider is registered on. For a custom Eloquent builder
+     * (Post::query()->scopeMethod($x)) that class is the builder, so `self` wrongly
+     * expands to the builder and Psalm emits a false-positive InvalidArgument (issue
+     * #1031). Pre-expanding here pins `self`/`static`/`$this` to the model before the
+     * params are handed back, so the same concrete type is checked regardless of which
+     * class serves the params (a custom builder, the model itself, or a relation chain;
+     * all callers share this helper).
+     *
+     * `static`/`$this` are resolved to the plain model class (via TypeExpander's
+     * `final: true`), NOT the late-static-bound `Model&static` form. A scope parameter is
+     * an accept position and Laravel passes the model instance, so the `&static`
+     * intersection would wrongly reject a plain model argument (ArgumentTypeCoercion);
+     * a plain model param already accepts subclass instances by ordinary subtyping.
+     * Scopes declared directly on the model already resolve `self` to the model at scan
+     * time, so this is a no-op for them.
+     *
+     * Caveat: for a trait-hosted scope, `self`/`static` pin to the model being queried,
+     * not necessarily the class that declares the trait. Querying a subclass narrows the
+     * param to that subclass — strictly more precise than the pre-fix builder type, and
+     * correct for the common single-using-class case.
+     *
+     * @param class-string<Model> $modelClass
+     * @param list<FunctionLikeParameter> $params
+     * @return list<FunctionLikeParameter>
+     */
+    private static function expandScopeParamSelfReferences(
+        Codebase $codebase,
+        string $modelClass,
+        array $params,
+    ): array {
+        return \array_map(
+            static function (FunctionLikeParameter $param) use ($codebase, $modelClass): FunctionLikeParameter {
+                if (!$param->type instanceof \Psalm\Type\Union) {
+                    return $param;
+                }
+
+                // setType() clones (mutation-free): never mutate the shared method-storage
+                // parameter, which would corrupt the model's own scope signature.
+                return $param->setType(TypeExpander::expandUnion(
+                    $codebase,
+                    $param->type,
+                    $modelClass, // `self`
+                    $modelClass, // `static` / `$this`
+                    null, // `parent` — not meaningful for a scope parameter
+                    evaluate_class_constants: true,
+                    evaluate_conditional_types: false,
+                    // `final: true` resolves `static`/`$this` to the plain model class
+                    // instead of the late-static-bound `Model&static` form. A scope is a
+                    // parameter (accept) position, and Laravel passes the model instance,
+                    // so the intersection would wrongly reject a plain model argument
+                    // (ArgumentTypeCoercion) — normal contravariance already accepts
+                    // subclasses. `self` is unaffected (it never carries `&static`).
+                    final: true,
+                ));
+            },
+            $params,
         );
     }
 

--- a/tests/Application/app/Models/Concerns/ComparesRank.php
+++ b/tests/Application/app/Models/Concerns/ComparesRank.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Concerns;
+
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Trait-hosted scopes whose non-query parameter is typed `self` or `static`.
+ *
+ * Reproduces issue #1031: when a model with a custom Eloquent builder uses these scopes,
+ * the scope's params provider is registered on the *builder* class, so Psalm expands the
+ * `self`/`static` parameter typehint against the builder instead of the model and reports
+ * a false-positive InvalidArgument. The scope must resolve `self`/`static` to the using
+ * model regardless of which class serves the params.
+ *
+ * Scopes declared directly on a model class are unaffected because Psalm resolves their
+ * `self` to the model at scan time; only trait-declared scopes keep `self`/`static`
+ * unresolved until argument-check time, which is why this archetype lives in a trait.
+ *
+ * Only the legacy `scopeXxx()` form is covered: trait-hosted `#[Scope]`-attributed scopes
+ * are not detected on builder instances at all (a separate pre-existing gap — they surface
+ * as UndefinedMagicMethod on a custom builder and as an unchecked call on the base builder),
+ * so a `#[Scope]` scope here would not reach the self/static expansion under test.
+ *
+ * @psalm-require-extends \Illuminate\Database\Eloquent\Model
+ */
+trait ComparesRank
+{
+    /**
+     * Legacy scope with a native `self`-typed non-query parameter.
+     *
+     * @param Builder<self> $query
+     */
+    public function scopeRankedAbove(Builder $query, self $model): void
+    {
+        $query->whereKeyNot($model->getKey());
+    }
+
+    /**
+     * Legacy scope with a docblock-only `static`-typed non-query parameter.
+     *
+     * `static` is not a legal native parameter type, so it can only be expressed in a
+     * docblock. This exercises the `static` resolution arm and the docblock-only param
+     * path, neither of which the native `self` typehint above reaches.
+     *
+     * @param Builder<static> $query
+     * @param static $model
+     */
+    public function scopeRankedBelow(Builder $query, $model): void
+    {
+        $query->whereKeyNot($model->getKey());
+    }
+
+    /**
+     * Legacy scope with a `self` nested inside a generic (`list<self>`).
+     *
+     * Exercises the nested-generic arm: TypeExpander recurses into type parameters, so
+     * `list<self>` must expand to `list<Model>` — not `list<Builder>` — when served on a
+     * custom builder. A flat `self` param would not reach this code path.
+     *
+     * @param Builder<self> $query
+     * @param list<self> $models
+     */
+    public function scopeRankedAmong(Builder $query, array $models): void
+    {
+        $query->whereKeyNot(\array_map(static fn(self $model) => $model->getKey(), $models));
+    }
+}

--- a/tests/Application/app/Models/Contract.php
+++ b/tests/Application/app/Models/Contract.php
@@ -4,14 +4,21 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\ComparesRank;
 use App\Models\Concerns\HasFlaggedScope;
 
 /**
  * Child of AbstractDocument: exercises inherited and trait-hosted scopes
  * called on builder instances.
+ *
+ * Uses ComparesRank (self/static scope params) on a model WITHOUT a custom builder,
+ * so its scope params provider registers on the base Illuminate Builder — the same
+ * self/static misexpansion (issue #1031) is possible there and must also resolve to
+ * the model. WorkOrder covers the custom-builder variant.
  */
 final class Contract extends AbstractDocument
 {
+    use ComparesRank;
     use HasFlaggedScope;
 
     protected $table = 'contracts';

--- a/tests/Application/app/Models/WorkOrder.php
+++ b/tests/Application/app/Models/WorkOrder.php
@@ -6,6 +6,7 @@ namespace App\Models;
 
 use App\Builders\WorkOrderBuilder;
 use App\Collections\WorkOrderCollection;
+use App\Models\Concerns\ComparesRank;
 use Illuminate\Database\Eloquent\Attributes\CollectedBy;
 use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
@@ -31,6 +32,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 #[UseEloquentBuilder(WorkOrderBuilder::class)]
 final class WorkOrder extends Model
 {
+    use ComparesRank;
     use SoftDeletes;
 
     protected $table = 'work_orders';

--- a/tests/Type/tests/Builder/Issue1031TraitScopeSelfParamTest.phpt
+++ b/tests/Type/tests/Builder/Issue1031TraitScopeSelfParamTest.phpt
@@ -1,0 +1,117 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Contract;
+use App\Models\Mechanic;
+use App\Models\WorkOrder;
+
+/**
+ * Issue #1031: a scope declared in a trait with a `self`/`static`-typed non-query
+ * parameter must resolve `self`/`static` to the model — not to the class the scope
+ * params provider is registered on, and not to a stricter `Model&static` form that
+ * would reject a plain model argument on the accept side.
+ *
+ * Both archetypes use the ComparesRank trait, whose scopes declare self/static params:
+ *  - WorkOrder has a custom builder (WorkOrderBuilder), so its params provider registers
+ *    on the builder class. Before the fix `self` expanded to WorkOrderBuilder.
+ *  - Contract has no custom builder, so its params provider registers on the base
+ *    Illuminate Builder. The same misexpansion is possible there.
+ *
+ * The three callers that share getScopeParams() are all exercised: instance builder
+ * (Model::query()->scope()), static model call (Model::scope()), and relation chain
+ * ($model->relation()->scope()).
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1031
+ */
+
+/* -- Custom builder, instance call (WorkOrder::query()) ---------------------- */
+
+/** Positive: native `self` param accepts the model; result keeps the custom builder type. */
+function test_self_param_accepts_model(WorkOrder $workOrder): void
+{
+    $_result = WorkOrder::query()->rankedAbove($workOrder);
+    /** @psalm-check-type-exact $_result = App\Builders\WorkOrderBuilder<App\Models\WorkOrder> */
+}
+
+/** Negative: the `self` param resolves to WorkOrder, so a non-model arg is rejected. */
+function test_self_param_is_type_checked(): void
+{
+    WorkOrder::query()->rankedAbove('not a model');
+}
+
+/** Positive: docblock-only `static` param accepts a plain model (no `&static` over-narrowing). */
+function test_static_param_accepts_model(WorkOrder $workOrder): void
+{
+    $_result = WorkOrder::query()->rankedBelow($workOrder);
+    /** @psalm-check-type-exact $_result = App\Builders\WorkOrderBuilder<App\Models\WorkOrder> */
+}
+
+/** Negative: `static` resolves to the model, so a non-model arg is rejected. */
+function test_static_param_is_type_checked(): void
+{
+    WorkOrder::query()->rankedBelow('not a model');
+}
+
+/** Positive: `self` nested in a generic (list<self>) accepts a list of models. */
+function test_nested_generic_param_accepts_models(WorkOrder $workOrder): void
+{
+    $_result = WorkOrder::query()->rankedAmong([$workOrder]);
+    /** @psalm-check-type-exact $_result = App\Builders\WorkOrderBuilder<App\Models\WorkOrder> */
+}
+
+/** Negative: list<self> expands to list<WorkOrder>, not list<Builder>. */
+function test_nested_generic_param_is_type_checked(): void
+{
+    WorkOrder::query()->rankedAmong(['not a model']);
+}
+
+/* -- Custom builder, static model call (WorkOrder::scope()) ------------------ */
+
+/** Positive: the static model-call path resolves the `self` param to the model. */
+function test_static_model_call_accepts_model(WorkOrder $workOrder): void
+{
+    WorkOrder::rankedAbove($workOrder);
+}
+
+/** Negative: the static model-call path still type-checks the `self` param. */
+function test_static_model_call_is_type_checked(): void
+{
+    WorkOrder::rankedAbove('not a model');
+}
+
+/* -- Custom builder, relation chain ($model->relation()->scope()) ------------ */
+
+/** Positive: scope on a relation query resolves the `self` param to the related model. */
+function test_relation_chain_accepts_model(Mechanic $mechanic, WorkOrder $workOrder): void
+{
+    $mechanic->workOrders()->rankedAbove($workOrder);
+}
+
+/** Negative: scope on a relation query still type-checks the `self` param. */
+function test_relation_chain_is_type_checked(Mechanic $mechanic): void
+{
+    $mechanic->workOrders()->rankedAbove('not a model');
+}
+
+/* -- Base builder (Contract, no custom builder) ----------------------------- */
+
+/** Positive: on the base Builder the `self` param resolves to Contract. */
+function test_base_builder_self_param_accepts_model(Contract $contract): void
+{
+    $_result = Contract::query()->rankedAbove($contract);
+    /** @psalm-check-type-exact $_result = Illuminate\Database\Eloquent\Builder<App\Models\Contract> */
+}
+
+/** Negative: the `self` param resolves to Contract, so a non-model arg is rejected. */
+function test_base_builder_self_param_is_type_checked(): void
+{
+    Contract::query()->rankedAbove('not a model');
+}
+?>
+--EXPECTF--
+InvalidArgument on line %d: Argument 1 of App\Builders\WorkOrderBuilder::rankedabove expects App\Models\WorkOrder, but 'not a model' provided
+InvalidArgument on line %d: Argument 1 of App\Builders\WorkOrderBuilder::rankedbelow expects App\Models\WorkOrder, but 'not a model' provided
+InvalidArgument on line %d: Argument 1 of App\Builders\WorkOrderBuilder::rankedamong expects list<App\Models\WorkOrder>, but list{'not a model'} provided
+InvalidArgument on line %d: Argument 1 of App\Models\WorkOrder::rankedabove expects App\Models\WorkOrder, but 'not a model' provided
+InvalidArgument on line %d: Argument 1 of Illuminate\Database\Eloquent\Relations\HasMany::rankedabove expects App\Models\WorkOrder, but 'not a model' provided
+InvalidArgument on line %d: Argument 1 of Illuminate\Database\Eloquent\Builder::rankedabove expects App\Models\Contract, but 'not a model' provided


### PR DESCRIPTION
## Issue to Solve

A Laravel query scope declared **in a trait** with a non-query parameter typed `self` (or `static`) raised a false-positive `InvalidArgument` when called on a model that uses a custom Eloquent builder. Psalm reported the expected argument type as the custom builder class instead of the model:

```
ERROR: InvalidArgument
Argument 1 of App\Builders\WorkOrderBuilder::rankedabove expects App\Builders\WorkOrderBuilder,
but App\Models\WorkOrder provided
```

The same scope declared directly on the model class was unaffected.

## Related

Fixes #1031

## Solution Description

**Root cause.** For a trait method, Psalm stores the `self`/`static` parameter typehint unresolved and expands it at argument-check time against the class the params provider is registered on. The custom builder support (#630) registers the scope params provider on the *builder* class, so `self` expanded to the builder rather than the model. Scopes declared directly on the model are unaffected because Psalm resolves their `self` to the model at scan time.

**Fix.** `BuilderScopeHandler::getScopeParams()` now pre-expands each scope parameter type with `TypeExpander::expandUnion()`, pinning `self`/`static`/`$this` to the model class before the params are handed back. `getScopeParams()` is the single helper shared by all three callers (instance builder, static model call, relation chain), so the same concrete type is now checked regardless of which class serves the params. The expansion folds into the method's existing memoization, so it runs once per model+method and stays off the per-call-expression hot path. `FunctionLikeParameter::setType()` is used so the shared method storage parameter is never mutated. Nested generics (e.g. `list<self>`) are expanded recursively by `TypeExpander`.

`static`/`$this` are resolved to the **plain model class** (`TypeExpander`'s `final: true`), not the late-static-bound `Model&static` form. A scope parameter is an accept position and Laravel passes the model instance, so the `&static` intersection would wrongly reject a plain model argument (`ArgumentTypeCoercion`); normal contravariance already accepts subclasses.

**Tests.** A new type test exercises the legacy `scopeXxx()` form with a native `self` parameter, a docblock-only `static` parameter, and a `list<self>` (nested-generic) parameter, across all three caller paths (instance builder, static model call, relation chain) on both a custom builder (`WorkOrder`) and the base Illuminate builder (`Contract`, no custom builder). Each arm has a positive (valid model accepted, builder type preserved) and a negative (wrong-typed argument raises `InvalidArgument` naming the model) assertion. Verified with the full suite (436 type tests), `composer psalm` (no errors, 100% type inference coverage), `composer rector`, and `composer cs`.

**Known limitation (separate from this fix).** Trait-hosted `#[Scope]`-attributed scopes are not detected on builder instances at all (they surface as `UndefinedMagicMethod` on a custom builder and as an unchecked call on the base builder), so the regression test covers the legacy `scopeXxx()` trait form. This is a pre-existing detection gap, not introduced here.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)