### PR TITLE
Add `PublicModelScope` and `PublicModelAccessor` rules for public model scopes and accessors

### DIFF
--- a/docs/issues/PublicModelAccessor.md
+++ b/docs/issues/PublicModelAccessor.md
@@ -1,0 +1,57 @@
+---
+title: PublicModelAccessor
+parent: Custom Issues
+nav_order: 9
+---
+
+# PublicModelAccessor
+
+A `public` legacy Eloquent convention method: a legacy `scopeXxx()` query scope, or a legacy `getXxxAttribute()` / `setXxxAttribute()` accessor or mutator. Laravel's convention is `protected`. Enabled by default; see [How to disable](#how-to-disable).
+
+## Why it matters
+
+These are dispatched indirectly (scopes through the query builder, accessors through `__get()` / `__set()` magic) and never called by their declared name, so `public` only widens the model's API surface. Unlike a public `#[Scope]`, whose idiomatic static call fatals ([PublicModelScope](PublicModelScope.md)), these break nothing on the path anyone writes, so each is a pure convention nit on otherwise-correct code.
+
+Reported as an error only at Psalm's strictest level (1) and downgraded for everyone else, so a hard failure is effectively opt-in through maximum strictness. A method whose visibility is forced by a contract (an interface method, a parent override, or an abstract trait method) is not reported, since it cannot be narrowed.
+
+## Example
+
+```php
+class Post extends Model
+{
+    protected function scopePublished(Builder $query): Builder // public here would be reported
+    {
+        return $query->whereNotNull('published_at');
+    }
+
+    protected function getTitleAttribute(): string // and so would a public accessor
+    {
+        return ucfirst($this->attributes['title']);
+    }
+}
+```
+
+New code should prefer the modern accessor form, which is out of scope for this check:
+
+```php
+protected function title(): Attribute
+{
+    return Attribute::get(fn (mixed $value, array $attributes): string => ucfirst($attributes['title']));
+}
+```
+
+## How to fix
+
+Change `public` to `protected`, or migrate an accessor to the modern `Attribute` form above. Call sites are unaffected.
+
+## How to disable
+
+```xml
+<issueHandlers>
+    <PluginIssue name="PublicModelAccessor" errorLevel="suppress" />
+</issueHandlers>
+```
+
+## Scope
+
+Only the legacy forms are detected: `scopeXxx()`, `getXxxAttribute()`, `setXxxAttribute()`. The modern `Attribute`-returning accessor form is out of scope, the framework's own `getAttribute()` / `setAttribute()` are never matched, and `private` is left alone. The sibling check for `public` `#[Scope]` scopes is [PublicModelScope](PublicModelScope.md).

--- a/docs/issues/PublicModelScope.md
+++ b/docs/issues/PublicModelScope.md
@@ -1,0 +1,44 @@
+---
+title: PublicModelScope
+parent: Custom Issues
+nav_order: 8
+---
+
+# PublicModelScope
+
+A `public` `#[Scope]`-attributed Eloquent query scope. Laravel's convention is `protected`. Enabled by default; see [How to disable](#how-to-disable).
+
+## Why it matters
+
+A `public` `#[Scope]` is a runtime hazard, not just a convention slip. A static call such as `Post::published()` fatals, because PHP resolves the accessible non-static method before `__callStatic` can forward it to the query builder (see #634 and vimeo/psalm#11876). Keeping it `protected` leaves the static call routed to the builder.
+
+Reported as an error at project error levels 1 to 4, the range most analysis-serious codebases use; downgraded at looser levels (5 to 8). A scope whose visibility is forced by a contract (an interface method, a parent override, or an abstract trait method) is not reported, since it cannot be narrowed.
+
+Legacy `scopeXxx()` scopes go to [PublicModelAccessor](PublicModelAccessor.md) instead: their idiomatic call (`Post::active()`) is unaffected by visibility, so they are treated as a pure convention nit.
+
+## Example
+
+```php
+class Post extends Model
+{
+    #[Scope]
+    protected function published(Builder $query): Builder // public here would be reported
+    {
+        return $query->whereNotNull('published_at');
+    }
+}
+```
+
+## How to fix
+
+Change `public` to `protected`. Call sites are unaffected.
+
+## How to disable
+
+```xml
+<issueHandlers>
+    <PluginIssue name="PublicModelScope" errorLevel="suppress" />
+</issueHandlers>
+```
+
+`private` is intentionally not flagged; a private `#[Scope]` is rejected by Laravel and surfaces elsewhere. The sibling check for legacy scopes and accessors is [PublicModelAccessor](PublicModelAccessor.md).

--- a/docs/issues/index.md
+++ b/docs/issues/index.md
@@ -15,5 +15,7 @@ The plugin ships advanced Laravel-aware static analysis checks that extend Psalm
 - [MissingTranslation](MissingTranslation.md) — `__()` or `trans()` references an undefined translation key (opt-in)
 - [ModelMakeDiscouraged](ModelMakeDiscouraged.md) — `Model::make()` used instead of `new Model()`
 - [OctaneIncompatibleBinding](OctaneIncompatibleBinding.md) — `singleton()` closure resolves a request-scoped service such as Request, Session, or Auth (auto-enabled when `laravel/octane` is installed)
+- [PublicModelScope](PublicModelScope.md) — `public` `#[Scope]` Eloquent query scope, whose static call is a runtime fatal (reported at error levels 1 to 4)
+- [PublicModelAccessor](PublicModelAccessor.md) — `public` legacy `scopeXxx()` scope or legacy `getXxxAttribute()` / `setXxxAttribute()` accessor, a pure convention nit (reported at error level 1)
 
 Each issue page explains what it detects, why it matters, and how to fix it.

--- a/src/Handlers/Eloquent/BuilderScopeHandler.php
+++ b/src/Handlers/Eloquent/BuilderScopeHandler.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Handlers\Eloquent;
 
-use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use PhpParser\Node\Expr\MethodCall;
@@ -15,6 +14,7 @@ use Psalm\Exception\UnpopulatedClasslikeException;
 use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
 use Psalm\Internal\MethodIdentifier;
 use Psalm\Internal\Type\TypeExpander;
+use Psalm\LaravelPlugin\Util\EloquentModelMethods;
 use Psalm\LaravelPlugin\Util\ModelPropertyResolver;
 use Psalm\Plugin\EventHandler\Event\MethodParamsProviderEvent;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
@@ -690,22 +690,8 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
             return false;
         }
 
-        // A private #[Scope] is never a usable scope on any supported Laravel (12-13). Laravel
-        // 13.8+ rejects it outright in Model::isScopeMethodWithAttribute (`! isPrivate() && ...`);
-        // on 12.4–13.7 it is broken anyway — callNamedScope dispatches the scope from the base
-        // Model's $this, where the subclass's private method is unreachable, so it routes back
-        // through __call and recurses. Either way it can't dispatch, so a legacy scopeXxx twin
-        // (resolved separately) wins, or it is nothing.
-        if ($methodStorage->visibility === ClassLikeAnalyzer::VISIBILITY_PRIVATE) {
-            return false;
-        }
-
-        foreach ($methodStorage->attributes as $attribute) {
-            if ($attribute->fq_class_name === Scope::class) {
-                return true;
-            }
-        }
-
-        return false;
+        // Shared with SuppressHandler (#874) and PublicScopeAccessorVisibilityHandler (#695): the
+        // attribute check plus the private-#[Scope] gate live in EloquentModelMethods::hasScopeAttribute.
+        return EloquentModelMethods::hasScopeAttribute($methodStorage);
     }
 }

--- a/src/Handlers/Rules/PublicScopeAccessorVisibilityHandler.php
+++ b/src/Handlers/Rules/PublicScopeAccessorVisibilityHandler.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Rules;
+
+use Illuminate\Database\Eloquent\Model;
+use Psalm\CodeLocation;
+use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
+use Psalm\IssueBuffer;
+use Psalm\LaravelPlugin\Issues\PublicModelAccessor;
+use Psalm\LaravelPlugin\Issues\PublicModelScope;
+use Psalm\LaravelPlugin\Util\EloquentModelMethods;
+use Psalm\Plugin\EventHandler\AfterCodebasePopulatedInterface;
+use Psalm\Plugin\EventHandler\Event\AfterCodebasePopulatedEvent;
+use Psalm\Storage\MethodStorage;
+
+/**
+ * Flags `public` Eloquent scopes and legacy attribute accessors/mutators, which Laravel's convention wants
+ * `protected` (they are dispatched indirectly and never called by name). Routes by the method's danger:
+ * a `public` `#[Scope]` (the only one with a static-call runtime footgun) emits {@see PublicModelScope};
+ * a legacy `scopeXxx()` scope or a legacy `getXxxAttribute()` / `setXxxAttribute()` accessor (pure
+ * convention) emits {@see PublicModelAccessor}. Those issue classes carry the full rationale, their error
+ * levels, and the public-only decision.
+ *
+ * Enabled by default: registered unconditionally (see Plugin::registerHandlers()), like ModelMakeHandler.
+ * Silence per project through the issueHandlers config.
+ *
+ * Hook choice — AfterCodebasePopulated:
+ *  - Inheritance is fully resolved, so a scope/accessor hosted on a trait resolves to its declaring
+ *    storage via {@see EloquentModelMethods::appearingMethods()} (the declaring-storage path #1048
+ *    introduced for the suppressors), and is reported at the trait's own declaration.
+ *  - A single pass over the codebase lets us dedupe a trait scope shared by several models to one
+ *    report (a trait method yields the same MethodStorage instance once per composing model).
+ *  - The hook fires on every full-scan run, which is the only mode in the pinned Psalm 7 beta (it
+ *    hardcodes `is_diff = false`). Emissions survive worker forking: the parent emits before
+ *    `analyzeFiles()` forks, and `IssueBuffer::addIssues()` merges worker issues on top without
+ *    resetting the parent buffer (verified under `--threads`). The trade-off versus an analysis-time
+ *    hook: were Psalm to re-enable `--diff`, a warm run that skips the declaring file would not re-emit,
+ *    because populate-time emissions are not replayed from the per-file issue cache.
+ */
+final class PublicScopeAccessorVisibilityHandler implements AfterCodebasePopulatedInterface
+{
+    /** @inheritDoc */
+    #[\Override]
+    public static function afterCodebasePopulated(AfterCodebasePopulatedEvent $event): void
+    {
+        $provider = $event->getCodebase()->classlike_storage_provider;
+
+        // A trait scope/accessor is yielded once per composing model (the same shared MethodStorage),
+        // so dedupe on storage identity to emit one report at the trait declaration. `add()` would also
+        // dedupe by location+message, but skipping here avoids the redundant accepts() calls.
+        $reported = [];
+
+        foreach ($provider::getAll() as $classStorage) {
+            if (!$classStorage->user_defined || $classStorage->is_interface) {
+                continue;
+            }
+
+            // Mirror SuppressHandler: parent_classes stores FQCNs in original case, so Model::class
+            // (no leading backslash) matches. Traits never extend Model, so a scope-hosting trait is
+            // reached only through a composing model below, never iterated as a top-level target.
+            if (!\in_array(Model::class, $classStorage->parent_classes, true)) {
+                continue;
+            }
+
+            foreach (EloquentModelMethods::appearingMethods($classStorage, $provider) as $methodName => $methodStorage) {
+                // The convention violation is the PUBLIC case only: protected is correct, and private is
+                // a separate dead-code concern (see the issue classes). Filter before classifying.
+                if ($methodStorage->visibility !== ClassLikeAnalyzer::VISIBILITY_PUBLIC) {
+                    continue;
+                }
+
+                // Skip a method whose `public` visibility is dictated by a contract it satisfies: an
+                // interface method, an abstract parent/trait method it implements, or a parent method it
+                // overrides cannot be narrowed to `protected` (PHP forbids reducing visibility below the
+                // inherited or required declaration), so the report would be unactionable. Psalm's
+                // Populator fills overridden_method_ids from implemented interfaces, parent classes, and
+                // abstract trait requirements. Test for a NON-EMPTY list: the key is also present with an
+                // empty array for a root declaration that overrides nothing, so isset() would over-skip.
+                if (($classStorage->overridden_method_ids[$methodName] ?? []) !== []) {
+                    continue;
+                }
+
+                $kind = self::classify($methodName, $methodStorage);
+                if ($kind === null) {
+                    continue;
+                }
+
+                $location = $methodStorage->location;
+                if (!$location instanceof CodeLocation) {
+                    continue;
+                }
+
+                $storageId = \spl_object_id($methodStorage);
+                if (isset($reported[$storageId])) {
+                    continue;
+                }
+
+                $reported[$storageId] = true;
+
+                $casedName = $methodStorage->cased_name ?? $methodName;
+
+                // Route to the issue whose ERROR_LEVEL matches the method's danger. Messages are anchored on
+                // the method (not the model), so a trait method shared by several models dedupes to one
+                // diagnostic at the trait declaration: same type, location, message.
+                //  - #[Scope] is the only static-call footgun -> PublicModelScope (error at levels 1-4).
+                //  - legacy scopeXxx() and legacy accessors are pure convention -> PublicModelAccessor (level 1).
+                $issue = match ($kind) {
+                    'scope-attribute' => new PublicModelScope(self::scopeAttributeMessage($casedName), $location),
+                    'scope-legacy' => new PublicModelAccessor(self::legacyScopeMessage($casedName), $location),
+                    'accessor' => new PublicModelAccessor(self::accessorMessage($casedName), $location),
+                };
+
+                IssueBuffer::accepts($issue, $methodStorage->suppressed_issues);
+            }
+        }
+    }
+
+    /**
+     * Classify a public model method by the convention it breaks, or null if it is neither a scope nor a
+     * legacy accessor. `#[Scope]` is checked first so an attributed method routes to the danger issue even
+     * when its name also matches the legacy `scopeXxx` convention.
+     *
+     * @return 'scope-attribute'|'scope-legacy'|'accessor'|null
+     *
+     * @psalm-mutation-free
+     */
+    private static function classify(string $methodName, MethodStorage $methodStorage): ?string
+    {
+        if (EloquentModelMethods::hasScopeAttribute($methodStorage)) {
+            return 'scope-attribute';
+        }
+
+        if (EloquentModelMethods::isLegacyScopeMethodName($methodName, $methodStorage->cased_name)) {
+            return 'scope-legacy';
+        }
+
+        if (EloquentModelMethods::isLegacyAccessorMethodName($methodName)) {
+            return 'accessor';
+        }
+
+        return null;
+    }
+
+    /** @psalm-pure */
+    private static function scopeAttributeMessage(string $methodName): string
+    {
+        return "Eloquent #[Scope] method {$methodName}() should be protected, not public: called statically "
+            . "(Model::{$methodName}()) it is a runtime fatal.";
+    }
+
+    /** @psalm-pure */
+    private static function legacyScopeMessage(string $methodName): string
+    {
+        return "Eloquent query scope {$methodName}() should be protected, not public; it is dispatched "
+            . 'through the query builder, never by name.';
+    }
+
+    /** @psalm-pure */
+    private static function accessorMessage(string $methodName): string
+    {
+        return "Eloquent accessor/mutator {$methodName}() should be protected, not public; it is dispatched "
+            . 'via __get()/__set(), never by name.';
+    }
+}

--- a/src/Handlers/SuppressHandler.php
+++ b/src/Handlers/SuppressHandler.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Handlers;
 
-use Illuminate\Database\Eloquent\Attributes\Scope;
 use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
 use Psalm\Internal\Provider\ClassLikeStorageProvider;
+use Psalm\LaravelPlugin\Util\EloquentModelMethods;
 use Psalm\Plugin\EventHandler\AfterClassLikeVisitInterface;
 use Psalm\Plugin\EventHandler\AfterCodebasePopulatedInterface;
 use Psalm\Plugin\EventHandler\Event\AfterClassLikeVisitEvent;
@@ -448,68 +448,6 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
     }
 
     /**
-     * Yield, for every method that *appears* on $classStorage, the MethodStorage of the class that
-     * actually declares it — the model itself, a trait it composes, or a parent model.
-     *
-     * Eloquent hosts scopes and accessors on traits at least as often as on the model body, and
-     * Psalm never copies a trait method's MethodStorage into the using class's `$storage->methods`
-     * (Populator::inheritMethodsFromParent only wires up appearing_method_ids / declaring_method_ids,
-     * never `methods`). It also reads a method's `suppressed_issues` — during the unused-method check
-     * in ClassLikes::checkMethodReferences() — off the DECLARING class's storage, not the using
-     * model's. So iterating `$classStorage->methods` both misses trait-hosted scopes entirely and,
-     * even where a model-local override existed, would mutate the wrong object. Resolving to the
-     * declaring storage mirrors markFrameworkInitializedProperties() (declaring_property_ids) and
-     * BuilderScopeHandler::hasScopeAttribute() (#1046).
-     *
-     * Only methods whose appearing class is $classStorage itself are visited, matching
-     * checkMethodReferences() which flags an unused method on the class where it appears. A scope
-     * inherited from a parent model appears — and is checked, and gets suppressed — when that parent
-     * is iterated separately in afterCodebasePopulated(), so the parent path is covered there rather
-     * than double-handled here.
-     *
-     * Caveat: the resolved MethodStorage is shared with every other class composing the same trait,
-     * so suppressing here also silences the scope on a non-Model class that happens to use the trait.
-     * That is harmless — a genuine Eloquent scope trait is only ever composed by models, and Psalm
-     * reads the same shared storage for all composers.
-     *
-     * Mutation-free: this only reads the storage graph and yields existing MethodStorage instances.
-     * The suppression mutation happens in the callers (suppress*Methods), on the yielded objects.
-     *
-     * Scope: only the three Eloquent suppressors (accessor / #[Scope] / legacy scopeXxx) route
-     * through here, because trait-hosted scopes and accessors are idiomatic. The notification /
-     * mailable hook suppressors below intentionally keep their direct `$classStorage->methods`
-     * lookup — trait-hosted toMail()/envelope()/viaQueues() are rare enough not to warrant the
-     * declaring-storage resolution. Use this helper for any future trait-hostable suppressor.
-     *
-     * @return \Generator<lowercase-string, MethodStorage>
-     *
-     * @psalm-mutation-free
-     */
-    private static function appearingMethods(
-        ClassLikeStorage $classStorage,
-        ClassLikeStorageProvider $provider,
-    ): \Generator {
-        foreach ($classStorage->appearing_method_ids as $methodName => $appearingMethodId) {
-            if ($appearingMethodId->fq_class_name !== $classStorage->name) {
-                continue;
-            }
-
-            $declaringMethodId = $classStorage->declaring_method_ids[$methodName] ?? $appearingMethodId;
-
-            if (!$provider->has($declaringMethodId->fq_class_name)) {
-                continue;
-            }
-
-            $declaringMethodStorage
-                = $provider->get($declaringMethodId->fq_class_name)->methods[$declaringMethodId->method_name] ?? null;
-
-            if ($declaringMethodStorage instanceof MethodStorage) {
-                yield $methodName => $declaringMethodStorage;
-            }
-        }
-    }
-
-    /**
      * Suppress PossiblyUnusedMethod for legacy Eloquent accessor/mutator methods.
      *
      * Methods matching getXxxAttribute() and setXxxAttribute() are invoked via
@@ -534,8 +472,8 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
         ClassLikeStorage $classStorage,
         ClassLikeStorageProvider $provider,
     ): void {
-        foreach (self::appearingMethods($classStorage, $provider) as $methodName => $methodStorage) {
-            if (\preg_match('/^get.+attribute$/', $methodName) || \preg_match('/^set.+attribute$/', $methodName)) {
+        foreach (EloquentModelMethods::appearingMethods($classStorage, $provider) as $methodName => $methodStorage) {
+            if (EloquentModelMethods::isLegacyAccessorMethodName($methodName)) {
                 self::suppressInternalDispatchMethod('PossiblyUnusedMethod', $methodStorage);
             }
         }
@@ -560,34 +498,14 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
         ClassLikeStorage $classStorage,
         ClassLikeStorageProvider $provider,
     ): void {
-        foreach (self::appearingMethods($classStorage, $provider) as $methodStorage) {
-            if (!self::hasScopeAttribute($methodStorage)) {
+        foreach (EloquentModelMethods::appearingMethods($classStorage, $provider) as $methodStorage) {
+            if (!EloquentModelMethods::hasScopeAttribute($methodStorage)) {
                 continue;
             }
 
             self::suppressInternalDispatchMethod('PossiblyUnusedMethod', $methodStorage);
             self::suppressInternalDispatchMethod('UnusedMethod', $methodStorage);
         }
-    }
-
-    /** @psalm-mutation-free */
-    private static function hasScopeAttribute(MethodStorage $methodStorage): bool
-    {
-        // A private #[Scope] is not a usable scope on any supported Laravel — see the rationale
-        // on BuilderScopeHandler::hasScopeAttribute. Leave it reported as genuinely unused rather
-        // than silencing dead code. (suppressInternalDispatchMethod also gates private downstream;
-        // this keeps the helper itself honest.)
-        if ($methodStorage->visibility === ClassLikeAnalyzer::VISIBILITY_PRIVATE) {
-            return false;
-        }
-
-        foreach ($methodStorage->attributes as $attribute) {
-            if ($attribute->fq_class_name === Scope::class) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /**
@@ -616,33 +534,14 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
         ClassLikeStorage $classStorage,
         ClassLikeStorageProvider $provider,
     ): void {
-        foreach (self::appearingMethods($classStorage, $provider) as $methodName => $methodStorage) {
-            if (!self::isLegacyScopeMethodName($methodName, $methodStorage->cased_name)) {
+        foreach (EloquentModelMethods::appearingMethods($classStorage, $provider) as $methodName => $methodStorage) {
+            if (!EloquentModelMethods::isLegacyScopeMethodName($methodName, $methodStorage->cased_name)) {
                 continue;
             }
 
             self::suppressInternalDispatchMethod('PossiblyUnusedMethod', $methodStorage);
             self::suppressInternalDispatchMethod('UnusedMethod', $methodStorage);
         }
-    }
-
-    /** @psalm-pure */
-    private static function isLegacyScopeMethodName(string $lowercaseName, ?string $casedName): bool
-    {
-        if ($casedName === null || \strlen($casedName) < 6) {
-            return false;
-        }
-
-        if (!\str_starts_with($lowercaseName, 'scope')) {
-            return false;
-        }
-
-        // Laravel resolves $builder->active() via `scope` . ucfirst('active') => `scopeActive`.
-        // PHP dispatch is case-insensitive so a `scopeactive()` would technically work, but we gate
-        // on the `scope` + StudlyCase convention to avoid over-suppressing methods like `scoped()`.
-        $firstNameChar = $casedName[5];
-
-        return $firstNameChar >= 'A' && $firstNameChar <= 'Z';
     }
 
     /**

--- a/src/Issues/PublicModelAccessor.php
+++ b/src/Issues/PublicModelAccessor.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Issues;
+
+use Psalm\Issue\PluginIssue;
+
+/**
+ * Reported when an Eloquent model exposes a `public` legacy convention method that Laravel dispatches
+ * indirectly and the convention wants `protected`:
+ *
+ *  - a legacy `scopeXxx()` query scope (dispatched through the query builder), or
+ *  - a legacy attribute accessor / mutator `getXxxAttribute()` / `setXxxAttribute()` (dispatched through
+ *    `__get()` / `__set()` magic).
+ *
+ * These are never called by their declared name, so `public` only widens the model's API surface. Unlike a
+ * `public` `#[Scope]`, whose idiomatic static call fatals (see {@see PublicModelScope}), these break nothing
+ * on the path anyone writes, so each is a pure convention nit on otherwise-correct code. Only `public` is
+ * reported; `private` is a separate dead-code question. The modern `firstName(): Attribute` accessor form is
+ * out of scope.
+ *
+ * Enabled by default. Silence per project via
+ * `<PluginIssue name="PublicModelAccessor" errorLevel="suppress" />` in psalm.xml's issueHandlers.
+ */
+final class PublicModelAccessor extends PluginIssue
+{
+    public const DOCUMENTATION_URL = 'https://psalm.github.io/psalm-plugin-laravel/issues/PublicModelAccessor/';
+
+    // A public legacy scope/accessor works fine at runtime; it is purely a visibility convention. Report it
+    // as an error only at Psalm's strictest level (1) and downgrade for everyone else, i.e. you opt into a
+    // hard failure only by having already chosen maximum strictness.
+    public const ERROR_LEVEL = 1;
+}

--- a/src/Issues/PublicModelScope.php
+++ b/src/Issues/PublicModelScope.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Issues;
+
+use Psalm\Issue\PluginIssue;
+
+/**
+ * Reported when an Eloquent model exposes a `public` `#[Scope]`-attributed query scope.
+ *
+ * A `public` `#[Scope]` is more than a convention slip: calling it statically (`Post::published()`) is a
+ * runtime fatal, because PHP resolves the accessible non-static method and throws before `__callStatic`
+ * can route it through the query builder (see #634 / vimeo/psalm#11876). Laravel's convention is
+ * `protected`, which keeps the static call routed to the builder.
+ *
+ * Legacy `scopeXxx()` scopes are NOT reported here. Their idiomatic call (`Post::active()`) is unaffected
+ * by visibility, so the plugin treats them as a pure convention nit under {@see PublicModelAccessor}. Only
+ * `public` is reported; `private` is a separate dead-code question (a private `#[Scope]` is also rejected
+ * by Laravel).
+ *
+ * Enabled by default. Silence per project via
+ * `<PluginIssue name="PublicModelScope" errorLevel="suppress" />` in psalm.xml's issueHandlers.
+ */
+final class PublicModelScope extends PluginIssue
+{
+    public const DOCUMENTATION_URL = 'https://psalm.github.io/psalm-plugin-laravel/issues/PublicModelScope/';
+
+    // A public #[Scope] enables a real runtime fatal (static dispatch), so report it as an error for
+    // strict-to-moderate projects (levels 1-4) and downgrade only for loose projects (5-8). Not -1: the
+    // declaration itself dispatches fine as a scope; it only becomes a fault if someone calls it
+    // statically. Mirrors NoEnvOutsideConfig's level for "real-consequence but contextual".
+    public const ERROR_LEVEL = 4;
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -290,6 +290,12 @@ final class Plugin implements PluginEntryPointInterface
             require_once __DIR__ . '/Handlers/Views/MissingViewHandler.php';
             $registration->registerHooksFromClass(Handlers\Views\MissingViewHandler::class);
         }
+
+        // Flag `public` Eloquent scopes / legacy accessors (Laravel's convention is `protected` — they
+        // are dispatched indirectly, never called by name). Enabled by default; silence per project via
+        // the issueHandlers config (PublicModelScope / PublicModelAccessor).
+        require_once __DIR__ . '/Handlers/Rules/PublicScopeAccessorVisibilityHandler.php';
+        $registration->registerHooksFromClass(Handlers\Rules\PublicScopeAccessorVisibilityHandler::class);
     }
 
     /**

--- a/src/Util/EloquentModelMethods.php
+++ b/src/Util/EloquentModelMethods.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Util;
+
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
+use Psalm\Internal\Provider\ClassLikeStorageProvider;
+use Psalm\Storage\ClassLikeStorage;
+use Psalm\Storage\MethodStorage;
+
+/**
+ * Classification and traversal helpers for the methods Eloquent dispatches indirectly: query scopes
+ * (legacy `scopeXxx()` and `#[Scope]`-attributed) and legacy attribute accessors/mutators
+ * (`getXxxAttribute()` / `setXxxAttribute()`).
+ *
+ * These four primitives were originally private to {@see \Psalm\LaravelPlugin\Handlers\SuppressHandler}
+ * (#874, #1048). They live here because three independent handlers now need the same classification:
+ *  - SuppressHandler silences PossiblyUnusedMethod/UnusedMethod on them (they have no visible caller);
+ *  - {@see \Psalm\LaravelPlugin\Handlers\Eloquent\BuilderScopeHandler} resolves #[Scope] call types;
+ *  - {@see \Psalm\LaravelPlugin\Handlers\Rules\PublicScopeAccessorVisibilityHandler} enforces the
+ *    protected-visibility convention (#695).
+ *
+ * Keeping a single copy stops the StudlyCase / declaring-storage subtleties from drifting apart.
+ *
+ * @internal
+ * @psalm-immutable
+ */
+final class EloquentModelMethods
+{
+    /**
+     * Yield, for every method that *appears* on $classStorage, the MethodStorage of the class that
+     * actually declares it — the class itself, a trait it composes, or a parent.
+     *
+     * Eloquent hosts scopes and accessors on traits at least as often as on the class body, and Psalm
+     * never copies a trait method's MethodStorage into the using class's `$storage->methods`
+     * (Populator::inheritMethodsFromParent only wires up appearing_method_ids / declaring_method_ids,
+     * never `methods`). So iterating `$classStorage->methods` misses trait-hosted scopes entirely.
+     * Resolving to the declaring storage mirrors SuppressHandler::markFrameworkInitializedProperties()
+     * (declaring_property_ids) and BuilderScopeHandler::hasScopeAttribute() (#1046).
+     *
+     * Only methods whose appearing class is $classStorage itself are visited: a method inherited from
+     * a parent appears on (and is yielded for) the parent when that parent is iterated separately, so a
+     * caller looping the whole codebase sees each declaration once per declaring storage. A trait method
+     * shared by N composing classes yields the SAME MethodStorage instance N times (once per composer);
+     * a caller that emits must dedupe on the storage identity (the suppressors here mutate idempotently
+     * so they do not).
+     *
+     * Mutation-free: only reads the storage graph and yields existing MethodStorage instances.
+     *
+     * @return \Generator<lowercase-string, MethodStorage>
+     *
+     * @psalm-mutation-free
+     */
+    public static function appearingMethods(
+        ClassLikeStorage $classStorage,
+        ClassLikeStorageProvider $provider,
+    ): \Generator {
+        foreach ($classStorage->appearing_method_ids as $methodName => $appearingMethodId) {
+            if ($appearingMethodId->fq_class_name !== $classStorage->name) {
+                continue;
+            }
+
+            $declaringMethodId = $classStorage->declaring_method_ids[$methodName] ?? $appearingMethodId;
+
+            if (!$provider->has($declaringMethodId->fq_class_name)) {
+                continue;
+            }
+
+            $declaringMethodStorage
+                = $provider->get($declaringMethodId->fq_class_name)->methods[$declaringMethodId->method_name] ?? null;
+
+            if ($declaringMethodStorage instanceof MethodStorage) {
+                yield $methodName => $declaringMethodStorage;
+            }
+        }
+    }
+
+    /**
+     * Whether $methodStorage carries the modern `#[Scope]` attribute.
+     *
+     * Psalm stores attribute metadata on the *declaring* class's MethodStorage, so callers should pass
+     * the declaring storage (via {@see self::appearingMethods()} or `getDeclaringMethodId()`), not the
+     * inheriting class's entry.
+     *
+     * A private `#[Scope]` is never a usable scope on any supported Laravel (12-13): 13.8+ rejects it in
+     * Model::isScopeMethodWithAttribute (`! isPrivate() && ...`), and on 12.4-13.7 callNamedScope
+     * dispatches from the base Model's `$this`, where a subclass's private method is unreachable, so it
+     * routes back through __call and recurses. Either way it cannot dispatch, so report it as "not a
+     * scope" rather than treating it as a real (dead) one.
+     *
+     * @psalm-mutation-free
+     */
+    public static function hasScopeAttribute(MethodStorage $methodStorage): bool
+    {
+        if ($methodStorage->visibility === ClassLikeAnalyzer::VISIBILITY_PRIVATE) {
+            return false;
+        }
+
+        foreach ($methodStorage->attributes as $attribute) {
+            if ($attribute->fq_class_name === Scope::class) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Whether a method is a legacy `scopeXxx()` query scope.
+     *
+     * Detection: the lowercase key starts with `scope` AND the original-cased name has an uppercase
+     * ASCII letter directly after `scope` — the `scope` + StudlyCase convention Laravel resolves via
+     * `'scope' . ucfirst($scope)` in Model::callNamedScope(). PHP dispatch is case-insensitive, so a
+     * `scopeactive()` is technically reachable as `active()`; we still require the uppercase letter to
+     * avoid matching ordinary methods that merely share the prefix (`scoped()`, `scopes()`,
+     * `scopedQuery()`). A literal `scope()` is excluded by the length guard.
+     *
+     * @psalm-pure
+     */
+    public static function isLegacyScopeMethodName(string $lowercaseName, ?string $casedName): bool
+    {
+        if ($casedName === null || \strlen($casedName) < 6) {
+            return false;
+        }
+
+        if (!\str_starts_with($lowercaseName, 'scope')) {
+            return false;
+        }
+
+        $firstNameChar = $casedName[5];
+
+        return $firstNameChar >= 'A' && $firstNameChar <= 'Z';
+    }
+
+    /**
+     * Whether a method is a legacy attribute accessor (`getXxxAttribute()`) or mutator
+     * (`setXxxAttribute()`), dispatched via Eloquent's `__get()` / `__set()` magic.
+     *
+     * Matches the lowercase method key — `$classStorage->methods` and appearing_method_ids are keyed
+     * lowercase. The `.+` requires at least one character between the prefix and `attribute`, so the
+     * framework's own bare `getAttribute()` / `setAttribute()` are not matched.
+     *
+     * @psalm-pure
+     */
+    public static function isLegacyAccessorMethodName(string $lowercaseName): bool
+    {
+        return \preg_match('/^get.+attribute$/', $lowercaseName) === 1
+            || \preg_match('/^set.+attribute$/', $lowercaseName) === 1;
+    }
+}

--- a/tests/Type/tests/Model/LegacyScopeUnusedMethodTest.phpt
+++ b/tests/Type/tests/Model/LegacyScopeUnusedMethodTest.phpt
@@ -44,3 +44,4 @@ final class LegacyScopeModel extends Model
 new LegacyScopeModel();
 ?>
 --EXPECT--
+PublicModelAccessor on line 29: Eloquent query scope scopeActive() should be protected, not public; it is dispatched through the query builder, never by name.

--- a/tests/Type/tests/Model/ScopeAttributeUnusedMethodTest.phpt
+++ b/tests/Type/tests/Model/ScopeAttributeUnusedMethodTest.phpt
@@ -47,3 +47,4 @@ final class ScopeAttributeModel extends Model
 new ScopeAttributeModel();
 ?>
 --EXPECT--
+PublicModelScope on line 34: Eloquent #[Scope] method publicPublished() should be protected, not public: called statically (Model::publicPublished()) it is a runtime fatal.

--- a/tests/Type/tests/PublicScopeAccessorVisibilityTest.phpt
+++ b/tests/Type/tests/PublicScopeAccessorVisibilityTest.phpt
@@ -1,0 +1,158 @@
+--FILE--
+<?php declare(strict_types=1);
+
+// A non-App\Models namespace on purpose: these fixtures share the default-config scan with the real
+// tests/Application app models, and `App\Models\*` names (e.g. PrivateScopeModel) would collide.
+namespace Tests\Psalm\LaravelPlugin\Sandbox;
+
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class PublicScopesModel extends Model
+{
+    // Reported as PublicModelScope: a public #[Scope] (its static call is a runtime fatal).
+    #[Scope]
+    public function active(Builder $query): Builder
+    {
+        return $query;
+    }
+
+    // Reported as PublicModelAccessor: a public legacy scopeXxx().
+    public function scopePublished(Builder $query): Builder
+    {
+        return $query;
+    }
+
+    // Reported as PublicModelAccessor: a public legacy accessor.
+    public function getTitleAttribute(): string
+    {
+        return 'Untitled';
+    }
+
+    // Reported as PublicModelAccessor: a public legacy mutator.
+    public function setTitleAttribute(string $value): void
+    {
+        $this->attributes['title'] = $value;
+    }
+
+    // Clean: a protected #[Scope] (the correct convention).
+    #[Scope]
+    protected function draft(Builder $query): Builder
+    {
+        return $query;
+    }
+
+    // Clean: a protected accessor.
+    protected function getSlugAttribute(): string
+    {
+        return 'slug';
+    }
+
+    // Clean: an ordinary public method, not a scope or accessor.
+    public function publish(): void
+    {
+    }
+
+    // Clean: a public method that only shares the `scope` prefix.
+    public function scoped(): void
+    {
+    }
+}
+
+// Clean: a private scope is a separate dead-code concern, not a visibility convention one.
+class PrivateScopeFixtureModel extends Model
+{
+    private function scopeSecret(Builder $query): Builder
+    {
+        return $query;
+    }
+}
+
+// A public legacy scope on a trait is reported once (PublicModelAccessor), at the trait's own declaration.
+trait HasArchivedScope
+{
+    public function scopeArchived(Builder $query): Builder
+    {
+        return $query;
+    }
+}
+
+class TraitScopeModel extends Model
+{
+    use HasArchivedScope;
+}
+
+// A second model composing the same trait does NOT add a second report (deduped on the shared storage).
+class SecondTraitScopeModel extends Model
+{
+    use HasArchivedScope;
+}
+
+// A public legacy scope on an ABSTRACT base is reported at the base's own declaration...
+abstract class AbstractBaseModel extends Model
+{
+    public function scopeOnBase(Builder $query): Builder
+    {
+        return $query;
+    }
+}
+
+// ...and the concrete child that inherits it is not reported again.
+class ConcreteChildModel extends AbstractBaseModel
+{
+}
+
+// Public visibility forced by a contract is not reported (it cannot be narrowed to protected). The guard
+// keys off overridden_method_ids, which Psalm fills identically for parent classes, implemented interfaces,
+// and abstract trait requirements; the two cases below cover that path (an interface implementation behaves
+// the same but is omitted because the strict test config trips unrelated MissingAbstractPureAnnotation
+// noise on the interface declaration).
+
+// An override of a public parent scope.
+class OverridingChildModel extends PublicScopesModel
+{
+    #[\Override]
+    public function scopePublished(Builder $query): Builder
+    {
+        return $query;
+    }
+}
+
+// A scope required by an abstract trait method.
+trait RequiresPublishedScope
+{
+    abstract public function scopeRequiredPublished(Builder $query): Builder;
+}
+
+class AbstractTraitRequiredModel extends Model
+{
+    use RequiresPublishedScope;
+
+    #[\Override]
+    public function scopeRequiredPublished(Builder $query): Builder
+    {
+        return $query;
+    }
+}
+
+// Clean: a non-Model class with scope/accessor-shaped methods is never flagged.
+class NotAModel
+{
+    public function scopePublished(): void
+    {
+    }
+
+    public function getTitleAttribute(): string
+    {
+        return 'x';
+    }
+}
+?>
+--EXPECTF--
+PublicModelScope on line %d: Eloquent #[Scope] method active() should be protected, not public: called statically (Model::active()) it is a runtime fatal.
+PublicModelAccessor on line %d: Eloquent query scope scopePublished() should be protected, not public; it is dispatched through the query builder, never by name.
+PublicModelAccessor on line %d: Eloquent accessor/mutator getTitleAttribute() should be protected, not public; it is dispatched via __get()/__set(), never by name.
+PublicModelAccessor on line %d: Eloquent accessor/mutator setTitleAttribute() should be protected, not public; it is dispatched via __get()/__set(), never by name.
+PublicModelAccessor on line %d: Eloquent query scope scopeArchived() should be protected, not public; it is dispatched through the query builder, never by name.
+PublicModelAccessor on line %d: Eloquent query scope scopeOnBase() should be protected, not public; it is dispatched through the query builder, never by name.

--- a/tests/Unit/Util/EloquentModelMethodsTest.php
+++ b/tests/Unit/Util/EloquentModelMethodsTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Util;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Util\EloquentModelMethods;
+
+/**
+ * Direct coverage for the pure name classifiers. They were promoted from private SuppressHandler helpers
+ * to a shared util now consumed by three handlers, so the subtle StudlyCase gate and the `.+` accessor
+ * guard get a dedicated truth table here rather than being exercised only through the full Psalm pipeline.
+ */
+#[CoversClass(EloquentModelMethods::class)]
+final class EloquentModelMethodsTest extends TestCase
+{
+    #[Test]
+    public function isLegacyScopeMethodName_recognises_studly_scopes(): void
+    {
+        $this->assertTrue(EloquentModelMethods::isLegacyScopeMethodName('scopepublished', 'scopePublished'));
+        $this->assertTrue(EloquentModelMethods::isLegacyScopeMethodName('scopeactive', 'scopeActive'));
+        // Single-letter scope name is still StudlyCase after `scope`.
+        $this->assertTrue(EloquentModelMethods::isLegacyScopeMethodName('scopex', 'scopeX'));
+    }
+
+    #[Test]
+    public function isLegacyScopeMethodName_rejects_non_scopes(): void
+    {
+        // Bare `scope()` is excluded by the length guard (< 6 chars).
+        $this->assertFalse(EloquentModelMethods::isLegacyScopeMethodName('scope', 'scope'));
+        // Prefix-only collisions: the char after `scope` is lowercase, not StudlyCase.
+        $this->assertFalse(EloquentModelMethods::isLegacyScopeMethodName('scoped', 'scoped'));
+        $this->assertFalse(EloquentModelMethods::isLegacyScopeMethodName('scopes', 'scopes'));
+        $this->assertFalse(EloquentModelMethods::isLegacyScopeMethodName('scopedquery', 'scopedQuery'));
+        // All-lowercase `scopeactive()` is technically dispatchable but intentionally not matched:
+        // the StudlyCase gate trades a near-zero-frequency miss for far fewer false positives.
+        $this->assertFalse(EloquentModelMethods::isLegacyScopeMethodName('scopeactive', 'scopeactive'));
+        // Not a scope prefix at all.
+        $this->assertFalse(EloquentModelMethods::isLegacyScopeMethodName('published', 'published'));
+        // Null cased name (no original spelling to inspect).
+        $this->assertFalse(EloquentModelMethods::isLegacyScopeMethodName('scopepublished', null));
+    }
+
+    #[Test]
+    public function isLegacyAccessorMethodName_recognises_get_and_set_attribute(): void
+    {
+        $this->assertTrue(EloquentModelMethods::isLegacyAccessorMethodName('gettitleattribute'));
+        $this->assertTrue(EloquentModelMethods::isLegacyAccessorMethodName('settitleattribute'));
+        $this->assertTrue(EloquentModelMethods::isLegacyAccessorMethodName('getforeignattribute'));
+    }
+
+    #[Test]
+    public function isLegacyAccessorMethodName_excludes_bare_and_unrelated(): void
+    {
+        // The `.+` requires a middle segment, so the framework's own bare accessors are NOT matched.
+        // A regression to `.*` would start flagging legitimate getAttribute()/setAttribute() overrides.
+        $this->assertFalse(EloquentModelMethods::isLegacyAccessorMethodName('getattribute'));
+        $this->assertFalse(EloquentModelMethods::isLegacyAccessorMethodName('setattribute'));
+        // Must end exactly in `attribute`: plural and suffixed names are excluded.
+        $this->assertFalse(EloquentModelMethods::isLegacyAccessorMethodName('getattributes'));
+        $this->assertFalse(EloquentModelMethods::isLegacyAccessorMethodName('getattributevalue'));
+        $this->assertFalse(EloquentModelMethods::isLegacyAccessorMethodName('setrawattributes'));
+        // Real framework methods that merely start with get/set.
+        $this->assertFalse(EloquentModelMethods::isLegacyAccessorMethodName('getroutekeyname'));
+        $this->assertFalse(EloquentModelMethods::isLegacyAccessorMethodName('getmorphclass'));
+        $this->assertFalse(EloquentModelMethods::isLegacyAccessorMethodName('title'));
+    }
+}


### PR DESCRIPTION
## Issue to Solve

Laravel query scopes and legacy attribute accessors should be `protected`, not `public`. They are dispatched indirectly (scopes through the query builder, accessors through `__get()` / `__set()`), so `public` only widens the model's API surface. A `public` `#[Scope]` is worse: a static call (`Post::published()`) is a runtime fatal, because PHP resolves the accessible non-static method before `__callStatic` can forward it to the builder (#634 / vimeo/psalm#11876).

## Related

Closes #695.

## Solution Description

Two custom issues, both enabled by default, routed by the method's runtime danger:

- **`PublicModelScope`** (`ERROR_LEVEL` 4) — a `public` `#[Scope]` method. The static-call fatal is a real consequence, so it errors for strict-to-moderate projects (error levels 1 to 4) and downgrades for loose ones.
- **`PublicModelAccessor`** (`ERROR_LEVEL` 1) — a `public` legacy `scopeXxx()` scope or a `public` legacy `getXxxAttribute()` / `setXxxAttribute()` accessor. These work fine at runtime, so it is a pure convention nit: a hard error only at Psalm's strictest level.

Each is suppressible per project via `<PluginIssue name="..." errorLevel="suppress" />`.

### Contract-forced visibility is exempt

A `public` member whose visibility is dictated by a contract it satisfies (an interface method, a parent override, or an abstract trait method) is not reported: PHP forbids narrowing it below the inherited or required declaration, so the report would be unactionable. The guard keys off `overridden_method_ids`, which Psalm populates from interfaces, parent classes, and abstract trait requirements.

### Trait-hosted members

The handler runs on `AfterCodebasePopulated` and resolves each model's methods through their declaring storage (`EloquentModelMethods::appearingMethods()`, the #1048 path), so a trait-hosted scope/accessor is reported once, at the trait declaration, even across many composing models.

### Shared classifier extraction

The scope/accessor classifiers previously private to `SuppressHandler` (and partly duplicated in `BuilderScopeHandler`) are extracted into `src/Util/EloquentModelMethods.php`; both delegate to it.

### Real-app impact (enabled by default)

`/psalm-delta` (base `a2533530` vs head):

The two issues add diagnostics only where real apps carry public scopes/accessors; no other issue type moves. The danger split shows in the data: `PublicModelScope` (public `#[Scope]`, the rare runtime-hazard case) is just **4** findings across the whole app set, while `PublicModelAccessor` (legacy scopes plus accessors, the common convention case) accounts for the rest.

Public apps with findings (the remaining nine are at ΔNet 0):

| App | ΔNet |
|-----|-----:|
| pixelfed | +36 |
| corcel | +17 |
| solidtime | +14 |
| coolify | +13 |
| vito | +11 |
| bookstack | +9 |
| laravel-permission | +7 |
| monica | +6 |

Almost all are `PublicModelAccessor` (error level 1, so only the strictest projects see them); the handful of `PublicModelScope` findings (error levels 1 to 4) are the genuine static-call hazards worth fixing first. The classifier extraction stays behavior-preserving (no movement in any other issue type).

### How verified

- `composer psalm` clean, 100% type coverage on new files.
- `composer test:type` (453), `composer test:unit` (789), `composer test:app` green.
- The `AfterCodebasePopulated` emission survives multi-threaded analysis (`--threads=4`).
- Two in-suite scope-suppression fixtures keep a deliberate `public` scope and now assert the new diagnostics (a `#[Scope]` -> `PublicModelScope`, a legacy `scopeXxx()` -> `PublicModelAccessor`).

## Checklist

- [x] Tests cover the change: type test `PublicScopeAccessorVisibilityTest.phpt` (routing, dedup, abstract base, and the contract-exempt cases) and unit test `EloquentModelMethodsTest` (classifier truth table).
- [x] Documentation is updated: `docs/issues/PublicModelScope.md`, `docs/issues/PublicModelAccessor.md`, `docs/issues/index.md`.
