### PR TITLE
test(eloquent): pin scope resolution behavior (collisions, instance calls, when(), whereXxx, static #[Scope] semantics)

### DIFF
--- a/tests/Application/app/Models/CollidingScopeModel.php
+++ b/tests/Application/app/Models/CollidingScopeModel.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Archetype: a model whose scope names collide with real Builder/QueryBuilder
+ * methods (find/count/latest) and with Laravel's dynamic-where parsing (whereActive).
+ *
+ * Kept isolated from the shared archetypes (Customer, Vehicle, …) so the colliding
+ * scope names cannot perturb the many other suites that import those models.
+ *
+ * @property bool $active
+ */
+final class CollidingScopeModel extends Model
+{
+    protected $table = 'colliding_scope_models';
+
+    /**
+     * Collides with Eloquent\Builder::find(), a REAL method — so this scope is unreachable
+     * dead code at runtime (__call never fires for find).
+     *
+     * @param  Builder<self>  $query
+     * @return Builder<self>
+     */
+    public function scopeFind($query)
+    {
+        return $query->where('active', true);
+    }
+
+    /**
+     * Collides with count(), which is passthru-only on Eloquent\Builder — so __call DOES fire
+     * and this scope shadows the aggregate at runtime (the count()/sum()/exists() footgun).
+     *
+     * @param  Builder<self>  $query
+     * @return Builder<self>
+     */
+    public function scopeCount($query)
+    {
+        return $query->where('active', true);
+    }
+
+    /**
+     * Collides with Eloquent\Builder::latest(), a REAL method whose own return is the builder —
+     * so this scope is dead code but the inferred Builder type still matches runtime.
+     *
+     * @param  Builder<self>  $query
+     * @return Builder<self>
+     */
+    public function scopeLatest($query)
+    {
+        return $query->where('active', true);
+    }
+
+    /**
+     * Name parses as dynamic-where (whereActive -> where('active', ...)) but is
+     * declared as a scope; Laravel's hasNamedScope() wins over dynamicWhere.
+     *
+     * @param  Builder<self>  $query
+     * @return Builder<self>
+     */
+    public function scopeWhereActive($query)
+    {
+        return $query->where('active', true);
+    }
+}

--- a/tests/Application/app/Models/DirectScopeModel.php
+++ b/tests/Application/app/Models/DirectScopeModel.php
@@ -7,6 +7,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
  * Fixture for psalm/psalm-plugin-laravel#1034.
@@ -47,5 +48,11 @@ final class DirectScopeModel extends Model
     protected function active(Builder $query): void
     {
         $this->hasAnyName($query, ['a', 'b']);
+    }
+
+    /** @psalm-return HasMany<self, $this> */
+    public function children(): HasMany
+    {
+        return $this->hasMany(self::class);
     }
 }

--- a/tests/Type/tests/Builder/ConditionableScopeClosureTest.phpt
+++ b/tests/Type/tests/Builder/ConditionableScopeClosureTest.phpt
@@ -1,0 +1,70 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Pins scope calls inside when()/unless() closures — the most common real-world conditional
+ * query shape, previously untested.
+ *
+ * Three findings are pinned:
+ *
+ * 1. The chain stays a builder. Conditionable::when()/unless() are stubbed `@return $this`
+ *    (stubs/common/Support/Traits/Conditionable.phpstub) because Psalm 7 collapses Laravel's
+ *    templated `@return $this|TWhenReturnType` to mixed. So the closure's own return value is
+ *    discarded and the chain keeps the receiver type — here Builder<Customer>&static. The outer
+ *    `&static` is introduced by when()'s `@return $this` (Customer::query() alone is plain
+ *    Builder<Customer>, per StaticBuilderMethodsTest::test_static_query).
+ *
+ * 2. LIMITATION — an UNANNOTATED closure parameter is `mixed`. The stub types $callback as a
+ *    bare `?callable` with no callable-signature, so Psalm cannot push Builder<Customer> into
+ *    $q. Until the stub gains a typed callable, an unannotated $q->scope() is a MixedMethodCall
+ *    (and Psalm also flags the untyped closure param/return). This is the behavior a future
+ *    typed-callback stub would change.
+ *
+ * 3. The escape hatch works. A closure that annotates `@param Builder<Customer> $q` resolves the
+ *    scope cleanly with no diagnostics — the path real users rely on today.
+ */
+
+/** Closure RETURNS the scoped builder; when() discards it and the chain stays the builder. */
+function test_scope_inside_when_arrow_closure_keeps_builder(bool $flag): void
+{
+    $_result = Customer::query()->when($flag, fn ($q) => $q->active());
+    /** @psalm-check-type-exact $_result = Builder<Customer>&static */
+}
+
+/** Closure RETURNS void; pins that the param is mixed (no typed callable in the stub). */
+function test_when_closure_parameter_is_mixed(bool $flag): void
+{
+    Customer::query()->when($flag, function ($q): void {
+        /** @psalm-check-type-exact $q = mixed */
+        $q->active();
+    });
+}
+
+/** unless() behaves identically to when() for chaining. */
+function test_scope_inside_unless_arrow_closure_keeps_builder(bool $flag): void
+{
+    $_result = Customer::query()->unless($flag, fn ($q) => $q->active());
+    /** @psalm-check-type-exact $_result = Builder<Customer>&static */
+}
+
+/** Escape hatch: annotating the closure param types $q and resolves the scope with no errors. */
+function test_when_annotated_closure_resolves_scope(bool $flag): void
+{
+    Customer::query()->when($flag, /** @param Builder<Customer> $q */ function ($q): void {
+        /** @psalm-check-type-exact $q = Builder<Customer> */
+        $q->active();
+    });
+}
+?>
+--EXPECTF--
+MissingClosureReturnType on line %d: Closure does not have a return type, expecting mixed
+MissingClosureParamType on line %d: Parameter $q has no provided type
+MixedMethodCall on line %d: Cannot determine the type of $q when calling method active
+MissingClosureParamType on line %d: Parameter $q has no provided type
+MixedMethodCall on line %d: Cannot determine the type of $q when calling method active
+MissingClosureReturnType on line %d: Closure does not have a return type, expecting mixed
+MissingClosureParamType on line %d: Parameter $q has no provided type
+MixedMethodCall on line %d: Cannot determine the type of $q when calling method active

--- a/tests/Type/tests/Builder/CustomQueryBuilderTest.phpt
+++ b/tests/Type/tests/Builder/CustomQueryBuilderTest.phpt
@@ -187,11 +187,14 @@ function test_scope_attribute_on_custom_builder_via_query(): void
 }
 
 /**
- * Known limitation: #[Scope] methods work at runtime via __callStatic -> query() -> Builder,
- * but Psalm sees them as real instance methods and reports InvalidStaticInvocation.
- * Same behavior as Customer::verified() in StaticBuilderMethodsTest.
+ * TRUE positive: WorkOrder::completed() is a PUBLIC #[Scope] called statically. PHP raises
+ * `Error: Non-static method ... cannot be called statically` for an accessible non-static method
+ * BEFORE __callStatic is consulted, so this is a runtime fatal, not a forwarded scope call —
+ * InvalidStaticInvocation is correct. Same true-positive case as Customer::verified() in
+ * StaticBuilderMethodsTest::test_public_scope_attribute_static_is_invalid (the custom builder
+ * makes no difference: the static dispatch fatals before any builder is involved).
  */
-function test_scope_attribute_static_is_invalid_on_custom_builder(): void
+function test_public_scope_attribute_static_is_invalid_on_custom_builder(): void
 {
     $_result = WorkOrder::completed();
 }

--- a/tests/Type/tests/Builder/ModelInstanceScopeCallTest.phpt
+++ b/tests/Type/tests/Builder/ModelInstanceScopeCallTest.phpt
@@ -1,0 +1,79 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Pins LEGACY scope calls made on a MODEL INSTANCE ($customer->active()), distinct from the
+ * builder-instance form covered by InstanceScopeCallTest (Customer::query()->active()).
+ *
+ * Runtime: $customer->active() is not a real method, so Model::__call forwards it to
+ * $this->newQuery()->active() (vendor/laravel/framework/.../Model.php), which routes through
+ * Builder::__call -> callNamedScope and returns the builder. Forwarding happens whenever the
+ * bare-name method is unreachable from outside — nonexistent (legacy `scopeXxx`) or inaccessible
+ * (a protected/private #[Scope], pinned in ProtectedScopeSurfacesTest). A PUBLIC #[Scope] is the
+ * exception: its bare-name method is accessible, so PHP invokes it directly and hits the real
+ * signature ($customer->verified() raises TooFewArguments for the missing $query — an
+ * ArgumentCountError at runtime) instead of forwarding. The legacy `active`/`ofName` scopes and
+ * the public `verified` are both pinned below.
+ *
+ * Not pinnable by this suite: the in-body form `$this->active()`. Per-model providers are keyed
+ * on the exact concrete class, so a snippet-local subclass of a registered model is not itself
+ * registered (its scopes report UndefinedMagicMethod), and the bodies of the registered fixture
+ * models are never analyzed (test:app builds a fresh app without them; PHPT suites analyze only
+ * the snippet). The instance-receiver path below exercises the same resolution code.
+ */
+
+/** Legacy scope on a model instance resolves to the builder. */
+function test_legacy_scope_on_model_instance(Customer $customer): void
+{
+    $_result = $customer->active();
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
+
+/** Legacy scope with an argument: the value after $query is accepted. */
+function test_legacy_scope_with_arg_on_model_instance(Customer $customer): void
+{
+    $_result = $customer->ofName('Ada');
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
+
+/** Negative: the argument is type-checked against the scope's declared param (minus $query). */
+function test_scope_argument_type_checked_on_model_instance(Customer $customer): void
+{
+    $_result = $customer->ofName(123);
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
+
+/**
+ * Negative: too many args. Mirrors InstanceScopeCallTest's builder-instance coverage on this
+ * distinct model-instance route (Model::__call -> newQuery()), so a regression that dropped
+ * arity checking on the instance path would be caught.
+ */
+function test_scope_too_many_args_on_model_instance(Customer $customer): void
+{
+    $customer->ofName('a', 'b');
+}
+
+/** Negative: too few args (the required $name after $query is missing). */
+function test_scope_too_few_args_on_model_instance(Customer $customer): void
+{
+    $customer->ofName();
+}
+
+/**
+ * Contrast: a PUBLIC #[Scope] called on an instance is a real, accessible method, so PHP invokes
+ * it directly (no __call forwarding) — Psalm checks the real signature and reports the missing
+ * $query as TooFewArguments. True positive: at runtime this is an ArgumentCountError.
+ */
+function test_public_attribute_scope_on_instance_needs_query(Customer $customer): void
+{
+    $customer->verified();
+}
+?>
+--EXPECTF--
+InvalidArgument on line %d: Argument 1 of App\Models\Customer::ofname expects string, but 123 provided
+TooManyArguments on line %d: Too many arguments for App\Models\Customer::ofname - expecting 1 but saw 2
+TooFewArguments on line %d: Too few arguments for App\Models\Customer::ofname - expecting name to be passed
+TooFewArguments on line %d: Too few arguments for method App\Models\Customer::verified saw 0

--- a/tests/Type/tests/Builder/ProtectedScopeSurfacesTest.phpt
+++ b/tests/Type/tests/Builder/ProtectedScopeSurfacesTest.phpt
@@ -1,0 +1,67 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\DirectScopeModel;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * Pins a PROTECTED #[Scope] (Laravel's documented convention) on the two surfaces that work
+ * today: a builder instance (M::query()->scope()) and a relation chain
+ * ($owner->relation()->scope()). Runtime: Builder::__call / Relation::__call both consult
+ * hasNamedScope() and route to callNamedScope(); the relation decorates the forwarded call and
+ * returns itself, so the relation type is preserved for further chaining.
+ *
+ * Reuses DirectScopeModel::active (a protected #[Scope]). A protected method is inaccessible from
+ * outside the class, so PHP routes BOTH a static and a direct-instance call to __callStatic/__call
+ * and Laravel forwards to the scope (runtime-valid) — but Psalm checks the real protected signature
+ * and false-positives. Those two forms bound the supported surfaces: the static call
+ * (DirectScopeModel::active()) draws InvalidStaticInvocation in StaticBuilderMethodsTest, and the
+ * direct-instance call is pinned below as a documented false-positive TooFewArguments.
+ */
+
+/** Protected scope on a builder instance resolves to Builder<Model>. */
+function test_protected_scope_on_builder_instance(): void
+{
+    $_result = DirectScopeModel::query()->active();
+    /** @psalm-check-type-exact $_result = Builder<DirectScopeModel> */
+}
+
+/** Negative: the scope takes no args after $query, so an extra argument is rejected. */
+function test_protected_scope_rejects_extra_arg_on_builder(): void
+{
+    DirectScopeModel::query()->active('extra');
+}
+
+/**
+ * Protected scope on a relation chain keeps the relation type (HasMany), because Laravel's
+ * Relation::__call decorates the forwarded scope call and returns the relation for chaining.
+ */
+function test_protected_scope_on_relation_chain(DirectScopeModel $model): void
+{
+    $_result = $model->children()->active();
+    /** @psalm-check-type-exact $_result = HasMany<DirectScopeModel, DirectScopeModel> */
+}
+
+/** Negative: the same no-arg scope signature applies on the relation chain. */
+function test_protected_scope_rejects_extra_arg_on_relation(DirectScopeModel $model): void
+{
+    $model->children()->active('extra');
+}
+
+/**
+ * Documented FALSE positive (boundary): a direct protected-instance call is inaccessible from
+ * outside, so at runtime PHP routes it to Model::__call -> newQuery()->active() and the scope runs
+ * with an injected $query (valid). But Psalm sees the real active(Builder $query) signature and
+ * reports the missing $query as TooFewArguments. Mirrors the protected-static false positive in
+ * StaticBuilderMethodsTest.
+ */
+function test_protected_scope_direct_instance_call_false_positive(DirectScopeModel $model): void
+{
+    $model->active();
+}
+?>
+--EXPECTF--
+TooManyArguments on line %d: Too many arguments for Illuminate\Database\Eloquent\Builder::active - expecting 0 but saw 1
+TooManyArguments on line %d: Too many arguments for Illuminate\Database\Eloquent\Relations\HasMany::active - expecting 0 but saw 1
+TooFewArguments on line %d: Too few arguments for method App\Models\DirectScopeModel::active saw 0

--- a/tests/Type/tests/Builder/ScopeNameCollisionTest.phpt
+++ b/tests/Type/tests/Builder/ScopeNameCollisionTest.phpt
@@ -1,0 +1,121 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\CollidingScopeModel;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Pins how scope names that COLLIDE with built-in query methods resolve, anchored to
+ * Eloquent\Builder::__call (vendor/laravel/framework/.../Database/Eloquent/Builder.php,
+ * ~line 2266): __call fires only for names that are NOT real methods on the builder, and
+ * inside __call hasNamedScope() is consulted BEFORE the $passthru aggregate forward and before
+ * forwardCallTo()/dynamicWhere(). The collision outcome therefore depends on WHICH bucket the
+ * colliding name falls into:
+ *
+ *   A. Real Eloquent\Builder methods (find, latest): __call never fires, so the like-named
+ *      scope is unreachable dead code. The runtime value is whatever the real method returns.
+ *        - find() returns Model|null  -> the plugin's Builder<M> here is WRONG (see the BUG note).
+ *        - latest() returns the builder -> the plugin's Builder<M> coincidentally matches.
+ *
+ *   B. Names a scope may legitimately shadow via __call (count is passthru-only on
+ *      Eloquent\Builder; whereActive is a dynamic where): __call DOES fire and hasNamedScope
+ *      wins, so the scope runs and returns the builder at runtime. The plugin's Builder<M> is
+ *      CORRECT — this is the classic count()/sum()/exists() scope-shadowing footgun.
+ *
+ * CollidingScopeModel is a dedicated archetype (never a shared model) so these pathological
+ * scope names cannot perturb the many suites that import Customer/Vehicle/etc.
+ *
+ * KNOWN BUG (find return type, pinned-as-limitation below, tracked in #1039):
+ * BuilderScopeHandler::getMethodReturnType lacks the isRealBuilderMethod() guard that
+ * getMethodParams() carries, so for a scope name that collides with a REAL Eloquent\Builder
+ * method it overrides the real return type with Builder<M>.
+ * Argument checking is unaffected (the params path keeps the guard and falls back to the real
+ * method's signature), which test_find_argument_checking_uses_real_builder_signature pins. The
+ * assertion is deliberately pinned to today's wrong output so a future refactor that extends the
+ * guard to the return path flips this test to the correct Model|null. Note this is find-SPECIFIC:
+ * count is passthru-only (bucket B), so its Builder<M> is correct, not a bug.
+ */
+
+/**
+ * BUG (pinned-as-limitation): find() is a real Eloquent\Builder method, so at runtime the scope
+ * is dead code and CollidingScopeModel::query()->find(1) returns CollidingScopeModel|null. The
+ * plugin currently infers Builder<CollidingScopeModel> because the return-type path lacks the
+ * isRealBuilderMethod() guard. Pinned to the wrong output as a tripwire — see the file docblock.
+ */
+function test_find_real_eloquent_method_return_type_is_shadowed(): void
+{
+    $_result = CollidingScopeModel::query()->find(1);
+    /** @psalm-check-type-exact $_result = Builder<CollidingScopeModel> */
+}
+
+/**
+ * Argument checking for find() uses the REAL Builder::find signature ($id, $columns), not the
+ * colliding scope's params — proof the params path keeps the isRealBuilderMethod guard even
+ * though the return path does not. Both the surplus third argument and the wrong column type
+ * are reported against the real method.
+ */
+function test_find_argument_checking_uses_real_builder_signature(): void
+{
+    CollidingScopeModel::query()->find(1, 2, 3);
+}
+
+/**
+ * count() is passthru-only on Eloquent\Builder, so __call fires and hasNamedScope wins over the
+ * aggregate forward: the scope runs and returns the builder at runtime. The inferred Builder<M>
+ * is CORRECT — the well-known footgun where a scopeCount()/scopeSum() shadows the aggregate.
+ */
+function test_count_passthru_aggregate_is_shadowed_by_scope(): void
+{
+    $_result = CollidingScopeModel::query()->count();
+    /** @psalm-check-type-exact $_result = Builder<CollidingScopeModel> */
+}
+
+/**
+ * latest() is a real Eloquent\Builder method whose own return value IS the builder, so even
+ * though the like-named scope is dead code the inferred Builder<M> matches runtime.
+ */
+function test_latest_real_eloquent_method_returns_builder(): void
+{
+    $_result = CollidingScopeModel::query()->latest('created_at');
+    /** @psalm-check-type-exact $_result = Builder<CollidingScopeModel> */
+}
+
+/**
+ * whereActive() parses as a dynamic where (where('active', ...)) but is declared as a scope.
+ * On a builder instance hasNamedScope wins over dynamicWhere, so it resolves to the scope
+ * returning Builder<M>.
+ */
+function test_where_named_scope_wins_over_dynamic_where_on_builder(): void
+{
+    $_result = CollidingScopeModel::query()->whereActive();
+    /** @psalm-check-type-exact $_result = Builder<CollidingScopeModel> */
+}
+
+/** Same precedence when forwarded statically through Model::__callStatic. */
+function test_where_named_scope_wins_over_dynamic_where_when_static(): void
+{
+    $_result = CollidingScopeModel::whereActive();
+    /** @psalm-check-type-exact $_result = Builder<CollidingScopeModel> */
+}
+
+/**
+ * Negative: the scope takes no args after $query, so a value argument is rejected. A dynamic
+ * where (where('active', $value)) WOULD accept it — this proves the scope, not dynamicWhere,
+ * supplied the parameter list.
+ */
+function test_where_named_scope_rejects_value_arg_on_builder(): void
+{
+    CollidingScopeModel::query()->whereActive('extra');
+}
+
+/** Same negative on the static forwarding path. */
+function test_where_named_scope_rejects_value_arg_when_static(): void
+{
+    CollidingScopeModel::whereActive('extra');
+}
+?>
+--EXPECTF--
+TooManyArguments on line %d: Too many arguments for method Illuminate\Database\Eloquent\Builder::find - saw 3
+InvalidArgument on line %d: Argument 2 of Illuminate\Database\Eloquent\Builder::find expects list<non-empty-string>, but 2 provided
+TooManyArguments on line %d: Too many arguments for Illuminate\Database\Eloquent\Builder::whereactive - expecting 0 but saw 1
+TooManyArguments on line %d: Too many arguments for App\Models\CollidingScopeModel::whereactive - expecting 0 but saw 1

--- a/tests/Type/tests/Builder/StaticBuilderMethodsTest.phpt
+++ b/tests/Type/tests/Builder/StaticBuilderMethodsTest.phpt
@@ -2,6 +2,7 @@
 <?php declare(strict_types=1);
 
 use App\Models\Customer;
+use App\Models\DirectScopeModel;
 use App\Models\Vehicle;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
@@ -71,7 +72,7 @@ function test_static_legacy_scope(): void
  * See InstanceScopeCallTest.phpt for the dedicated coverage.
  *
  * Calling Customer::verified() statically triggers InvalidStaticInvocation because
- * it's a real instance method — see test_scope_attribute_static_is_invalid below.
+ * it's a real instance method — see test_public_scope_attribute_static_is_invalid below.
  */
 /** @return Builder<Customer> */
 function test_scope_attribute_via_builder(): Builder
@@ -80,12 +81,36 @@ function test_scope_attribute_via_builder(): Builder
 }
 
 /**
- * Known limitation: #[Scope] methods work at runtime via __callStatic -> query() -> Builder,
- * but Psalm sees them as real instance methods and reports InvalidStaticInvocation.
+ * TRUE positive: a PUBLIC #[Scope] method called statically. PHP raises
+ * `Error: Non-static method ... cannot be called statically` for an ACCESSIBLE non-static
+ * method BEFORE __callStatic is consulted, so Customer::verified() is a runtime fatal, not a
+ * forwarded scope call. InvalidStaticInvocation is correct — suppressing it would hide the
+ * crash. (Contrast the protected #[Scope] static call below, where __callStatic IS reached and
+ * the same diagnostic becomes a false positive.)
  */
-function test_scope_attribute_static_is_invalid(): void
+function test_public_scope_attribute_static_is_invalid(): void
 {
     $_result = Customer::verified();
+}
+
+/**
+ * FALSE positive (documented limitation): a PROTECTED #[Scope] method called statically. PHP's
+ * static-call rule is accessibility-gated — a protected method is inaccessible from outside the
+ * class, so PHP routes to __callStatic, which Laravel implements as static::query()->scope().
+ * This is the runtime-valid form the Laravel 12 docs use. Psalm still emits
+ * InvalidStaticInvocation because MethodAnalyzer::checkStatic (MethodAnalyzer.php:132-163)
+ * decides purely on `!$storage->is_static`, with no accessibility/__callStatic consideration.
+ * Blocked on an upstream fix: https://github.com/vimeo/psalm/issues/11876
+ * (repro: https://psalm.dev/r/7589c15285).
+ *
+ * Only InvalidStaticInvocation fires here, not the InaccessibleMethod the raw (plugin-less)
+ * repro also shows: the plugin's per-model visibility provider
+ * (ModelMethodHandler::isMethodVisible) reports the scope method as visible, which suppresses
+ * the accessibility diagnostic but not the static-call one.
+ */
+function test_protected_scope_attribute_static_is_invalid(): void
+{
+    $_result = DirectScopeModel::active();
 }
 
 // -----------------------------------------------------------------------
@@ -173,6 +198,7 @@ function test_nonexistent_method(): void
 ?>
 --EXPECTF--
 InvalidStaticInvocation on line %d: Method App\Models\Customer::verified is not static, but is called statically
+InvalidStaticInvocation on line %d: Method App\Models\DirectScopeModel::active is not static, but is called statically
 MixedReturnStatement on line %d: Could not infer a return type
 UndefinedMagicMethod on line %d: Magic method App\Builders\VehicleBuilder::withtrashed does not exist
 UndefinedMagicMethod on line %d: Magic method App\Models\Customer::completelyfakemethod does not exist


### PR DESCRIPTION
## Issue to Solve

Several Eloquent scope-resolution behaviors are correct only empirically, with nothing pinning them. Two refactors land next (a `BuilderScopeHandler::isDirectScopeCall` rewrite and a `$pendingScopeParams` rework); this PR is the regression net they will be validated against. Tests only, zero `src/` changes.

## Related

- Documents (does not fix) #1039: the `find()` return-type shadow surfaced while pinning and is pinned here as a documented limitation.
- Upstream limitation referenced by the static `#[Scope]` tests: vimeo/psalm#11876.

## Solution Description

Every assertion was probe-verified against the plugin's actual output, then checked against Laravel runtime truth before pinning. Wrong-but-current outputs are pinned only with an explicit limitation docblock, never asserted as if desired.

| Behavior | File | What it pins | Runtime truth |
|---|---|---|---|
| Scope names colliding with real / passthru / dynamic-where methods | `ScopeNameCollisionTest.phpt` | `find`/`latest` are real `Eloquent\Builder` methods (the scope is dead code); `count` (`$passthru`) and `whereActive` (dynamic-where) are legitimately shadowed by the scope | `Eloquent\Builder::__call` consults `hasNamedScope` (~Builder.php:2266) before `$passthru` and `forwardCallTo`/`dynamicWhere` |
| Model-instance scope calls | `ModelInstanceScopeCallTest.phpt` | `$customer->active()` to `Builder<Customer>`; arg type/arity checks; public `#[Scope]` instance call to `TooFewArguments` | `Model::__call` forwards inaccessible/legacy scopes via `newQuery()->scope()`; a public `#[Scope]` is invoked directly and needs `$query` |
| Scopes inside `when()`/`unless()` closures | `ConditionableScopeClosureTest.phpt` | chain stays `Builder<Customer>&static`; an unannotated closure param is `mixed`; an annotated `@param Builder<Customer>` resolves cleanly | `Conditionable::when()`/`unless()` return `$this` (stub `@return $this`) |
| `whereXxx`-named scope vs dynamic where | `ScopeNameCollisionTest.phpt` | `whereActive()` resolves as the scope; an extra arg gives `TooManyArguments` | `hasNamedScope` wins over `dynamicWhere` in `Builder::__call` |
| Static `#[Scope]` semantics | `StaticBuilderMethodsTest.phpt`, `CustomQueryBuilderTest.phpt` | public `#[Scope]` static to `InvalidStaticInvocation` (true positive; rewrote the stale "known limitation" docblocks); protected `#[Scope]` static to `InvalidStaticInvocation` (false positive) | public accessible non-static called statically fatals before `__callStatic`; protected routes to `__callStatic` then `static::query()->scope()` (valid), see vimeo/psalm#11876 |
| Protected `#[Scope]` on supported surfaces | `ProtectedScopeSurfacesTest.phpt` | builder-instance to `Builder<M>`; relation-chain to `HasMany<M, M>`; arg-check negatives; direct-instance to `TooFewArguments` (false positive) | `Builder::__call`/`Relation::__call` route to `callNamedScope`; a protected instance call routes to `__call` (valid) but Psalm sees the real signature |

Fixtures: a new `CollidingScopeModel` archetype (isolated so its pathological scope names cannot perturb other suites); `DirectScopeModel` gains a self-relation for the relation-chain case.

### Found while pinning

`M::query()->find(1)` where the model declares `scopeFind` infers `Builder<M>` instead of `Model|null`. `find` is a real `Eloquent\Builder` method, so at runtime the scope is unreachable dead code and the real `find` runs. `BuilderScopeHandler::getMethodReturnType` lacks the `isRealBuilderMethod` guard that `getMethodParams` already applies, so argument checking correctly uses the real `find` signature while only the return type is shadowed. Pinned as a documented limitation (`test_find_real_eloquent_method_return_type_is_shadowed`) so a guard-adding fix flips the assertion. Tracked in #1039.

`count`/`sum`/`exists` are NOT affected: they are `$passthru`-only, so the scope legitimately shadows them at runtime and `Builder<M>` is correct there.

## Checklist
- [x] Tests cover the change (type tests in `tests/Type/`)
