### PR TITLE
Resolve trait-hosted scope `self` param to the composing class

### DIFF
--- a/src/Handlers/Eloquent/BuilderScopeHandler.php
+++ b/src/Handlers/Eloquent/BuilderScopeHandler.php
@@ -332,49 +332,64 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
         // leading $query param; the caller passes everything after it.
         $callerParams = \array_slice($codebase->methods->getMethodParams($scopeMethodId), 1);
 
-        // expandScopeParamSelfReferences() pins self/static to the model (see its docblock).
-        // Memoized, so it runs once per model+method.
-        return self::$scopeParamsCache[$key] = self::expandScopeParamSelfReferences($codebase, $modelClass, $callerParams);
+        // `self` in a trait- or parent-hosted scope follows PHP trait semantics: it binds to
+        // the class that *composes* the scope method (its appearing class), not the subclass
+        // being queried. Resolve it from the scope MethodIdentifier built above; fall back to
+        // the queried model when the appearing id is unavailable. `static`/`$this` stay pinned
+        // to the queried model inside expandScopeParamSelfReferences() (late static binding).
+        $selfClass = $codebase->methods->getAppearingMethodId($scopeMethodId)?->fq_class_name ?? $modelClass;
+
+        return self::$scopeParamsCache[$key] = self::expandScopeParamSelfReferences(
+            $codebase,
+            $selfClass,
+            $modelClass,
+            $callerParams,
+        );
     }
 
     /**
      * Pin `self`/`static`/`$this` (and nested generics like `list<self>`) in scope
-     * parameter types to the model class.
-     *
-     * A scope declared in a trait keeps its `self`/`static` parameter typehints
-     * unresolved: Psalm expands them at argument-check time against whatever class the
-     * params provider is registered on. For a custom Eloquent builder
-     * (Post::query()->scopeMethod($x)) that class is the builder, so `self` wrongly
-     * expands to the builder and Psalm emits a false-positive InvalidArgument (issue
-     * #1031). Pre-expanding here pins `self`/`static`/`$this` to the model before the
-     * params are handed back, so the same concrete type is checked regardless of which
+     * parameter types to concrete classes, so the same types are checked no matter which
      * class serves the params (a custom builder, the model itself, or a relation chain;
      * all callers share this helper).
      *
-     * `static`/`$this` are resolved to the plain model class (via TypeExpander's
-     * `final: true`), NOT the late-static-bound `Model&static` form. A scope parameter is
-     * an accept position and Laravel passes the model instance, so the `&static`
-     * intersection would wrongly reject a plain model argument (ArgumentTypeCoercion);
-     * a plain model param already accepts subclass instances by ordinary subtyping.
-     * Scopes declared directly on the model already resolve `self` to the model at scan
-     * time, so this is a no-op for them.
+     * A scope declared in a trait keeps its `self`/`static` parameter typehints unresolved:
+     * Psalm expands them at argument-check time against whatever class the params provider is
+     * registered on. For a custom Eloquent builder (Post::query()->scopeMethod($x)) that class
+     * is the builder, so `self` wrongly expands to the builder and Psalm emits a false-positive
+     * InvalidArgument (issue #1031). Pre-expanding here pins them before the params are handed back.
      *
-     * Caveat: for a trait-hosted scope, `self`/`static` pin to the model being queried,
-     * not necessarily the class that declares the trait. Querying a subclass narrows the
-     * param to that subclass — strictly more precise than the pre-fix builder type, and
-     * correct for the common single-using-class case.
+     * `self` resolves to `$selfClass` — the scope method's *composing* class (the class that
+     * uses the trait, or the parent that hosts the scope), NOT the queried subclass. This
+     * mirrors PHP: inside a trait method `self` is the class that uses the trait, fixed at
+     * composition time, so `Child::query()->traitScope($sibling)` is runtime-valid when both
+     * `Child` and the sibling extend the composing parent. Narrowing `self` to the queried
+     * subclass (as an earlier revision did) rejected those sibling args with a false positive.
+     * For a scope composed directly on the queried model, `$selfClass` *is* that model, so the
+     * behavior is unchanged there.
      *
-     * @param class-string<Model> $modelClass
+     * `static`/`$this` resolve to `$modelClass` — the queried model (late static binding) — as
+     * the plain model class, not the `Model&static` intersection. See the `final: true` argument
+     * below for why the intersection would over-reject on this accept-side position.
+     *
+     * A scope whose `self` is declared *directly* in a class body (not via a trait) — including
+     * on an abstract parent — already has `self` resolved to that class by Psalm at scan time.
+     * There `$selfClass` equals the declaring class, the param type holds a concrete class with no
+     * `self` token left, and the expansion is idempotent (it recomputes the same type).
+     *
+     * @param string $selfClass `self` → the scope's composing (appearing) class
+     * @param class-string<Model> $modelClass `static`/`$this` → the queried model
      * @param list<FunctionLikeParameter> $params
      * @return list<FunctionLikeParameter>
      */
     private static function expandScopeParamSelfReferences(
         Codebase $codebase,
+        string $selfClass,
         string $modelClass,
         array $params,
     ): array {
         return \array_map(
-            static function (FunctionLikeParameter $param) use ($codebase, $modelClass): FunctionLikeParameter {
+            static function (FunctionLikeParameter $param) use ($codebase, $selfClass, $modelClass): FunctionLikeParameter {
                 if (!$param->type instanceof \Psalm\Type\Union) {
                     return $param;
                 }
@@ -384,8 +399,8 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
                 return $param->setType(TypeExpander::expandUnion(
                     $codebase,
                     $param->type,
-                    $modelClass, // `self`
-                    $modelClass, // `static` / `$this`
+                    $selfClass, // `self` → composing class (PHP trait `self` semantics)
+                    $modelClass, // `static` / `$this` → queried model (late static binding)
                     null, // `parent` — not meaningful for a scope parameter
                     evaluate_class_constants: true,
                     evaluate_conditional_types: false,

--- a/tests/Application/app/Models/AbstractDocument.php
+++ b/tests/Application/app/Models/AbstractDocument.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\ComparesRank;
 use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -11,14 +12,36 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Abstract parent declaring scopes: instance scope calls on a child's builder
  * must resolve params from the declaring (parent) class.
+ *
+ * Composes ComparesRank HERE (not on the concrete children) so the trait's `self`-typed
+ * scope params reproduce the trait-on-parent hierarchy: PHP binds a trait method's `self`
+ * to the *composing* class — AbstractDocument — fixed at composition time, NOT to whichever
+ * child subclass runs the query. So `Contract::query()->rankedAbove($receipt)` is
+ * runtime-valid (Contract and Receipt are sibling children of AbstractDocument) and the
+ * plugin must accept it (issue #1031).
  */
 abstract class AbstractDocument extends Model
 {
+    use ComparesRank;
+
     /**
      * @param  Builder<self>  $query
      */
     public function scopeSignedBetween(Builder $query, CarbonInterface $from, CarbonInterface $to): void
     {
         $query->whereBetween('signed_at', [$from, $to]);
+    }
+
+    /**
+     * Control for a `self`-typed scope param declared DIRECTLY on the abstract parent
+     * (not via a trait). Psalm resolves this `self` to AbstractDocument at scan time, so the
+     * handler's re-expansion is idempotent — the directly-declared and trait-hosted paths
+     * must agree that `self` is the composing class. A sibling child is therefore accepted.
+     *
+     * @param  Builder<self>  $query
+     */
+    public function scopeSupersedes(Builder $query, self $document): void
+    {
+        $query->whereKeyNot($document->getKey());
     }
 }

--- a/tests/Application/app/Models/Concerns/ComparesRank.php
+++ b/tests/Application/app/Models/Concerns/ComparesRank.php
@@ -12,8 +12,8 @@ use Illuminate\Database\Eloquent\Builder;
  * Reproduces issue #1031: when a model with a custom Eloquent builder uses these scopes,
  * the scope's params provider is registered on the *builder* class, so Psalm expands the
  * `self`/`static` parameter typehint against the builder instead of the model and reports
- * a false-positive InvalidArgument. The scope must resolve `self`/`static` to the using
- * model regardless of which class serves the params.
+ * a false-positive InvalidArgument. The scope must resolve `self` to the trait's composing
+ * class and `static`/`$this` to the queried model, regardless of which class serves the params.
  *
  * Scopes declared directly on a model class are unaffected because Psalm resolves their
  * `self` to the model at scan time; only trait-declared scopes keep `self`/`static`

--- a/tests/Application/app/Models/Contract.php
+++ b/tests/Application/app/Models/Contract.php
@@ -4,21 +4,21 @@ declare(strict_types=1);
 
 namespace App\Models;
 
-use App\Models\Concerns\ComparesRank;
 use App\Models\Concerns\HasFlaggedScope;
 
 /**
  * Child of AbstractDocument: exercises inherited and trait-hosted scopes
  * called on builder instances.
  *
- * Uses ComparesRank (self/static scope params) on a model WITHOUT a custom builder,
- * so its scope params provider registers on the base Illuminate Builder — the same
- * self/static misexpansion (issue #1031) is possible there and must also resolve to
- * the model. WorkOrder covers the custom-builder variant.
+ * Inherits ComparesRank from AbstractDocument — the trait is composed on the PARENT, not
+ * here — so the trait's `self`-typed scope params resolve to AbstractDocument (the composing
+ * class), making a sibling child such as Receipt an accepted argument (issue #1031). Contract
+ * has no custom builder, so its scope params provider registers on the base Illuminate
+ * Builder; WorkOrder covers the custom-builder variant and the directly-composed trait
+ * (where `self` == the model itself).
  */
 final class Contract extends AbstractDocument
 {
-    use ComparesRank;
     use HasFlaggedScope;
 
     protected $table = 'contracts';

--- a/tests/Application/app/Models/Customer.php
+++ b/tests/Application/app/Models/Customer.php
@@ -134,6 +134,22 @@ class Customer extends Authenticatable
         return $query->where('status', $status);
     }
 
+    /**
+     * Legacy variadic scope: called as Customer::query()->ofNames('Ada', 'Bo').
+     *
+     * Exercises variadic forwarding: the native variadic flag on `...$names` must survive the
+     * leading-$query slice in getScopeParams() so a zero-arg call is allowed (variadic =
+     * optional, no TooFewArguments) and extra args draw no TooManyArguments, while each forwarded
+     * value is still checked against the `string` element type.
+     *
+     * @param  Builder<self>  $query
+     * @return Builder<self>
+     */
+    public function scopeOfNames($query, string ...$names)
+    {
+        return $query->whereIn('name', $names);
+    }
+
     public function getFirstNameUsingLegacyAccessorAttribute(): string
     {
         return $this->name;

--- a/tests/Application/app/Models/DirectScopeModel.php
+++ b/tests/Application/app/Models/DirectScopeModel.php
@@ -50,6 +50,20 @@ final class DirectScopeModel extends Model
         $this->hasAnyName($query, ['a', 'b']);
     }
 
+    /**
+     * Variadic #[Scope]: exercises the variadic flag on BOTH dispatch paths. A direct call
+     * ($model->ofAnyName($query, 'a')) invokes the full signature — the leading $query plus the
+     * `string ...$names` tail — while the magic-forwarded form
+     * (DirectScopeModel::query()->ofAnyName('a', 'b')) strips $query and keeps the variadic tail.
+     *
+     * @param  Builder<self>  $query
+     */
+    #[Scope]
+    public function ofAnyName(Builder $query, string ...$names): void
+    {
+        $query->whereIn('name', $names);
+    }
+
     /** @psalm-return HasMany<self, $this> */
     public function children(): HasMany
     {

--- a/tests/Application/app/Models/Receipt.php
+++ b/tests/Application/app/Models/Receipt.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+/**
+ * Sibling of Contract under AbstractDocument: a second concrete child that inherits the
+ * parent-composed ComparesRank scopes. Exists so a trait scope's `self` param — which binds
+ * to the composing parent (AbstractDocument), not the queried child — can be exercised with a
+ * *sibling* argument: `Contract::query()->rankedAbove($receipt)` is runtime-valid and must
+ * type-check (issue #1031). A queried-model `self` pin would wrongly reject it.
+ *
+ * Minimal by design (mirrors Contract): the only archetype it adds is "second child of an
+ * abstract parent that hosts a trait scope".
+ */
+final class Receipt extends AbstractDocument
+{
+    protected $table = 'receipts';
+}

--- a/tests/Type/tests/Builder/Issue1031TraitScopeSelfParamTest.phpt
+++ b/tests/Type/tests/Builder/Issue1031TraitScopeSelfParamTest.phpt
@@ -3,19 +3,28 @@
 
 use App\Models\Contract;
 use App\Models\Mechanic;
+use App\Models\Receipt;
 use App\Models\WorkOrder;
 
 /**
- * Issue #1031: a scope declared in a trait with a `self`/`static`-typed non-query
- * parameter must resolve `self`/`static` to the model — not to the class the scope
- * params provider is registered on, and not to a stricter `Model&static` form that
- * would reject a plain model argument on the accept side.
+ * Issue #1031: a scope declared in a trait (or on an abstract parent) with a
+ * `self`/`static`-typed non-query parameter must resolve those references the way PHP does at
+ * runtime — not to the class the scope params provider happens to be registered on.
  *
- * Both archetypes use the ComparesRank trait, whose scopes declare self/static params:
- *  - WorkOrder has a custom builder (WorkOrderBuilder), so its params provider registers
- *    on the builder class. Before the fix `self` expanded to WorkOrderBuilder.
- *  - Contract has no custom builder, so its params provider registers on the base
- *    Illuminate Builder. The same misexpansion is possible there.
+ *  - `self` binds to the scope's *composing* class (the class that uses the trait, or the
+ *    parent that declares the scope), fixed at composition time. Querying a child subclass does
+ *    NOT narrow `self` to that child, so a *sibling* child is a valid argument.
+ *  - `static`/`$this` bind to the queried model (late static binding), so they DO narrow to the
+ *    subclass the scope is invoked on — and a sibling child is rejected.
+ *
+ * Archetypes:
+ *  - WorkOrder composes ComparesRank DIRECTLY and has a custom builder (WorkOrderBuilder), so its
+ *    params provider registers on the builder class and `self` == WorkOrder (composing ==
+ *    queried). This block is the directly-composed control: unaffected by the parent-hosted
+ *    resolution and byte-identical to the original fix.
+ *  - Contract has NO custom builder (params provider on the base Illuminate Builder) and inherits
+ *    ComparesRank from its abstract parent AbstractDocument, so `self` == the parent. Receipt is a
+ *    sibling child used to prove the sibling argument is accepted.
  *
  * The three callers that share getScopeParams() are all exercised: instance builder
  * (Model::query()->scope()), static model call (Model::scope()), and relation chain
@@ -24,7 +33,7 @@ use App\Models\WorkOrder;
  * @see https://github.com/psalm/psalm-plugin-laravel/issues/1031
  */
 
-/* -- Custom builder, instance call (WorkOrder::query()) ---------------------- */
+/* -- Custom builder, instance call (WorkOrder::query()) — directly-composed control --------- */
 
 /** Positive: native `self` param accepts the model; result keeps the custom builder type. */
 function test_self_param_accepts_model(WorkOrder $workOrder): void
@@ -93,19 +102,68 @@ function test_relation_chain_is_type_checked(Mechanic $mechanic): void
     $mechanic->workOrders()->rankedAbove('not a model');
 }
 
-/* -- Base builder (Contract, no custom builder) ----------------------------- */
+/* -- Base builder, trait composed on the PARENT (Contract : AbstractDocument) -------------- */
 
-/** Positive: on the base Builder the `self` param resolves to Contract. */
+/**
+ * Positive: `self` resolves to the composing parent (AbstractDocument), which the queried child
+ * Contract satisfies. Return type stays Builder<Contract> (keyed on the queried model).
+ */
 function test_base_builder_self_param_accepts_model(Contract $contract): void
 {
     $_result = Contract::query()->rankedAbove($contract);
     /** @psalm-check-type-exact $_result = Illuminate\Database\Eloquent\Builder<App\Models\Contract> */
 }
 
-/** Negative: the `self` param resolves to Contract, so a non-model arg is rejected. */
+/**
+ * Positive (the #1031 fix): a SIBLING child is accepted because the trait's `self` binds to the
+ * composing parent, not the queried child. Before the fix `self` pinned to Contract and this
+ * raised a false InvalidArgument.
+ */
+function test_base_builder_self_param_accepts_sibling(Receipt $receipt): void
+{
+    $_result = Contract::query()->rankedAbove($receipt);
+    /** @psalm-check-type-exact $_result = Illuminate\Database\Eloquent\Builder<App\Models\Contract> */
+}
+
+/**
+ * Negative: the `self` param resolves to the composing parent, so a non-model arg is rejected.
+ * The expected class is AbstractDocument (the trait's composing class), NOT the queried Contract
+ * — this is the observable message change of the fix.
+ */
 function test_base_builder_self_param_is_type_checked(): void
 {
     Contract::query()->rankedAbove('not a model');
+}
+
+/**
+ * Static-arm control, positive: `static` binds to the queried model (Contract), which accepts a
+ * Contract instance.
+ */
+function test_base_builder_static_param_accepts_model(Contract $contract): void
+{
+    $_result = Contract::query()->rankedBelow($contract);
+    /** @psalm-check-type-exact $_result = Illuminate\Database\Eloquent\Builder<App\Models\Contract> */
+}
+
+/**
+ * Static-arm control, negative (discriminator): `static` narrows to the queried Contract via late
+ * static binding, so a SIBLING child is REJECTED — proving `self` (parent) and `static` (queried
+ * model) now resolve differently.
+ */
+function test_base_builder_static_param_rejects_sibling(Receipt $receipt): void
+{
+    Contract::query()->rankedBelow($receipt);
+}
+
+/**
+ * Variant control: a `self`-typed param on a scope declared DIRECTLY on the abstract parent
+ * (scopeSupersedes, not via a trait) resolves `self` to AbstractDocument at scan time. The
+ * handler's re-expansion is idempotent, so the sibling child is accepted here too.
+ */
+function test_directly_declared_parent_self_accepts_sibling(Receipt $receipt): void
+{
+    $_result = Contract::query()->supersedes($receipt);
+    /** @psalm-check-type-exact $_result = Illuminate\Database\Eloquent\Builder<App\Models\Contract> */
 }
 ?>
 --EXPECTF--
@@ -114,4 +172,5 @@ InvalidArgument on line %d: Argument 1 of App\Builders\WorkOrderBuilder::rankedb
 InvalidArgument on line %d: Argument 1 of App\Builders\WorkOrderBuilder::rankedamong expects list<App\Models\WorkOrder>, but list{'not a model'} provided
 InvalidArgument on line %d: Argument 1 of App\Models\WorkOrder::rankedabove expects App\Models\WorkOrder, but 'not a model' provided
 InvalidArgument on line %d: Argument 1 of Illuminate\Database\Eloquent\Relations\HasMany::rankedabove expects App\Models\WorkOrder, but 'not a model' provided
-InvalidArgument on line %d: Argument 1 of Illuminate\Database\Eloquent\Builder::rankedabove expects App\Models\Contract, but 'not a model' provided
+InvalidArgument on line %d: Argument 1 of Illuminate\Database\Eloquent\Builder::rankedabove expects App\Models\AbstractDocument, but 'not a model' provided
+InvalidArgument on line %d: Argument 1 of Illuminate\Database\Eloquent\Builder::rankedbelow expects App\Models\Contract, but App\Models\Receipt provided

--- a/tests/Type/tests/Builder/ScopeVariadicNamedArgTest.phpt
+++ b/tests/Type/tests/Builder/ScopeVariadicNamedArgTest.phpt
@@ -1,0 +1,108 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use App\Models\DirectScopeModel;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Pins variadic and named-argument scope-call handling on the forwarded path (where the plugin
+ * strips the leading $query that Laravel injects) and the direct path (real signature).
+ *
+ * Laravel's Builder::__call / Model::callNamedScope forward every caller argument after the
+ * injected $query, so a forwarded variadic scope must keep its variadic flag through the strip:
+ * a zero-arg call is valid, extra args draw no TooManyArguments, and each value is still checked
+ * against the element type. Named arguments and argument unpacking are forwarded verbatim.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1039
+ */
+
+/* -- Forwarded legacy variadic scope (Customer::scopeOfNames) ---------------- */
+
+/** Forwarded variadic: multiple values accepted, result keeps the model template. */
+function test_variadic_forwarded_multiple(): void
+{
+    $_result = Customer::query()->ofNames('Ada', 'Bo');
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
+
+/** Zero args: a variadic tail is optional, so no TooFewArguments. */
+function test_variadic_forwarded_zero_args(): void
+{
+    $_result = Customer::query()->ofNames();
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
+
+/** More args than declared params: the variadic flag survives the $query slice — no TooManyArguments. */
+function test_variadic_forwarded_extra_args(): void
+{
+    $_result = Customer::query()->ofNames('Ada', 'Bo', 'Cy');
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
+
+/** Wrong element type is still checked against the variadic's `string`. */
+function test_variadic_forwarded_wrong_type(): void
+{
+    $_result = Customer::query()->ofNames(1);
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
+
+/* -- Named args / spread on a forwarded scope (Customer::scopeOfName) -------- */
+
+/** Named argument matching the scope's (post-strip) param name resolves cleanly. */
+function test_named_arg_forwarded(): void
+{
+    $_result = Customer::query()->ofName(name: 'Ada');
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
+
+/** Spread of a positional list into a forwarded scope. */
+function test_spread_arg_forwarded(): void
+{
+    $_result = Customer::query()->ofName(...['Ada']);
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
+
+/* -- Forwarded variadic #[Scope] (DirectScopeModel::ofAnyName) --------------- */
+
+/** Forwarded modern #[Scope] variadic: same forwarding behavior as the legacy form. */
+function test_attribute_variadic_forwarded(): void
+{
+    $_result = DirectScopeModel::query()->ofAnyName('a', 'b');
+    /** @psalm-check-type-exact $_result = Builder<DirectScopeModel> */
+}
+
+/** Forwarded #[Scope] variadic, zero args: still optional. */
+function test_attribute_variadic_forwarded_zero_args(): void
+{
+    $_result = DirectScopeModel::query()->ofAnyName();
+    /** @psalm-check-type-exact $_result = Builder<DirectScopeModel> */
+}
+
+/* -- Direct call of a variadic #[Scope] (real signature applies) ------------- */
+
+/**
+ * Direct instance call passing $query explicitly: ofAnyName is a real, accessible method, so
+ * dispatch is direct and the full variadic signature applies — one trailing string is valid.
+ *
+ * @param Builder<DirectScopeModel> $query
+ */
+function test_attribute_variadic_direct_call(DirectScopeModel $model, Builder $query): void
+{
+    $model->ofAnyName($query, 'a');
+}
+
+/**
+ * Direct call, wrong variadic element type: reported as argument 2 against the real signature
+ * (no left-shift), not argument 1.
+ *
+ * @param Builder<DirectScopeModel> $query
+ */
+function test_attribute_variadic_direct_call_wrong_type(DirectScopeModel $model, Builder $query): void
+{
+    $model->ofAnyName($query, 1);
+}
+?>
+--EXPECTF--
+InvalidArgument on line %d: Argument 1 of Illuminate\Database\Eloquent\Builder::ofnames expects string, but 1 provided
+InvalidArgument on line %d: Argument 2 of App\Models\DirectScopeModel::ofAnyName expects string, but 1 provided


### PR DESCRIPTION
## Issue to Solve

A scope parameter typed `self` was pinned to the **queried model**, raising a false-positive `InvalidArgument` when a trait- or parent-hosted scope is given a sibling-subclass argument.

Inside a trait method PHP binds `self` to the **composing class** (the class that `use`s the trait, or the parent that declares the scope), fixed at composition time, not the subclass being queried. So when a trait is composed on an abstract parent and queried through a child, a sibling child is a runtime-valid argument that the plugin wrongly rejected:

```php
// scopeRankedAbove(Builder $q, self $model) lives in trait ComparesRank
abstract class AbstractDocument extends Model { use ComparesRank; }
final class Contract extends AbstractDocument {}
final class Receipt  extends AbstractDocument {}

Contract::query()->rankedAbove($receipt); // runtime-valid: self == AbstractDocument
```

Before this change the plugin pinned `self` to the queried `Contract` and reported a false `InvalidArgument` on `$receipt`.

## Related

Closes #1031. Refs #1034, #1039.

## Solution Description

### Part 1 — fix (#1031)

A scope parameter typed `self` now resolves to the scope method's **composing class**; `static`/`$this` continue to resolve to the **queried model** (late static binding).

`BuilderScopeHandler::getScopeParams` resolves the composing class via `Codebase\Methods::getAppearingMethodId` (the appearing id is the composing class for trait methods; `getDeclaringMethodId` would surface the trait itself) and threads it into `expandScopeParamSelfReferences`, which expands `self` to the composing class and `static`/`$this` to the queried model.

**Observable change (scoped).** Only **trait-on-parent** hierarchies are affected:

- The expected class in the `InvalidArgument` message for such a scope shifts from the queried child to the composing parent (e.g. `expects App\Models\Contract` becomes `expects App\Models\AbstractDocument`).
- **Directly-composed** scopes are unchanged. `WorkOrder` uses `ComparesRank` directly, so its composing class equals the queried model (`WorkOrder`); every existing expectation stays byte-identical.
- `static`/`$this` still narrow to the queried model, so a sibling is still correctly rejected on the `static` arm.

### Part 2 — tests only (#1039)

Pin variadic and named-argument scope-call behavior, which the Wave 2 dispatch classifier (#1034) left unpinned. No production code changes; bundled here as opportunistic coverage since it exercises the same handler.

| Call (forwarded unless noted) | Pinned result |
| --- | --- |
| `ofNames('Ada', 'Bo')` | `Builder<Customer>` |
| `ofNames()` (zero args) | clean, variadic is optional, no `TooFewArguments` |
| `ofNames('a', 'b', 'c')` (extra args) | clean, no `TooManyArguments` (variadic flag survives the `$query` slice) |
| `ofNames(1)` (wrong element type) | `InvalidArgument`, element still checked against `string` |
| `ofName(name: 'Ada')` (named arg) | `Builder<Customer>` |
| `ofName(...['Ada'])` (unpacking) | `Builder<Customer>` |
| `ofAnyName('a', 'b')` (`#[Scope]` variadic) | `Builder<DirectScopeModel>` |
| `$m->ofAnyName($q, 'a')` (direct call) | real signature applies, no `$query` strip |

All pinned behavior matches Laravel's `Builder::__call` / `callNamedScope` forwarding (verified against framework source on 12 and 13). No "Found while pinning" contradictions surfaced.

### How it was verified

- New / updated type tests (below) plus a local reproduction: false positives disappear, genuine errors remain, and the message-class shift is exactly the documented one.
- Suites green: `test:type` (446), `test:unit` (784), `test:app`, `psalm` self-analysis (clean, 100% coverage), `cs`.

**Tests / fixtures.** `Issue1031TraitScopeSelfParamTest.phpt`: the WorkOrder block is byte-identical; added a sibling-accepted positive, the `static`-arm sibling-rejected discriminator, and a variant control for a `self` param declared directly on the abstract parent. `ScopeVariadicNamedArgTest.phpt` is new. `ComparesRank` moved from `Contract` to its parent `AbstractDocument`; new minimal sibling `Receipt`; `Customer::scopeOfNames` and `DirectScopeModel::ofAnyName` variadics added.

### Real-world delta (psalm-delta, 17 apps)

Base `032097d6` vs this branch. **16/17 apps: zero movement.** The lone non-zero row is pre-existing Psalm multi-thread non-determinism, not caused by this change.

| App | ΔNet issues | ΔCoverage |
| --- | ---: | ---: |
| filament | +2 (flaky, see note) | -0.00 |
| other 16 apps | 0 | 0.00 |

_Other 16: aureuserp, bagisto, bookstack, coolify, corcel, monica, pixelfed, solidtime, spatie-dashboard, tastyigniter, unit3d, vito, laravel-excel, laravel-backup, laravel-permission, laravel-socialite._

**The filament `+2` is environmental flakiness, verified.** The two deltas (`MixedArgument` + `MixedArgumentTypeCoercion` in `packages/tables/src/Concerns/HasBulkActions.php:120-121`, a `Collection::reduce` closure) reproduce on the **base** ref alone: three back-to-back base runs gave 13966 / 13968 / 13968 issues, flipping those exact two lines. Psalm runs multi-threaded here and that `mixed`-inference spot is analysis-order sensitive. This change touches only scope parameter `self`/`static` resolution, which has no path to that code (`getFilteredTableQuery(): ?Builder` is non-generic; no scope is involved). No issues were removed because none of the 17 apps contain the targeted shape (a trait scope with a `self` param composed on an abstract parent).

## Checklist
- [x] Tests cover the change (type tests in `tests/Type/tests/Builder/`)
