### PR TITLE
Reference vimeo/psalm#11880 in the instance scope-vs-QueryBuilder limitation docblocks

### DIFF
--- a/tests/Application/app/Models/CollidingScopeModel.php
+++ b/tests/Application/app/Models/CollidingScopeModel.php
@@ -84,7 +84,8 @@ final class CollidingScopeModel extends Model
      * calls (Model::query()->orderBy()) resolve through the Query\Builder mixin on Eloquent\Builder,
      * which rewrites the call to Query\Builder::orderBy before BuilderScopeHandler can be consulted,
      * so Query\Builder params win there. That is an upstream Psalm limitation, not fixable at the
-     * plugin level (see test_instance_call_limitation in ScopeVsQueryBuilderParamsTest).
+     * plugin level (see test_instance_call_limitation in ScopeVsQueryBuilderParamsTest, and
+     * https://github.com/vimeo/psalm/issues/11880).
      *
      * @param  Builder<self>  $query
      * @return Builder<self>

--- a/tests/Type/tests/Model/ScopeVsQueryBuilderParamsTest.phpt
+++ b/tests/Type/tests/Model/ScopeVsQueryBuilderParamsTest.phpt
@@ -63,6 +63,10 @@ function test_aggregate_scope_unaffected(): void
  * expose no receiver to distinguish a colliding-scope model from a plain Builder. (Forcing
  * interception via an existence provider only reverses the return-type/params hook order and makes
  * Psalm throw on the absent Builder::orderBy storage.) Keep this test until upstream changes.
+ *
+ * Tracked upstream: https://github.com/vimeo/psalm/issues/11880 (@mixin-host method providers not
+ * consulted for mixin-forwarded methods, a beta19 regression). When it is fixed this test starts
+ * failing and must be converted to assert the correct output.
  */
 function test_instance_call_limitation(): void
 {


### PR DESCRIPTION
## Issue to Solve

The instance-call scope-vs-`Query\Builder` limitation documented in #1047 referred to it generically as an "upstream Psalm limitation". It now has a concrete tracking issue: **vimeo/psalm#11880** (`@mixin`-host method providers not consulted for mixin-forwarded methods, a 7.0.0-beta19 regression of the 2020 #3536 `$premixin_method_id` fix).

## Solution Description

Doc-only. Adds the #11880 URL to the two docblocks that describe the limitation:

- `tests/Type/tests/Model/ScopeVsQueryBuilderParamsTest.phpt` — the `test_instance_call_limitation` tripwire (now names the upstream issue that will flip it).
- `tests/Application/app/Models/CollidingScopeModel.php` — the `scopeOrderBy` fixture comment.

No behavior change; `test_instance_call_limitation` and its `--EXPECTF--` are unchanged. Makes the existing tripwire self-documenting.

## Checklist
- [x] Documentation is updated