### PR TITLE
Add reproducer tests for `belongsTo()` chain collapse and abstract-model scope gaps

### DIFF
--- a/tests/Type/tests/Model/AbstractModelScopeUnresolvedTest.phpt
+++ b/tests/Type/tests/Model/AbstractModelScopeUnresolvedTest.phpt
@@ -1,0 +1,52 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\AbstractDocument;
+use App\Models\Contract;
+
+/**
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/901
+ * It documents the existing issue as is, ideally this test should have zero expected Psalm output.
+ *
+ * Pins the CURRENT (broken) behavior: a scope declared on an ABSTRACT base model is not
+ * resolved when the call-site receiver is typed as that abstract base — UndefinedMagicMethod.
+ *
+ * Root cause: src/Handlers/Eloquent/ModelRegistrationHandler::afterCodebasePopulated() skips
+ * every `$storage->abstract` class (the `if ($storage->abstract) { continue; }` guard) before it
+ * reaches registerHandlersForModel(), so the per-model instance __call forwarding providers
+ * (ModelMethodHandler) are never registered for the abstract base. An abstract base cannot be
+ * instantiated, but it CAN be a typed parameter / property, so the instance-forwarding path needs
+ * registering for abstract user models too.
+ *
+ * Autoloadable fixtures are required here: an inline (non-autoloadable) base would instead fail
+ * the `class_exists($storage->name, true)` gate further down the same loop and miss registration
+ * for an unrelated reason, masking the abstract guard. AbstractDocument is a real abstract fixture;
+ * Contract is a concrete child of it.
+ *
+ * Scope of the repro (narrower than the original filing): only the abstract-typed *instance*
+ * receiver regresses. A concrete-typed instance (`$contract->signedBetween(...)`) resolves today
+ * and stays green — included below as the contrast that flips together with the fix. The
+ * builder/static path (`Contract::query()->signedBetween(...)`) resolves via the global
+ * BuilderScopeHandler and is already covered by InstanceScopeCallTest.phpt.
+ */
+
+/**
+ * BROKEN: receiver typed as the abstract base. Pins UndefinedMagicMethod.
+ */
+function pin_901_abstract_typed_instance(AbstractDocument $document): void
+{
+    $document->signedBetween(now(), now());
+}
+
+/**
+ * Control: concrete child instance resolves today (concrete models register normally).
+ * Produces no output; must stay green and is the partner that flips when #901 is fixed.
+ */
+function pin_901_concrete_typed_instance(Contract $contract): void
+{
+    $contract->signedBetween(now(), now());
+}
+
+?>
+--EXPECTF--
+UndefinedMagicMethod on line %d: Magic method App\Models\AbstractDocument::signedbetween does not exist

--- a/tests/Type/tests/Relation/BelongsToChainSelfTemplateCollapseTest.phpt
+++ b/tests/Type/tests/Relation/BelongsToChainSelfTemplateCollapseTest.phpt
@@ -1,0 +1,64 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Sandbox;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/913
+ * It documents the existing issue as is, ideally this test should have zero expected Psalm output.
+ *
+ * Pins the CURRENT (broken) behavior: chaining a Builder/Relation method directly off
+ * $this->belongsTo(...) inside a relation method collapses the receiver to `mixed` and
+ * raises MixedMethodCall.
+ *
+ * Root cause: stubs/common/Database/Eloquent/Concerns/HasRelationships.phpstub declares
+ * belongsTo(): BelongsTo<TRelatedModel, $this>. Psalm 7 does not substitute the `$this`
+ * template argument when the returned relation is chained, so the intermediate type
+ * degrades to mixed (see the `$this`-vs-`static` note in CLAUDE.md / stub-authoring rules).
+ *
+ * The fix is NOT a one-liner: switching `$this` to `static` removes the collapse but then
+ * BelongsTo<Customer, Order&static> no longer matches a declared `@return BelongsTo<Customer, self>`
+ * (InvalidReturnStatement). A clean fix also needs TDeclaringModel to be covariant across the
+ * relation stubs. Both halves were verified against this exact shape.
+ *
+ * Contrast: tests/Type/tests/Relation/ForwardingHandlerTest.phpt::test_mixin_only_preserves_relation_type
+ * shows withoutGlobalScopes() works when the relation is first bound to a concrete local — the
+ * App model's own @return annotation applies there; the collapse only happens off the raw stub call.
+ */
+class Customer extends Model
+{
+}
+
+class Order extends Model
+{
+    /**
+     * The exact shape reported in #913.
+     *
+     * @return BelongsTo<Customer, self>
+     */
+    public function customer(): BelongsTo
+    {
+        return $this->belongsTo(Customer::class)->withoutGlobalScopes();
+    }
+}
+
+/**
+ * The same collapse observed at a call site: the relation method above merely wraps this
+ * expression. Asserts the type that SHOULD be inferred; the EXPECTF mismatch below records
+ * that the plugin produces `mixed` today.
+ */
+function pin_913_call_site(Order $order): void
+{
+    $_relation = $order->belongsTo(Customer::class)->withoutGlobalScopes();
+    /** @psalm-check-type-exact $_relation = BelongsTo<Customer, Order> */
+}
+
+?>
+--EXPECTF--
+MixedReturnStatement on line %d: Could not infer a return type
+MixedMethodCall on line %d: Cannot determine the type of the object on the left hand side of this expression
+MixedMethodCall on line %d: Cannot determine the type of the object on the left hand side of this expression
+CheckType on line %d: Checked variable $_relation = Illuminate\Database\Eloquent\Relations\BelongsTo<Tests\Psalm\LaravelPlugin\Sandbox\Customer, Tests\Psalm\LaravelPlugin\Sandbox\Order> does not match $_relation = mixed


### PR DESCRIPTION
## Issue to Solve

Two open issues still reproduce on current `master` (re-verified after rebasing onto `63a8d90e`; the relevant fixes through #1046 are present) but had no regression coverage. This PR adds reproducer type tests that document the current (broken) behavior as-is. It does NOT fix the underlying bugs.

## Related

Refs #913
Refs #901

Part of a retest batch of #929 / #913 / #901. #929's originally filed `UndefinedMagicMethod` is already resolved on `master`; its residual imprecise return type is pinned by the existing `tests/Type/tests/Builder/SoftDeletesRestoreTest.phpt`, so nothing is added here for it.

## Solution Description

Adds two PHPT type tests following the documented-as-is pattern of `SoftDeletesRestoreTest` (the EXPECTF block captures the current buggy output, with a "ideally this test should have zero expected Psalm output" note).

- `tests/Type/tests/Relation/BelongsToChainSelfTemplateCollapseTest.phpt` (#913): chaining `withoutGlobalScopes()` directly off `$this->belongsTo(...)` collapses the receiver to `mixed` (`MixedMethodCall`). Root cause: the `HasRelationships` stub returns `BelongsTo<TRelatedModel, $this>` and Psalm 7 does not substitute the `$this` template argument when the relation is chained. The fixture is intentionally non-final, so a partial `$this`-to-`static` fix surfaces `InvalidReturnStatement` (a clean fix also needs covariant `TDeclaringModel` across the relation stubs), keeping the pin honest.
- `tests/Type/tests/Model/AbstractModelScopeUnresolvedTest.phpt` (#901): a scope declared on an abstract base model is unresolved when the call-site receiver is typed as that abstract base (`UndefinedMagicMethod`), because `ModelRegistrationHandler` skips abstract classes before registering the per-model instance-forwarding providers. Uses the autoloadable `AbstractDocument` / `Contract` fixtures; a concrete-child instance stays green, and disabling the abstract guard flips the pin (verified).

Both tests pass on `master` (full type suite: 451 tests). When either bug is fixed, the corresponding test fails and must be converted to assert the correct output.

## Checklist
- [x] Tests cover the change (type tests in `tests/Type/`)
