### PR TITLE
Use real return type for direct scope calls passing `$query`

### DIFF
--- a/src/Handlers/Eloquent/BuilderScopeHandler.php
+++ b/src/Handlers/Eloquent/BuilderScopeHandler.php
@@ -10,8 +10,12 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
 use Psalm\Codebase;
+use Psalm\Context;
+use Psalm\Exception\UnpopulatedClasslikeException;
 use Psalm\Internal\MethodIdentifier;
+use Psalm\Internal\Type\Comparator\UnionTypeComparator;
 use Psalm\Internal\Type\TypeExpander;
 use Psalm\LaravelPlugin\Util\ModelPropertyResolver;
 use Psalm\Plugin\EventHandler\Event\MethodParamsProviderEvent;
@@ -325,6 +329,96 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
             },
             $params,
         );
+    }
+
+    /**
+     * Detect a direct call to a scope's underlying method that passes the $query builder explicitly.
+     *
+     * Scope-param stripping ({@see getScopeParams}: declared params minus the leading $query)
+     * models Laravel's *forwarded* scope calls — Model::someScope() via __callStatic and
+     * $builder->someScope() via __call — where Laravel injects $query at runtime. A direct call
+     * to the real method ($this->someScope($query, ...) from a sibling #[Scope] method) bypasses
+     * that forwarding: PHP invokes the method with its real, unstripped signature. Applying the
+     * stripped params there shifts every argument one position left and emits a false
+     * InvalidArgument (issue #1034). Legacy scopeXxx() methods are immune — their direct calls
+     * use the `scope`-prefixed name, which the strip logic (keyed on the bare scope name)
+     * never matches.
+     *
+     * The params/return-type provider events expose no instance-vs-forwarded flag, so the call
+     * form is inferred from the arguments: a direct call supplies the full unstripped arity with
+     * a Builder as the first argument, while forwarded calls never pass the builder themselves.
+     * When the first argument's type cannot be resolved we assume a forwarded call, preserving
+     * the established stripped-signature behavior.
+     *
+     * @param list<\PhpParser\Node\Arg>|null $callArgs
+     * @param list<FunctionLikeParameter> $scopeParams scope's declared params minus the leading $query
+     */
+    public static function isDirectScopeCall(
+        Codebase $codebase,
+        StatementsSource $source,
+        ?array $callArgs,
+        ?Context $context,
+        array $scopeParams,
+    ): bool {
+        if ($callArgs === null || $callArgs === []) {
+            return false;
+        }
+
+        $firstArg = $callArgs[0];
+
+        // Spread/named arguments defeat positional reasoning — treat as forwarded.
+        if ($firstArg->unpack || $firstArg->name !== null) {
+            return false;
+        }
+
+        // The params provider can fire before the call's argument nodes have a recorded
+        // type (verified: inside a registered model's own method body the node type is
+        // absent here), so fall back to the surrounding scope's variable types — this is
+        // the live path for the issue-#1034 shape `$this->scope($query, ...)`.
+        $argType = $source->getNodeTypeProvider()->getType($firstArg->value);
+        if (!$argType instanceof Union && $firstArg->value instanceof Variable && \is_string($firstArg->value->name)) {
+            $argType = $context?->vars_in_scope['$' . $firstArg->value->name] ?? null;
+        }
+
+        if ($argType === null || !$argType->isSingle()) {
+            return false;
+        }
+
+        $atomic = $argType->getSingleAtomic();
+        if (!$atomic instanceof TNamedObject) {
+            return false;
+        }
+
+        try {
+            $isBuilderArg = \strtolower($atomic->value) === \strtolower(Builder::class)
+                || ($codebase->classExists($atomic->value) && $codebase->classExtends($atomic->value, Builder::class));
+        } catch (UnpopulatedClasslikeException|\InvalidArgumentException) {
+            // classExists() doesn't guarantee populated storage, and classExtends() throws on
+            // unpopulated/aliased classes — unresolved first arg means "assume forwarded".
+            return false;
+        }
+
+        if (!$isBuilderArg) {
+            return false;
+        }
+
+        // A Builder first argument is decisive — unless the scope's own first param (after
+        // $query) would also accept it on a forwarded call, e.g. someScope(Builder $query,
+        // Builder $other) called as Model::someScope($otherBuilder), or an untyped/mixed
+        // param. Only that ambiguous case needs the arity tie-breaker: a direct call must
+        // satisfy the unstripped arity (the explicit $query plus every required scope param),
+        // while the forwarded form passes one argument less.
+        $firstScopeParamType = isset($scopeParams[0]) ? $scopeParams[0]->type : null;
+        if ($firstScopeParamType === null || UnionTypeComparator::isContainedBy($codebase, $argType, $firstScopeParamType)) {
+            $requiredScopeParamsCount = \count(\array_filter(
+                $scopeParams,
+                static fn(FunctionLikeParameter $param): bool => !$param->is_optional,
+            ));
+
+            return \count($callArgs) >= 1 + $requiredScopeParamsCount;
+        }
+
+        return true;
     }
 
     /**

--- a/src/Handlers/Eloquent/ModelMethodHandler.php
+++ b/src/Handlers/Eloquent/ModelMethodHandler.php
@@ -10,7 +10,6 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
 use Psalm\Codebase;
-use Psalm\Context;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Internal\MethodIdentifier;
 use Psalm\LaravelPlugin\Util\DynamicWhereResolver;
@@ -282,7 +281,7 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
             // $query and need the stripped params. Detect the direct form by its explicit Builder
             // first argument and decline, so Psalm checks against the real method signature
             // instead of shifting every argument left by one. See issue #1034.
-            if (self::isDirectScopeCallPassingQuery($event, $codebase)) {
+            if (BuilderScopeHandler::isDirectScopeCall($codebase, $source, $event->getCallArgs(), $event->getContext(), $scopeParams)) {
                 return null;
             }
 
@@ -304,62 +303,6 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
         }
 
         return null;
-    }
-
-    /**
-     * Whether the call is a direct instance invocation of a scope that passes the query
-     * builder explicitly — e.g. `$this->otherScope($query, ...)` from inside the model —
-     * as opposed to a magic-forwarded call (`Model::scope()` / `$builder->scope()`) where
-     * Laravel injects $query.
-     *
-     * The params event carries no AST node and no instance-vs-static flag, and argument
-     * expression types are not yet inferred when the params provider runs, so the call form
-     * cannot be read from the inferred arg type. The discriminator is the leading argument:
-     * a forwarded call omits $query, while a direct call supplies it. In practice the explicit
-     * $query is a plain variable ($this->otherScope($query, ...)), whose type is already in
-     * scope, so resolve the first argument variable from the context and check whether it is
-     * an Eloquent Builder. Non-variable first arguments fall through to the stripped signature.
-     *
-     * @see https://github.com/psalm/psalm-plugin-laravel/issues/1034
-     * @psalm-external-mutation-free
-     */
-    private static function isDirectScopeCallPassingQuery(MethodParamsProviderEvent $event, Codebase $codebase): bool
-    {
-        $args = $event->getCallArgs();
-        $context = $event->getContext();
-
-        if ($args === null || $args === [] || !$context instanceof Context) {
-            return false;
-        }
-
-        $firstArg = $args[0]->value;
-        if (!$firstArg instanceof Variable || !\is_string($firstArg->name)) {
-            return false;
-        }
-
-        $firstArgType = $context->vars_in_scope['$' . $firstArg->name] ?? null;
-        if (!$firstArgType instanceof Union) {
-            return false;
-        }
-
-        // TGenericObject (Builder<Model>) extends TNamedObject, so both the bare and the
-        // templated builder types are covered. A custom builder (e.g. PostBuilder) counts
-        // too — its instances are what a custom-builder model's scopes receive as $query.
-        foreach ($firstArgType->getAtomicTypes() as $atomic) {
-            if (!$atomic instanceof Type\Atomic\TNamedObject) {
-                continue;
-            }
-
-            $class = $atomic->value;
-            if (
-                \strtolower($class) === \strtolower(Builder::class)
-                || ($codebase->classExists($class) && $codebase->classExtends($class, Builder::class))
-            ) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /**
@@ -398,8 +341,18 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
         // Scope methods: return Builder<Model> directly.
         // Using executeFakeCall for scopes doesn't work reliably because the scope
         // is resolved via Builder's __call magic which may fail in a fake call context.
+        // A non-null getScopeParams() result implies the method is a real scope — no
+        // separate hasScopeMethod() guard needed (mirrors the params provider above).
         /** @var class-string<Model> $modelClass */
-        if (BuilderScopeHandler::hasScopeMethod($codebase, $modelClass, $methodName)) {
+        $scopeParams = BuilderScopeHandler::getScopeParams($codebase, $modelClass, $methodName);
+        if ($scopeParams !== null) {
+            // Direct calls to the underlying method ($this->someScope($query, ...))
+            // return whatever the method declares (often void), not Builder<Model> —
+            // decline and let Psalm use the real declared return type (issue #1034).
+            if (BuilderScopeHandler::isDirectScopeCall($codebase, $source, $event->getCallArgs(), $event->getContext(), $scopeParams)) {
+                return null;
+            }
+
             return new Union([self::builderType($builderClass, $calledClass, $codebase)]);
         }
 

--- a/tests/Application/app/Models/DirectScopeModel.php
+++ b/tests/Application/app/Models/DirectScopeModel.php
@@ -30,4 +30,22 @@ final class DirectScopeModel extends Model
     {
         $query->whereIn('name', $names);
     }
+
+    /**
+     * The issue's exact shape: a sibling #[Scope] method called directly, passing $query.
+     *
+     * Inside a registered model's own body the call's argument nodes have no recorded
+     * type yet when the params provider fires, so detection resolves $query through the
+     * Context::vars_in_scope fallback in BuilderScopeHandler::isDirectScopeCall().
+     * Note: no suite analyzes this method body today (test:app builds a fresh app without
+     * these fixtures; PHPT suites analyze only the snippet file), so this documents the
+     * pattern; it was verified against the issue's reproduction.
+     *
+     * @param  Builder<self>  $query
+     */
+    #[Scope]
+    protected function active(Builder $query): void
+    {
+        $this->hasAnyName($query, ['a', 'b']);
+    }
 }

--- a/tests/Type/tests/Model/DirectScopeCallTest.phpt
+++ b/tests/Type/tests/Model/DirectScopeCallTest.phpt
@@ -1,7 +1,9 @@
 --FILE--
 <?php declare(strict_types=1);
 
+use App\Models\Customer;
 use App\Models\DirectScopeModel;
+use App\Models\Vehicle;
 use Illuminate\Database\Eloquent\Builder;
 
 /**
@@ -9,13 +11,21 @@ use Illuminate\Database\Eloquent\Builder;
  *
  * A direct instance call to a #[Scope] (or legacy scopeXxx()) method that passes the
  * $query builder explicitly — e.g. one scope calling another, $this->otherScope($query, ...) —
- * invokes the real method and must be type-checked against its full declared signature.
+ * invokes the real method and must be type-checked against its full declared signature:
+ * params (no left-shift of arguments) AND return type (no fabricated Builder<Model>).
  *
  * The plugin strips the leading $query parameter for the magic-forwarded forms
  * (DirectScopeModel::hasAnyName(...) via __callStatic, $builder->hasAnyName(...)), where
  * Laravel injects it. Applying that stripped signature to a direct call shifted every
  * argument left by one and produced a false-positive InvalidArgument (the explicit Builder
  * checked against the second declared parameter) plus a spurious TooManyArguments.
+ *
+ * The issue's in-model sibling form (DirectScopeModel::active()) resolves the first arg
+ * through the Context::vars_in_scope fallback of BuilderScopeHandler::isDirectScopeCall(),
+ * which no suite can exercise: snippet-defined models are never registered (class_exists
+ * fails in ModelRegistrationHandler) and no suite analyzes the fixture models' bodies.
+ * The calls below go through the same detection helper via the node-type path; the
+ * sibling form itself was verified against the issue's reproduction.
  */
 
 /**
@@ -28,11 +38,65 @@ function test_direct_scope_call_with_explicit_query(DirectScopeModel $model, Bui
     $model->hasAnyName($query, ['a', 'b']);
 }
 
+/**
+ * Direct call returns what the method declares (void here), not a fabricated
+ * Builder<Model> — the expected AssignmentToVoid proves the real return type applies.
+ *
+ * @param Builder<DirectScopeModel> $query
+ */
+function test_direct_scope_call_uses_real_return_type(DirectScopeModel $model, Builder $query): void
+{
+    $_result = $model->hasAnyName($query, ['a', 'b']);
+}
+
+/**
+ * Wrong arg AFTER $query on a direct call: reported as argument 2 (real signature).
+ *
+ * @param Builder<DirectScopeModel> $query
+ */
+function test_direct_scope_call_wrong_second_arg(DirectScopeModel $model, Builder $query): void
+{
+    $model->hasAnyName($query, 'not-a-list');
+}
+
 /** Forwarded builder-instance call still uses the stripped (query-less) signature. */
 function test_forwarded_scope_call_still_strips_query(): void
 {
     $_result = DirectScopeModel::query()->hasAnyName(['a', 'b']);
     /** @psalm-check-type-exact $_result = Builder<DirectScopeModel> */
 }
+
+/** Forwarded call with a wrong arg keeps stripped positions: reported as argument 1. */
+function test_forwarded_scope_call_wrong_arg(): void
+{
+    $_result = DirectScopeModel::query()->hasAnyName('not-a-list');
+    /** @psalm-check-type-exact $_result = Builder<DirectScopeModel> */
+}
+
+/**
+ * Custom-builder model: the explicitly-passed builder is a Builder subclass
+ * (VehicleBuilder), exercising the classExtends arm of the direct-call detection.
+ */
+function test_direct_scope_call_with_custom_builder(Vehicle $vehicle): void
+{
+    $query = Vehicle::query();
+    $_result = $vehicle->electric($query);
+}
+
+/**
+ * Legacy scopeXxx() direct calls are immune to scope-param stripping: the
+ * `scope`-prefixed name never matches the strip logic (keyed on the bare scope
+ * name), so the real signature (leading $query, Builder return) applies.
+ */
+function test_direct_legacy_scope_call(Customer $customer): void
+{
+    $query = Customer::query();
+    $_result = $customer->scopeOfName($query, 'Ada');
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
 ?>
---EXPECT--
+--EXPECTF--
+AssignmentToVoid on line %d: Cannot assign $_result to type void
+InvalidArgument on line %d: Argument 2 of App\Models\DirectScopeModel::hasAnyName expects list<string>, but 'not-a-list' provided
+InvalidArgument on line %d: Argument 1 of Illuminate\Database\Eloquent\Builder::hasanyname expects list<string>, but 'not-a-list' provided
+AssignmentToVoid on line %d: Cannot assign $_result to type void


### PR DESCRIPTION
## Issue to Solve

Follow-up to #1035, which fixed the params side of #1034: a direct instance call to a `#[Scope]` method (`$this->siblingScope($query, ...)`, passing the builder explicitly) is no longer checked against the stripped, `$query`-less signature. Two gaps remained:

1. The return-type provider still fabricated `Builder<Model>` for direct calls. The common void scope silently typed as a builder, masking the method's real declared return type (`$result = $this->someScope($query)` inferred `Builder<Model>` instead of erroring on a void assignment).
2. The detection helper was minimal: variable-first-arg only, and an unguarded `classExists() && classExtends()` pair that can throw `UnpopulatedClasslikeException` out of the provider mid-analysis (`classExists()` does not guarantee populated storage).

## Related

Fixes #1034 (return-type side; params side fixed by #1035).

## Solution Description

Detection moves from `ModelMethodHandler` into `BuilderScopeHandler::isDirectScopeCall()` (the canonical home for scope semantics since #1032, right next to the `getScopeParams()` stripping it inverts), and both providers now share it: the params provider declines as before, and the return-type provider's scope branch declines too, letting Psalm resolve the real method end to end. That branch now keys on `getScopeParams() !== null` (non-null implies a real scope) instead of a redundant `hasScopeMethod()` pre-check.

Hardening over the #1035 helper:

- The first argument resolves via the node-type provider first, falling back to `Context::vars_in_scope`. The fallback is the live path inside model bodies (argument nodes have no recorded type yet when providers fire there); the node-type path covers non-variable arguments elsewhere.
- `classExtends()` is wrapped in `try/catch (UnpopulatedClasslikeException|InvalidArgumentException)`, mirroring every other call site in the codebase ("cannot resolve" means "assume forwarded").
- Spread and named arguments are skipped (no positional reasoning possible).
- An arity tie-breaker (via `UnionTypeComparator`) handles the ambiguous case where the scope's own first parameter would also accept a Builder on a forwarded call, so `Model::someScope($otherBuilder)` keeps the stripped signature.

Verified with the issue's reproduction (sibling-scope call inside a model: false positive on `master` before #1035, clean now, including the return type) and against a throwaway project covering direct wrong-arg, under-arity, optional-param, and forwarded wrong-arg shapes.

Note on coverage: the in-model sibling form resolves through the `vars_in_scope` fallback, which no suite can exercise today. Snippet-defined models are never registered (`class_exists` fails in `ModelRegistrationHandler`) and no suite analyzes the fixture models' bodies (`test:app` builds a fresh app without them). The `DirectScopeModel::active()` fixture documents the shape; the PHPT pins the same helper through the node-type path: real-signature argument positions (`Argument 2 of ...` on a direct call vs `Argument 1 of ...` on a forwarded one), the void return (`AssignmentToVoid`), the custom-builder `classExtends` arm (`VehicleBuilder`), and legacy `scopeXxx()` immunity.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)
