### PR TITLE
Document instance-call scope-vs-QueryBuilder limitation as upstream-blocked

### DIFF
--- a/tests/Application/app/Models/CollidingScopeModel.php
+++ b/tests/Application/app/Models/CollidingScopeModel.php
@@ -81,9 +81,10 @@ final class CollidingScopeModel extends Model
      * passing a string is invalid for the scope and valid for Query\Builder::orderBy.
      *
      * Scope-first precedence is fixed for STATIC model calls (Model::orderBy()). Builder-instance
-     * calls (Model::query()->orderBy()) still resolve through the Query\Builder mixin on
-     * Eloquent\Builder before BuilderScopeHandler fires, so Query\Builder params win there;
-     * tracked as a dedicated follow-up.
+     * calls (Model::query()->orderBy()) resolve through the Query\Builder mixin on Eloquent\Builder,
+     * which rewrites the call to Query\Builder::orderBy before BuilderScopeHandler can be consulted,
+     * so Query\Builder params win there. That is an upstream Psalm limitation, not fixable at the
+     * plugin level (see test_instance_call_limitation in ScopeVsQueryBuilderParamsTest).
      *
      * @param  Builder<self>  $query
      * @return Builder<self>

--- a/tests/Type/tests/Model/ScopeVsQueryBuilderParamsTest.phpt
+++ b/tests/Type/tests/Model/ScopeVsQueryBuilderParamsTest.phpt
@@ -50,11 +50,19 @@ function test_aggregate_scope_unaffected(): void
 }
 
 /**
- * Known limitation: the scope-first fix applies only to static model calls routed through
- * ModelMethodHandler. Builder-instance calls (query()->orderBy()) reach Query\Builder::orderBy
- * via Eloquent\Builder's @mixin QueryBuilder BEFORE BuilderScopeHandler fires, so the scope
- * params are never consulted and an int arg still raises InvalidArgument against the
- * Query\Builder string-column signature. Tracked as a dedicated follow-up fix.
+ * Upstream-blocked limitation (not a pending plugin fix): the scope-first precedence applies only to
+ * static model calls routed through ModelMethodHandler. Builder-instance calls (query()->orderBy())
+ * resolve orderBy through Eloquent\Builder's @mixin Query\Builder, which rewrites the call to
+ * Query\Builder::orderBy BEFORE argument checking. Psalm keys its params/return-type provider lookups
+ * on that resolved Query\Builder class, never on the Builder host where BuilderScopeHandler is
+ * registered, so the scope params are never consulted and an int arg still raises InvalidArgument
+ * against the Query\Builder string-column signature.
+ *
+ * Not fixable at the plugin level — it is an upstream Psalm limitation: @mixin-forwarded methods are
+ * not offered to providers registered on the mixin host, and the params/existence provider events
+ * expose no receiver to distinguish a colliding-scope model from a plain Builder. (Forcing
+ * interception via an existence provider only reverses the return-type/params hook order and makes
+ * Psalm throw on the absent Builder::orderBy storage.) Keep this test until upstream changes.
  */
 function test_instance_call_limitation(): void
 {


### PR DESCRIPTION
## Issue to Solve

`Model::query()->orderBy(5)` raises a false `InvalidArgument` (checked against `Query\Builder::orderBy(string $column)`), and `->orderBy('column')` is a false negative, when a model declares a scope whose name collides with a `Query\Builder`-only method (`scopeOrderBy`). #1046 fixed the scope-first precedence for the **static** `Model::orderBy(...)` path only; this is the **Builder-instance** follow-up.

## Related

Follow-up to #1046.

## Solution Description

A feasibility investigation concluded the instance path is **not fixable at the plugin level** — it is an upstream Psalm `@mixin` provider-dispatch limitation. Verified against Psalm 7.0.0-beta19:

- `@mixin Query\Builder` resolution rewrites the call to `Query\Builder::orderBy` **before** argument checking (`AtomicMethodCallAnalyzer::handleRegularMixins`).
- The params and return-type provider lookups key on that resolved `Query\Builder` class, never on the `Builder` host where `BuilderScopeHandler` is registered (`Methods::getMethodParams`, `MethodCallReturnTypeFetcher`).
- `MethodParamsProviderEvent` and `MethodExistenceProviderEvent` expose no LHS receiver, so a colliding-scope model is indistinguishable from a plain `Builder` (or a raw `DB::table()` query). Only `MethodReturnTypeProviderEvent` carries the statement.
- Forcing interception via an existence provider reverses the params/return-type hook order and makes Psalm throw on the absent `Builder::orderBy` storage (confirmed empirically).

This PR is **documentation only**: it reframes the `test_instance_call_limitation` and `CollidingScopeModel::scopeOrderBy` docblocks from "tracked as a follow-up fix" to an upstream-blocked limitation. No behavior change. The limitation test body and `--EXPECTF--` are unchanged; it doubles as a tripwire that fails if upstream ever changes `@mixin` provider dispatch.

Verified: `composer test:type` (limitation test green), `composer psalm` (self-analysis clean), `composer cs` clean.

## Checklist
- [x] Tests cover the change (existing `test_instance_call_limitation` retained; behavior unchanged)
- [x] Documentation is updated
