### PR TITLE
Resolve docblock-only `@method scopeXxx` scopes on builders

### DIFF
--- a/src/Handlers/Eloquent/BuilderScopeHandler.php
+++ b/src/Handlers/Eloquent/BuilderScopeHandler.php
@@ -32,11 +32,17 @@ use Psalm\Type\Union;
  * When a method call on Builder doesn't match a real method, checks the model for:
  * 1. Legacy scopeXxx() methods (e.g., scopeActive → active())
  * 2. Methods with #[Scope] attribute (e.g., #[Scope] active() → active())
- * 3. Trait-declared builder methods (e.g., SoftDeletes::withTrashed → withTrashed())
+ * 3. Docblock-only scopes documented as a class-level `@method scopeXxx()` tag — no concrete
+ *    scopeXxx() body and no #[Scope] method. Resolved from the model's pseudo_static_methods/
+ *    pseudo_methods, after 1 and 2, by trusting the tag (Larastan parity; note the tag is NOT
+ *    runtime-dispatchable on its own). See #1054 and resolvePseudoScopeParams.
+ * 4. Trait-declared builder methods (e.g., SoftDeletes::withTrashed → withTrashed())
  *    These are registered as Builder macros at runtime via global scopes
  *    (e.g., SoftDeletingScope::extend), and declared via @method static returning
  *    Builder<static> on the model trait.
- * 4. @method PHPDoc scopes are handled natively by Psalm
+ * 5. Public-form `@method published()` scopes (the bare call name documented directly, not the
+ *    scope-prefixed form) are handled natively by Psalm — the call name matches the tag, so no
+ *    scope-prefix lookup or $query stripping applies.
  *
  * @internal
  */
@@ -295,10 +301,11 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
      * such scope.
      *
      * Dispatch mirrors Laravel's Model::callNamedScope: a #[Scope]-attributed
-     * method wins over a legacy scopeXxx() method of the same name. Detection is
-     * strict (bare methods require the attribute), so a non-null return implies
-     * the method is a real scope — callers don't need a separate hasScopeMethod()
-     * guard.
+     * method wins over a legacy scopeXxx() method of the same name. When the model
+     * has NEITHER, a class-level `@method scopeXxx()` PHPDoc tag is consulted as a
+     * final fallback (trusting the tag; see resolvePseudoScopeParams). Detection is
+     * strict (bare methods require the attribute), so a non-null return implies the
+     * method is a scope — callers don't need a separate hasScopeMethod() guard.
      *
      * Memoized: deterministic per model+method once the codebase is populated.
      *
@@ -324,7 +331,13 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
         } elseif ($codebase->methodExists($modelClass . '::scope' . \ucfirst($methodName))) {
             $scopeMethodId = new MethodIdentifier($modelClass, 'scope' . $methodName);
         } else {
-            return self::$scopeParamsCache[$key] = null;
+            // Final fallback: a scope documented only as a class-level `@method scopeXxx()` tag,
+            // with no concrete scopeXxx() body and no #[Scope] method (see resolvePseudoScopeParams).
+            return self::$scopeParamsCache[$key] = self::resolvePseudoScopeParams(
+                $codebase,
+                $modelClass,
+                $methodName,
+            );
         }
 
         // Methods::getMethodParams resolves the declaring class internally, so scopes
@@ -345,6 +358,71 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
             $modelClass,
             $callerParams,
         );
+    }
+
+    /**
+     * Resolve scope params from a class-level `@method scopeXxx()` pseudo-method — the final
+     * fallback when the model has NEITHER a concrete scopeXxx() body NOR a #[Scope] method.
+     *
+     * This trusts the `@method`-declared scopeXxx tag the way Psalm/PHPStan trust any `@method`, and
+     * mirrors Larastan's BuilderHelper (which shifts the first @method-scope param the same way):
+     * take the declared params, drop the leading $query a real scope receives, and let
+     * {@see getMethodReturnType} fabricate the Builder<TModel> return (the tag's own return type is
+     * ignored, exactly as a real scope's often-void return is). The plugin does NOT verify that a
+     * dispatchable scope actually exists. A `@method scopeXxx()` with no backing real scopeXxx()
+     * method or #[Scope] anywhere is NOT callable at runtime — Model::hasNamedScope() is
+     * method_exists-gated, so the bare `xxx()` call throws BadMethodCallException. That is the
+     * deliberate trade-off of supporting these tags (issue #1054, Larastan parity): the tag is a
+     * developer assertion that a scope exists, and a wrong assertion types runtime-fatal code as
+     * valid — the same caveat as any incorrect `@method`.
+     *
+     * Reads the model's LOCAL pseudo_static_methods / pseudo_methods. Psalm's Populator flattens
+     * BOTH trait-declared (populateDataFromTrait) AND (abstract-)parent-declared
+     * (populateDataFromParentClass) `@method` tags into a class's local maps whenever the class has
+     * no real same-named method, so a scope documented on a `use`d trait — the package/trait case
+     * the issue describes — or on a parent model resolves here too, not only tags written directly
+     * on the model.
+     *
+     * `self`/`static`/`$this` in such a param resolve to the queried model ($modelClass). That is
+     * correct for a tag written directly on the model and for one merged from a `use`d trait (PHP
+     * trait `self` is the using class — the model). It over-narrows for a `self`-typed param on a
+     * tag INHERITED from a parent: `self` there should be the declaring parent, so a sibling-typed
+     * argument is wrongly rejected. We cannot fix it cheaply — Psalm records no declaring class for
+     * a STATIC pseudo-method (declaring_pseudo_method_ids is instance-only, ClassLikeNodeScanner),
+     * and the real-scope path's getAppearingMethodId has no pseudo equivalent. Accepted as a niche
+     * limitation (issue #1054); the common direct/trait forms are exact. {@see expandScopeParamSelfReferences}.
+     *
+     * @param class-string<Model> $modelClass
+     * @param lowercase-string $methodName
+     * @return list<FunctionLikeParameter>|null
+     * @see https://github.com/psalm/psalm-plugin-laravel/issues/1054
+     */
+    private static function resolvePseudoScopeParams(
+        Codebase $codebase,
+        string $modelClass,
+        string $methodName,
+    ): ?array {
+        try {
+            $storage = $codebase->classlike_storage_provider->get(\strtolower($modelClass));
+        } catch (\InvalidArgumentException) {
+            return null;
+        }
+
+        // Psalm lowercases pseudo-method keys. A scope is conventionally `@method static`, but
+        // accept the instance form too — both are valid ways to document a scope.
+        $pseudoName = 'scope' . $methodName;
+        $pseudoMethod = $storage->pseudo_static_methods[$pseudoName]
+            ?? $storage->pseudo_methods[$pseudoName]
+            ?? null;
+        if ($pseudoMethod === null) {
+            return null;
+        }
+
+        // Drop the leading $query a real scope receives (Laravel injects it at runtime); the caller
+        // passes the rest. array_slice on a zero-param tag is a no-op — `@method scopePublishedDoc()` yields [].
+        $callerParams = \array_slice($pseudoMethod->params, 1);
+
+        return self::expandScopeParamSelfReferences($codebase, $modelClass, $modelClass, $callerParams);
     }
 
     /**
@@ -543,9 +621,10 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
      * Check if the model has a scope for the given method name.
      *
      * Boolean-equivalent to {@see getScopeParams()} !== null — both detect a #[Scope]-attributed
-     * method (visibility-gated) or a legacy scopeXxx() twin — so this delegates instead of
-     * duplicating the detection and its cache. getScopeParams returns null cheaply for a
-     * non-scope (no param expansion) and memoizes the verdict.
+     * method (visibility-gated), a legacy scopeXxx() twin, or a docblock-only `@method scopeXxx()`
+     * pseudo-method (issue #1054) — so this delegates instead of duplicating the detection and its
+     * cache. getScopeParams returns null cheaply for a non-scope (no param expansion) and memoizes
+     * the verdict.
      *
      * Public so ModelMethodHandler can reuse this for method existence checks
      * on static Model calls (e.g., User::active() → scopeActive).

--- a/tests/Application/app/Models/AbstractPseudoScopeBase.php
+++ b/tests/Application/app/Models/AbstractPseudoScopeBase.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Abstract base carrying a docblock-only pseudo-scope. Psalm's
+ * Populator::populateDataFromParentClass copies this class-level @method tag into a concrete
+ * child's LOCAL pseudo_static_methods (when the child has no real same-named method), so
+ * BuilderScopeHandler::resolvePseudoScopeParams resolves a parent-declared pseudo-scope on the
+ * child from the child's own maps. Pins that inherited path (PseudoScopeModel extends this).
+ *
+ * @method static Builder<static> scopeFromParentDoc(Builder $query)
+ */
+abstract class AbstractPseudoScopeBase extends Model {}

--- a/tests/Application/app/Models/Concerns/HasDocblockScopes.php
+++ b/tests/Application/app/Models/Concerns/HasDocblockScopes.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Concerns;
+
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * A docblock-only pseudo-scope hosted on a TRAIT — the literal issue #1054 shape ("a scope a
+ * package/trait documents via @method"). There is no scopeXxx() body; only the class-level tag.
+ *
+ * Psalm's Populator::populateDataFromTrait merges this tag into the using model's LOCAL
+ * pseudo_static_methods, so BuilderScopeHandler::resolvePseudoScopeParams resolves it from the
+ * model's own maps just like a directly-declared tag.
+ *
+ * The `self $owner` param (after the stripped $query) is left raw by Psalm for a trait tag, so it
+ * must expand to the USING model — this pins expandScopeParamSelfReferences running on a
+ * pseudo-method param (the param SOURCE differs from a real scope's reflected params).
+ *
+ * @method static Builder<static> scopeFromTraitDoc(Builder $query, self $owner)
+ *
+ * @psalm-require-extends \Illuminate\Database\Eloquent\Model
+ */
+trait HasDocblockScopes {}

--- a/tests/Application/app/Models/PseudoScopeModel.php
+++ b/tests/Application/app/Models/PseudoScopeModel.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Models\Concerns\HasDocblockScopes;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Archetype for scopes that exist ONLY as a class-level `@method scopeXxx()` PHPDoc tag — no
+ * concrete scopeXxx() body and no #[Scope] method. Psalm stores these as pseudo_static_methods /
+ * pseudo_methods on the model's ClassLikeStorage; the plugin resolves the stripped public form
+ * (publishedDoc(), ofTypeDoc(), …) from them, dropping the leading $query a real scope receives,
+ * matching Larastan's BuilderHelper. See https://github.com/psalm/psalm-plugin-laravel/issues/1054.
+ *
+ * These tags are a static-analysis convenience that TRUSTS the developer's assertion; the plugin
+ * does not verify a runtime scope exists. A tag with no backing real scopeXxx()/#[Scope] is NOT
+ * dispatchable at runtime (Model::hasNamedScope is method_exists-gated, so the bare call throws
+ * BadMethodCallException) — this fixture documents the analysis behavior, not a runnable scope.
+ *
+ * Coverage spread across the three sources Psalm flattens into a model's local pseudo maps:
+ *  - direct tags below (scopePublishedDoc, scopeOfTypeDoc, scopeInstanceDoc, scopeOptionalVariadicDoc);
+ *  - a `use`d trait (HasDocblockScopes::scopeFromTraitDoc) — the issue's package/trait shape;
+ *  - an abstract parent (AbstractPseudoScopeBase::scopeFromParentDoc) — inherited tag.
+ *
+ * Scopes are conventionally documented as `@method static` (stored in pseudo_static_methods). The
+ * instance form (`@method`, no `static`) lands in pseudo_methods instead; the plugin consults
+ * both, matching Larastan's getMethodTags(). scopeInstanceDoc() pins that second lookup.
+ *
+ * Deliberately a BASE-builder model: docblock-only @method scopes on a CUSTOM builder are
+ * CustomBuilderMethodHandler's domain (their Builder<static> pseudos are remapped/removed during
+ * registration), so this archetype uses the default Eloquent builder. Kept isolated from the
+ * shared archetypes (Customer, Vehicle, …) so the pseudo-scope tags cannot perturb other suites.
+ *
+ * @method static Builder<static> scopePublishedDoc()
+ * @method static Builder<static> scopeOfTypeDoc(Builder $query, string $type)
+ * @method static Builder<static> scopeOptionalVariadicDoc(Builder $query, string $tag = 'x', string ...$rest)
+ * @method Builder<static> scopeInstanceDoc()
+ */
+final class PseudoScopeModel extends AbstractPseudoScopeBase
+{
+    use HasDocblockScopes;
+
+    protected $table = 'pseudo_scope_models';
+}

--- a/tests/Type/tests/Builder/PseudoMethodScopeTest.phpt
+++ b/tests/Type/tests/Builder/PseudoMethodScopeTest.phpt
@@ -1,0 +1,143 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\PseudoScopeModel;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Scopes declared ONLY as a class-level `@method scopeXxx()` PHPDoc tag — no concrete scopeXxx()
+ * body and no #[Scope] method — resolve on a Builder, exactly like a real legacy scope.
+ * BuilderScopeHandler::getScopeParams consults the model's pseudo_static_methods / pseudo_methods
+ * as a final fallback (after a real scopeXxx() and a #[Scope] method), strips the leading $query a
+ * real scope receives, and fabricates Builder<TModel>. This trusts the tag (Larastan parity).
+ *
+ * NOTE: a tag with no backing real scopeXxx()/#[Scope] is NOT runtime-dispatchable
+ * (Model::hasNamedScope is method_exists-gated, so the bare call throws BadMethodCallException);
+ * the plugin types it optimistically by trusting the developer's @method assertion. This suite
+ * pins the static-analysis behaviour, not a runnable scope.
+ *
+ * Psalm flattens a model's tags from three sources into its local pseudo maps, all covered here:
+ * direct tags, a `use`d trait (the issue's package/trait shape), and an abstract parent.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1054
+ */
+
+/** Zero-arg pseudo-scope (the issue's exact shape) resolves to the builder. */
+function test_pseudo_scope_resolves(): void
+{
+    $_result = PseudoScopeModel::query()->publishedDoc();
+    /** @psalm-check-type-exact $_result = Builder<PseudoScopeModel> */
+}
+
+/**
+ * A scope documented as a NON-static `@method` tag (stored in pseudo_methods, not
+ * pseudo_static_methods) resolves through the same fallback — the plugin consults both maps.
+ */
+function test_pseudo_scope_instance_method_tag_resolves(): void
+{
+    $_result = PseudoScopeModel::query()->instanceDoc();
+    /** @psalm-check-type-exact $_result = Builder<PseudoScopeModel> */
+}
+
+/**
+ * The literal #1054 shape: a pseudo-scope hosted on a `use`d trait (HasDocblockScopes), merged
+ * into the model's local pseudo maps by Populator::populateDataFromTrait. The trait tag's raw
+ * `self $owner` param (after the stripped $query) expands to the using model, so a model instance
+ * is accepted.
+ */
+function test_pseudo_scope_from_trait_resolves(PseudoScopeModel $owner): void
+{
+    $_result = PseudoScopeModel::query()->fromTraitDoc($owner);
+    /** @psalm-check-type-exact $_result = Builder<PseudoScopeModel> */
+}
+
+/**
+ * A pseudo-scope declared on the ABSTRACT parent (AbstractPseudoScopeBase), inherited via
+ * Populator::populateDataFromParentClass copying the tag into the child's local pseudo maps.
+ */
+function test_pseudo_scope_from_parent_resolves(): void
+{
+    $_result = PseudoScopeModel::query()->fromParentDoc();
+    /** @psalm-check-type-exact $_result = Builder<PseudoScopeModel> */
+}
+
+/** Optional post-$query param may be omitted; a variadic tail accepts any number of values. */
+function test_pseudo_scope_optional_and_variadic(): void
+{
+    $_omitted = PseudoScopeModel::query()->optionalVariadicDoc();
+    /** @psalm-check-type-exact $_omitted = Builder<PseudoScopeModel> */
+
+    $_variadic = PseudoScopeModel::query()->optionalVariadicDoc('a', 'b', 'c');
+    /** @psalm-check-type-exact $_variadic = Builder<PseudoScopeModel> */
+}
+
+/** Pseudo-scope with a param after $query: the post-$query value is accepted (strip). */
+function test_pseudo_scope_with_arg(): void
+{
+    $_result = PseudoScopeModel::query()->ofTypeDoc('post');
+    /** @psalm-check-type-exact $_result = Builder<PseudoScopeModel> */
+}
+
+/** Negative: the argument is type-checked against the scope's declared param (minus $query). */
+function test_pseudo_scope_arg_type_checked(): void
+{
+    PseudoScopeModel::query()->ofTypeDoc(123);
+}
+
+/** Negative: too few args — the required $type after $query is missing. */
+function test_pseudo_scope_too_few_args(): void
+{
+    PseudoScopeModel::query()->ofTypeDoc();
+}
+
+/** Negative: too many args — only one post-$query param ($type) is declared. */
+function test_pseudo_scope_too_many_args(): void
+{
+    PseudoScopeModel::query()->ofTypeDoc('a', 'b');
+}
+
+/** Negative: the trait scope's `self $owner` expanded to the model, so a non-model is rejected. */
+function test_pseudo_scope_trait_self_param_rejects_non_model(): void
+{
+    PseudoScopeModel::query()->fromTraitDoc('not-a-model');
+}
+
+/** Negative: the optional param is still type-checked when supplied. */
+function test_pseudo_scope_optional_arg_type_checked(): void
+{
+    PseudoScopeModel::query()->optionalVariadicDoc(123);
+}
+
+/** Negative: the variadic TAIL element type is enforced too (not silently widened to mixed). */
+function test_pseudo_scope_variadic_element_type_checked(): void
+{
+    PseudoScopeModel::query()->optionalVariadicDoc('ok', 123);
+}
+
+/**
+ * The fix also flows through the STATIC model form (Model::publishedDoc()), via the per-model
+ * existence/params/return providers (ModelMethodHandler) which share getScopeParams/hasScopeMethod.
+ * The fixture is autoloadable, so it is registered. Same stripped-$query convention, so the
+ * post-$query argument is still checked. (Runtime note: this form also throws BadMethodCallException
+ * for a tag-only scope; the plugin types it by trusting the tag.)
+ */
+function test_pseudo_scope_static_model_form(): void
+{
+    $_result = PseudoScopeModel::publishedDoc();
+    /** @psalm-check-type-exact $_result = Builder<PseudoScopeModel> */
+}
+
+/** Negative on the static form: the post-$query argument is type-checked there as well. */
+function test_pseudo_scope_static_arg_type_checked(): void
+{
+    PseudoScopeModel::ofTypeDoc(123);
+}
+?>
+--EXPECTF--
+InvalidArgument on line %d: Argument 1 of Illuminate\Database\Eloquent\Builder::oftypedoc expects string, but 123 provided
+TooFewArguments on line %d: Too few arguments for Illuminate\Database\Eloquent\Builder::oftypedoc - expecting type to be passed
+TooManyArguments on line %d: Too many arguments for Illuminate\Database\Eloquent\Builder::oftypedoc - expecting 1 but saw 2
+InvalidArgument on line %d: Argument 1 of Illuminate\Database\Eloquent\Builder::fromtraitdoc expects App\Models\PseudoScopeModel, but 'not-a-model' provided
+InvalidArgument on line %d: Argument 1 of Illuminate\Database\Eloquent\Builder::optionalvariadicdoc expects string, but 123 provided
+InvalidArgument on line %d: Argument 2 of Illuminate\Database\Eloquent\Builder::optionalvariadicdoc expects string, but 123 provided
+InvalidArgument on line %d: Argument 1 of App\Models\PseudoScopeModel::oftypedoc expects string, but 123 provided


### PR DESCRIPTION
## Issue to Solve

Eloquent scopes documented only as a class level `@method scopeXxx()` tag (no concrete `scopeXxx()` body and no `#[Scope]` method) resolved to `mixed` when called on a Builder. For a model annotated `@method static Builder<static> scopePublished()`, `Article::query()->published()` inferred `mixed` instead of `Builder<Article>`.

## Related

Closes #1054

## Solution Description

`BuilderScopeHandler::getScopeParams()` gains a third fallback, after a real `scopeXxx()` method and a `#[Scope]` method: a new `resolvePseudoScopeParams()` reads the model's `pseudo_static_methods` / `pseudo_methods` from `ClassLikeStorage`, drops the leading `$query` that a real scope receives, and reuses the existing `self`/`static` param expansion. The return is fabricated as `Builder<TModel>`, exactly as for a real (often void) scope. This mirrors Larastan's `BuilderHelper`, which shifts the first `@method` scope param the same way. Because Psalm's `Populator` flattens trait and parent `@method` tags into a model's local pseudo maps, scopes documented on a `use`d trait (the package or trait case the issue describes) or on an abstract parent resolve through the same path. The static `Model::scope()` form is covered too, via the shared `hasScopeMethod()`.

Why trust the tag: a scope prefixed `@method scopeXxx()` with no backing real method is not dispatchable at runtime (`Model::hasNamedScope()` is `method_exists` gated, so the bare call throws `BadMethodCallException`). The plugin trusts the developer's `@method` assertion the way Psalm and PHPStan trust any pseudo method, accepting that a wrong tag types runtime fatal code. That is the deliberate Larastan parity trade off.

Known limitation: a `self` typed param on a tag inherited from a parent over narrows to the queried subclass, because Psalm records no declaring class for a static pseudo method (`declaring_pseudo_method_ids` is instance only), so the real scope `getAppearingMethodId` path has no equivalent. The common direct and trait merged forms are exact.

## Solution Verification

New type test `tests/Type/tests/Builder/PseudoMethodScopeTest.phpt` covers the builder instance and static model forms, the `$query` strip arity (too few, too many, wrong type), optional and variadic post `$query` params, trait merged and parent inherited resolution, and the instance vs static `@method` map distinction. Full suite green: `composer test:type` (452), `composer test:unit` (785), `composer psalm` (100% coverage, no errors), `composer cs`, `composer rector`.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
- [x] Documentation is updated (handler docblocks document the resolution order, the trust the tag rationale and runtime caveat, and the parent `self` limitation)
