### PR TITLE
Classify Eloquent scope calls by PHP dispatch, not argument shape

### DIFF
--- a/src/Handlers/Eloquent/BuilderScopeHandler.php
+++ b/src/Handlers/Eloquent/BuilderScopeHandler.php
@@ -10,12 +10,11 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Expr\Variable;
 use Psalm\Codebase;
 use Psalm\Context;
 use Psalm\Exception\UnpopulatedClasslikeException;
+use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
 use Psalm\Internal\MethodIdentifier;
-use Psalm\Internal\Type\Comparator\UnionTypeComparator;
 use Psalm\Internal\Type\TypeExpander;
 use Psalm\LaravelPlugin\Util\ModelPropertyResolver;
 use Psalm\Plugin\EventHandler\Event\MethodParamsProviderEvent;
@@ -332,93 +331,125 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
     }
 
     /**
-     * Detect a direct call to a scope's underlying method that passes the $query builder explicitly.
+     * Whether a bare-name scope call dispatches to the model's real method (direct) rather
+     * than routing through Laravel's magic __call / __callStatic forwarding.
      *
-     * Scope-param stripping ({@see getScopeParams}: declared params minus the leading $query)
-     * models Laravel's *forwarded* scope calls — Model::someScope() via __callStatic and
-     * $builder->someScope() via __call — where Laravel injects $query at runtime. A direct call
-     * to the real method ($this->someScope($query, ...) from a sibling #[Scope] method) bypasses
-     * that forwarding: PHP invokes the method with its real, unstripped signature. Applying the
-     * stripped params there shifts every argument one position left and emits a false
-     * InvalidArgument (issue #1034). Legacy scopeXxx() methods are immune — their direct calls
-     * use the `scope`-prefixed name, which the strip logic (keyed on the bare scope name)
-     * never matches.
+     * PHP reaches __call / __callStatic ONLY when the named method does not exist under that
+     * name OR is inaccessible from the calling scope; an existing, accessible method is
+     * invoked directly with its real signature. This classifier mirrors that dispatch rule
+     * instead of guessing the call form from argument shapes:
      *
-     * The params/return-type provider events expose no instance-vs-forwarded flag, so the call
-     * form is inferred from the arguments: a direct call supplies the full unstripped arity with
-     * a Builder as the first argument, while forwarded calls never pass the builder themselves.
-     * When the first argument's type cannot be resolved we assume a forwarded call, preserving
-     * the established stripped-signature behavior.
+     *   direct  ⇔  the model really declares <methodName> (the BARE name, not scopeXxx)
+     *              AND that method is accessible from the caller ($context->self)
      *
-     * @param list<\PhpParser\Node\Arg>|null $callArgs
-     * @param list<FunctionLikeParameter> $scopeParams scope's declared params minus the leading $query
+     * Why it matters: scope-param stripping ({@see getScopeParams}: declared params minus the
+     * leading $query) models the *forwarded* forms, where Laravel injects $query at runtime.
+     * A direct call invokes the real method with its full, unstripped signature, so the two
+     * {@see ModelMethodHandler} providers (params + return type) must consult this together
+     * and decline for direct calls — applying the stripped signature there shifts every
+     * argument one position left (false InvalidArgument) and fabricates a Builder<TModel>
+     * return over the method's real one (issue #1034).
+     *
+     * Consequences, each a Laravel runtime truth (verified in Model::__call / Builder::__call
+     * and Model::callNamedScope, identical across 12/13):
+     *   - Legacy scopeXxx (bare name absent): the bare call has no real target, so Laravel
+     *     always forwards → not direct, stripped signature applies.
+     *   - public #[Scope]: accessible everywhere → always direct (PHP never reaches __call).
+     *   - protected/private #[Scope], caller inside the class hierarchy: accessible → direct
+     *     (the issue #1034 sibling form $this->scope($query, ...), now argument-shape
+     *     independent: non-variable args, nullable ?Builder, clone $query, variadic scopes
+     *     all classify correctly without special-casing).
+     *   - protected/private #[Scope], caller outside the hierarchy: inaccessible → forwarded.
+     *
+     * No caller context (Psalm resolving a method's OWN declaration passes a null context):
+     * the call cannot be proven to forward, so a real declared method is treated as direct.
+     * Declining there keeps the method's real signature for its body analysis instead of
+     * leaking the stripped (query-less) params into the declaration — which otherwise drops
+     * $query and raises UndefinedVariable inside a child overriding a parent #[Scope].
+     *
+     * @param class-string<Model> $modelClass
      */
     public static function isDirectScopeCall(
         Codebase $codebase,
-        StatementsSource $source,
-        ?array $callArgs,
+        string $modelClass,
+        string $methodName,
         ?Context $context,
-        array $scopeParams,
     ): bool {
-        if ($callArgs === null || $callArgs === []) {
+        $methodId = new MethodIdentifier($modelClass, \strtolower($methodName));
+
+        // Bare name is not a real method (legacy scopeXxx, or nothing): Laravel forwards.
+        if (!$codebase->methodExists($methodId)) {
             return false;
         }
 
-        $firstArg = $callArgs[0];
-
-        // Spread/named arguments defeat positional reasoning — treat as forwarded.
-        if ($firstArg->unpack || $firstArg->name !== null) {
-            return false;
+        // Real method, but no caller scope to test accessibility against (declaration
+        // analysis): cannot prove forwarding → treat as direct so the real signature wins.
+        if (!$context instanceof Context) {
+            return true;
         }
 
-        // The params provider can fire before the call's argument nodes have a recorded
-        // type (verified: inside a registered model's own method body the node type is
-        // absent here), so fall back to the surrounding scope's variable types — this is
-        // the live path for the issue-#1034 shape `$this->scope($query, ...)`.
-        $argType = $source->getNodeTypeProvider()->getType($firstArg->value);
-        if (!$argType instanceof Union && $firstArg->value instanceof Variable && \is_string($firstArg->value->name)) {
-            $argType = $context?->vars_in_scope['$' . $firstArg->value->name] ?? null;
-        }
+        return self::isMethodAccessibleFrom($codebase, $methodId, $context->self);
+    }
 
-        if ($argType === null || !$argType->isSingle()) {
-            return false;
-        }
-
-        $atomic = $argType->getSingleAtomic();
-        if (!$atomic instanceof TNamedObject) {
-            return false;
-        }
+    /**
+     * Whether $methodId is accessible from $callerClass under PHP's visibility rules.
+     *
+     * Public is reachable everywhere; from outside any class scope ($callerClass === null,
+     * e.g. a free function) only public is reachable. Protected is reachable from anywhere in
+     * the declaring class's inheritance chain (the declaring class, its subclasses, and its
+     * ancestors). Private is reachable only from the exact declaring class. Mirroring PHP's
+     * own dispatch lets an inaccessible method be classified as __call-forwarded.
+     *
+     * Visibility is read from the *declaring* class's storage, so an inherited or overridden
+     * scope is judged where it is actually declared.
+     *
+     * @psalm-mutation-free
+     */
+    private static function isMethodAccessibleFrom(
+        Codebase $codebase,
+        MethodIdentifier $methodId,
+        ?string $callerClass,
+    ): bool {
+        $declaringMethodId = $codebase->methods->getDeclaringMethodId($methodId) ?? $methodId;
 
         try {
-            $isBuilderArg = \strtolower($atomic->value) === \strtolower(Builder::class)
-                || ($codebase->classExists($atomic->value) && $codebase->classExtends($atomic->value, Builder::class));
-        } catch (UnpopulatedClasslikeException|\InvalidArgumentException) {
-            // classExists() doesn't guarantee populated storage, and classExtends() throws on
-            // unpopulated/aliased classes — unresolved first arg means "assume forwarded".
+            $visibility = $codebase->methods->getStorage($declaringMethodId)->visibility;
+        } catch (\UnexpectedValueException) {
+            // No storage to inspect — assume accessible (real signature is the safe default).
+            return true;
+        }
+
+        if ($visibility === ClassLikeAnalyzer::VISIBILITY_PUBLIC) {
+            return true;
+        }
+
+        if ($callerClass === null) {
             return false;
         }
 
-        if (!$isBuilderArg) {
+        $callerClassLower = \strtolower($callerClass);
+        $declaringClassLower = \strtolower($declaringMethodId->fq_class_name);
+
+        if ($callerClassLower === $declaringClassLower) {
+            return true;
+        }
+
+        if ($visibility === ClassLikeAnalyzer::VISIBILITY_PRIVATE) {
             return false;
         }
 
-        // A Builder first argument is decisive — unless the scope's own first param (after
-        // $query) would also accept it on a forwarded call, e.g. someScope(Builder $query,
-        // Builder $other) called as Model::someScope($otherBuilder), or an untyped/mixed
-        // param. Only that ambiguous case needs the arity tie-breaker: a direct call must
-        // satisfy the unstripped arity (the explicit $query plus every required scope param),
-        // while the forwarded form passes one argument less.
-        $firstScopeParamType = isset($scopeParams[0]) ? $scopeParams[0]->type : null;
-        if ($firstScopeParamType === null || UnionTypeComparator::isContainedBy($codebase, $argType, $firstScopeParamType)) {
-            $requiredScopeParamsCount = \count(\array_filter(
-                $scopeParams,
-                static fn(FunctionLikeParameter $param): bool => !$param->is_optional,
-            ));
-
-            return \count($callArgs) >= 1 + $requiredScopeParamsCount;
+        // Protected: accessible from anywhere in the declaring class's inheritance chain —
+        // a subclass calling an inherited scope, or a parent dispatching to a child override.
+        try {
+            return $codebase->classExtends($callerClassLower, $declaringClassLower)
+                || $codebase->classExtends($declaringClassLower, $callerClassLower);
+        } catch (\InvalidArgumentException|UnpopulatedClasslikeException) {
+            // classExtends (called with from_api: true) throws InvalidArgumentException on
+            // missing/aliased storage and UnpopulatedClasslikeException — a sibling
+            // LogicException, NOT an InvalidArgumentException — when storage exists but isn't
+            // populated yet. Both mean we can't prove the chain → treat as not in it (forwarded).
+            return false;
         }
-
-        return true;
     }
 
     /**
@@ -569,6 +600,16 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
                 new MethodIdentifier($modelClass, \strtolower($methodName)),
             );
         } catch (\InvalidArgumentException|\UnexpectedValueException) {
+            return false;
+        }
+
+        // A private #[Scope] is never a usable scope on any supported Laravel (12-13). Laravel
+        // 13.8+ rejects it outright in Model::isScopeMethodWithAttribute (`! isPrivate() && ...`);
+        // on 12.4–13.7 it is broken anyway — callNamedScope dispatches the scope from the base
+        // Model's $this, where the subclass's private method is unreachable, so it routes back
+        // through __call and recurses. Either way it can't dispatch, so a legacy scopeXxx twin
+        // (resolved separately) wins, or it is nothing.
+        if ($methodStorage->visibility === ClassLikeAnalyzer::VISIBILITY_PRIVATE) {
             return false;
         }
 

--- a/src/Handlers/Eloquent/ModelMethodHandler.php
+++ b/src/Handlers/Eloquent/ModelMethodHandler.php
@@ -275,13 +275,16 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
         /** @var class-string<Model> $modelClass */
         $scopeParams = BuilderScopeHandler::getScopeParams($codebase, $modelClass, $methodName);
         if ($scopeParams !== null) {
-            // A direct instance call ($this->otherScope($query, ...)) invokes the real method,
-            // so its full declared signature — including the leading $query — applies. Only the
-            // magic-forwarded forms (Model::scope() via __callStatic, $builder->scope()) inject
-            // $query and need the stripped params. Detect the direct form by its explicit Builder
-            // first argument and decline, so Psalm checks against the real method signature
-            // instead of shifting every argument left by one. See issue #1034.
-            if (BuilderScopeHandler::isDirectScopeCall($codebase, $source, $event->getCallArgs(), $event->getContext(), $scopeParams)) {
+            // A direct call ($this->otherScope($query, ...) inside the model, or any call to an
+            // accessible real scope method) invokes the real method, so its full declared
+            // signature — including the leading $query — applies. Only the magic-forwarded forms
+            // (Model::scope() via __callStatic, $builder->scope()) inject $query and need the
+            // stripped params. The classifier decides from PHP dispatch semantics, not argument
+            // shapes, and declines for direct calls so Psalm checks the real signature instead of
+            // shifting every argument left by one. A null context (Psalm resolving this method's
+            // own declaration) also declines, keeping $query in scope for an overriding child.
+            // See issue #1034.
+            if (BuilderScopeHandler::isDirectScopeCall($codebase, $modelClass, $methodName, $event->getContext())) {
                 return null;
             }
 
@@ -346,10 +349,12 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
         /** @var class-string<Model> $modelClass */
         $scopeParams = BuilderScopeHandler::getScopeParams($codebase, $modelClass, $methodName);
         if ($scopeParams !== null) {
-            // Direct calls to the underlying method ($this->someScope($query, ...))
-            // return whatever the method declares (often void), not Builder<Model> —
-            // decline and let Psalm use the real declared return type (issue #1034).
-            if (BuilderScopeHandler::isDirectScopeCall($codebase, $source, $event->getCallArgs(), $event->getContext(), $scopeParams)) {
+            // Direct calls to the underlying method ($this->someScope($query, ...), or any call
+            // to an accessible real scope method) return whatever the method declares (often
+            // void), not Builder<Model> — decline and let Psalm use the real declared return
+            // type. The classifier shares the params provider's dispatch-truth verdict so the
+            // two decline together (issue #1034).
+            if (BuilderScopeHandler::isDirectScopeCall($codebase, $modelClass, $methodName, $event->getContext())) {
                 return null;
             }
 

--- a/src/Handlers/SuppressHandler.php
+++ b/src/Handlers/SuppressHandler.php
@@ -501,6 +501,14 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
     /** @psalm-mutation-free */
     private static function hasScopeAttribute(MethodStorage $methodStorage): bool
     {
+        // A private #[Scope] is not a usable scope on any supported Laravel — see the rationale
+        // on BuilderScopeHandler::hasScopeAttribute. Leave it reported as genuinely unused rather
+        // than silencing dead code. (suppressInternalDispatchMethod also gates private downstream;
+        // this keeps the helper itself honest.)
+        if ($methodStorage->visibility === ClassLikeAnalyzer::VISIBILITY_PRIVATE) {
+            return false;
+        }
+
         foreach ($methodStorage->attributes as $attribute) {
             if ($attribute->fq_class_name === Scope::class) {
                 return true;

--- a/tests/Application/app/Models/DirectScopeModel.php
+++ b/tests/Application/app/Models/DirectScopeModel.php
@@ -35,11 +35,11 @@ final class DirectScopeModel extends Model
     /**
      * The issue's exact shape: a sibling #[Scope] method called directly, passing $query.
      *
-     * Inside a registered model's own body the call's argument nodes have no recorded
-     * type yet when the params provider fires, so detection resolves $query through the
-     * Context::vars_in_scope fallback in BuilderScopeHandler::isDirectScopeCall().
-     * Note: no suite analyzes this method body today (test:app builds a fresh app without
-     * these fixtures; PHPT suites analyze only the snippet file), so this documents the
+     * hasAnyName is a real, accessible (public) method, so BuilderScopeHandler::isDirectScopeCall
+     * classifies this as a direct call from PHP dispatch alone — independent of argument shapes —
+     * and the params/return providers decline, leaving the real (Builder $query, list<string>)
+     * signature. Note: no suite analyzes this method body today (test:app builds a fresh app
+     * without these fixtures; PHPT suites analyze only the snippet file), so this documents the
      * pattern; it was verified against the issue's reproduction.
      *
      * @param  Builder<self>  $query

--- a/tests/Application/app/Models/PrivateScopeModel.php
+++ b/tests/Application/app/Models/PrivateScopeModel.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Archetype for #[Scope] VISIBILITY handling.
+ *
+ * A private #[Scope] is never a usable scope on any supported Laravel (12-13): 13.8+ rejects
+ * it in Model::isScopeMethodWithAttribute, and earlier versions break at runtime anyway (it
+ * recurses through __call, since callNamedScope dispatches from the base Model's $this where
+ * the subclass's private method is unreachable). So the plugin treats it as not-a-scope — a
+ * legacy scopeXxx twin (if any) wins, otherwise it is nothing.
+ *
+ * Kept isolated from the shared archetypes (Customer, Vehicle, …) so these visibility shapes
+ * cannot perturb the many suites that import those models.
+ */
+final class PrivateScopeModel extends Model
+{
+    protected $table = 'private_scope_models';
+
+    /**
+     * Private #[Scope] shadowed by a legacy twin. The private attribute is never dispatchable
+     * (see class docblock: 13.8+ rejects it, earlier versions recurse), so the only working
+     * scope here is the legacy scopePublished() — the plugin must resolve via the legacy scope.
+     *
+     * @param  Builder<self>  $query
+     */
+    #[Scope]
+    private function published(Builder $query): void
+    {
+        $query->where('published', true);
+    }
+
+    /**
+     * Legacy twin of the private #[Scope] above — this is what Laravel actually dispatches.
+     *
+     * @param  Builder<self>  $query
+     * @return Builder<self>
+     */
+    public function scopePublished($query)
+    {
+        return $query->where('published', true);
+    }
+
+    /**
+     * Private #[Scope] with NO legacy twin: not dispatchable at runtime, so not a usable scope.
+     * The plugin must NOT resolve it.
+     *
+     * @param  Builder<self>  $query
+     */
+    #[Scope]
+    private function archived(Builder $query): void
+    {
+        $query->where('archived', true);
+    }
+}

--- a/tests/Type/tests/Builder/LegacyScopeBuilderArgTest.phpt
+++ b/tests/Type/tests/Builder/LegacyScopeBuilderArgTest.phpt
@@ -1,0 +1,63 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Regression for the dispatch-truth classifier (replacing BuilderScopeHandler's old
+ * argument-shape heuristic).
+ *
+ * A legacy scopeXxx() method has NO bare-name method, so a call to the bare name ALWAYS
+ * forwards through Laravel's __call / __callStatic, independent of what is passed as the first
+ * argument. The previous heuristic inferred "direct call" from a Builder-typed first argument
+ * and then declined, leaving the call with no resolved params/return and surfacing a false
+ * `UndefinedMagicMethod`. The classifier keys on PHP dispatch (the bare name is not a real
+ * method) instead, so the stripped signature applies and the misplaced Builder argument is
+ * reported precisely against the scope's declared parameter. (A Builder passed to a `string`
+ * param draws both InvalidArgument and InvalidCast, since Builder has no __toString, where the
+ * old heuristic emitted a single false UndefinedMagicMethod.)
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1034
+ */
+
+/**
+ * Legacy scope, static call, Builder passed as the first argument. Forwarded: the Builder is
+ * checked against the stripped param (string $name), not misread as the injected $query.
+ */
+function test_legacy_static_with_builder_first_arg(): void
+{
+    Customer::ofName(Customer::query());
+}
+
+/** Same call on a builder instance: also forwarded, same diagnostics. */
+function test_legacy_builder_instance_with_builder_first_arg(): void
+{
+    Customer::query()->ofName(Customer::query());
+}
+
+/**
+ * Legacy scope whose post-$query param is OPTIONAL (defaulted). The old heuristic's arity
+ * tie-breaker (required-count 0) made a single Builder argument satisfy "direct" and produced
+ * the false UndefinedMagicMethod; dispatch truth still forwards, so the Builder is checked
+ * against the stripped `string $status`.
+ */
+function test_legacy_optional_param_with_builder_first_arg(): void
+{
+    Customer::ofStatus(Customer::query());
+}
+
+/** Control: a correctly-typed forwarded argument resolves cleanly to Builder<Customer>. */
+function test_legacy_static_valid_arg(): void
+{
+    $_result = Customer::ofName('Ada');
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
+?>
+--EXPECTF--
+InvalidArgument on line %d: Argument 1 of App\Models\Customer::ofname expects string, but Illuminate\Database\Eloquent\Builder<App\Models\Customer> provided
+InvalidCast on line %d: Illuminate\Database\Eloquent\Builder<App\Models\Customer> cannot be cast to string
+InvalidArgument on line %d: Argument 1 of Illuminate\Database\Eloquent\Builder::ofname expects string, but Illuminate\Database\Eloquent\Builder<App\Models\Customer> provided
+InvalidCast on line %d: Illuminate\Database\Eloquent\Builder<App\Models\Customer> cannot be cast to string
+InvalidArgument on line %d: Argument 1 of App\Models\Customer::ofstatus expects string, but Illuminate\Database\Eloquent\Builder<App\Models\Customer> provided
+InvalidCast on line %d: Illuminate\Database\Eloquent\Builder<App\Models\Customer> cannot be cast to string

--- a/tests/Type/tests/Builder/ModelInstanceScopeCallTest.phpt
+++ b/tests/Type/tests/Builder/ModelInstanceScopeCallTest.phpt
@@ -66,6 +66,11 @@ function test_scope_too_few_args_on_model_instance(Customer $customer): void
  * Contrast: a PUBLIC #[Scope] called on an instance is a real, accessible method, so PHP invokes
  * it directly (no __call forwarding) — Psalm checks the real signature and reports the missing
  * $query as TooFewArguments. True positive: at runtime this is an ArgumentCountError.
+ *
+ * The dispatch-truth classifier (replacing the old argument-shape heuristic) now classifies this
+ * accessible real method as a direct call and declines, so the real signature drives both the
+ * named "expecting query to be passed" diagnostic and the generic "saw 0" — sharpening the
+ * previous single "saw 0" line. Both are the same true positive.
  */
 function test_public_attribute_scope_on_instance_needs_query(Customer $customer): void
 {
@@ -76,4 +81,5 @@ function test_public_attribute_scope_on_instance_needs_query(Customer $customer)
 InvalidArgument on line %d: Argument 1 of App\Models\Customer::ofname expects string, but 123 provided
 TooManyArguments on line %d: Too many arguments for App\Models\Customer::ofname - expecting 1 but saw 2
 TooFewArguments on line %d: Too few arguments for App\Models\Customer::ofname - expecting name to be passed
+TooFewArguments on line %d: Too few arguments for App\Models\Customer::verified - expecting query to be passed
 TooFewArguments on line %d: Too few arguments for method App\Models\Customer::verified saw 0

--- a/tests/Type/tests/Builder/PrivateScopeVisibilityTest.phpt
+++ b/tests/Type/tests/Builder/PrivateScopeVisibilityTest.phpt
@@ -1,0 +1,36 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\PrivateScopeModel;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Pins #[Scope] VISIBILITY handling: a private #[Scope] is never a usable scope on any
+ * supported Laravel (12-13) — 13.8+ rejects it in Model::isScopeMethodWithAttribute, and
+ * earlier versions break at runtime anyway (it recurses through __call). So the plugin must
+ * not treat it as a scope.
+ *
+ * Before the dispatch-truth work the plugin's #[Scope] detection was visibility-blind, so a
+ * private #[Scope] alone was wrongly resolved as a scope (Builder<Model>). Now it is rejected:
+ * a legacy scopeXxx twin wins, and a private #[Scope] with no twin stays unresolved.
+ */
+
+/** Private #[Scope] shadowed by a legacy twin: resolves via the legacy scopePublished(). */
+function test_private_attribute_scope_falls_through_to_legacy(): void
+{
+    $_result = PrivateScopeModel::query()->published();
+    /** @psalm-check-type-exact $_result = Builder<PrivateScopeModel> */
+}
+
+/**
+ * Private #[Scope] with no legacy twin: not a usable scope, so the call is not resolved by the
+ * scope handler and stays mixed (Builder::__call's runtime default), exactly as a nonexistent
+ * builder method does.
+ */
+function test_private_attribute_scope_alone_is_not_a_scope(): void
+{
+    $_result = PrivateScopeModel::query()->archived();
+    /** @psalm-check-type-exact $_result = mixed */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Model/DirectScopeCallTest.phpt
+++ b/tests/Type/tests/Model/DirectScopeCallTest.phpt
@@ -9,10 +9,10 @@ use Illuminate\Database\Eloquent\Builder;
 /**
  * Regression test for psalm/psalm-plugin-laravel#1034.
  *
- * A direct instance call to a #[Scope] (or legacy scopeXxx()) method that passes the
- * $query builder explicitly — e.g. one scope calling another, $this->otherScope($query, ...) —
- * invokes the real method and must be type-checked against its full declared signature:
- * params (no left-shift of arguments) AND return type (no fabricated Builder<Model>).
+ * A direct call to a #[Scope] method that passes the $query builder explicitly — e.g. one
+ * scope calling another, $this->otherScope($query, ...), or any call to an accessible real
+ * scope method — invokes the real method and must be type-checked against its full declared
+ * signature: params (no left-shift of arguments) AND return type (no fabricated Builder<Model>).
  *
  * The plugin strips the leading $query parameter for the magic-forwarded forms
  * (DirectScopeModel::hasAnyName(...) via __callStatic, $builder->hasAnyName(...)), where
@@ -20,12 +20,13 @@ use Illuminate\Database\Eloquent\Builder;
  * argument left by one and produced a false-positive InvalidArgument (the explicit Builder
  * checked against the second declared parameter) plus a spurious TooManyArguments.
  *
- * The issue's in-model sibling form (DirectScopeModel::active()) resolves the first arg
- * through the Context::vars_in_scope fallback of BuilderScopeHandler::isDirectScopeCall(),
- * which no suite can exercise: snippet-defined models are never registered (class_exists
- * fails in ModelRegistrationHandler) and no suite analyzes the fixture models' bodies.
- * The calls below go through the same detection helper via the node-type path; the
- * sibling form itself was verified against the issue's reproduction.
+ * The dispatch-truth classifier ({@see BuilderScopeHandler::isDirectScopeCall}) decides direct
+ * vs forwarded from PHP dispatch semantics — the bare name is a real, accessible method — not
+ * from the argument shapes. So the calls below classify correctly regardless of whether the
+ * first argument is a plain Builder, a Builder subclass, a nullable ?Builder, or a non-variable
+ * expression. DirectScopeModel::hasAnyName is public, so an external call from these snippet
+ * functions is accessible and resolves as direct, exercising the same path as the issue's
+ * in-model sibling form $this->hasAnyName($query, ...).
  */
 
 /**
@@ -59,6 +60,19 @@ function test_direct_scope_call_wrong_second_arg(DirectScopeModel $model, Builde
     $model->hasAnyName($query, 'not-a-list');
 }
 
+/**
+ * A NULLABLE Builder first argument (two atomics) no longer flips the classification to
+ * forwarded — dispatch truth keeps it direct, so the real signature applies and the null is a
+ * PossiblyNullArgument against the real $query param, not a false InvalidArgument from the
+ * stripped signature. Regression for the fa3 shape.
+ *
+ * @param Builder<DirectScopeModel>|null $query
+ */
+function test_direct_scope_call_nullable_query_arg(DirectScopeModel $model, ?Builder $query): void
+{
+    $model->hasAnyName($query, ['a', 'b']);
+}
+
 /** Forwarded builder-instance call still uses the stripped (query-less) signature. */
 function test_forwarded_scope_call_still_strips_query(): void
 {
@@ -74,8 +88,9 @@ function test_forwarded_scope_call_wrong_arg(): void
 }
 
 /**
- * Custom-builder model: the explicitly-passed builder is a Builder subclass
- * (VehicleBuilder), exercising the classExtends arm of the direct-call detection.
+ * Custom-builder model: the explicitly-passed builder is a Builder subclass (VehicleBuilder),
+ * and electric() is a public #[Scope], so the call is accessible and classifies as direct —
+ * the real void return drives AssignmentToVoid.
  */
 function test_direct_scope_call_with_custom_builder(Vehicle $vehicle): void
 {
@@ -98,5 +113,6 @@ function test_direct_legacy_scope_call(Customer $customer): void
 --EXPECTF--
 AssignmentToVoid on line %d: Cannot assign $_result to type void
 InvalidArgument on line %d: Argument 2 of App\Models\DirectScopeModel::hasAnyName expects list<string>, but 'not-a-list' provided
+PossiblyNullArgument on line %d: Argument 1 of App\Models\DirectScopeModel::hasAnyName cannot be null, possibly null value provided
 InvalidArgument on line %d: Argument 1 of Illuminate\Database\Eloquent\Builder::hasanyname expects list<string>, but 'not-a-list' provided
 AssignmentToVoid on line %d: Cannot assign $_result to type void


### PR DESCRIPTION
## Issue to Solve

`BuilderScopeHandler::isDirectScopeCall` decided whether a scope call was a *direct* call to the model's real method (full signature applies) or a *magic-forwarded* call (Laravel injects `$query`, stripped signature applies) by **sniffing the arguments**: first-arg-is-a-`Builder`, a `UnionTypeComparator` containment probe, and an arity tie-breaker. That heuristic mis-fired on several valid shapes:

- a legacy scope called with a `Builder` first argument surfaced a false `UndefinedMagicMethod`;
- a nullable `?Builder` (or any non-`Builder`-resolvable) first argument on a direct sibling `#[Scope]` call produced a false `InvalidArgument` from the stripped signature plus a fabricated `Builder<Model>` return;
- a child overriding a parent `#[Scope]` got `UndefinedVariable $query` in the override body.

## Related

Refs #1034

## Solution Description

Replace the heuristic with **dispatch-truth classification** that mirrors PHP/Laravel runtime dispatch:

> A bare-name scope call is **direct** iff the model really declares the bare method **and** that method is accessible from the calling scope (`$context->self`); otherwise it is **magic-forwarded**.

Because the decision no longer inspects arguments, variadic scopes, nullable `?Builder` args, non-variable expressions, and `clone $query` all classify correctly with no special-casing. Both `ModelMethodHandler` provider sites (params + return type) consult the same classifier so they decline together.

| Call shape | Before (master) | After |
|---|---|---|
| `Model::legacyScope($builder)` — legacy scope, `Builder` as first arg | false `UndefinedMagicMethod` | `InvalidArgument` against the scope's declared param |
| `$this->protectedScope($nullableBuilder, …)` — direct sibling call, nullable first arg | false `InvalidArgument` (stripped) + fabricated `Builder<Model>` return | `PossiblyNullArgument` + real `void` return |
| legacy scope with all-optional params + `Builder` first arg | false `UndefinedMagicMethod` | `InvalidArgument` |
| child overriding a parent `#[Scope]` | `UndefinedVariable $query` + `MixedMethodCall` in the override body | clean — real signature drives the declaration |
| private `#[Scope]` (no legacy twin) | wrongly resolved as a scope (`Builder<Model>`) | not a scope (`mixed`) |

Why each moves:

- **Legacy scopes are always forwarded.** The bare name is not a real method, so PHP always routes through `__call` / `__callStatic`. The old heuristic could mis-read a `Builder` first arg as a direct call and decline, leaving the call unresolved.
- **`#[Scope]` direct calls are argument-shape-independent.** A real, accessible method is invoked directly regardless of how its args are typed.
- **Declaration analysis passes a null context.** The classifier declines there, so the stripped (query-less) params do not leak into a method's own body and drop `$query` on an overriding child.
- **Private `#[Scope]` rejection mirrors Laravel.** A private `#[Scope]` is never dispatchable (Laravel 13.8+ rejects it in `isScopeMethodWithAttribute`; earlier versions recurse), so `hasScopeAttribute` in `BuilderScopeHandler` and `SuppressHandler` reject it — a legacy `scopeXxx` twin wins, or it is nothing.

**Wave-1 pin updates**

- `ModelInstanceScopeCallTest` — `$customer->verified()` (public `#[Scope]` instance call) now classifies as direct, so the real signature drives a precise `TooFewArguments … expecting query to be passed` alongside the prior generic `saw 0`. Both are true positives (runtime `ArgumentCountError`); the pin is refined, not regressed.
- `DirectScopeCallTest` — docblock rewritten (the old argument-shape / `vars_in_scope` mechanism is gone) and a nullable-`?Builder` direct-call case added.

**Verification**

- Type tests: 443 ✓ · Unit: 783 ✓ · `composer psalm` no errors, 100% coverage ✓ · `composer cs` clean ✓ · `composer test:app` pass ✓.
- New `LegacyScopeBuilderArgTest` (legacy + `Builder`-first-arg) and `PrivateScopeVisibilityTest` (+ isolated `PrivateScopeModel` fixture, verified to fail without the visibility fix).
- The `find()`-collision return-type limitation (#1039) is intentionally untouched here — its `isRealBuilderMethod` guard on the return path is a separate follow-up.
- **Coverage note:** the override-declaration case and cross-file static-state cases cannot be hosted in the PHPT suite (snippet-defined models are not registered, and the type-test Testbench app scans fixtures without analyzing their bodies). The override case is validated against a manual reproduction.

**`/psalm-delta` (17 real-world apps)** — 16/17 apps show zero issue delta. filament shows +2 (`MixedArgument` / `MixedArgumentTypeCoercion` in a `Collection::reduce` closure over a bare `?Builder`) that does **not** reproduce under `--threads=1` on either base or head — multi-threaded-analysis nondeterminism, not introduced here (verified by deterministic re-runs against both builds). ΔType coverage -0.00%; ΔTime **-10.6s** total (the classifier is cheaper than the removed `UnionTypeComparator` probe).

## Checklist
- [x] Tests cover the change (type tests in `tests/Type/`)
