### PR TITLE
Keep real signature for direct scope calls passing $query

### DIFF
--- a/src/Handlers/Eloquent/ModelMethodHandler.php
+++ b/src/Handlers/Eloquent/ModelMethodHandler.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
 use Psalm\Codebase;
+use Psalm\Context;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Internal\MethodIdentifier;
 use Psalm\LaravelPlugin\Util\DynamicWhereResolver;
@@ -275,6 +276,16 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
         /** @var class-string<Model> $modelClass */
         $scopeParams = BuilderScopeHandler::getScopeParams($codebase, $modelClass, $methodName);
         if ($scopeParams !== null) {
+            // A direct instance call ($this->otherScope($query, ...)) invokes the real method,
+            // so its full declared signature — including the leading $query — applies. Only the
+            // magic-forwarded forms (Model::scope() via __callStatic, $builder->scope()) inject
+            // $query and need the stripped params. Detect the direct form by its explicit Builder
+            // first argument and decline, so Psalm checks against the real method signature
+            // instead of shifting every argument left by one. See issue #1034.
+            if (self::isDirectScopeCallPassingQuery($event, $codebase)) {
+                return null;
+            }
+
             return $scopeParams;
         }
 
@@ -293,6 +304,62 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
         }
 
         return null;
+    }
+
+    /**
+     * Whether the call is a direct instance invocation of a scope that passes the query
+     * builder explicitly — e.g. `$this->otherScope($query, ...)` from inside the model —
+     * as opposed to a magic-forwarded call (`Model::scope()` / `$builder->scope()`) where
+     * Laravel injects $query.
+     *
+     * The params event carries no AST node and no instance-vs-static flag, and argument
+     * expression types are not yet inferred when the params provider runs, so the call form
+     * cannot be read from the inferred arg type. The discriminator is the leading argument:
+     * a forwarded call omits $query, while a direct call supplies it. In practice the explicit
+     * $query is a plain variable ($this->otherScope($query, ...)), whose type is already in
+     * scope, so resolve the first argument variable from the context and check whether it is
+     * an Eloquent Builder. Non-variable first arguments fall through to the stripped signature.
+     *
+     * @see https://github.com/psalm/psalm-plugin-laravel/issues/1034
+     * @psalm-external-mutation-free
+     */
+    private static function isDirectScopeCallPassingQuery(MethodParamsProviderEvent $event, Codebase $codebase): bool
+    {
+        $args = $event->getCallArgs();
+        $context = $event->getContext();
+
+        if ($args === null || $args === [] || !$context instanceof Context) {
+            return false;
+        }
+
+        $firstArg = $args[0]->value;
+        if (!$firstArg instanceof Variable || !\is_string($firstArg->name)) {
+            return false;
+        }
+
+        $firstArgType = $context->vars_in_scope['$' . $firstArg->name] ?? null;
+        if (!$firstArgType instanceof Union) {
+            return false;
+        }
+
+        // TGenericObject (Builder<Model>) extends TNamedObject, so both the bare and the
+        // templated builder types are covered. A custom builder (e.g. PostBuilder) counts
+        // too — its instances are what a custom-builder model's scopes receive as $query.
+        foreach ($firstArgType->getAtomicTypes() as $atomic) {
+            if (!$atomic instanceof Type\Atomic\TNamedObject) {
+                continue;
+            }
+
+            $class = $atomic->value;
+            if (
+                \strtolower($class) === \strtolower(Builder::class)
+                || ($codebase->classExists($class) && $codebase->classExtends($class, Builder::class))
+            ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Application/app/Models/DirectScopeModel.php
+++ b/tests/Application/app/Models/DirectScopeModel.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Fixture for psalm/psalm-plugin-laravel#1034.
+ *
+ * The scope is public so a `.phpt` can perform a direct instance call that passes the
+ * $query builder explicitly ($model->hasAnyName($query, ...)). Such a call invokes the
+ * real method and must be checked against its full signature, whereas the magic-forwarded
+ * forms (DirectScopeModel::hasAnyName(...) / $builder->hasAnyName(...)) strip the leading
+ * $query that Laravel injects.
+ */
+final class DirectScopeModel extends Model
+{
+    protected $table = 'direct_scope_models';
+
+    /**
+     * @param  Builder<self>  $query
+     * @param  list<string>  $names
+     */
+    #[Scope]
+    public function hasAnyName(Builder $query, array $names): void
+    {
+        $query->whereIn('name', $names);
+    }
+}

--- a/tests/Type/tests/Model/DirectScopeCallTest.phpt
+++ b/tests/Type/tests/Model/DirectScopeCallTest.phpt
@@ -1,0 +1,38 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\DirectScopeModel;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Regression test for psalm/psalm-plugin-laravel#1034.
+ *
+ * A direct instance call to a #[Scope] (or legacy scopeXxx()) method that passes the
+ * $query builder explicitly — e.g. one scope calling another, $this->otherScope($query, ...) —
+ * invokes the real method and must be type-checked against its full declared signature.
+ *
+ * The plugin strips the leading $query parameter for the magic-forwarded forms
+ * (DirectScopeModel::hasAnyName(...) via __callStatic, $builder->hasAnyName(...)), where
+ * Laravel injects it. Applying that stripped signature to a direct call shifted every
+ * argument left by one and produced a false-positive InvalidArgument (the explicit Builder
+ * checked against the second declared parameter) plus a spurious TooManyArguments.
+ */
+
+/**
+ * Direct instance call passing the query builder explicitly — no error.
+ *
+ * @param Builder<DirectScopeModel> $query
+ */
+function test_direct_scope_call_with_explicit_query(DirectScopeModel $model, Builder $query): void
+{
+    $model->hasAnyName($query, ['a', 'b']);
+}
+
+/** Forwarded builder-instance call still uses the stripped (query-less) signature. */
+function test_forwarded_scope_call_still_strips_query(): void
+{
+    $_result = DirectScopeModel::query()->hasAnyName(['a', 'b']);
+    /** @psalm-check-type-exact $_result = Builder<DirectScopeModel> */
+}
+?>
+--EXPECT--


### PR DESCRIPTION
Fixes #1034.

### Problem

Calling one `#[Scope]` (or legacy `scopeXxx()`) method from another **as a direct instance method**, passing the `$query` builder explicitly — e.g. one scope composing another:

```php
/** @param list<string> $names */
#[Scope]
protected function hasAnyName(Builder $query, array $names): void { /* ... */ }

#[Scope]
protected function active(Builder $query): void
{
    $this->hasAnyName($query, ['a', 'b']);
}
```

emits a false-positive `InvalidArgument`:

```
Argument 1 of …::hasAnyName expects list<string>,
but Illuminate\Database\Eloquent\Builder<…> provided
```

`ModelMethodHandler::getMethodParams()` strips the leading `$query` parameter for **every** scope call. That is correct for the magic-forwarded forms (`Model::scope()` via `__callStatic`, `$builder->scope()`), where Laravel injects `$query` — but wrong for a direct instance call, where PHP runs the real method with its real signature. The stripped signature shifts every argument left by one, so the explicit `$query` is checked against the scope's *second* declared parameter.

This is specific to the `#[Scope]` attribute: with legacy `scopeXxx()`, the direct internal call used the prefixed name (`$this->scopeHasAnyName(...)`), which the strip logic (keyed on the bare scope name) never matched.

### Fix

`MethodParamsProviderEvent` exposes no AST node, and argument expression types are not yet inferred when the params provider runs, so the call form cannot be read from the inferred arg type. The discriminator is the leading argument: a forwarded call omits `$query`, a direct call supplies it — and in practice the explicit `$query` is a plain variable (`$this->otherScope($query, ...)`) whose type is already in scope.

`getMethodParams()` now resolves the first-argument variable from the analysis context and, when it is an Eloquent `Builder` (base or custom), declines — letting Psalm type-check against the real method signature. Forwarded calls omit `$query`, so their stripped signature is unchanged.

### Tests

- `tests/Type/tests/Model/DirectScopeCallTest.phpt` — direct instance call passing the builder produces no error; the forwarded builder-instance call still resolves to `Builder<Model>` with the stripped signature.
- `tests/Application/app/Models/DirectScopeModel.php` — autoloadable fixture (per-model providers only register for autoloadable classes).

Verified the new test fails on `master` and passes with the fix. Full `test:type`, `test:unit`, `psalm`, `cs:check`, and `rector` are green.
