### PR TITLE
Harden Eloquent scope hand-off and fix Builder name-collision return types

### DIFF
--- a/src/Handlers/Eloquent/BuilderScopeHandler.php
+++ b/src/Handlers/Eloquent/BuilderScopeHandler.php
@@ -7,7 +7,6 @@ namespace Psalm\LaravelPlugin\Handlers\Eloquent;
 use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Query\Builder as QueryBuilder;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use Psalm\Codebase;
@@ -43,33 +42,32 @@ use Psalm\Type\Union;
  */
 final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, MethodParamsProviderInterface
 {
-    /** @var array<string, bool> */
-    private static array $scopeCache = [];
-
     /**
      * Cache for isTraitBuilderMethod results.
      *
-     * Separate from $scopeCache to keep concerns distinct.
+     * Separate from {@see $scopeParamsCache} to keep concerns distinct.
      *
      * @var array<string, bool>
      */
     private static array $traitBuilderCache = [];
 
     /**
-     * Scope params hand-off: lowercase scope name -> params (minus the leading $query).
+     * Scope hand-off: lowercase scope name -> the model FQCN whose scope was resolved.
      *
      * Populated by the return type provider when it resolves an instance scope call
      * (Customer::query()->active()); consumed by {@see getMethodParams} when Psalm
-     * immediately follows up with checkMethodArgs for the same call. Keyed by method
-     * name only: the producer always runs right before the consumer within one
-     * analysis thread, so the latest entry matches the call being checked even when
-     * two models declare a scope with the same name. Entries persist across files,
-     * so the consumer rejects names that are real Builder methods (see
-     * {@see isRealBuilderMethod}) to avoid shadowing genuine calls analyzed later.
+     * immediately follows up with checkMethodArgs for the same call. Keyed by method name
+     * only: the producer always runs right before the consumer within one analysis thread
+     * (MissingMethodCallHandler -> checkMethodArgs is the lone follow-up), so the latest
+     * entry matches the call being checked even when two models declare a scope with the
+     * same name. The consumer {@see \unset()}s the entry immediately after reading it, so a
+     * stale entry can never shadow a later call — which is why this stores the model class
+     * and re-resolves params through the memoized {@see getScopeParams} rather than caching
+     * a param list (mirrors {@see \Psalm\LaravelPlugin\Handlers\Magic\MethodForwardingHandler}).
      *
-     * @var array<lowercase-string, list<FunctionLikeParameter>>
+     * @var array<lowercase-string, class-string<Model>>
      */
-    private static array $pendingScopeParams = [];
+    private static array $pendingScopeModel = [];
 
     /**
      * Memoization for {@see getScopeParams}: 'Model::method' -> params or null (not a scope).
@@ -108,6 +106,24 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
     {
         // array_merge would re-index; += preserves keys and keeps the first registration.
         self::$baseBuilderTraitMethods += $methods;
+    }
+
+    /**
+     * Reset all mutable per-process state. Called once per Plugin::__construct so a re-bootstrap
+     * (a config flip across analysis runs, or a test fixture re-booting the plugin) starts from a
+     * clean slate instead of inheriting the previous run's caches and registrations.
+     *
+     * $pendingScopeModel in particular is a short-lived producer->consumer hand-off; clearing it
+     * here guarantees no entry survives into a fresh run even if a producer write went unconsumed.
+     *
+     * @psalm-external-mutation-free
+     */
+    public static function init(): void
+    {
+        self::$pendingScopeModel = [];
+        self::$scopeParamsCache = [];
+        self::$traitBuilderCache = [];
+        self::$baseBuilderTraitMethods = [];
     }
 
     /**
@@ -162,17 +178,31 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
             ]),
         ]);
 
-        // A non-null result implies the model declares the scope (detection is strict,
-        // see getScopeParams). On failure to resolve we decline entirely — falling back
-        // to mixed is honest, while returning a type with a fabricated zero-param
+        // A non-null getScopeParams() implies the model declares the scope (detection is
+        // strict, see getScopeParams). On failure to resolve we decline entirely — falling
+        // back to mixed is honest, while returning a type with a fabricated zero-param
         // signature would emit TooManyArguments on every scope call with args.
-        $scopeParams = self::getScopeParams($codebase, $modelClass, $methodName);
-        if ($scopeParams !== null) {
-            // Hand the scope's params (minus the leading $query) to the params
-            // provider: Psalm follows this return type with checkMethodArgs for
-            // Builder::<scope>, which has no real method storage and would otherwise
-            // throw UnexpectedValueException in Codebase\Methods::getMethodParams.
-            self::$pendingScopeParams[$methodName] = $scopeParams;
+        //
+        // EXCEPT when the bare name is a real Eloquent\Builder method (find, latest): Psalm
+        // resolves those natively and Laravel's Builder::__call never fires for a declared
+        // name, so a like-named scope cannot shadow it at runtime. Returning the scope's
+        // Builder<TModel> here would wrongly mask the real return type (find -> TModel|null;
+        // issue #1039). Names that route through __call STAY scope-eligible: __call checks
+        // hasNamedScope before the $passthru aggregate forward (count, sum, exists) and before
+        // forwarding to Query\Builder, so the scope legitimately wins there (the classic
+        // scopeCount() footgun).
+        //
+        // (isRealPublicBuilderMethod classifies via PHP reflection, not Psalm storage — see its
+        // docblock for why the stub's $passthru aggregates force that distinction.)
+        if (
+            self::getScopeParams($codebase, $modelClass, $methodName) !== null
+            && !self::isRealPublicBuilderMethod($methodName)
+        ) {
+            // Hand the model to the params provider, consumed once (see $pendingScopeModel):
+            // Psalm follows this return type with checkMethodArgs for Builder::<scope>, which
+            // has no real method storage and would otherwise throw UnexpectedValueException in
+            // Codebase\Methods::getMethodParams.
+            self::$pendingScopeModel[$methodName] = $modelClass;
 
             return $builderReturn;
         }
@@ -199,7 +229,7 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
      * doesn't exist as a real method, getMethodParams would throw UnexpectedValueException
      * unless we intercept it here with the params from the trait's @method static annotation.
      *
-     * Covers instance scope calls via the {@see $pendingScopeParams} hand-off populated
+     * Covers instance scope calls via the {@see $pendingScopeModel} hand-off populated
      * by the return type provider, then $baseBuilderTraitMethods (e.g., SoftDeletes
      * methods) — mirroring the precedence in {@see getMethodReturnType} (scopes first).
      *
@@ -211,12 +241,52 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
         /** @var lowercase-string $methodName */
         $methodName = $event->getMethodNameLowercase();
 
-        $scopeParams = self::$pendingScopeParams[$methodName] ?? null;
-        if ($scopeParams !== null && !self::isRealBuilderMethod($event, $methodName)) {
-            return $scopeParams;
+        // Instance scope hand-off (see $pendingScopeModel), consumed once: re-resolve the
+        // scope's params (minus the leading $query) through the memoized getScopeParams and
+        // unset the entry so a stale value can never shadow a later call. No isRealBuilderMethod
+        // guard is needed: the producer already excluded real Eloquent\Builder methods, and
+        // consume-once prevents cross-call leaks.
+        $modelClass = self::$pendingScopeModel[$methodName] ?? null;
+        if ($modelClass !== null) {
+            unset(self::$pendingScopeModel[$methodName]);
+
+            $source = $event->getStatementsSource();
+            if ($source instanceof StatementsSource) {
+                $scopeParams = self::getScopeParams($source->getCodebase(), $modelClass, $methodName);
+                if ($scopeParams !== null) {
+                    return $scopeParams;
+                }
+            }
         }
 
         return self::$baseBuilderTraitMethods[$methodName] ?? null;
+    }
+
+    /**
+     * Whether $methodName is a real PUBLIC method on the actual Eloquent\Builder class.
+     *
+     * Real public methods (find, latest, where, get, ...) are invoked directly by PHP, so
+     * Builder::__call never fires and a like-named scope is dead code — the producer skips them.
+     * The check uses runtime reflection on the loaded core Builder class rather than Psalm storage,
+     * because the stub declares the $passthru aggregates (count, sum) on Eloquent\Builder for
+     * typing while Laravel routes them through __call; only PHP's view tells them apart. It runs
+     * gated behind a confirmed scope, so only the rare scope-vs-real-method collision pays for it.
+     *
+     * The PUBLIC gate matters: Builder's protected helpers (callScope, forwardCallTo) are reachable
+     * from outside only via __call, so a like-named scope could legitimately shadow them — they
+     * must stay scope-eligible, not be skipped.
+     */
+    private static function isRealPublicBuilderMethod(string $methodName): bool
+    {
+        if (!\method_exists(Builder::class, $methodName)) {
+            return false;
+        }
+
+        try {
+            return (new \ReflectionMethod(Builder::class, $methodName))->isPublic();
+        } catch (\ReflectionException) {
+            return false;
+        }
     }
 
     /**
@@ -237,6 +307,11 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
      */
     public static function getScopeParams(Codebase $codebase, string $modelClass, string $methodName): ?array
     {
+        // Normalize once: Psalm lowercases method names before invoking providers, but external
+        // callers (ModelMethodHandler, MethodForwardingHandler) may pass any casing. Lowercasing
+        // here de-fragments the cache key and lets the MethodIdentifier constructor accept it.
+        $methodName = \strtolower($methodName);
+
         $key = $modelClass . '::' . $methodName;
         if (\array_key_exists($key, self::$scopeParamsCache)) {
             return self::$scopeParamsCache[$key];
@@ -245,12 +320,9 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
         if ($codebase->methodExists($modelClass . '::' . $methodName)
             && self::hasScopeAttribute($codebase, $modelClass, $methodName)
         ) {
-            /** @var lowercase-string $methodName */
             $scopeMethodId = new MethodIdentifier($modelClass, $methodName);
         } elseif ($codebase->methodExists($modelClass . '::scope' . \ucfirst($methodName))) {
-            /** @var lowercase-string $legacyScopeLower */
-            $legacyScopeLower = 'scope' . $methodName;
-            $scopeMethodId = new MethodIdentifier($modelClass, $legacyScopeLower);
+            $scopeMethodId = new MethodIdentifier($modelClass, 'scope' . $methodName);
         } else {
             return self::$scopeParamsCache[$key] = null;
         }
@@ -453,28 +525,12 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
     }
 
     /**
-     * Whether the Builder (or the mixed-in Query\Builder) declares the method for real.
-     *
-     * Guards the scope hand-off in {@see getMethodParams}: $pendingScopeParams entries
-     * persist across files, so a model's scopeLatest() must not shadow a genuine
-     * Builder::latest() call on an unrelated model analyzed later — real methods keep
-     * their own storage-backed params.
-     */
-    private static function isRealBuilderMethod(MethodParamsProviderEvent $event, string $methodName): bool
-    {
-        $source = $event->getStatementsSource();
-        if (!$source instanceof StatementsSource) {
-            return false;
-        }
-
-        $codebase = $source->getCodebase();
-
-        return $codebase->methodExists(Builder::class . '::' . $methodName)
-            || $codebase->methodExists(QueryBuilder::class . '::' . $methodName);
-    }
-
-    /**
      * Check if the model has a scope for the given method name.
+     *
+     * Boolean-equivalent to {@see getScopeParams()} !== null — both detect a #[Scope]-attributed
+     * method (visibility-gated) or a legacy scopeXxx() twin — so this delegates instead of
+     * duplicating the detection and its cache. getScopeParams returns null cheaply for a
+     * non-scope (no param expansion) and memoizes the verdict.
      *
      * Public so ModelMethodHandler can reuse this for method existence checks
      * on static Model calls (e.g., User::active() → scopeActive).
@@ -483,30 +539,7 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
      */
     public static function hasScopeMethod(Codebase $codebase, string $modelClass, string $methodName): bool
     {
-        $key = $modelClass . '::' . $methodName;
-
-        if (\array_key_exists($key, self::$scopeCache)) {
-            return self::$scopeCache[$key];
-        }
-
-        // Check legacy scope prefix: scopeActive → active
-        $legacyScopeMethod = $modelClass . '::scope' . \ucfirst($methodName);
-        if ($codebase->methodExists($legacyScopeMethod)) {
-            self::$scopeCache[$key] = true;
-            return true;
-        }
-
-        // Check #[Scope] attribute via Psalm's storage instead of runtime Reflection.
-        // This avoids loading the model class into PHP's runtime and constructing
-        // ReflectionMethod objects for every non-scope method on the model.
-        $directMethod = $modelClass . '::' . $methodName;
-        if ($codebase->methodExists($directMethod) && self::hasScopeAttribute($codebase, $modelClass, $methodName)) {
-            self::$scopeCache[$key] = true;
-            return true;
-        }
-
-        self::$scopeCache[$key] = false;
-        return false;
+        return self::getScopeParams($codebase, $modelClass, $methodName) !== null;
     }
 
     /**
@@ -563,6 +596,16 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
      * specifically when Psalm routes unknown method calls through MissingMethodCallHandler,
      * which invokes return type providers without forwarding the LHS object's type params.
      *
+     * A single Builder generic in the LHS is unambiguous. When the LHS is a union of 2+ Builder
+     * generics with DIFFERENT template params (e.g. `Builder<A>|Builder<B>` from a ternary),
+     * this declines to null: Psalm dispatches the method per-atomic, but the provider event only
+     * exposes the whole union, so picking one atomic would silently drop the others and check
+     * arguments against the wrong model. Declining yields honest mixed instead of a wrong type.
+     *
+     * TODO(upstream): MethodReturnTypeProviderEvent / MethodParamsProviderEvent expose no
+     * per-atomic context, which forces this union case to mixed. Worth filing a vimeo/psalm
+     * feature request so the provider can answer per dispatched atomic.
+     *
      * @return non-empty-list<Union>|null
      */
     private static function extractTemplateParamsFromCallStmt(
@@ -578,13 +621,36 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
             return null;
         }
 
+        $firstParams = null;
+        $firstId = null;
         foreach ($lhsType->getAtomicTypes() as $atomic) {
-            if ($atomic instanceof TGenericObject && \strtolower($atomic->value) === \strtolower(Builder::class)) {
-                return $atomic->type_params;
+            if (!$atomic instanceof TGenericObject || \strtolower($atomic->value) !== \strtolower(Builder::class)) {
+                continue;
+            }
+
+            $id = self::templateParamsId($atomic->type_params);
+            if ($firstParams === null) {
+                $firstParams = $atomic->type_params;
+                $firstId = $id;
+            } elseif ($id !== $firstId) {
+                // 2+ distinct Builder generics in the union → can't resolve one honestly.
+                return null;
             }
         }
 
-        return null;
+        return $firstParams;
+    }
+
+    /**
+     * Stable identity for a Builder atomic's template params, so identical generics
+     * (Builder<A>|Builder<A>) collapse while distinct ones (Builder<A>|Builder<B>) compare unequal.
+     *
+     * @param list<Union> $params
+     * @psalm-mutation-free
+     */
+    private static function templateParamsId(array $params): string
+    {
+        return \implode(',', \array_map(static fn(Union $param): string => $param->getId(), $params));
     }
 
     /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -176,6 +176,7 @@ final class Plugin implements PluginEntryPointInterface
         $registration->registerHooksFromClass(Handlers\Eloquent\ModelMethodHandler::class);
         require_once __DIR__ . '/Util/ModelPropertyResolver.php';
         require_once __DIR__ . '/Handlers/Eloquent/BuilderScopeHandler.php';
+        Handlers\Eloquent\BuilderScopeHandler::init();
         $registration->registerHooksFromClass(Handlers\Eloquent\BuilderScopeHandler::class);
         require_once __DIR__ . '/Handlers/Eloquent/BuilderPluckHandler.php';
         $registration->registerHooksFromClass(Handlers\Eloquent\BuilderPluckHandler::class);

--- a/tests/Application/app/Models/ScopeMacroCollisionModel.php
+++ b/tests/Application/app/Models/ScopeMacroCollisionModel.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Archetype for the scope hand-off lifecycle: a model that declares a legacy scope whose name
+ * collides with a SoftDeletes builder macro (withTrashed), WITHOUT using SoftDeletes itself.
+ *
+ * Calling this scope populates BuilderScopeHandler's producer->consumer hand-off for the
+ * `withtrashed` key. The consumer must consume it once (unset) so the entry cannot leak and
+ * shadow a genuine SoftDeletes withTrashed() macro on a different model analyzed afterwards.
+ *
+ * Kept isolated from the shared archetypes so this pathological scope name cannot perturb the
+ * many suites that import Customer/Vehicle/etc.
+ */
+final class ScopeMacroCollisionModel extends Model
+{
+    protected $table = 'scope_macro_collision_models';
+
+    /**
+     * @param  Builder<self>  $query
+     * @return Builder<self>
+     */
+    public function scopeWithTrashed($query)
+    {
+        return $query;
+    }
+}

--- a/tests/Type/tests/Builder/ScopeHandoffConsumeOnceTest.phpt
+++ b/tests/Type/tests/Builder/ScopeHandoffConsumeOnceTest.phpt
@@ -1,0 +1,32 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use App\Models\ScopeMacroCollisionModel;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Pins the consume-once behavior of BuilderScopeHandler's scope hand-off.
+ *
+ * A scope call on one model populates the producer->consumer hand-off keyed by the bare method
+ * name. If that entry survived, a same-named SoftDeletes macro on a DIFFERENT model analyzed
+ * afterwards would be checked against the scope's (zero-arg) signature instead of the macro's.
+ *
+ * ScopeMacroCollisionModel declares scopeWithTrashed (no SoftDeletes); its call below populates
+ * the `withtrashed` hand-off. The consumer unsets it, so the subsequent Customer (SoftDeletes)
+ * withTrashed(false) resolves against the macro signature and accepts the bool argument with no
+ * false TooManyArguments. The statements run in order within one analysis pass, so the hand-off
+ * state genuinely flows from the first call to the second.
+ */
+function test_scope_handoff_does_not_shadow_softdeletes_macro(): void
+{
+    // Populates and immediately consumes the `withtrashed` hand-off for ScopeMacroCollisionModel.
+    ScopeMacroCollisionModel::query()->withTrashed();
+
+    // SoftDeletes macro on a different model: must use the macro signature (accepts the bool),
+    // not the stale scope signature that would reject the argument.
+    $_result = Customer::query()->withTrashed(false);
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Builder/ScopeNameCollisionTest.phpt
+++ b/tests/Type/tests/Builder/ScopeNameCollisionTest.phpt
@@ -13,46 +13,43 @@ use Illuminate\Database\Eloquent\Builder;
  * colliding name falls into:
  *
  *   A. Real Eloquent\Builder methods (find, latest): __call never fires, so the like-named
- *      scope is unreachable dead code. The runtime value is whatever the real method returns.
- *        - find() returns Model|null  -> the plugin's Builder<M> here is WRONG (see the BUG note).
- *        - latest() returns the builder -> the plugin's Builder<M> coincidentally matches.
+ *      scope is unreachable dead code. The producer skips these names (it tests PHP's runtime
+ *      method_exists on the real class), so Psalm uses the real method's return type:
+ *        - find() returns TModel|null  -> CollidingScopeModel|null (the real signature; #1039).
+ *        - latest() returns $this      -> Builder<M>&static.
  *
  *   B. Names a scope may legitimately shadow via __call (count is passthru-only on
  *      Eloquent\Builder; whereActive is a dynamic where): __call DOES fire and hasNamedScope
  *      wins, so the scope runs and returns the builder at runtime. The plugin's Builder<M> is
- *      CORRECT — this is the classic count()/sum()/exists() scope-shadowing footgun.
+ *      CORRECT — this is the classic count()/sum()/exists() scope-shadowing footgun. The producer
+ *      keeps these scope-eligible (method_exists is false for them on the real Eloquent\Builder).
  *
  * CollidingScopeModel is a dedicated archetype (never a shared model) so these pathological
  * scope names cannot perturb the many suites that import Customer/Vehicle/etc.
  *
- * KNOWN BUG (find return type, pinned-as-limitation below, tracked in #1039):
- * BuilderScopeHandler::getMethodReturnType lacks the isRealBuilderMethod() guard that
- * getMethodParams() carries, so for a scope name that collides with a REAL Eloquent\Builder
- * method it overrides the real return type with Builder<M>.
- * Argument checking is unaffected (the params path keeps the guard and falls back to the real
- * method's signature), which test_find_argument_checking_uses_real_builder_signature pins. The
- * assertion is deliberately pinned to today's wrong output so a future refactor that extends the
- * guard to the return path flips this test to the correct Model|null. Note this is find-SPECIFIC:
- * count is passthru-only (bucket B), so its Builder<M> is correct, not a bug.
+ * Resolves #1039: the producer now skips scope handling for names that are real Eloquent\Builder
+ * methods, so a scope can no longer mask find()'s real TModel|null return. The distinction is
+ * made with PHP's runtime method_exists (not Psalm's), because the stub declares the $passthru
+ * aggregates (count, sum) on Eloquent\Builder for typing while Laravel routes them through __call.
  */
 
 /**
- * BUG (pinned-as-limitation): find() is a real Eloquent\Builder method, so at runtime the scope
- * is dead code and CollidingScopeModel::query()->find(1) returns CollidingScopeModel|null. The
- * plugin currently infers Builder<CollidingScopeModel> because the return-type path lacks the
- * isRealBuilderMethod() guard. Pinned to the wrong output as a tripwire — see the file docblock.
+ * find() is a real Eloquent\Builder method, so at runtime the like-named scope is dead code and
+ * CollidingScopeModel::query()->find(1) returns CollidingScopeModel|null. The producer skips
+ * scope handling for real Eloquent\Builder methods, so Psalm uses the real find() signature
+ * instead of masking it with Builder<M> (resolves #1039).
  */
-function test_find_real_eloquent_method_return_type_is_shadowed(): void
+function test_find_real_eloquent_method_return_type_is_not_shadowed(): void
 {
     $_result = CollidingScopeModel::query()->find(1);
-    /** @psalm-check-type-exact $_result = Builder<CollidingScopeModel> */
+    /** @psalm-check-type-exact $_result = CollidingScopeModel|null */
 }
 
 /**
  * Argument checking for find() uses the REAL Builder::find signature ($id, $columns), not the
- * colliding scope's params — proof the params path keeps the isRealBuilderMethod guard even
- * though the return path does not. Both the surplus third argument and the wrong column type
- * are reported against the real method.
+ * colliding scope's params. The producer skips find (a real public Eloquent\Builder method), so
+ * no scope params are handed off and Psalm checks arguments against the real method. Both the
+ * surplus third argument and the wrong column type are reported against it.
  */
 function test_find_argument_checking_uses_real_builder_signature(): void
 {
@@ -71,13 +68,13 @@ function test_count_passthru_aggregate_is_shadowed_by_scope(): void
 }
 
 /**
- * latest() is a real Eloquent\Builder method whose own return value IS the builder, so even
- * though the like-named scope is dead code the inferred Builder<M> matches runtime.
+ * latest() is a real Eloquent\Builder method (@return $this), so the producer skips the like-named
+ * scope and Psalm uses the real signature: Builder<M>&static. The dead scope never participates.
  */
 function test_latest_real_eloquent_method_returns_builder(): void
 {
     $_result = CollidingScopeModel::query()->latest('created_at');
-    /** @psalm-check-type-exact $_result = Builder<CollidingScopeModel> */
+    /** @psalm-check-type-exact $_result = Builder<CollidingScopeModel>&static */
 }
 
 /**

--- a/tests/Type/tests/Builder/UnionBuilderScopeTest.phpt
+++ b/tests/Type/tests/Builder/UnionBuilderScopeTest.phpt
@@ -1,0 +1,39 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use App\Models\DirectScopeModel;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Pins union-LHS scope resolution.
+ *
+ * The return-type / params providers see the whole LHS union, but Psalm dispatches the method
+ * per-atomic. When the receiver is a single Builder generic the scope resolves normally; when it
+ * is a union of 2+ DISTINCT Builder generics the providers cannot tell which atomic they are
+ * answering for, so they decline to honest mixed instead of silently resolving to the FIRST
+ * model's scope (which would drop the other arm and check arguments against the wrong model).
+ *
+ * Customer (legacy scopeActive) and DirectScopeModel (#[Scope] active) both declare an `active`
+ * scope and are base-Builder models, so the ternary below yields Builder<Customer>|Builder<
+ * DirectScopeModel> — exactly the 2-distinct-generic shape. Because the call resolves to mixed,
+ * no scope params are handed off either, so the argument is not checked against either model.
+ */
+
+/** Single Builder generic: the scope resolves to Builder<Customer>. */
+function test_single_builder_scope_resolves(): void
+{
+    $b = Customer::query();
+    $_result = $b->active();
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
+
+/** Union of 2 distinct Builder generics, both declaring `active`: declines to mixed. */
+function test_union_distinct_builder_generics_decline_to_mixed(bool $cond): void
+{
+    $b = $cond ? Customer::query() : DirectScopeModel::query();
+    $_result = $b->active();
+    /** @psalm-check-type-exact $_result = mixed */
+}
+?>
+--EXPECTF--

--- a/tests/Unit/Handlers/Eloquent/BuilderScopeHandlerInitTest.php
+++ b/tests/Unit/Handlers/Eloquent/BuilderScopeHandlerInitTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Eloquent;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Handlers\Eloquent\BuilderScopeHandler;
+
+#[CoversClass(BuilderScopeHandler::class)]
+final class BuilderScopeHandlerInitTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        BuilderScopeHandler::init();
+    }
+
+    /**
+     * Regression: Plugin::registerHandlers calls BuilderScopeHandler::init() on every
+     * (re-)bootstrap so no per-process state leaks across analysis runs. $pendingScopeModel
+     * is the most sensitive entry — a short-lived producer->consumer hand-off whose stale
+     * survival would shadow a later scope call — but every cache must clear too so a config
+     * flip or a test fixture re-boot starts clean.
+     */
+    #[Test]
+    public function init_clears_all_mutable_statics(): void
+    {
+        $reflection = new \ReflectionClass(BuilderScopeHandler::class);
+
+        // Discover every mutable static array property by reflection rather than hardcoding the
+        // list, so a future cache that init() forgets to clear fails this test instead of silently
+        // leaking across a re-bootstrap.
+        $arrayStatics = \array_filter(
+            $reflection->getProperties(\ReflectionProperty::IS_STATIC),
+            static fn(\ReflectionProperty $property): bool
+                => $property->getType() instanceof \ReflectionNamedType
+                    && $property->getType()->getName() === 'array',
+        );
+
+        $this->assertNotEmpty($arrayStatics, 'Expected BuilderScopeHandler to declare mutable static array state.');
+
+        foreach ($arrayStatics as $property) {
+            $property->setValue(null, ['__seed__' => '__seed__']);
+        }
+
+        BuilderScopeHandler::init();
+
+        foreach ($arrayStatics as $property) {
+            $this->assertSame(
+                [],
+                $property->getValue(),
+                "init() must clear \${$property->getName()} so a re-bootstrap does not inherit it.",
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Issue to Solve

A cluster of correctness and hygiene problems around `BuilderScopeHandler`'s scope hand-off:

- A scope call left a params entry in a process-wide cache that was never cleared, so a same-named SoftDeletes macro on a *different* model analyzed afterwards was checked against the scope's (zero-arg) signature → a false `TooManyArguments` on e.g. `SomeModel::query()->withTrashed(false)`.
- A scope name colliding with a real `Eloquent\Builder` method (#1039) masked the real return type: `Model::query()->find(1)` inferred `Builder<Model>` instead of `Model|null`.
- A union LHS (`Builder<A>|Builder<B>`, e.g. from a ternary) silently resolved to the first atomic, checking arguments against the wrong model.

## Related

Closes #1039

> Stacked on #1041 — the base branch is `fix/scope-dispatch-classifier`. Rebase onto `master` once #1041 merges.

## Solution Description

- **Consume-once hand-off.** The producer→consumer hand-off now stores the model FQCN (`$pendingScopeModel`) and the consumer `unset()`s the entry immediately after reading it, re-resolving params through the memoized `getScopeParams`. A stale entry can no longer shadow a later same-named call (mirrors `MethodForwardingHandler`'s model-FQCN + `init()` pattern).
- **Producer skips real public Builder methods (#1039).** Before handing off, the producer skips names that are real *public* methods on the actual `Eloquent\Builder` class (`find`, `latest`), so a like-named scope no longer masks the real return type — `find()` now infers `TModel|null`. The check uses PHP runtime reflection rather than `$codebase->methodExists`: the stub declares the `$passthru` aggregates (`count`, `sum`) on `Eloquent\Builder` for typing, so only PHP's view distinguishes a real method from a passthru. `count`/`sum`/`exists` stay scope-eligible (the classic `scopeCount()` footgun), since `Builder::__call` checks `hasNamedScope` before the passthru forward; protected helpers (`callScope`) stay scope-eligible too (the public-visibility gate).
- **Union-LHS honesty.** `extractTemplateParamsFromCallStmt` declines to `mixed` when the LHS is a union of 2+ distinct `Builder` generics, instead of silently picking the first atomic and checking arguments against the wrong model. (The provider event exposes only the whole union; per-atomic dispatch context would need an upstream Psalm change — noted in a `TODO(upstream)` comment.)
- **Lifecycle + normalization.** New `BuilderScopeHandler::init()` (wired in `Plugin::registerHandlers`) resets all mutable statics on re-bootstrap; `getScopeParams` lowercases the method name once at the top (de-fragments the cache key, kills a latent mixed-case crash).
- **De-duplication.** Removes the now-redundant `isRealBuilderMethod` consumer guard (the producer-skip + consume-once cover it) and the `$scopeCache` (`hasScopeMethod` delegates to `getScopeParams(...) !== null`).

**Verification**

- Type tests: 445 ✓ · Unit: 784 ✓ · `composer psalm` no errors, 100% coverage ✓ · `composer cs` clean ✓ · `composer test:app` pass ✓.
- New `ScopeHandoffConsumeOnceTest` (+ isolated `ScopeMacroCollisionModel` fixture; verified to fail without the consume-once `unset`), `UnionBuilderScopeTest`, and `BuilderScopeHandlerInitTest` (discovers static state by reflection, so a future un-reset cache fails it). `ScopeNameCollisionTest` pins updated for the now-correct `find()` → `Model|null` and `latest()` → `Builder<M>&static`.

## Delta vs base (real-world apps)

`/psalm-delta` across 17 real-world apps, isolated against the PR-A base (`fix/scope-dispatch-classifier`):

- **16/17 apps: zero issue delta.**
- **filament: −2** (`MixedArgument` + `MixedArgumentTypeCoercion` in the same `Collection::reduce` closure over a bare `?Builder` that PR-A's delta reported as +2). It does **not** reproduce under `--threads=1` on either side — it is the same multi-threaded-analysis nondeterminism (the benchmark runs Psalm without `--threads`), here flickering the other way, so it nets to zero across the two PRs. Verified deterministically against this branch.
- **ΔType coverage: +0.00%.**
- **ΔTime: +6.17s total** (~0.36s/app, within the ±1s per-app run-to-run scatter). The producer-skip's runtime reflection runs only for the rare scope-name-collides-with-real-Builder-method case, so it is not a systematic cost.

Net: no real issue changes; #1039's `find()` collision and the union-LHS / stale-hand-off bugs are fixed without regressions on the app set.

## Checklist
- [x] Tests cover the change (type tests in `tests/Type/` + unit test in `tests/Unit/`)
