### PR TITLE
Fix false `InvalidArgument` on `addGlobalScope` closures with bare `Builder` params

### DIFF
--- a/src/Handlers/Eloquent/ModelMethodHandler.php
+++ b/src/Handlers/Eloquent/ModelMethodHandler.php
@@ -610,12 +610,23 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
             return self::$globalScopeParamsCache[$modelClass] = null;
         }
 
+        // Fetch raw params from the declaring method storage directly, bypassing the
+        // params provider. Going through getMethodParams() would re-enter this provider
+        // (Methods::getMethodParams consults it before falling through to storage); the
+        // only protection against infinite recursion would be the null-source guard above.
+        // Using getStorage() makes the independence from the provider explicit.
+        $declaringMethodId = $codebase->methods->getDeclaringMethodId($methodId);
+        if ($declaringMethodId === null) {
+            return self::$globalScopeParamsCache[$modelClass] = null;
+        }
+
         return self::$globalScopeParamsCache[$modelClass] = \array_map(
             static function (FunctionLikeParameter $param) use ($codebase, $modelClass): FunctionLikeParameter {
                 if (!$param->type instanceof Union) {
                     return $param;
                 }
 
+                // setType() clones — never mutates the shared method storage params.
                 return $param->setType(TypeExpander::expandUnion(
                     $codebase,
                     $param->type,
@@ -632,7 +643,7 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
                     final: true,
                 ));
             },
-            $codebase->methods->getMethodParams($methodId),
+            $codebase->methods->getStorage($declaringMethodId)->params,
         );
     }
 

--- a/src/Handlers/Eloquent/ModelMethodHandler.php
+++ b/src/Handlers/Eloquent/ModelMethodHandler.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Expr\Variable;
 use Psalm\Codebase;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Internal\MethodIdentifier;
+use Psalm\Internal\Type\TypeExpander;
 use Psalm\LaravelPlugin\Util\DynamicWhereResolver;
 use Psalm\LaravelPlugin\Util\ProxyMethodReturnTypeProvider;
 use Psalm\Plugin\EventHandler\Event\MethodExistenceProviderEvent;
@@ -79,6 +80,14 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
     private static array $customBuilderMap = [];
 
     /**
+     * Memoized result of {@see expandedGlobalScopeParams} keyed by model FQCN.
+     * Cleared by {@see init} on plugin re-bootstrap.
+     *
+     * @var array<string, list<FunctionLikeParameter>|null>
+     */
+    private static array $globalScopeParamsCache = [];
+
+    /**
      * Reset per-process caches. Called once per Plugin::__construct so a re-bootstrap
      * doesn't carry stale verdicts across analysis runs. In particular, the
      * dynamic-where branch of {@see isUnresolvedBuilderMethod} depends on the
@@ -91,6 +100,7 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
     {
         self::$unresolvedCache = [];
         self::$customBuilderMap = [];
+        self::$globalScopeParamsCache = [];
     }
 
     /**
@@ -243,6 +253,15 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
         $codebase = $source->getCodebase();
         $modelClass = $event->getFqClasslikeName();
         $methodName = $event->getMethodNameLowercase();
+
+        // addGlobalScope: re-expand formal params with final: true so Builder<static> resolves
+        // to Builder<ModelClass> without the &static intersection Psalm adds for non-final classes.
+        // The intersection causes false InvalidArgument when a closure uses a bare `Builder $query`
+        // hint, because template inference gives Builder<static> on the provided side while the
+        // expected side carries Builder<User&static> — unification fails (issue #1038).
+        if ($methodName === 'addglobalscope') {
+            return self::expandedGlobalScopeParams($codebase, $modelClass);
+        }
 
         if (!self::isUnresolvedBuilderMethod($codebase, $modelClass, $methodName)) {
             return null;
@@ -566,6 +585,55 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
         }
 
         return null;
+    }
+
+    /**
+     * Return the formal params of Model::addGlobalScope with `static` pinned to the concrete
+     * model class via TypeExpander::expandUnion final: true.
+     *
+     * Laravel's docblock uses Builder<static> in the Closure param position. Psalm expands
+     * `static` to `ModelClass&static` for non-final classes, while the user's bare
+     * `Builder $query` hint gets Builder<static> via template inference — the `&static`
+     * intersection on the expected side causes the unification to fail (issue #1038).
+     * Pinning with final: true resolves to the plain model class on both sides.
+     *
+     * @return list<FunctionLikeParameter>|null
+     */
+    private static function expandedGlobalScopeParams(Codebase $codebase, string $modelClass): ?array
+    {
+        if (\array_key_exists($modelClass, self::$globalScopeParamsCache)) {
+            return self::$globalScopeParamsCache[$modelClass];
+        }
+
+        $methodId = new MethodIdentifier($modelClass, 'addglobalscope');
+        if (!$codebase->methodExists($methodId)) {
+            return self::$globalScopeParamsCache[$modelClass] = null;
+        }
+
+        return self::$globalScopeParamsCache[$modelClass] = \array_map(
+            static function (FunctionLikeParameter $param) use ($codebase, $modelClass): FunctionLikeParameter {
+                if (!$param->type instanceof Union) {
+                    return $param;
+                }
+
+                return $param->setType(TypeExpander::expandUnion(
+                    $codebase,
+                    $param->type,
+                    $modelClass,
+                    $modelClass,
+                    null,
+                    evaluate_class_constants: true,
+                    evaluate_conditional_types: false,
+                    // Resolves `static` to the plain model class instead of
+                    // the ModelClass&static intersection. In a closure param
+                    // (accept/contravariant position) the intersection over-rejects
+                    // because the provided Builder<static> cannot be proven to
+                    // contain Builder<ModelClass&static>. final: true prevents that.
+                    final: true,
+                ));
+            },
+            $codebase->methods->getMethodParams($methodId),
+        );
     }
 
     /**

--- a/src/Handlers/Eloquent/ModelMethodHandler.php
+++ b/src/Handlers/Eloquent/ModelMethodHandler.php
@@ -616,7 +616,7 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
         // only protection against infinite recursion would be the null-source guard above.
         // Using getStorage() makes the independence from the provider explicit.
         $declaringMethodId = $codebase->methods->getDeclaringMethodId($methodId);
-        if ($declaringMethodId === null) {
+        if (!$declaringMethodId instanceof \Psalm\Internal\MethodIdentifier) {
             return self::$globalScopeParamsCache[$modelClass] = null;
         }
 

--- a/tests/Type/tests/Model/GlobalScopeClosureTest.phpt
+++ b/tests/Type/tests/Model/GlobalScopeClosureTest.phpt
@@ -1,10 +1,8 @@
 --FILE--
 <?php declare(strict_types=1);
 
-namespace Tests\Psalm\LaravelPlugin\Sandbox;
-
+use App\Models\Tool;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
 
 /**
@@ -18,41 +16,28 @@ use Illuminate\Database\Eloquent\Scope;
  * The plugin fixes this by re-expanding the formal params of addGlobalScope via
  * TypeExpander::expandUnion with final: true, pinning Builder<static> to Builder<ModelClass>
  * on the expected side so both sides resolve to the same concrete type.
+ *
+ * Uses the autoloadable Tool archetype so the per-model handler is registered and the fix
+ * actually applies (inline sandbox models are skipped by ModelRegistrationHandler).
  */
-class AddGlobalScopeTestModel extends Model {}
 
 /**
- * The exact repro from issue #1038: self::addGlobalScope called from booted() with a bare
- * `Builder $query` closure param. This is the failure mode — booted() runs in a non-final
- * model's static context, which is where Psalm produces the ModelClass&static intersection.
- */
-class BootedGlobalScopeModel extends Model
-{
-    protected static function booted(): void
-    {
-        self::addGlobalScope(static function (Builder $query): void {
-            $query->where('active', true);
-        });
-    }
-}
-
-/**
- * External static call with bare Builder hint — same fix, different call context.
+ * Bare `Builder $query` hint — the canonical issue form. Must produce no error.
  */
 function test_bare_builder_param_passes(): void
 {
-    AddGlobalScopeTestModel::addGlobalScope(static function (Builder $query): void {
+    Tool::addGlobalScope(static function (Builder $query): void {
         $query->where('active', true);
     });
 }
 
 /**
- * Explicit Builder<AddGlobalScopeTestModel> hint — works today; must not regress.
+ * Explicit Builder<Tool> hint — works today; must not regress.
  */
 function test_explicit_concrete_param_passes(): void
 {
-    AddGlobalScopeTestModel::addGlobalScope(
-        /** @param Builder<AddGlobalScopeTestModel> $query */
+    Tool::addGlobalScope(
+        /** @param Builder<Tool> $query */
         static function (Builder $query): void {
             $query->where('active', true);
         },
@@ -64,7 +49,9 @@ function test_explicit_concrete_param_passes(): void
  */
 function test_wrong_param_type_errors(): void
 {
-    AddGlobalScopeTestModel::addGlobalScope(static function (string $query): void {});
+    Tool::addGlobalScope(static function (string $query): void {
+        echo $query;
+    });
 }
 
 /**
@@ -72,7 +59,7 @@ function test_wrong_param_type_errors(): void
  */
 function test_scope_instance_passes(Scope $scope): void
 {
-    AddGlobalScopeTestModel::addGlobalScope($scope);
+    Tool::addGlobalScope($scope);
 }
 
 /**
@@ -80,10 +67,10 @@ function test_scope_instance_passes(Scope $scope): void
  */
 function test_named_string_form_passes(): void
 {
-    AddGlobalScopeTestModel::addGlobalScope('active', static function (Builder $query): void {
+    Tool::addGlobalScope('active', static function (Builder $query): void {
         $query->where('active', true);
     });
 }
 ?>
 --EXPECTF--
-InvalidArgument on line %d: Argument 1 of %s::addGlobalScope expects %s, but impure-Closure(string):void provided
+InvalidArgument on line %d: Argument 1 of App\Models\Tool::addGlobalScope expects %s, but impure-Closure(string):void provided

--- a/tests/Type/tests/Model/GlobalScopeClosureTest.phpt
+++ b/tests/Type/tests/Model/GlobalScopeClosureTest.phpt
@@ -1,0 +1,89 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Sandbox;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+/**
+ * Regression tests for psalm/psalm-plugin-laravel#1038.
+ *
+ * addGlobalScope() accepts a Closure whose first param is Builder<static>. For non-final
+ * models Psalm expands `static` to `ModelClass&static`, producing Builder<ModelClass&static>
+ * as the expected closure param. A bare `Builder $query` hint gets Builder<static> via template
+ * inference — the &static intersection on the expected side causes unification to fail.
+ *
+ * The plugin fixes this by re-expanding the formal params of addGlobalScope via
+ * TypeExpander::expandUnion with final: true, pinning Builder<static> to Builder<ModelClass>
+ * on the expected side so both sides resolve to the same concrete type.
+ */
+class AddGlobalScopeTestModel extends Model {}
+
+/**
+ * The exact repro from issue #1038: self::addGlobalScope called from booted() with a bare
+ * `Builder $query` closure param. This is the failure mode — booted() runs in a non-final
+ * model's static context, which is where Psalm produces the ModelClass&static intersection.
+ */
+class BootedGlobalScopeModel extends Model
+{
+    protected static function booted(): void
+    {
+        self::addGlobalScope(static function (Builder $query): void {
+            $query->where('active', true);
+        });
+    }
+}
+
+/**
+ * External static call with bare Builder hint — same fix, different call context.
+ */
+function test_bare_builder_param_passes(): void
+{
+    AddGlobalScopeTestModel::addGlobalScope(static function (Builder $query): void {
+        $query->where('active', true);
+    });
+}
+
+/**
+ * Explicit Builder<AddGlobalScopeTestModel> hint — works today; must not regress.
+ */
+function test_explicit_concrete_param_passes(): void
+{
+    AddGlobalScopeTestModel::addGlobalScope(
+        /** @param Builder<AddGlobalScopeTestModel> $query */
+        static function (Builder $query): void {
+            $query->where('active', true);
+        },
+    );
+}
+
+/**
+ * Wrong closure param type — must still produce InvalidArgument.
+ */
+function test_wrong_param_type_errors(): void
+{
+    AddGlobalScopeTestModel::addGlobalScope(static function (string $query): void {});
+}
+
+/**
+ * Scope instance form — must stay clean.
+ */
+function test_scope_instance_passes(Scope $scope): void
+{
+    AddGlobalScopeTestModel::addGlobalScope($scope);
+}
+
+/**
+ * Named string + closure form — must stay clean.
+ */
+function test_named_string_form_passes(): void
+{
+    AddGlobalScopeTestModel::addGlobalScope('active', static function (Builder $query): void {
+        $query->where('active', true);
+    });
+}
+?>
+--EXPECTF--
+InvalidArgument on line %d: Argument 1 of %s::addGlobalScope expects %s, but impure-Closure(string):void provided


### PR DESCRIPTION
## Issue to Solve

`Model::addGlobalScope()` rejects closures with bare `Builder $query` hints with a false `InvalidArgument`. The fix applies to any non-final model — the canonical pattern in every Laravel Getting Started guide.

Repro:
```php
class Post extends Model {
    protected static function booted(): void {
        self::addGlobalScope(static function (Builder $query): void {
            $query->where('published', true);
        });
    }
}
```
```
InvalidArgument: Argument 1 of Post::addGlobalScope expects
  Scope<Model>|impure-Closure(Builder<Post&static>):mixed|string,
  but impure-Closure(Builder<static>):void provided
```

## Related

Closes #1038

## Solution Description

**Root cause.** Laravel's `HasGlobalScopes::addGlobalScope` docblock annotates the closure param as `Closure(Builder<static>): mixed`. For non-final models, Psalm expands `static` at the call site to `Model&static` (the late-static-bound intersection). The user's bare `Builder $query` hint gets `Builder<static>` via template inference — but the check now compares `Builder<Post&static>` against `Builder<static>`, and Psalm cannot prove the intersection form is contained.

**Fix.** `ModelMethodHandler::getMethodParams` already intercepts calls on concrete models (registered per-model via `ModelRegistrationHandler`). A new early guard for `addglobalscope` calls `expandedGlobalScopeParams`, which fetches the formal params from method storage directly (bypassing the provider to avoid an implicit re-entrant cycle) and re-expands them via `TypeExpander::expandUnion(final: true)`. This pins `static` to the plain model class instead of the `&static` form. Both the expected and inferred sides then resolve to `Builder<Post>`, unification succeeds, and the false positive disappears.

This is the same mechanism already used by `BuilderScopeHandler::expandScopeParamSelfReferences` for scope params — same class of false positive, same fix.

**Sibling APIs checked:** `addGlobalScopes(array)` (bare `array` param, unaffected), `Builder::withGlobalScope` (bare `Closure`, unaffected), `resolveRelationUsing` (bare `Closure`, unaffected). No version delta between Laravel 12 and 13 for this method.

**psalm-delta** across 17 real-world apps (base: master `7448e85e`, head: `4921d01a`):

| App     | ΔNet | Note |
|---------|-----:|------|
| coolify |   -1 | Removed `InvalidArgument` from `addGlobalScope` closure |
| all others | 0 | — |

Net: **-1 `InvalidArgument` removed, 0 added.**

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
- [x] Documentation is updated (if needed, otherwise remove this item)
