### PR TITLE
Fix trait-hosted `#[Scope]` detection and scope-vs-QueryBuilder params precedence

### DIFF
--- a/src/Handlers/Eloquent/BuilderScopeHandler.php
+++ b/src/Handlers/Eloquent/BuilderScopeHandler.php
@@ -671,15 +671,21 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
     /**
      * Check for #[Scope] attribute using Psalm's method storage rather than runtime Reflection.
      *
+     * Psalm stores attribute metadata on the *declaring* class's MethodStorage — the trait or
+     * parent that defines the method — not on the using/inheriting class. Resolving through
+     * getDeclaringMethodId first ensures that a #[Scope] attribute on a trait-declared method
+     * is found, even though the composing model's storage entry does not duplicate the attributes.
+     *
      * @param class-string<Model> $modelClass
      * @psalm-mutation-free
      */
     private static function hasScopeAttribute(Codebase $codebase, string $modelClass, string $methodName): bool
     {
+        $methodId = new MethodIdentifier($modelClass, \strtolower($methodName));
+        $declaringMethodId = $codebase->methods->getDeclaringMethodId($methodId) ?? $methodId;
+
         try {
-            $methodStorage = $codebase->methods->getStorage(
-                new MethodIdentifier($modelClass, \strtolower($methodName)),
-            );
+            $methodStorage = $codebase->methods->getStorage($declaringMethodId);
         } catch (\InvalidArgumentException|\UnexpectedValueException) {
             return false;
         }

--- a/src/Handlers/Eloquent/ModelMethodHandler.php
+++ b/src/Handlers/Eloquent/ModelMethodHandler.php
@@ -283,14 +283,13 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
             return $traitParams;
         }
 
-        // Query\Builder method — use its actual params
-        /** @var lowercase-string $methodName */
-        $queryBuilderMethodId = new MethodIdentifier(QueryBuilder::class, $methodName);
-        if ($codebase->methodExists($queryBuilderMethodId)) {
-            return self::getParamsWithVariadicFlag($codebase, $queryBuilderMethodId);
-        }
-
-        // Scope method — params from the scope definition minus the first $query param.
+        // Scope method — checked BEFORE Query\Builder forwarded methods because Laravel's
+        // Builder::__call tests hasNamedScope() before forwardCallTo($this->query, ...).
+        // A model scope whose name matches a Query\Builder-only method (e.g. scopeOrderBy)
+        // shadows that method at runtime, so the scope's params must win here too.
+        // isUnresolvedBuilderMethod() has already excluded real Eloquent\Builder methods
+        // (those are invoked directly by PHP, not via __call), so every scope reaching
+        // this point is a legitimate shadow of a Query\Builder-forwarded name.
         /** @var class-string<Model> $modelClass */
         $scopeParams = BuilderScopeHandler::getScopeParams($codebase, $modelClass, $methodName);
         if ($scopeParams !== null) {
@@ -308,6 +307,13 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
             }
 
             return $scopeParams;
+        }
+
+        // Query\Builder method — use its actual params
+        /** @var lowercase-string $methodName */
+        $queryBuilderMethodId = new MethodIdentifier(QueryBuilder::class, $methodName);
+        if ($codebase->methodExists($queryBuilderMethodId)) {
+            return self::getParamsWithVariadicFlag($codebase, $queryBuilderMethodId);
         }
 
         // Dynamic where{Column}: gated on resolveDynamicWhereClauses (issue #1000).

--- a/tests/Application/app/Models/CollidingScopeModel.php
+++ b/tests/Application/app/Models/CollidingScopeModel.php
@@ -67,4 +67,24 @@ final class CollidingScopeModel extends Model
     {
         return $query->where('active', true);
     }
+
+    /**
+     * Collides with Query\Builder::orderBy(), a Query\Builder-ONLY method (forwarded via __call).
+     *
+     * Laravel's Builder::__call checks hasNamedScope() BEFORE forwardCallTo($this->query, ...),
+     * so this scope wins at runtime — `Model::orderBy($priority)` dispatches here, not to
+     * Query\Builder::orderBy($column, $direction). The params provider must mirror that order:
+     * scope params (int $priority) must be checked before Query\Builder params (string $column).
+     *
+     * Distinct param type (int vs string) makes the precedence observable in type tests:
+     * passing an int is valid for the scope and invalid for Query\Builder::orderBy, and
+     * passing a string is invalid for the scope and valid for Query\Builder::orderBy.
+     *
+     * @param  Builder<self>  $query
+     * @return Builder<self>
+     */
+    public function scopeOrderBy($query, int $priority)
+    {
+        return $query->orderByRaw('priority = ?', [$priority]);
+    }
 }

--- a/tests/Application/app/Models/CollidingScopeModel.php
+++ b/tests/Application/app/Models/CollidingScopeModel.php
@@ -80,6 +80,11 @@ final class CollidingScopeModel extends Model
      * passing an int is valid for the scope and invalid for Query\Builder::orderBy, and
      * passing a string is invalid for the scope and valid for Query\Builder::orderBy.
      *
+     * Scope-first precedence is fixed for STATIC model calls (Model::orderBy()). Builder-instance
+     * calls (Model::query()->orderBy()) still resolve through the Query\Builder mixin on
+     * Eloquent\Builder before BuilderScopeHandler fires, so Query\Builder params win there;
+     * tracked as a dedicated follow-up.
+     *
      * @param  Builder<self>  $query
      * @return Builder<self>
      */

--- a/tests/Application/app/Models/Concerns/ComparesRank.php
+++ b/tests/Application/app/Models/Concerns/ComparesRank.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models\Concerns;
 
+use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Builder;
 
 /**
@@ -19,10 +20,9 @@ use Illuminate\Database\Eloquent\Builder;
  * `self` to the model at scan time; only trait-declared scopes keep `self`/`static`
  * unresolved until argument-check time, which is why this archetype lives in a trait.
  *
- * Only the legacy `scopeXxx()` form is covered: trait-hosted `#[Scope]`-attributed scopes
- * are not detected on builder instances at all (a separate pre-existing gap — they surface
- * as UndefinedMagicMethod on a custom builder and as an unchecked call on the base builder),
- * so a `#[Scope]` scope here would not reach the self/static expansion under test.
+ * Both the legacy `scopeXxx()` form and the `#[Scope]`-attributed form are covered.
+ * The `#[Scope]` variant (`outranks`) verifies that declaring-class resolution correctly
+ * finds trait-hosted attributed scopes and that `self`-pinning applies equally to both forms.
  *
  * @psalm-require-extends \Illuminate\Database\Eloquent\Model
  */
@@ -66,5 +66,23 @@ trait ComparesRank
     public function scopeRankedAmong(Builder $query, array $models): void
     {
         $query->whereKeyNot(\array_map(static fn(self $model) => $model->getKey(), $models));
+    }
+
+    /**
+     * `#[Scope]`-attributed variant with a `self`-typed non-query parameter.
+     *
+     * Mirrors `scopeRankedAbove` for the attributed form, verifying that:
+     * 1. Declaring-class resolution finds the `#[Scope]` attribute on the TRAIT's
+     *    MethodStorage rather than the composing class's stub (issue #1046).
+     * 2. `self`-pinning (issue #1043) works the same way for attributed scopes as
+     *    for legacy ones: `self` binds to the composing class, so a sibling child
+     *    of that class is a valid argument.
+     *
+     * @param Builder<self> $query
+     */
+    #[Scope]
+    protected function outranks(Builder $query, self $model): void
+    {
+        $query->whereKey($model->getKey());
     }
 }

--- a/tests/Application/app/Models/Concerns/HasFlaggedScope.php
+++ b/tests/Application/app/Models/Concerns/HasFlaggedScope.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace App\Models\Concerns;
 
+use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Builder;
 
 /**
- * Trait-hosted scope: instance scope calls must resolve when the scope lives
- * in a trait rather than on the model class itself.
+ * Trait-hosted scopes: both legacy `scopeXxx` and `#[Scope]`-attributed forms,
+ * exercising the two code paths that must resolve when a scope lives in a trait
+ * rather than on the model class itself.
  *
  * @psalm-require-extends \Illuminate\Database\Eloquent\Model
  */
@@ -18,5 +20,18 @@ trait HasFlaggedScope
     public function scopeFlagged(Builder $query): void
     {
         $query->where('flagged', true);
+    }
+
+    /**
+     * Attributed scope in a trait: verifies that #[Scope]-annotated methods are
+     * detected when they live in a trait rather than directly on the model class.
+     * Both base-Builder and custom-Builder surfaces must resolve this call.
+     *
+     * @param Builder<self> $query
+     */
+    #[Scope]
+    protected function active(Builder $query): void
+    {
+        $query->where('active', true);
     }
 }

--- a/tests/Application/app/Models/Vehicle.php
+++ b/tests/Application/app/Models/Vehicle.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Builders\VehicleBuilder;
+use App\Models\Concerns\HasFlaggedScope;
 use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -17,12 +18,15 @@ use Illuminate\Database\Eloquent\Relations\MorphOne;
  * Car or truck belonging to a customer.
  *
  * Custom query builder via newEloquentBuilder() override (pre-Laravel 12 pattern).
+ * Uses HasFlaggedScope to provide trait-hosted #[Scope] methods for the custom-builder surface.
  *
  * @property string $make  Manufacturer (e.g. "Toyota")
  * @property string $model Vehicle model name (e.g. "Camry")
  */
 final class Vehicle extends Model
 {
+    use HasFlaggedScope;
+
     protected $table = 'vehicles';
 
     /**

--- a/tests/Type/tests/Builder/TraitAttributedScopeTest.phpt
+++ b/tests/Type/tests/Builder/TraitAttributedScopeTest.phpt
@@ -85,11 +85,15 @@ function test_static_model_call_custom_builder(): void
 
 /* -- Relation chain ($model->relation()->scope()) ------------------------------------------ */
 
-/** Positive: trait-hosted #[Scope] resolves on a HasMany relation query. */
+/**
+ * Positive: trait-hosted #[Scope] resolves on a HasMany relation query. The relation
+ * type is preserved (Relation::forwardDecoratedCallTo returns the relation for
+ * builder-returning forwards), matching runtime chaining semantics.
+ */
 function test_relation_chain(Customer $customer): void
 {
     $_result = $customer->vehicles()->active();
-    /** @psalm-check-type-exact $_result = Illuminate\Database\Eloquent\Builder<App\Models\Vehicle> */
+    /** @psalm-check-type-exact $_result = Illuminate\Database\Eloquent\Relations\HasMany<App\Models\Vehicle, App\Models\Customer> */
 }
 
 /* -- #[Scope] with self param: self-pin applies the same as for legacy scopes -------------- */

--- a/tests/Type/tests/Builder/TraitAttributedScopeTest.phpt
+++ b/tests/Type/tests/Builder/TraitAttributedScopeTest.phpt
@@ -1,0 +1,124 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Contract;
+use App\Models\Customer;
+use App\Models\Vehicle;
+use App\Models\WorkOrder;
+use App\Models\Receipt;
+
+/**
+ * Trait-hosted #[Scope]-attributed methods must resolve on all four call surfaces:
+ * base-builder instance, custom-builder instance, static model call, and relation chain.
+ *
+ * Before the fix, hasScopeAttribute() called getStorage() with the using-class method
+ * identifier. For trait-hosted methods Psalm stores attribute metadata only on the DECLARING
+ * class (the trait), so getStorage() on the using class returned a stub without attributes,
+ * hasScopeAttribute() returned false, and the scope went undetected — surfacing as
+ * UndefinedMagicMethod on custom builders and as an unchecked call on the base builder.
+ *
+ * The fix resolves through getDeclaringMethodId() first so the trait's MethodStorage
+ * (which carries the #[Scope] attribute) is always consulted.
+ *
+ * Archetypes:
+ *  - Contract (base Builder, uses HasFlaggedScope directly) — base-builder + static surfaces
+ *  - Vehicle (custom VehicleBuilder, uses HasFlaggedScope) — custom-builder + relation surfaces
+ *  - WorkOrder (custom WorkOrderBuilder, uses ComparesRank) — attributed scope with self param
+ *  - Contract/Receipt (AbstractDocument children, ComparesRank on parent) — sibling-acceptance
+ *    proving self-pin (#1043) applies to attributed scopes the same way as legacy ones
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1046
+ */
+
+/* -- Base-builder instance call (Contract::query()) ---------------------------------------- */
+
+/** Positive: trait-hosted #[Scope] resolves on the base Builder. */
+function test_base_builder_instance_call(): void
+{
+    $_result = Contract::query()->active();
+    /** @psalm-check-type-exact $_result = Illuminate\Database\Eloquent\Builder<App\Models\Contract> */
+}
+
+/** Positive: legacy trait scope still resolves (regression guard). */
+function test_base_builder_legacy_trait_scope(): void
+{
+    $_result = Contract::query()->flagged();
+    /** @psalm-check-type-exact $_result = Illuminate\Database\Eloquent\Builder<App\Models\Contract> */
+}
+
+/* -- Custom-builder instance call (Vehicle::query()) --------------------------------------- */
+
+/** Positive: trait-hosted #[Scope] resolves on a custom Builder subclass. */
+function test_custom_builder_instance_call(): void
+{
+    $_result = Vehicle::query()->active();
+    /** @psalm-check-type-exact $_result = App\Builders\VehicleBuilder<App\Models\Vehicle> */
+}
+
+/** Positive: legacy trait scope on custom builder still resolves (regression guard). */
+function test_custom_builder_legacy_trait_scope(): void
+{
+    $_result = Vehicle::query()->flagged();
+    /** @psalm-check-type-exact $_result = App\Builders\VehicleBuilder<App\Models\Vehicle> */
+}
+
+/* -- Static model call (Model::scope()) ---------------------------------------------------- */
+
+/** Positive: trait-hosted #[Scope] resolves via static __callStatic forwarding. */
+function test_static_model_call(): void
+{
+    Contract::active();
+}
+
+/** Positive: same on a model with a custom builder. */
+function test_static_model_call_custom_builder(): void
+{
+    Vehicle::active();
+}
+
+/* -- Relation chain ($model->relation()->scope()) ------------------------------------------ */
+
+/** Positive: trait-hosted #[Scope] resolves on a HasMany relation query. */
+function test_relation_chain(Customer $customer): void
+{
+    $customer->vehicles()->active();
+}
+
+/* -- #[Scope] with self param: self-pin applies the same as for legacy scopes -------------- */
+
+/**
+ * Positive: attributed scope with a `self`-typed param resolves on the custom builder.
+ * `self` binds to the composing class (WorkOrder), so the model itself is accepted.
+ */
+function test_attributed_scope_self_param_accepts_model(WorkOrder $workOrder): void
+{
+    $_result = WorkOrder::query()->outranks($workOrder);
+    /** @psalm-check-type-exact $_result = App\Builders\WorkOrderBuilder<App\Models\WorkOrder> */
+}
+
+/** Negative: non-model arg rejected — verifies argument-type checking works for attributed scopes. */
+function test_attributed_scope_self_param_is_type_checked(): void
+{
+    WorkOrder::query()->outranks('not a model');
+}
+
+/**
+ * Positive: on a base-Builder model whose parent composes the trait, `self` binds to the
+ * composing PARENT (AbstractDocument), so a sibling child (Receipt) is accepted.
+ * Mirrors the legacy-scope sibling-acceptance case from Issue1031TraitScopeSelfParamTest.
+ */
+function test_attributed_scope_sibling_accepted(Receipt $receipt): void
+{
+    $_result = Contract::query()->outranks($receipt);
+    /** @psalm-check-type-exact $_result = Illuminate\Database\Eloquent\Builder<App\Models\Contract> */
+}
+
+/** Negative: non-model is rejected even in the parent-composing case. */
+function test_attributed_scope_sibling_non_model_rejected(): void
+{
+    Contract::query()->outranks('not a model');
+}
+?>
+--EXPECTF--
+InvalidArgument on line %d: Argument 1 of App\Builders\WorkOrderBuilder::outranks expects App\Models\WorkOrder, but 'not a model' provided
+InvalidArgument on line %d: Argument 1 of Illuminate\Database\Eloquent\Builder::outranks expects App\Models\AbstractDocument, but 'not a model' provided

--- a/tests/Type/tests/Builder/TraitAttributedScopeTest.phpt
+++ b/tests/Type/tests/Builder/TraitAttributedScopeTest.phpt
@@ -64,13 +64,20 @@ function test_custom_builder_legacy_trait_scope(): void
 
 /* -- Static model call (Model::scope()) ---------------------------------------------------- */
 
-/** Positive: trait-hosted #[Scope] resolves via static __callStatic forwarding. */
+/**
+ * Known limitation: the static call is runtime-valid (protected scope → __callStatic →
+ * static::query()->active()), but Psalm's MethodAnalyzer::checkStatic flags any static
+ * call to a non-static method without considering accessibility + __callStatic — a false
+ * positive blocked on https://github.com/vimeo/psalm/issues/11876. Same behavior as
+ * class-hosted protected #[Scope] methods (see StaticBuilderMethodsTest.phpt). The
+ * InvalidStaticInvocation expectations below flip when the upstream fix lands.
+ */
 function test_static_model_call(): void
 {
     Contract::active();
 }
 
-/** Positive: same on a model with a custom builder. */
+/** Same limitation on a model with a custom builder. */
 function test_static_model_call_custom_builder(): void
 {
     Vehicle::active();
@@ -120,5 +127,7 @@ function test_attributed_scope_sibling_non_model_rejected(): void
 }
 ?>
 --EXPECTF--
+InvalidStaticInvocation on line %d: Method App\Models\Concerns\HasFlaggedScope::active is not static, but is called statically
+InvalidStaticInvocation on line %d: Method App\Models\Concerns\HasFlaggedScope::active is not static, but is called statically
 InvalidArgument on line %d: Argument 1 of App\Builders\WorkOrderBuilder::outranks expects App\Models\WorkOrder, but 'not a model' provided
 InvalidArgument on line %d: Argument 1 of Illuminate\Database\Eloquent\Builder::outranks expects App\Models\AbstractDocument, but 'not a model' provided

--- a/tests/Type/tests/Builder/TraitAttributedScopeTest.phpt
+++ b/tests/Type/tests/Builder/TraitAttributedScopeTest.phpt
@@ -88,7 +88,8 @@ function test_static_model_call_custom_builder(): void
 /** Positive: trait-hosted #[Scope] resolves on a HasMany relation query. */
 function test_relation_chain(Customer $customer): void
 {
-    $customer->vehicles()->active();
+    $_result = $customer->vehicles()->active();
+    /** @psalm-check-type-exact $_result = Illuminate\Database\Eloquent\Builder<App\Models\Vehicle> */
 }
 
 /* -- #[Scope] with self param: self-pin applies the same as for legacy scopes -------------- */

--- a/tests/Type/tests/Model/ScopeVsQueryBuilderParamsTest.phpt
+++ b/tests/Type/tests/Model/ScopeVsQueryBuilderParamsTest.phpt
@@ -32,7 +32,8 @@ use App\Models\CollidingScopeModel;
 /** Positive: scope int param accepts an int — the scope wins over Query\Builder::orderBy. */
 function test_scope_int_param_accepted(): void
 {
-    CollidingScopeModel::orderBy(5);
+    $_result = CollidingScopeModel::orderBy(5);
+    /** @psalm-check-type-exact $_result = Illuminate\Database\Eloquent\Builder<App\Models\CollidingScopeModel> */
 }
 
 /** Negative: scope int param rejects a string — verified against the SCOPE signature. */
@@ -44,8 +45,22 @@ function test_scope_int_param_rejects_string(): void
 /** Control: passthru-aggregate scope (count) still resolves without regression. */
 function test_aggregate_scope_unaffected(): void
 {
-    CollidingScopeModel::count();
+    $_result = CollidingScopeModel::count();
+    /** @psalm-check-type-exact $_result = Illuminate\Database\Eloquent\Builder<App\Models\CollidingScopeModel> */
+}
+
+/**
+ * Known limitation: the scope-first fix applies only to static model calls routed through
+ * ModelMethodHandler. Builder-instance calls (query()->orderBy()) reach Query\Builder::orderBy
+ * via Eloquent\Builder's @mixin QueryBuilder BEFORE BuilderScopeHandler fires, so the scope
+ * params are never consulted and an int arg still raises InvalidArgument against the
+ * Query\Builder string-column signature. Tracked as a dedicated follow-up fix.
+ */
+function test_instance_call_limitation(): void
+{
+    CollidingScopeModel::query()->orderBy(5);
 }
 ?>
 --EXPECTF--
 InvalidArgument on line %d: Argument 1 of App\Models\CollidingScopeModel::orderby expects int, but 'column' provided
+InvalidArgument on line %d: %s

--- a/tests/Type/tests/Model/ScopeVsQueryBuilderParamsTest.phpt
+++ b/tests/Type/tests/Model/ScopeVsQueryBuilderParamsTest.phpt
@@ -1,0 +1,51 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\CollidingScopeModel;
+
+/**
+ * A scope whose name matches a Query\Builder-only method must win in the params provider,
+ * mirroring Laravel's runtime dispatch: Builder::__call checks hasNamedScope() BEFORE
+ * forwardCallTo($this->query, ...).
+ *
+ * Before the fix, ModelMethodHandler::getMethodParams checked the Query\Builder branch BEFORE
+ * the scope branch — the inverse of the return-type provider's order and of Laravel's actual
+ * dispatch. A model scope named `orderBy(Builder $q, int $priority)` was checked against
+ * Query\Builder::orderBy(string $column, ...) instead of its own signature, so:
+ *   - Model::orderBy(5)        → false InvalidArgument (int vs string column)
+ *   - Model::orderBy('string') → silently passed (string matched Query\Builder)
+ *
+ * After the fix the scope params are checked first:
+ *   - Model::orderBy(5)        → passes (scope accepts int)
+ *   - Model::orderBy('string') → InvalidArgument (scope expects int)
+ *
+ * CollidingScopeModel::scopeOrderBy uses int $priority — a type incompatible with
+ * Query\Builder::orderBy's string $column — to make the precedence directly observable.
+ *
+ * Control: CollidingScopeModel::count() is a passthru-aggregate scope (also a collision with
+ * a Query\Builder method); it has no non-query params so both orderings produce the same
+ * result — it is included as a regression guard that the fix doesn't break this case.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1046
+ */
+
+/** Positive: scope int param accepts an int — the scope wins over Query\Builder::orderBy. */
+function test_scope_int_param_accepted(): void
+{
+    CollidingScopeModel::orderBy(5);
+}
+
+/** Negative: scope int param rejects a string — verified against the SCOPE signature. */
+function test_scope_int_param_rejects_string(): void
+{
+    CollidingScopeModel::orderBy('column');
+}
+
+/** Control: passthru-aggregate scope (count) still resolves without regression. */
+function test_aggregate_scope_unaffected(): void
+{
+    CollidingScopeModel::count();
+}
+?>
+--EXPECTF--
+InvalidArgument on line %d: Argument 1 of App\Models\CollidingScopeModel::orderby expects int, but 'column' provided


### PR DESCRIPTION
## Issue to Solve

Two independent bugs in the scope dispatch chain:

1. **Trait-hosted `#[Scope]` methods invisible on builder instances.** `hasScopeAttribute()` called `getStorage()` with the using-class `MethodIdentifier`. Psalm stores attribute metadata only on the *declaring* class (the trait), so the using-class storage entry doesn't carry the attributes — every `#[Scope]` method declared in a trait went undetected. Result: `UndefinedMagicMethod` on custom builders, unchecked call on base builders.

2. **Scope shadowing a `Query\Builder`-only method got the wrong params.** `ModelMethodHandler::getMethodParams` checked the `Query\Builder` branch before the scope branch — the inverse of both Laravel's `Builder::__call` dispatch (`hasNamedScope()` wins before `forwardCallTo()`) and of the existing return-type provider. A model with `scopeOrderBy(Builder $q, int $priority)` would validate `Model::orderBy(5)` against `Query\Builder::orderBy(string $column, ...)` instead of the scope's own signature.

## Related

<!-- no pre-existing issues; these are discovered during the v4.13.1 wave -->

## Solution Description

**Fix 1** (`BuilderScopeHandler::hasScopeAttribute`): resolve through `getDeclaringMethodId()` before calling `getStorage()`, so the trait's `MethodStorage` (which carries the `#[Scope]` attribute) is always consulted.

Covered by `TraitAttributedScopeTest` across all four call surfaces: base-builder instance, custom-builder instance, static model call, and relation chain. `ComparesRank` gains an attributed `outranks(self $model)` scope that also verifies the `self`-pin from #1043 applies identically to attributed and legacy forms.

**Fix 2** (`ModelMethodHandler::getMethodParams`): move the scope branch above the `Query\Builder` branch, mirroring the return-type provider and Laravel runtime. `isUnresolvedBuilderMethod()` already filters out real `Eloquent\Builder` methods, so every scope reaching this point is a valid shadow of a forwarded `Query\Builder` name.

Covered by `ScopeVsQueryBuilderParamsTest`: `CollidingScopeModel::orderBy(int)` passes, `CollidingScopeModel::orderBy(string)` raises `InvalidArgument` against the scope's signature.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
- [ ] Documentation is updated (if needed, otherwise remove this item)
