### PR TITLE
Suppress unused-method false positives on trait-hosted Eloquent scopes

### DIFF
--- a/src/Handlers/SuppressHandler.php
+++ b/src/Handlers/SuppressHandler.php
@@ -307,7 +307,7 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
                 continue;
             }
 
-            self::suppressByParentClass($classStorage);
+            self::suppressByParentClass($classStorage, $provider);
             self::suppressByUsedTraits($classStorage);
             self::suppressByInterface($classStorage);
         }
@@ -354,8 +354,10 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
         $storage->initialized_properties[$propertyName] = true;
     }
 
-    private static function suppressByParentClass(ClassLikeStorage $classStorage): void
-    {
+    private static function suppressByParentClass(
+        ClassLikeStorage $classStorage,
+        ClassLikeStorageProvider $provider,
+    ): void {
         $parents = $classStorage->parent_classes;
 
         if ($parents === []) {
@@ -399,9 +401,9 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
         }
 
         if (\in_array('Illuminate\Database\Eloquent\Model', $parents, true)) {
-            self::suppressEloquentAccessorMethods($classStorage);
-            self::suppressEloquentScopeMethods($classStorage);
-            self::suppressLegacyEloquentScopeMethods($classStorage);
+            self::suppressEloquentAccessorMethods($classStorage, $provider);
+            self::suppressEloquentScopeMethods($classStorage, $provider);
+            self::suppressLegacyEloquentScopeMethods($classStorage, $provider);
         }
 
         if (\in_array('Illuminate\Notifications\Notification', $parents, true)) {
@@ -446,6 +448,68 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
     }
 
     /**
+     * Yield, for every method that *appears* on $classStorage, the MethodStorage of the class that
+     * actually declares it — the model itself, a trait it composes, or a parent model.
+     *
+     * Eloquent hosts scopes and accessors on traits at least as often as on the model body, and
+     * Psalm never copies a trait method's MethodStorage into the using class's `$storage->methods`
+     * (Populator::inheritMethodsFromParent only wires up appearing_method_ids / declaring_method_ids,
+     * never `methods`). It also reads a method's `suppressed_issues` — during the unused-method check
+     * in ClassLikes::checkMethodReferences() — off the DECLARING class's storage, not the using
+     * model's. So iterating `$classStorage->methods` both misses trait-hosted scopes entirely and,
+     * even where a model-local override existed, would mutate the wrong object. Resolving to the
+     * declaring storage mirrors markFrameworkInitializedProperties() (declaring_property_ids) and
+     * BuilderScopeHandler::hasScopeAttribute() (#1046).
+     *
+     * Only methods whose appearing class is $classStorage itself are visited, matching
+     * checkMethodReferences() which flags an unused method on the class where it appears. A scope
+     * inherited from a parent model appears — and is checked, and gets suppressed — when that parent
+     * is iterated separately in afterCodebasePopulated(), so the parent path is covered there rather
+     * than double-handled here.
+     *
+     * Caveat: the resolved MethodStorage is shared with every other class composing the same trait,
+     * so suppressing here also silences the scope on a non-Model class that happens to use the trait.
+     * That is harmless — a genuine Eloquent scope trait is only ever composed by models, and Psalm
+     * reads the same shared storage for all composers.
+     *
+     * Mutation-free: this only reads the storage graph and yields existing MethodStorage instances.
+     * The suppression mutation happens in the callers (suppress*Methods), on the yielded objects.
+     *
+     * Scope: only the three Eloquent suppressors (accessor / #[Scope] / legacy scopeXxx) route
+     * through here, because trait-hosted scopes and accessors are idiomatic. The notification /
+     * mailable hook suppressors below intentionally keep their direct `$classStorage->methods`
+     * lookup — trait-hosted toMail()/envelope()/viaQueues() are rare enough not to warrant the
+     * declaring-storage resolution. Use this helper for any future trait-hostable suppressor.
+     *
+     * @return \Generator<lowercase-string, MethodStorage>
+     *
+     * @psalm-mutation-free
+     */
+    private static function appearingMethods(
+        ClassLikeStorage $classStorage,
+        ClassLikeStorageProvider $provider,
+    ): \Generator {
+        foreach ($classStorage->appearing_method_ids as $methodName => $appearingMethodId) {
+            if ($appearingMethodId->fq_class_name !== $classStorage->name) {
+                continue;
+            }
+
+            $declaringMethodId = $classStorage->declaring_method_ids[$methodName] ?? $appearingMethodId;
+
+            if (!$provider->has($declaringMethodId->fq_class_name)) {
+                continue;
+            }
+
+            $declaringMethodStorage
+                = $provider->get($declaringMethodId->fq_class_name)->methods[$declaringMethodId->method_name] ?? null;
+
+            if ($declaringMethodStorage instanceof MethodStorage) {
+                yield $methodName => $declaringMethodStorage;
+            }
+        }
+    }
+
+    /**
      * Suppress PossiblyUnusedMethod for legacy Eloquent accessor/mutator methods.
      *
      * Methods matching getXxxAttribute() and setXxxAttribute() are invoked via
@@ -460,11 +524,17 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
      * `suppressInternalDispatchMethod()`, which keeps `private` accessors flagged as the
      * real bug they are.
      *
+     * Trait-hosted accessors (e.g. a `HasSlug` trait declaring getSlugAttribute()) hit the same
+     * dispatch path, so resolve through appearingMethods() to reach the declaring storage rather
+     * than iterating the model's own `methods` (which never holds trait copies).
+     *
      * Note: method names are stored lowercase in ClassLikeStorage.
      */
-    private static function suppressEloquentAccessorMethods(ClassLikeStorage $classStorage): void
-    {
-        foreach ($classStorage->methods as $methodName => $methodStorage) {
+    private static function suppressEloquentAccessorMethods(
+        ClassLikeStorage $classStorage,
+        ClassLikeStorageProvider $provider,
+    ): void {
+        foreach (self::appearingMethods($classStorage, $provider) as $methodName => $methodStorage) {
             if (\preg_match('/^get.+attribute$/', $methodName) || \preg_match('/^set.+attribute$/', $methodName)) {
                 self::suppressInternalDispatchMethod('PossiblyUnusedMethod', $methodStorage);
             }
@@ -486,9 +556,11 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
      * model instance from `Builder`'s foreign scope — a `private` scope is unreachable from that
      * dispatch site and would fatal, so leaving it reported surfaces the real bug.
      */
-    private static function suppressEloquentScopeMethods(ClassLikeStorage $classStorage): void
-    {
-        foreach ($classStorage->methods as $methodStorage) {
+    private static function suppressEloquentScopeMethods(
+        ClassLikeStorage $classStorage,
+        ClassLikeStorageProvider $provider,
+    ): void {
+        foreach (self::appearingMethods($classStorage, $provider) as $methodStorage) {
             if (!self::hasScopeAttribute($methodStorage)) {
                 continue;
             }
@@ -528,18 +600,23 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
      * Sibling of psalm/psalm-plugin-laravel#874, deferred there to keep the diff focused.
      *
      * Detection: lowercase method key starts with `scope` AND the original-cased name has an
-     * uppercase ASCII letter directly after `scope` (matches Laravel's `ucfirst()` resolution
-     * at `Model.php:1981`). The cased-name check prevents misclassifying methods like
-     * `scopeactive` (which Laravel cannot dispatch — `ucfirst()` produces `scopeActive`) or
-     * a literal `scope()` method.
+     * uppercase ASCII letter directly after `scope` — the `scope` + StudlyCase convention Laravel
+     * resolves via `'scope'.ucfirst($scope)` in `Model::callNamedScope()`. PHP method dispatch is
+     * case-insensitive, so a `scopeactive()` method *is* technically reachable as `active()`; we
+     * still require the uppercase letter because matching lowercase-after-`scope` would over-suppress
+     * ordinary methods that only share the prefix (`scoped()`, `scopes()`, `scopedQuery()`). A literal
+     * `scope()` is already excluded earlier by the length guard. The convention gate trades a
+     * near-zero-frequency miss for far fewer false suppressions.
      *
      * Visibility: same routing as the modern variant — `private` stays flagged because the
      * dispatch lives on `$this` in `Model::callNamedScope()` and a `private` override on a
      * subclass would not be resolvable from the parent scope (PHP private scoping).
      */
-    private static function suppressLegacyEloquentScopeMethods(ClassLikeStorage $classStorage): void
-    {
-        foreach ($classStorage->methods as $methodName => $methodStorage) {
+    private static function suppressLegacyEloquentScopeMethods(
+        ClassLikeStorage $classStorage,
+        ClassLikeStorageProvider $provider,
+    ): void {
+        foreach (self::appearingMethods($classStorage, $provider) as $methodName => $methodStorage) {
             if (!self::isLegacyScopeMethodName($methodName, $methodStorage->cased_name)) {
                 continue;
             }
@@ -561,7 +638,8 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
         }
 
         // Laravel resolves $builder->active() via `scope` . ucfirst('active') => `scopeActive`.
-        // A `scopeactive()` method is dispatch-unreachable, so don't suppress it.
+        // PHP dispatch is case-insensitive so a `scopeactive()` would technically work, but we gate
+        // on the `scope` + StudlyCase convention to avoid over-suppressing methods like `scoped()`.
         $firstNameChar = $casedName[5];
 
         return $firstNameChar >= 'A' && $firstNameChar <= 'Z';

--- a/tests/Unit/Handlers/Fixtures/SuppressScopeUnusedCode/app/Concerns/HasInlineScopes.php
+++ b/tests/Unit/Handlers/Fixtures/SuppressScopeUnusedCode/app/Concerns/HasInlineScopes.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ScopeUnusedCodeFixture\Concerns;
+
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Trait-hosted scopes — the case #1046's detection fix left leaking under findUnusedCode.
+ *
+ * @psalm-require-extends \Illuminate\Database\Eloquent\Model
+ */
+trait HasInlineScopes
+{
+    /**
+     * Trait-hosted #[Scope] (protected). Dispatched via Builder::__call, never referenced
+     * directly, so it must be suppressed rather than reported PossiblyUnusedMethod.
+     *
+     * @param Builder<self> $query
+     */
+    #[Scope]
+    protected function active(Builder $query): void
+    {
+        $query->where('active', true);
+    }
+
+    /**
+     * Trait-hosted legacy scope (public). Dispatched via Model::callNamedScope.
+     *
+     * @param Builder<self> $query
+     */
+    public function scopeFlagged(Builder $query): void
+    {
+        $query->where('flagged', true);
+    }
+
+    /**
+     * Trait-hosted legacy accessor. Dispatched via __get magic ($model->computed), never referenced
+     * directly, so it must be suppressed rather than reported PossiblyUnusedMethod — exercises the
+     * accessor branch of the same trait-resolution path.
+     */
+    protected function getComputedAttribute(): string
+    {
+        return 'computed';
+    }
+
+    /**
+     * Private #[Scope]: never a usable scope (Eloquent cannot dispatch it), so the handler does
+     * NOT suppress it. It produces no output here regardless — Psalm only emits UnusedMethod for a
+     * private method when the class has no __call, and every Model declares __call. Present to
+     * document that the visibility carve-out is intact, not to assert a report.
+     *
+     * @param Builder<self> $query
+     */
+    #[Scope]
+    private function secret(Builder $query): void
+    {
+        $query->where('secret', true);
+    }
+}

--- a/tests/Unit/Handlers/Fixtures/SuppressScopeUnusedCode/app/Models/TraitScopeModel.php
+++ b/tests/Unit/Handlers/Fixtures/SuppressScopeUnusedCode/app/Models/TraitScopeModel.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ScopeUnusedCodeFixture\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use ScopeUnusedCodeFixture\Concerns\HasInlineScopes;
+
+/**
+ * Hosts every scope shape at once so a single Psalm run covers them all under findUnusedCode:
+ *  - trait #[Scope]   -> HasInlineScopes::active
+ *  - trait legacy     -> HasInlineScopes::scopeFlagged
+ *  - direct #[Scope]  -> self::published
+ *  - direct legacy    -> self::scopeArchived
+ * None are dispatched anywhere, so without SuppressHandler each would surface as
+ * PossiblyUnusedMethod. `helperNonScope` is the surgical control: a non-scope method that MUST
+ * stay reported, proving the suppressor only touches genuine scopes.
+ */
+final class TraitScopeModel extends Model
+{
+    use HasInlineScopes;
+
+    /**
+     * Direct #[Scope] (protected).
+     *
+     * @param Builder<self> $query
+     */
+    #[Scope]
+    protected function published(Builder $query): void
+    {
+        $query->where('published', true);
+    }
+
+    /**
+     * Direct legacy scope (public).
+     *
+     * @param Builder<self> $query
+     */
+    public function scopeArchived(Builder $query): void
+    {
+        $query->where('archived', true);
+    }
+
+    /**
+     * Direct legacy accessor (no-regression control for the accessor path). Dispatched via __get
+     * ($model->display_name), so it must stay suppressed.
+     */
+    protected function getDisplayNameAttribute(): string
+    {
+        return 'name';
+    }
+
+    /**
+     * Control: neither #[Scope] nor scopeXxx, never called. Must STAY PossiblyUnusedMethod.
+     *
+     * @param Builder<self> $query
+     */
+    protected function helperNonScope(Builder $query): void
+    {
+        $query->where('legacy', true);
+    }
+}

--- a/tests/Unit/Handlers/Fixtures/SuppressScopeUnusedCode/app/entry.php
+++ b/tests/Unit/Handlers/Fixtures/SuppressScopeUnusedCode/app/entry.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ScopeUnusedCodeFixture;
+
+use ScopeUnusedCodeFixture\Models\TraitScopeModel;
+
+// Reference the model so it is not reported UnusedClass; deliberately do NOT dispatch any scope,
+// mirroring real code where scopes are only ever called through the query builder. The strict
+// (errorLevel=1) run may add unrelated notes here (e.g. MissingPureAnnotation); that is fine — the
+// test filters findings to unused-method types, so only the scope/accessor suppression is asserted.
+function consume(TraitScopeModel $model): string
+{
+    return $model::class;
+}

--- a/tests/Unit/Handlers/Fixtures/SuppressScopeUnusedCode/autoload.php
+++ b/tests/Unit/Handlers/Fixtures/SuppressScopeUnusedCode/autoload.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+// Standalone classmap-style autoloader for the fixture classes. The SuppressHandler reproduction
+// is run as a separate Psalm subprocess (see SuppressScopeUnusedCodeTest) that loads the plugin,
+// which reflects on the model at runtime — so the fixture classes must be loadable in that process.
+// A dedicated, non-Composer namespace keeps the fixture isolated from the package autoloader.
+\spl_autoload_register(static function (string $class): void {
+    $prefix = 'ScopeUnusedCodeFixture\\';
+
+    if (!\str_starts_with($class, $prefix)) {
+        return;
+    }
+
+    $relative = \str_replace('\\', '/', \substr($class, \strlen($prefix)));
+    $file = __DIR__ . '/app/' . $relative . '.php';
+
+    if (\is_file($file)) {
+        require_once $file;
+    }
+});

--- a/tests/Unit/Handlers/Fixtures/SuppressScopeUnusedCode/psalm.xml
+++ b/tests/Unit/Handlers/Fixtures/SuppressScopeUnusedCode/psalm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="1"
+    findUnusedCode="true"
+    autoloader="autoload.php"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+>
+    <projectFiles>
+        <directory name="app" />
+    </projectFiles>
+    <plugins>
+        <pluginClass class="Psalm\LaravelPlugin\Plugin" />
+    </plugins>
+</psalm>

--- a/tests/Unit/Handlers/SuppressScopeUnusedCodeTest.php
+++ b/tests/Unit/Handlers/SuppressScopeUnusedCodeTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Handlers\SuppressHandler;
+use Symfony\Component\Process\Process;
+
+/**
+ * End-to-end guard for SuppressHandler's Eloquent scope/accessor suppression under findUnusedCode.
+ *
+ * Why a real Psalm subprocess instead of a phpt: psalm-tester always passes the snippet as an
+ * explicit file argument, and Psalm only runs whole-program dead-code detection
+ * (UnusedMethod / PossiblyUnusedMethod / UnusedClass) over a config's <projectFiles>, never over
+ * file arguments. So a phpt cannot observe these findings at all — "assert empty" would pass with
+ * or without the fix and guard nothing. This test points Psalm at a self-contained fixture
+ * project (tests/Unit/Handlers/Fixtures/SuppressScopeUnusedCode) with findUnusedCode enabled, the
+ * way real applications run it, and asserts the suppression actually takes effect.
+ *
+ * The fixture hosts all four scope shapes (trait/direct x modern #[Scope]/legacy scopeXxx) and a
+ * trait + direct legacy accessor, plus one non-scope control method. Without the trait-aware fix
+ * the trait-hosted scope and accessor leak as PossiblyUnusedMethod; with it, only the control
+ * remains.
+ *
+ * Placement note: this is the suite's only test that forks a real `vendor/bin/psalm` subprocess
+ * (it boots Laravel via the plugin, ~6s), because whole-program dead-code detection cannot be
+ * observed in-process here. It lives in tests/Unit for proximity to the handler it guards rather
+ * than in tests/Application, which is reserved for the fresh-app shell harness (laravel-test.sh).
+ */
+#[CoversClass(SuppressHandler::class)]
+final class SuppressScopeUnusedCodeTest extends TestCase
+{
+    /**
+     * Methods Eloquent dispatches indirectly, so each MUST be suppressed (absent from the report).
+     * Covers both the trait-hosted forms (the regression this fixes) and the direct forms (kept as
+     * no-regression controls). `secret` is deliberately NOT here: a private #[Scope] is structurally
+     * unflaggable on a Model (see runtime note below), so asserting its absence would prove nothing.
+     */
+    private const SUPPRESSED_SCOPE_MARKERS = [
+        '::active',               // trait #[Scope]
+        '::scopeFlagged',         // trait legacy
+        '::getComputedAttribute', // trait legacy accessor
+        '::published',            // direct #[Scope]
+        '::scopeArchived',        // direct legacy
+        '::getDisplayNameAttribute', // direct legacy accessor
+    ];
+
+    #[Test]
+    public function it_suppresses_trait_and_direct_eloquent_scopes_but_not_a_plain_unused_method(): void
+    {
+        $unusedMethodFindings = $this->runPsalmAndCollectUnusedMethodFindings();
+
+        $messages = \array_map(
+            static fn(array $finding): string => $finding['message'],
+            $unusedMethodFindings,
+        );
+        $joined = \implode("\n", $messages);
+
+        // Surgical control: the one non-scope method that is genuinely never called must stay
+        // reported, proving the suppressor narrows to real scopes rather than silencing every
+        // unused method on the model. assertCount(1) also guarantees nothing else leaks — including
+        // the private `secret` scope, which Psalm never emits for a __call class anyway.
+        self::assertCount(
+            1,
+            $unusedMethodFindings,
+            "Expected exactly one unused-method finding (the non-scope control), got:\n{$joined}",
+        );
+        self::assertStringContainsString('TraitScopeModel::helperNonScope', $messages[0]);
+
+        // Every dispatched scope/accessor must be suppressed rather than reported as unused.
+        foreach (self::SUPPRESSED_SCOPE_MARKERS as $marker) {
+            self::assertStringNotContainsString(
+                $marker,
+                $joined,
+                "Scope/accessor method {$marker} must be suppressed, not reported as unused.",
+            );
+        }
+    }
+
+    /**
+     * @return list<array{type: string, message: string}>
+     */
+    private function runPsalmAndCollectUnusedMethodFindings(): array
+    {
+        $projectRoot = \dirname(__DIR__, 3);
+        $fixtureDir = __DIR__ . '/Fixtures/SuppressScopeUnusedCode';
+        $psalmBinary = $projectRoot . '/vendor/bin/psalm';
+
+        self::assertFileExists($psalmBinary, 'Psalm binary not found — run composer install.');
+
+        $process = new Process(
+            [\PHP_BINARY, $psalmBinary, '-c', 'psalm.xml', '--no-cache', '--threads=1', '--no-progress', '--output-format=json'],
+            $fixtureDir,
+        );
+        $process->setTimeout(300);
+        // Psalm exits non-zero when it reports issues; that is expected here, so do not mustRun().
+        $process->run();
+
+        $stdout = $process->getOutput();
+        $decoded = \json_decode($stdout, true);
+
+        self::assertIsArray(
+            $decoded,
+            "Psalm did not return a JSON array.\nstdout:\n{$stdout}\nstderr:\n{$process->getErrorOutput()}",
+        );
+
+        $unusedMethodFindings = [];
+        foreach ($decoded as $finding) {
+            if (!\is_array($finding) || !isset($finding['type'], $finding['message'])) {
+                continue;
+            }
+
+            if ($finding['type'] === 'PossiblyUnusedMethod' || $finding['type'] === 'UnusedMethod') {
+                $unusedMethodFindings[] = ['type' => (string) $finding['type'], 'message' => (string) $finding['message']];
+            }
+        }
+
+        return $unusedMethodFindings;
+    }
+}

--- a/tests/Unit/Handlers/SuppressScopeUnusedCodeTest.php
+++ b/tests/Unit/Handlers/SuppressScopeUnusedCodeTest.php
@@ -64,20 +64,12 @@ final class SuppressScopeUnusedCodeTest extends TestCase
         // reported, proving the suppressor narrows to real scopes rather than silencing every
         // unused method on the model. assertCount(1) also guarantees nothing else leaks — including
         // the private `secret` scope, which Psalm never emits for a __call class anyway.
-        self::assertCount(
-            1,
-            $unusedMethodFindings,
-            "Expected exactly one unused-method finding (the non-scope control), got:\n{$joined}",
-        );
-        self::assertStringContainsString('TraitScopeModel::helperNonScope', $messages[0]);
+        $this->assertCount(1, $unusedMethodFindings, "Expected exactly one unused-method finding (the non-scope control), got:\n{$joined}");
+        $this->assertStringContainsString('TraitScopeModel::helperNonScope', $messages[0]);
 
         // Every dispatched scope/accessor must be suppressed rather than reported as unused.
         foreach (self::SUPPRESSED_SCOPE_MARKERS as $marker) {
-            self::assertStringNotContainsString(
-                $marker,
-                $joined,
-                "Scope/accessor method {$marker} must be suppressed, not reported as unused.",
-            );
+            $this->assertStringNotContainsString($marker, $joined, "Scope/accessor method {$marker} must be suppressed, not reported as unused.");
         }
     }
 
@@ -90,7 +82,7 @@ final class SuppressScopeUnusedCodeTest extends TestCase
         $fixtureDir = __DIR__ . '/Fixtures/SuppressScopeUnusedCode';
         $psalmBinary = $projectRoot . '/vendor/bin/psalm';
 
-        self::assertFileExists($psalmBinary, 'Psalm binary not found — run composer install.');
+        $this->assertFileExists($psalmBinary, 'Psalm binary not found — run composer install.');
 
         $process = new Process(
             [\PHP_BINARY, $psalmBinary, '-c', 'psalm.xml', '--no-cache', '--threads=1', '--no-progress', '--output-format=json'],
@@ -103,10 +95,7 @@ final class SuppressScopeUnusedCodeTest extends TestCase
         $stdout = $process->getOutput();
         $decoded = \json_decode($stdout, true);
 
-        self::assertIsArray(
-            $decoded,
-            "Psalm did not return a JSON array.\nstdout:\n{$stdout}\nstderr:\n{$process->getErrorOutput()}",
-        );
+        $this->assertIsArray($decoded, "Psalm did not return a JSON array.\nstdout:\n{$stdout}\nstderr:\n{$process->getErrorOutput()}");
 
         $unusedMethodFindings = [];
         foreach ($decoded as $finding) {


### PR DESCRIPTION
## Issue to Solve

Under `findUnusedCode="true"` (the plugin's own `psalm.xml` uses it, as do many real apps), an Eloquent model that hosts its scopes or accessors in a **trait** got false `UnusedMethod` / `PossiblyUnusedMethod` on those methods. This covers modern `#[Scope]`-attributed scopes, legacy `scopeXxx()` scopes, and legacy `getXxxAttribute` / `setXxxAttribute` accessors. Scopes/accessors declared **directly** on the model were already suppressed (#874); only the trait case leaked.

Repro (before), against a model that composes a scope trait and never dispatches the scopes:

```
PossiblyUnusedMethod: Cannot find any calls to method App\Models\TraitScopeModel::active        (trait #[Scope])
PossiblyUnusedMethod: Cannot find any calls to method App\Models\TraitScopeModel::scopeFlagged   (trait legacy)
```

Direct-on-model scopes stayed clean; the two trait scopes leaked.

## Related

Follow-up to #1046, which fixed trait-hosted `#[Scope]` *detection* (`BuilderScopeHandler`) but not the *suppression* side (`SuppressHandler`).

## Solution Description

**Root cause (verified against Psalm source).** The three Eloquent suppressors iterated `$classStorage->methods` (the model's own method storages). For a method hosted in a trait, that array is empty of it: `Populator::inheritMethodsFromParent()` only wires up `appearing_method_ids` / `declaring_method_ids` for trait/inherited methods, never copying the `MethodStorage` into the using model's `methods`. Separately, `ClassLikes::checkMethodReferences()` reads a method's `suppressed_issues` off the **declaring** (trait) class's storage during the unused-method check. So the old loop both never saw trait scopes and, even if it had, would have mutated the wrong object.

**Fix.** A shared `appearingMethods()` generator resolves each method that *appears* on the model to its **declaring** `MethodStorage` — iterating `appearing_method_ids` filtered to the model itself (mirroring `checkMethodReferences`), then resolving via `declaring_method_ids` + `ClassLikeStorageProvider`. The three suppressors (accessor / `#[Scope]` / legacy `scopeXxx`) consume it; the provider is threaded through `suppressByParentClass`. This parallels the file's existing `markFrameworkInitializedProperties()` (which resolves `declaring_property_ids`) and #1046's `BuilderScopeHandler::hasScopeAttribute()` (`getDeclaringMethodId`). The direct-on-model path is unchanged: declaring class == model, so resolution is a no-op on the same object the old code mutated.

The **private-visibility carve-out is preserved**: a `private` scope is never suppressed (it would fatal at runtime if Eloquent tried to dispatch it, so leaving it reported surfaces the real bug). The visibility is now read from the declaring storage.

### Two findings worth flagging (the task spec asked me to verify its own assumptions)

1. **A private `#[Scope]` is structurally unflaggable on a Model**, so it cannot be asserted as "stays reported". `ClassLikes::checkMethodReferences()` only emits `UnusedMethod` for a private method when the class has **no** `__call` (`ClassLikes.php:1994`), and every `Eloquent\Model` declares `__call`; public/protected get `PossiblyUnusedMethod` with no such gate. The carve-out is therefore kept defensively (and for consistency with #1046), but Psalm never reports a private scope on a model regardless. This matches what the existing `ScopeAttributeUnusedMethodTest` / `LegacyScopeUnusedMethodTest` docblocks already note.

2. **A `psalm-tester` phpt cannot assert `findUnusedCode` findings.** psalm-tester always passes the snippet as an explicit **file argument**, and Psalm only runs whole-program dead-code detection over a config's `<projectFiles>`, never over file arguments (a file-arg run uses `checkPaths()`, which skips consolidation under `findUnusedCode="auto"`). An "assert empty" phpt would pass with or without the fix and guard nothing. (Side note: this means the two existing direct-scope smoke tests can't fail on regression either.)

**Verification.** Because of (2), the regression guard is a subprocess Psalm run over an isolated fixture project (`tests/Unit/Handlers/Fixtures/SuppressScopeUnusedCode/`, `findUnusedCode` on, plugin loaded). It hosts all four scope shapes (trait/direct × modern/legacy) + trait & direct accessors + one non-scope control. Confirmed to **fail before the fix** (trait scope + accessor leak → 4 findings) and **pass after** (only the non-scope control remains → 1 finding), proving the suppression is both effective and surgical.

Suites: `composer test:type` (449), `composer test:unit` (785, incl. the new test), `composer test:app` (fresh app, green), `composer psalm` self-analysis (clean, 100% type coverage), `composer cs` (clean). Self-analysis output is unchanged — only `src/` is scanned, so the `tests/` fixture isn't part of it.

## Checklist
- [x] Tests cover the change (subprocess integration test in `tests/Unit/Handlers/`, with an isolated fixture project; a phpt is structurally unable to assert `findUnusedCode` — see above)
