### PR TITLE
Trim deleted arg-shape heuristic archaeology from scope regression test

### DIFF
--- a/tests/Type/tests/Builder/LegacyScopeBuilderArgTest.phpt
+++ b/tests/Type/tests/Builder/LegacyScopeBuilderArgTest.phpt
@@ -37,10 +37,10 @@ function test_legacy_builder_instance_with_builder_first_arg(): void
 }
 
 /**
- * Legacy scope whose post-$query param is OPTIONAL (defaulted). The old heuristic's arity
- * tie-breaker (required-count 0) made a single Builder argument satisfy "direct" and produced
- * the false UndefinedMagicMethod; dispatch truth still forwards, so the Builder is checked
- * against the stripped `string $status`.
+ * Legacy scope whose post-$query param is OPTIONAL (defaulted). The old heuristic mis-classified
+ * this as a direct call (no required post-$query params), producing a false UndefinedMagicMethod.
+ * Dispatch truth still forwards — no bare-name method exists — so the Builder is checked against
+ * the stripped `string $status`.
  */
 function test_legacy_optional_param_with_builder_first_arg(): void
 {


### PR DESCRIPTION
## Issue to Solve

Post-rework consistency pass: a regression-test docblock in `LegacyScopeBuilderArgTest`
still described an internal implementation detail of the deleted arg-shape heuristic
(`arity tie-breaker / required-count 0`), which is archaeology that doesn't describe
any current code path.

## Related

Part of the v4.13.0 release consistency pass.

## Solution Description

Replaced the implementation-specific detail ("required-count 0 tie-breaker") with a
description of the *observable behaviour* that was wrong — the old heuristic
mis-classified a legacy scope with no required post-$query params as a direct call.
The why (this edge case exists specifically for legacy scopes with optional params)
and the current correct outcome (dispatch truth forwards; the Builder arg is checked
against the stripped `string $status`) are both preserved.

No logic change; the `--FILE--` and `--EXPECTF--` sections are unchanged and the
suite passes.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
