### PR TITLE
Honor value-returning Eloquent scope return types

### DIFF
--- a/src/Handlers/Eloquent/BuilderScopeHandler.php
+++ b/src/Handlers/Eloquent/BuilderScopeHandler.php
@@ -321,7 +321,7 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
         }
 
         $scopeMethodId = self::resolveScopeMethodId($codebase, $modelClass, $methodName);
-        if ($scopeMethodId === null) {
+        if (!$scopeMethodId instanceof \Psalm\Internal\MethodIdentifier) {
             return self::$scopeParamsCache[$key] = null;
         }
 
@@ -412,7 +412,7 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
         Union $fallback,
     ): Union {
         $scopeMethodId = self::resolveScopeMethodId($codebase, $modelClass, $methodName);
-        if ($scopeMethodId === null) {
+        if (!$scopeMethodId instanceof \Psalm\Internal\MethodIdentifier) {
             return $fallback;
         }
 
@@ -428,7 +428,7 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
 
         // No declared return, or `void`/`never`: the scope surfaces nothing, so `?? $this`
         // always falls back to the builder/relation — the long-standing behavior.
-        if ($declared === null || $declared->isVoid() || $declared->isNever()) {
+        if (!$declared instanceof \Psalm\Type\Union || $declared->isVoid() || $declared->isNever()) {
             return $fallback;
         }
 

--- a/src/Handlers/Eloquent/BuilderScopeHandler.php
+++ b/src/Handlers/Eloquent/BuilderScopeHandler.php
@@ -22,6 +22,7 @@ use Psalm\Plugin\EventHandler\MethodParamsProviderInterface;
 use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
 use Psalm\StatementsSource;
 use Psalm\Storage\FunctionLikeParameter;
+use Psalm\Type;
 use Psalm\Type\Atomic\TGenericObject;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Union;
@@ -204,7 +205,9 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
             // Codebase\Methods::getMethodParams.
             self::$pendingScopeModel[$methodName] = $modelClass;
 
-            return $builderReturn;
+            // A value-returning scope surfaces its declared return via Laravel's `?? $this`
+            // coalesce; a plain void/fluent scope keeps $builderReturn unchanged (issue #1053).
+            return self::forwardedScopeReturnType($codebase, $modelClass, $methodName, $builderReturn);
         }
 
         // Trait-declared builder methods (e.g., SoftDeletes::withTrashed) are registered
@@ -317,13 +320,8 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
             return self::$scopeParamsCache[$key];
         }
 
-        if ($codebase->methodExists($modelClass . '::' . $methodName)
-            && self::hasScopeAttribute($codebase, $modelClass, $methodName)
-        ) {
-            $scopeMethodId = new MethodIdentifier($modelClass, $methodName);
-        } elseif ($codebase->methodExists($modelClass . '::scope' . \ucfirst($methodName))) {
-            $scopeMethodId = new MethodIdentifier($modelClass, 'scope' . $methodName);
-        } else {
+        $scopeMethodId = self::resolveScopeMethodId($codebase, $modelClass, $methodName);
+        if ($scopeMethodId === null) {
             return self::$scopeParamsCache[$key] = null;
         }
 
@@ -345,6 +343,187 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
             $modelClass,
             $callerParams,
         );
+    }
+
+    /**
+     * Resolve the {@see MethodIdentifier} a scope name dispatches to, or null when the model
+     * declares no such scope.
+     *
+     * Mirrors Laravel's Model::callNamedScope precedence: a #[Scope]-attributed method wins
+     * over a legacy scopeXxx() twin of the same name. Shared by {@see getScopeParams} (params)
+     * and {@see forwardedScopeReturnType} (return type) so both consult one dispatch rule.
+     *
+     * @param class-string<Model> $modelClass
+     */
+    private static function resolveScopeMethodId(
+        Codebase $codebase,
+        string $modelClass,
+        string $methodName,
+    ): ?MethodIdentifier {
+        $methodName = \strtolower($methodName);
+
+        if ($codebase->methodExists($modelClass . '::' . $methodName)
+            && self::hasScopeAttribute($codebase, $modelClass, $methodName)
+        ) {
+            return new MethodIdentifier($modelClass, $methodName);
+        }
+
+        if ($codebase->methodExists($modelClass . '::scope' . \ucfirst($methodName))) {
+            return new MethodIdentifier($modelClass, 'scope' . $methodName);
+        }
+
+        return null;
+    }
+
+    /**
+     * Apply Laravel's `$scope(...) ?? $this` coalesce (Builder::callScope) to a FORWARDED
+     * scope call's return type.
+     *
+     * A local scope is NOT required to return the builder. callScope evaluates
+     * `$result = $scope(...) ?? $this` and returns `$result`, so a scope whose body returns a
+     * value (e.g. `->first()`, a count, a collection) propagates that value to the caller,
+     * while a null/void/builder-returning scope falls back to `$this`. That `$this` is the
+     * builder for the instance and static call forms, and the Relation for a relation chain
+     * (Relation::__call returns `$this` only when the forwarded result IS the wrapped query) —
+     * the caller passes it as $fallback. This is forwarded-only: a DIRECT call ($this->scope($q))
+     * never runs callScope, so its callers decline before reaching here (see isDirectScopeCall).
+     *
+     * Modeled exactly as PHP's `??`:
+     *   - no explicit declared return, or `void`/`never`, or a non-null part that is entirely a
+     *     Builder subtype  → $fallback unchanged. This is the overwhelmingly common void/fluent
+     *     scope and preserves the pre-#1053 behavior.
+     *   - non-null value scope (e.g. `int`)  → the declared type alone; the `?? $this` branch is
+     *     dead because the value is never null.
+     *   - nullable value scope (e.g. `?Post`)  → `(declared − null) | $fallback`; the null result
+     *     is the branch that falls back to $this, so the inferred type never contains null (a
+     *     downstream `=== null` check is then correctly redundant, matching the runtime).
+     *
+     * `self`/`static`/`$this` in the declared return are pinned first — `self` to the scope's
+     * composing class, `static`/`$this` to the queried model — so `?self` becomes `?Post` before
+     * the null is dropped (mirrors {@see expandScopeParamSelfReferences} for parameters).
+     *
+     * @see https://github.com/psalm/psalm-plugin-laravel/issues/1053
+     * @param class-string<Model> $modelClass
+     */
+    public static function forwardedScopeReturnType(
+        Codebase $codebase,
+        string $modelClass,
+        string $methodName,
+        Union $fallback,
+    ): Union {
+        $scopeMethodId = self::resolveScopeMethodId($codebase, $modelClass, $methodName);
+        if ($scopeMethodId === null) {
+            return $fallback;
+        }
+
+        $declaringMethodId = $codebase->methods->getDeclaringMethodId($scopeMethodId) ?? $scopeMethodId;
+
+        try {
+            $storage = $codebase->methods->getStorage($declaringMethodId);
+        } catch (\UnexpectedValueException) {
+            return $fallback;
+        }
+
+        $declared = $storage->return_type ?? $storage->signature_return_type;
+
+        // No declared return, or `void`/`never`: the scope surfaces nothing, so `?? $this`
+        // always falls back to the builder/relation — the long-standing behavior.
+        if ($declared === null || $declared->isVoid() || $declared->isNever()) {
+            return $fallback;
+        }
+
+        // Fast path for the common typed-fluent scope (`: Builder`, `: Builder<static>`,
+        // `: CustomBuilder`): a non-null builder-only return surfaces no value, so short-circuit
+        // to $fallback before the expandUnion + Union-clone work below that would only be
+        // discarded at the post-strip builder check. Sound on the RAW type because an atom's
+        // builder classification is invariant under expansion — expandUnion only rewrites
+        // self/static/$this and class constants (and an alias canonicalizes to the SAME class),
+        // never turning a non-builder into a builder or vice versa. It deliberately does NOT fire
+        // for `: self`/`: static` (their raw atoms aren't a Builder subtype) nor for a nullable
+        // return (the `null` atom fails the all-Builder test) — both still need the expansion
+        // below to resolve `?self` → `?Post`.
+        if (self::isEntirelyEloquentBuilder($codebase, $declared)) {
+            return $fallback;
+        }
+
+        // Pin `self` → composing class, `static`/`$this` → queried model, so `?self` resolves to
+        // `?Post` before the null is dropped below. `final: true` keeps `static` as the plain
+        // model (not `Model&static`): a returned value is checked against the plain class at the
+        // call site, exactly as a parameter is (see expandScopeParamSelfReferences).
+        $selfClass = $codebase->methods->getAppearingMethodId($scopeMethodId)?->fq_class_name ?? $modelClass;
+        $declared = TypeExpander::expandUnion(
+            $codebase,
+            $declared,
+            $selfClass,
+            $modelClass,
+            null,
+            evaluate_class_constants: true,
+            evaluate_conditional_types: false,
+            final: true,
+        );
+
+        $isNullable = $declared->isNullable();
+
+        $nonNull = $declared->getBuilder();
+        $nonNull->removeType('null');
+
+        // Declared `null`-only (nothing left after dropping null): always falls back to $this.
+        if ($nonNull->getAtomicTypes() === []) {
+            return $fallback;
+        }
+
+        $nonNullType = $nonNull->freeze();
+
+        // A builder-returning scope (the fluent common case): its declared Builder carries no
+        // surfaced value and is normalized to the caller-correct $fallback (Builder<Model> or the
+        // Relation), so return $fallback rather than the scope's own (possibly bare) `Builder`.
+        if (self::isEntirelyEloquentBuilder($codebase, $nonNullType)) {
+            return $fallback;
+        }
+
+        // Value-returning scope. A nullable declaration means the null branch falls back to
+        // $this; a non-null one can never trigger `?? $this`, so the value stands alone.
+        return $isNullable
+            ? Type::combineUnionTypes($nonNullType, $fallback, $codebase)
+            : $nonNullType;
+    }
+
+    /**
+     * Whether every atomic in $type is the Eloquent Builder or a subclass of it.
+     *
+     * A scope declared `: Builder`, `: Builder<static>`, or `: SomeCustomBuilder` is the ordinary
+     * fluent scope; its caller normalizes the type to the correct Builder<Model> / Relation
+     * fallback rather than surfacing the scope's own builder atom. Query\Builder is intentionally
+     * NOT matched: a scope returns the Eloquent builder, never the underlying query builder.
+     *
+     * @psalm-mutation-free
+     */
+    private static function isEntirelyEloquentBuilder(Codebase $codebase, Union $type): bool
+    {
+        $builderLower = \strtolower(Builder::class);
+
+        foreach ($type->getAtomicTypes() as $atomic) {
+            // TGenericObject extends TNamedObject, so `Builder<static>` is covered here too.
+            if (!$atomic instanceof TNamedObject) {
+                return false;
+            }
+
+            $classLower = \strtolower($atomic->value);
+            if ($classLower === $builderLower) {
+                continue;
+            }
+
+            try {
+                if (!$codebase->classExtends($classLower, $builderLower)) {
+                    return false;
+                }
+            } catch (\InvalidArgumentException|UnpopulatedClasslikeException) {
+                // Unknown/unpopulated class: can't prove it's a builder → treat it as a value.
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/Handlers/Eloquent/CustomBuilderMethodHandler.php
+++ b/src/Handlers/Eloquent/CustomBuilderMethodHandler.php
@@ -294,7 +294,16 @@ final class CustomBuilderMethodHandler
             return null;
         }
 
-        return new Union([ModelMethodHandler::builderType($builderClass, $modelClass, $codebase)]);
+        // A value-returning scope surfaces its declared return via Laravel's `?? $this` coalesce;
+        // a plain void/fluent scope keeps the custom builder type, CustomBuilder<Model> (issue #1053).
+        $scopeFallback = new Union([ModelMethodHandler::builderType($builderClass, $modelClass, $codebase)]);
+
+        return BuilderScopeHandler::forwardedScopeReturnType(
+            $codebase,
+            $modelClass,
+            $event->getMethodNameLowercase(),
+            $scopeFallback,
+        );
     }
 
     /**

--- a/src/Handlers/Eloquent/ModelMethodHandler.php
+++ b/src/Handlers/Eloquent/ModelMethodHandler.php
@@ -383,7 +383,11 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
                 return null;
             }
 
-            return new Union([self::builderType($builderClass, $calledClass, $codebase)]);
+            // A value-returning scope surfaces its declared return via Laravel's `?? $this`
+            // coalesce; a plain void/fluent scope keeps the builder type (issue #1053).
+            $scopeFallback = new Union([self::builderType($builderClass, $calledClass, $codebase)]);
+
+            return BuilderScopeHandler::forwardedScopeReturnType($codebase, $modelClass, $methodName, $scopeFallback);
         }
 
         // Trait-declared builder methods (e.g., SoftDeletes::withTrashed): return custom builder type.

--- a/src/Handlers/Magic/MethodForwardingHandler.php
+++ b/src/Handlers/Magic/MethodForwardingHandler.php
@@ -590,9 +590,15 @@ final class MethodForwardingHandler implements MethodReturnTypeProviderInterface
         $cacheKey = \strtolower($relationClass) . '::' . $methodName;
         self::$scopeParamsCache[$cacheKey] = $modelClass;
 
-        // Scope exists on the related model → method is fluent, return the full Relation type.
-        return new Union([
+        // Scope exists on the related model → method is fluent: the Relation type is the
+        // `?? $this` fallback. On a relation chain Laravel's callScope returns the wrapped
+        // query for a null result, and Relation::__call maps that back to $this (the Relation),
+        // so a value-returning scope surfaces `declared | Relation` while a void/fluent scope
+        // keeps the full Relation type (issue #1053).
+        $relationFallback = new Union([
             new TGenericObject($relationClass, $templateParams),
         ]);
+
+        return BuilderScopeHandler::forwardedScopeReturnType($codebase, $modelClass, $methodName, $relationFallback);
     }
 }

--- a/tests/Application/app/Models/AbstractDocument.php
+++ b/tests/Application/app/Models/AbstractDocument.php
@@ -61,6 +61,34 @@ abstract class AbstractDocument extends Model
     }
 
     /**
+     * Value-returning scope declared on the abstract PARENT: `->first()` returns `?self`, and
+     * `self` binds to the composing class (AbstractDocument), not the queried child. A forwarded
+     * child call (Contract::query()->firstSigned()) is therefore `AbstractDocument|Builder<Contract>`
+     * — the return's `self` pins to the parent while the `?? $this` fallback stays the child's
+     * builder. Locks the self-expansion path of forwardedScopeReturnType (issue #1053; mirrors the
+     * param `self` pinning of #1031).
+     *
+     * @param  Builder<self>  $query
+     */
+    public function scopeFirstSigned(Builder $query): ?self
+    {
+        return $query->whereNotNull('signed_at')->first();
+    }
+
+    /**
+     * Value-returning scope whose declared return is `?static` (late static binding). A forwarded
+     * child call (Contract::query()->firstSignedStatic()) pins `static` to the queried child as the
+     * PLAIN class — `Contract|Builder<Contract>`, not `Contract&static` — which is exactly what the
+     * `final: true` argument to TypeExpander buys on the return position (issue #1053).
+     *
+     * @param  Builder<static>  $query
+     */
+    public function scopeFirstSignedStatic(Builder $query): ?static
+    {
+        return $query->whereNotNull('signed_at')->first();
+    }
+
+    /**
      * Control for a `self`-typed scope param declared DIRECTLY on the abstract parent
      * (not via a trait). Psalm resolves this `self` to AbstractDocument at scan time, so the
      * handler's re-expansion is idempotent — the directly-declared and trait-hosted paths

--- a/tests/Application/app/Models/Customer.php
+++ b/tests/Application/app/Models/Customer.php
@@ -111,6 +111,30 @@ class Customer extends Authenticatable
     }
 
     /**
+     * Value-returning scope: ->first() returns ?self. Laravel's Builder::callScope evaluates
+     * `$scope(...) ?? $this`, so the null result is swapped for the builder and a forwarded
+     * call (Customer::query()->firstActive(), Customer::firstActive()) is `self | Builder<self>`,
+     * never null. Exercises issue #1053.
+     *
+     * @param  Builder<self>  $query
+     */
+    public function scopeFirstActive($query): ?self
+    {
+        return $query->where('active', 1)->first();
+    }
+
+    /**
+     * Non-null scalar value-returning scope: count() never returns null, so the `?? $this`
+     * fallback is dead and a forwarded call is a plain int, with no Builder union (issue #1053).
+     *
+     * @param  Builder<self>  $query
+     */
+    public function scopeActiveCount($query): int
+    {
+        return $query->where('active', 1)->count();
+    }
+
+    /**
      * Legacy scope with a parameter: called as Customer::query()->ofName('Ada').
      * Exercises the instance-call params hand-off (the caller passes everything after $query).
      *

--- a/tests/Application/app/Models/Vehicle.php
+++ b/tests/Application/app/Models/Vehicle.php
@@ -94,6 +94,19 @@ final class Vehicle extends Model
         $query->where('fuel_type', 'electric');
     }
 
+    /**
+     * Value-returning scope on a relation's related model. On a relation chain Laravel's
+     * callScope returns the wrapped query for a null result, which Relation::__call maps back
+     * to the Relation, so a forwarded call ($customer->vehicles()->firstElectric()) is
+     * `self | <Relation>`, never null. Exercises issue #1053 on the relation-chain path.
+     *
+     * @param  Builder<self>  $query
+     */
+    public function scopeFirstElectric($query): ?self
+    {
+        return $query->where('fuel_type', 'electric')->first();
+    }
+
     public function newEloquentBuilder($query): VehicleBuilder
     {
         return new VehicleBuilder($query);

--- a/tests/Type/tests/Builder/ValueReturningScopeTest.phpt
+++ b/tests/Type/tests/Builder/ValueReturningScopeTest.phpt
@@ -1,0 +1,113 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Builders\VehicleBuilder;
+use App\Models\AbstractDocument;
+use App\Models\Contract;
+use App\Models\Customer;
+use App\Models\Vehicle;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * A local scope is NOT required to return the builder. Laravel's Builder::callScope evaluates
+ * `$result = $scope(...) ?? $this` and returns $result, so a scope whose body `return`s a value
+ * (e.g. ->first(), a count) propagates that value to the caller; only a null/void/builder result
+ * falls back to $this (the builder for these instance and static call forms).
+ *
+ * The plugin used to type EVERY forwarded scope call as Builder<Model>, ignoring the scope's
+ * declared return. These assert the corrected `?? $this` coalesce.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1053
+ */
+
+/** Nullable value scope on a builder instance: self | Builder<self>, never null. */
+function test_nullable_value_scope_instance(): void
+{
+    $_r = Customer::query()->firstActive();
+    /** @psalm-check-type-exact $_r = Customer|Builder<Customer> */
+}
+
+/**
+ * The `?? $this` swap means the result is never null, so a downstream `=== null` check is
+ * correctly reported redundant — matching the runtime, where the scope's null result became
+ * the builder rather than null.
+ */
+function test_nullable_value_scope_is_never_null(): void
+{
+    $r = Customer::query()->firstActive();
+    if ($r === null) {
+        return;
+    }
+
+    $_r = $r;
+    /** @psalm-check-type-exact $_r = Customer|Builder<Customer> */
+}
+
+/** Narrowing to the model recovers the value side for member access. */
+function test_value_scope_narrows_to_model(): void
+{
+    $r = Customer::query()->firstActive();
+    if ($r instanceof Customer) {
+        $_r = $r;
+        /** @psalm-check-type-exact $_r = Customer */
+    }
+}
+
+/** Non-null scalar value scope: plain int, no Builder union. */
+function test_non_null_scalar_value_scope(): void
+{
+    $_r = Customer::query()->activeCount();
+    /** @psalm-check-type-exact $_r = int */
+}
+
+/** Static call form (legacy scope via __callStatic) surfaces the value the same way. */
+function test_nullable_value_scope_static(): void
+{
+    $_r = Customer::firstActive();
+    /** @psalm-check-type-exact $_r = Customer|Builder<Customer> */
+}
+
+/** Regression: a builder-returning scope keeps Builder<Model>. */
+function test_builder_returning_scope_unchanged(): void
+{
+    $_r = Customer::query()->active();
+    /** @psalm-check-type-exact $_r = Builder<Customer> */
+}
+
+/** Regression: a void scope keeps Builder<Model> (the `?? $this` fallback). */
+function test_void_scope_unchanged(): void
+{
+    $_r = Customer::query()->verified();
+    /** @psalm-check-type-exact $_r = Builder<Customer> */
+}
+
+/**
+ * Value scope declared on an abstract PARENT, queried via a concrete child: the return's `self`
+ * pins to the composing parent (AbstractDocument) while the `?? $this` fallback stays the child's
+ * builder (Builder<Contract>).
+ */
+function test_value_scope_self_pins_to_parent(): void
+{
+    $_r = Contract::query()->firstSigned();
+    /** @psalm-check-type-exact $_r = AbstractDocument|Builder<Contract> */
+}
+
+/**
+ * Value scope returning `?static`: pinned to the queried child as the PLAIN class
+ * (Contract|Builder<Contract>), not Contract&static — what `final: true` buys on the return.
+ */
+function test_value_scope_static_pins_to_child(): void
+{
+    $_r = Contract::query()->firstSignedStatic();
+    /** @psalm-check-type-exact $_r = Contract|Builder<Contract> */
+}
+
+/** Value scope on a CUSTOM-builder model: the fallback is the custom builder, not base Builder. */
+function test_value_scope_with_custom_builder(): void
+{
+    $_r = Vehicle::query()->firstElectric();
+    /** @psalm-check-type-exact $_r = VehicleBuilder<Vehicle>|Vehicle */
+}
+?>
+--EXPECTF--
+TypeDoesNotContainNull on line %d: App\Models\Customer|Illuminate\Database\Eloquent\Builder<App\Models\Customer> does not contain null

--- a/tests/Type/tests/Relation/RelationValueScopeTest.phpt
+++ b/tests/Type/tests/Relation/RelationValueScopeTest.phpt
@@ -1,0 +1,36 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use App\Models\Vehicle;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * A value-returning scope forwarded through a relation chain.
+ *
+ * On a relation chain Laravel's Builder::callScope still evaluates `$scope(...) ?? $this`, but
+ * here `$this` is the wrapped query; Relation::__call then maps a result identical to the query
+ * back to the Relation itself. So a scope whose body returns a value yields `value | Relation`,
+ * while the builder/void/null result keeps the Relation type for fluent chaining.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1053
+ */
+
+/** Value scope on a HasMany chain: related-model | the Relation. */
+function test_value_scope_on_hasmany(): void
+{
+    $r = (new Customer())->vehicles();
+    $_r = $r->firstElectric();
+    /** @psalm-check-type-exact $_r = Vehicle|HasMany<Vehicle, Customer> */
+}
+
+/** Regression: a builder/void scope on the same chain keeps the Relation type. */
+function test_builder_scope_on_hasmany_unchanged(): void
+{
+    $r = (new Customer())->vehicles();
+    $_r = $r->byMake('Toyota');
+    /** @psalm-check-type-exact $_r = HasMany<Vehicle, Customer> */
+}
+?>
+--EXPECTF--
+


### PR DESCRIPTION
## Issue to Solve

A local Eloquent scope is not required to return the builder. Laravel's `Builder::callScope()` evaluates `$result = $scope(...) ?? $this`, so a scope whose body `return`s a value (`->first()`, a count, a collection) propagates that value to the caller. Only a null, void, or builder result falls back to the builder.

The plugin typed **every** forwarded scope call as `Builder<Model>`, ignoring the scope's declared return. Downstream this produced false positives: a null check on a `?Model`-returning scope was flagged `TypeDoesNotContainNull` (redundant), and member access routed through the wrong type.

```php
class Post extends Model
{
    /** @param Builder<self> $query */
    public function scopeFirstPublished(Builder $query): ?self
    {
        return $query->where('published', true)->first();
    }
}

$r = Post::query()->firstPublished();
// before: Builder<Post>     after: Post|Builder<Post>
```

## Related

Closes #1053

## Solution Description

Adds `BuilderScopeHandler::forwardedScopeReturnType()`, modeling Laravel's `$scope(...) ?? $this` coalesce on a forwarded scope call's return type:

- nullable value scope (`?Post`) becomes `Post | <fallback>`. The null result is what `?? $this` swaps for the builder, so the inferred type is never null (a downstream `=== null` check is now correctly reported redundant, matching the runtime).
- non-null value scope (`int`) becomes the declared type alone (the `?? $this` branch is dead).
- void, builder-returning, or undeclared scope keeps the unchanged `<fallback>` (prior behavior preserved).

`<fallback>` is the `$this` of `callScope`, supplied by each of the four forwarded scope-call paths it is wired into:

| Path | Call form | Fallback |
| :--- | :--- | :--- |
| `BuilderScopeHandler` | `Post::query()->scope()` | `Builder<Post>` |
| `ModelMethodHandler` | `Post::scope()` (static) | `Builder<Post>` |
| `MethodForwardingHandler` | `$user->posts()->scope()` | the `Relation` (`Relation::__call` maps a query-identical result back to `$this`) |
| `CustomBuilderMethodHandler` | `Post::query()->scope()` on a custom builder | `CustomBuilder<Post>` |

`self`, `static`, and `$this` in the declared return are pinned first (`self` to the scope's composing class, `static` / `$this` to the queried model, with `final: true`), so `?self` resolves to `?Post` before null is dropped. This mirrors the parameter pinning of #1031. A raw-type early-out keeps the common void/fluent scope on its prior fast path. Direct calls (`$this->scope($q)`) are unchanged: they bypass `callScope` and already use the real declared return.

Verification: two new type tests (`ValueReturningScopeTest.phpt`, `RelationValueScopeTest.phpt`) cover all four paths, nullable, non-null scalar, and non-null object value scopes, `self`-vs-`static` pinning on an abstract parent, the custom-builder fallback, and the void/builder regressions. Value-scope fixtures were added to the `Customer`, `Vehicle`, and `AbstractDocument` archetype models. Full suite green (Type 455, Unit 789, app integration), Psalm self-analysis at 100% coverage, CS clean.

## Checklist
- [x] Tests cover the change (type tests in `tests/Type/`)
