### PR TITLE
Stop flagging public legacy `scopeXxx()` query scopes

### DIFF
--- a/docs/issues/PublicModelAccessor.md
+++ b/docs/issues/PublicModelAccessor.md
@@ -10,7 +10,7 @@ A `public` legacy Eloquent attribute accessor or mutator, `getXxxAttribute()` / 
 
 ## Why it matters
 
-It is dispatched indirectly through `__get()` / `__set()` magic and never called by its declared name, so `public` only widens the model's API surface. Unlike a public `#[Scope]`, whose idiomatic static call fatals ([PublicModelScope](PublicModelScope.md)), it breaks nothing on the path anyone writes, so it is a pure convention nit on otherwise-correct code.
+It is dispatched indirectly through `__get()` / `__set()` magic and never called by its declared name, so `public` only widens the model's API surface. It breaks nothing on the path anyone writes, so it is a pure convention nit on otherwise-correct code.
 
 Reported as an error only at Psalm's strictest level (1) and downgraded for everyone else, so a hard failure is effectively opt-in through maximum strictness. A method whose visibility is forced by a contract (an interface method, a parent override, or an abstract trait method) is not reported, since it cannot be narrowed.
 
@@ -49,4 +49,4 @@ Change `public` to `protected`, or migrate an accessor to the modern `Attribute`
 
 ## Scope
 
-Only the legacy accessor / mutator forms are detected: `getXxxAttribute()`, `setXxxAttribute()`. The modern `Attribute`-returning accessor form is out of scope, the framework's own `getAttribute()` / `setAttribute()` are never matched, and `private` is left alone. Legacy `scopeXxx()` query scopes are deliberately not reported, since `public` is Laravel's documented idiom for them. The sibling check for `public` `#[Scope]` scopes is [PublicModelScope](PublicModelScope.md).
+Only the legacy accessor / mutator forms are detected: `getXxxAttribute()`, `setXxxAttribute()`. The modern `Attribute`-returning accessor form is out of scope, the framework's own `getAttribute()` / `setAttribute()` are never matched, and `private` is left alone. Legacy `scopeXxx()` query scopes are deliberately not reported, since `public` is Laravel's documented idiom for them.

--- a/docs/issues/PublicModelAccessor.md
+++ b/docs/issues/PublicModelAccessor.md
@@ -6,11 +6,11 @@ nav_order: 9
 
 # PublicModelAccessor
 
-A `public` legacy Eloquent convention method: a legacy `scopeXxx()` query scope, or a legacy `getXxxAttribute()` / `setXxxAttribute()` accessor or mutator. Laravel's convention is `protected`. Enabled by default; see [How to disable](#how-to-disable).
+A `public` legacy Eloquent attribute accessor or mutator, `getXxxAttribute()` / `setXxxAttribute()`. Laravel's convention is `protected`. Enabled by default; see [How to disable](#how-to-disable).
 
 ## Why it matters
 
-These are dispatched indirectly (scopes through the query builder, accessors through `__get()` / `__set()` magic) and never called by their declared name, so `public` only widens the model's API surface. Unlike a public `#[Scope]`, whose idiomatic static call fatals ([PublicModelScope](PublicModelScope.md)), these break nothing on the path anyone writes, so each is a pure convention nit on otherwise-correct code.
+It is dispatched indirectly through `__get()` / `__set()` magic and never called by its declared name, so `public` only widens the model's API surface. Unlike a public `#[Scope]`, whose idiomatic static call fatals ([PublicModelScope](PublicModelScope.md)), it breaks nothing on the path anyone writes, so it is a pure convention nit on otherwise-correct code.
 
 Reported as an error only at Psalm's strictest level (1) and downgraded for everyone else, so a hard failure is effectively opt-in through maximum strictness. A method whose visibility is forced by a contract (an interface method, a parent override, or an abstract trait method) is not reported, since it cannot be narrowed.
 
@@ -19,12 +19,7 @@ Reported as an error only at Psalm's strictest level (1) and downgraded for ever
 ```php
 class Post extends Model
 {
-    protected function scopePublished(Builder $query): Builder // public here would be reported
-    {
-        return $query->whereNotNull('published_at');
-    }
-
-    protected function getTitleAttribute(): string // and so would a public accessor
+    protected function getTitleAttribute(): string // public here would be reported
     {
         return ucfirst($this->attributes['title']);
     }
@@ -54,4 +49,4 @@ Change `public` to `protected`, or migrate an accessor to the modern `Attribute`
 
 ## Scope
 
-Only the legacy forms are detected: `scopeXxx()`, `getXxxAttribute()`, `setXxxAttribute()`. The modern `Attribute`-returning accessor form is out of scope, the framework's own `getAttribute()` / `setAttribute()` are never matched, and `private` is left alone. The sibling check for `public` `#[Scope]` scopes is [PublicModelScope](PublicModelScope.md).
+Only the legacy accessor / mutator forms are detected: `getXxxAttribute()`, `setXxxAttribute()`. The modern `Attribute`-returning accessor form is out of scope, the framework's own `getAttribute()` / `setAttribute()` are never matched, and `private` is left alone. Legacy `scopeXxx()` query scopes are deliberately not reported, since `public` is Laravel's documented idiom for them. The sibling check for `public` `#[Scope]` scopes is [PublicModelScope](PublicModelScope.md).

--- a/docs/issues/PublicModelScope.md
+++ b/docs/issues/PublicModelScope.md
@@ -41,4 +41,4 @@ Change `public` to `protected`. Call sites are unaffected.
 </issueHandlers>
 ```
 
-`private` is intentionally not flagged; a private `#[Scope]` is rejected by Laravel and surfaces elsewhere. The sibling check for legacy accessors and mutators is [PublicModelAccessor](PublicModelAccessor.md).
+`private` is intentionally not flagged; a private `#[Scope]` is rejected by Laravel and surfaces elsewhere.

--- a/docs/issues/PublicModelScope.md
+++ b/docs/issues/PublicModelScope.md
@@ -14,7 +14,7 @@ A `public` `#[Scope]` is a runtime hazard, not just a convention slip. A static 
 
 Reported as an error at project error levels 1 to 4, the range most analysis-serious codebases use; downgraded at looser levels (5 to 8). A scope whose visibility is forced by a contract (an interface method, a parent override, or an abstract trait method) is not reported, since it cannot be narrowed.
 
-Legacy `scopeXxx()` scopes go to [PublicModelAccessor](PublicModelAccessor.md) instead: their idiomatic call (`Post::active()`) is unaffected by visibility, so they are treated as a pure convention nit.
+Legacy `scopeXxx()` scopes are not reported at all: `public` is Laravel's documented idiom for them, and their `$builder->active()` dispatch is unaffected by visibility, so there is nothing to flag. Only the `#[Scope]` form, whose static call is a genuine runtime fatal, is checked.
 
 ## Example
 
@@ -41,4 +41,4 @@ Change `public` to `protected`. Call sites are unaffected.
 </issueHandlers>
 ```
 
-`private` is intentionally not flagged; a private `#[Scope]` is rejected by Laravel and surfaces elsewhere. The sibling check for legacy scopes and accessors is [PublicModelAccessor](PublicModelAccessor.md).
+`private` is intentionally not flagged; a private `#[Scope]` is rejected by Laravel and surfaces elsewhere. The sibling check for legacy accessors and mutators is [PublicModelAccessor](PublicModelAccessor.md).

--- a/docs/issues/index.md
+++ b/docs/issues/index.md
@@ -16,6 +16,6 @@ The plugin ships advanced Laravel-aware static analysis checks that extend Psalm
 - [ModelMakeDiscouraged](ModelMakeDiscouraged.md) — `Model::make()` used instead of `new Model()`
 - [OctaneIncompatibleBinding](OctaneIncompatibleBinding.md) — `singleton()` closure resolves a request-scoped service such as Request, Session, or Auth (auto-enabled when `laravel/octane` is installed)
 - [PublicModelScope](PublicModelScope.md) — `public` `#[Scope]` Eloquent query scope, whose static call is a runtime fatal (reported at error levels 1 to 4)
-- [PublicModelAccessor](PublicModelAccessor.md) — `public` legacy `scopeXxx()` scope or legacy `getXxxAttribute()` / `setXxxAttribute()` accessor, a pure convention nit (reported at error level 1)
+- [PublicModelAccessor](PublicModelAccessor.md) — `public` legacy `getXxxAttribute()` / `setXxxAttribute()` accessor or mutator, a pure convention nit (reported at error level 1)
 
 Each issue page explains what it detects, why it matters, and how to fix it.

--- a/src/Handlers/Rules/PublicScopeAccessorVisibilityHandler.php
+++ b/src/Handlers/Rules/PublicScopeAccessorVisibilityHandler.php
@@ -16,12 +16,18 @@ use Psalm\Plugin\EventHandler\Event\AfterCodebasePopulatedEvent;
 use Psalm\Storage\MethodStorage;
 
 /**
- * Flags `public` Eloquent scopes and legacy attribute accessors/mutators, which Laravel's convention wants
- * `protected` (they are dispatched indirectly and never called by name). Routes by the method's danger:
- * a `public` `#[Scope]` (the only one with a static-call runtime footgun) emits {@see PublicModelScope};
- * a legacy `scopeXxx()` scope or a legacy `getXxxAttribute()` / `setXxxAttribute()` accessor (pure
- * convention) emits {@see PublicModelAccessor}. Those issue classes carry the full rationale, their error
- * levels, and the public-only decision.
+ * Flags `public` Eloquent `#[Scope]` methods and legacy attribute accessors/mutators, which Laravel's
+ * convention wants `protected` (they are dispatched indirectly and never called by name). Routes by the
+ * method's danger: a `public` `#[Scope]` (the only one with a static-call runtime footgun) emits
+ * {@see PublicModelScope}; a legacy `getXxxAttribute()` / `setXxxAttribute()` accessor (pure convention)
+ * emits {@see PublicModelAccessor}. Those issue classes carry the full rationale, their error levels, and
+ * the public-only decision.
+ *
+ * Legacy `scopeXxx()` methods are deliberately NOT flagged: Laravel's own documentation writes local
+ * scopes as `public function scopeActive()`, so `public` is the framework's documented idiom there, not a
+ * smell. Visibility is irrelevant to their `$builder->active()` dispatch, and reporting them lit up the
+ * normal style across whole codebases (see the v4.13.2 benchmark). Only the `#[Scope]` form, whose static
+ * call is a genuine runtime fatal, is worth flagging.
  *
  * Enabled by default: registered unconditionally (see Plugin::registerHandlers()), like ModelMakeHandler.
  * Silence per project through the issueHandlers config.
@@ -105,10 +111,9 @@ final class PublicScopeAccessorVisibilityHandler implements AfterCodebasePopulat
                 // the method (not the model), so a trait method shared by several models dedupes to one
                 // diagnostic at the trait declaration: same type, location, message.
                 //  - #[Scope] is the only static-call footgun -> PublicModelScope (error at levels 1-4).
-                //  - legacy scopeXxx() and legacy accessors are pure convention -> PublicModelAccessor (level 1).
+                //  - legacy accessors are pure convention -> PublicModelAccessor (level 1).
                 $issue = match ($kind) {
                     'scope-attribute' => new PublicModelScope(self::scopeAttributeMessage($casedName), $location),
-                    'scope-legacy' => new PublicModelAccessor(self::legacyScopeMessage($casedName), $location),
                     'accessor' => new PublicModelAccessor(self::accessorMessage($casedName), $location),
                 };
 
@@ -118,11 +123,11 @@ final class PublicScopeAccessorVisibilityHandler implements AfterCodebasePopulat
     }
 
     /**
-     * Classify a public model method by the convention it breaks, or null if it is neither a scope nor a
-     * legacy accessor. `#[Scope]` is checked first so an attributed method routes to the danger issue even
-     * when its name also matches the legacy `scopeXxx` convention.
+     * Classify a public model method by the convention it breaks, or null if it is neither a `#[Scope]`
+     * method nor a legacy accessor. Legacy `scopeXxx()` methods are intentionally ignored (see the class
+     * docblock): `public` is Laravel's documented idiom for them, so they are not a convention violation.
      *
-     * @return 'scope-attribute'|'scope-legacy'|'accessor'|null
+     * @return 'scope-attribute'|'accessor'|null
      *
      * @psalm-mutation-free
      */
@@ -130,10 +135,6 @@ final class PublicScopeAccessorVisibilityHandler implements AfterCodebasePopulat
     {
         if (EloquentModelMethods::hasScopeAttribute($methodStorage)) {
             return 'scope-attribute';
-        }
-
-        if (EloquentModelMethods::isLegacyScopeMethodName($methodName, $methodStorage->cased_name)) {
-            return 'scope-legacy';
         }
 
         if (EloquentModelMethods::isLegacyAccessorMethodName($methodName)) {
@@ -148,13 +149,6 @@ final class PublicScopeAccessorVisibilityHandler implements AfterCodebasePopulat
     {
         return "Eloquent #[Scope] method {$methodName}() should be protected, not public: called statically "
             . "(Model::{$methodName}()) it is a runtime fatal.";
-    }
-
-    /** @psalm-pure */
-    private static function legacyScopeMessage(string $methodName): string
-    {
-        return "Eloquent query scope {$methodName}() should be protected, not public; it is dispatched "
-            . 'through the query builder, never by name.';
     }
 
     /** @psalm-pure */

--- a/src/Issues/PublicModelAccessor.php
+++ b/src/Issues/PublicModelAccessor.php
@@ -7,18 +7,16 @@ namespace Psalm\LaravelPlugin\Issues;
 use Psalm\Issue\PluginIssue;
 
 /**
- * Reported when an Eloquent model exposes a `public` legacy convention method that Laravel dispatches
- * indirectly and the convention wants `protected`:
+ * Reported when an Eloquent model exposes a `public` legacy attribute accessor / mutator
+ * `getXxxAttribute()` / `setXxxAttribute()`, which Laravel dispatches indirectly through `__get()` /
+ * `__set()` magic and the convention wants `protected`.
  *
- *  - a legacy `scopeXxx()` query scope (dispatched through the query builder), or
- *  - a legacy attribute accessor / mutator `getXxxAttribute()` / `setXxxAttribute()` (dispatched through
- *    `__get()` / `__set()` magic).
- *
- * These are never called by their declared name, so `public` only widens the model's API surface. Unlike a
- * `public` `#[Scope]`, whose idiomatic static call fatals (see {@see PublicModelScope}), these break nothing
- * on the path anyone writes, so each is a pure convention nit on otherwise-correct code. Only `public` is
+ * It is never called by its declared name, so `public` only widens the model's API surface. Unlike a
+ * `public` `#[Scope]`, whose idiomatic static call fatals (see {@see PublicModelScope}), it breaks nothing
+ * on the path anyone writes, so it is a pure convention nit on otherwise-correct code. Only `public` is
  * reported; `private` is a separate dead-code question. The modern `firstName(): Attribute` accessor form is
- * out of scope.
+ * out of scope. Legacy `scopeXxx()` query scopes are NOT reported: `public` is Laravel's documented idiom
+ * for them (see {@see \Psalm\LaravelPlugin\Handlers\Rules\PublicScopeAccessorVisibilityHandler}).
  *
  * Enabled by default. Silence per project via
  * `<PluginIssue name="PublicModelAccessor" errorLevel="suppress" />` in psalm.xml's issueHandlers.

--- a/tests/Type/tests/Model/LegacyScopeUnusedMethodTest.phpt
+++ b/tests/Type/tests/Model/LegacyScopeUnusedMethodTest.phpt
@@ -19,6 +19,11 @@ use Illuminate\Database\Eloquent\Model;
  *  - Lock-in under findUnusedCode is deferred to #869 (default type-test config has it off).
  *  - Private negative case is structurally unflaggable in Psalm 7: ClassLikes.php:1994 skips
  *    unused-method emission on private methods of classes with __call, and Model declares __call.
+ *
+ * Under the default config (findUnusedCode off) this fixture emits NOTHING: PossiblyUnusedMethod is
+ * suppressed by SuppressHandler, and the public `scopeActive()` is no longer flagged either, because
+ * legacy `scopeXxx()` scopes are Laravel's documented `public` idiom and PublicScopeAccessorVisibilityHandler
+ * deliberately ignores them.
  */
 final class LegacyScopeModel extends Model
 {
@@ -44,4 +49,3 @@ final class LegacyScopeModel extends Model
 new LegacyScopeModel();
 ?>
 --EXPECT--
-PublicModelAccessor on line 29: Eloquent query scope scopeActive() should be protected, not public; it is dispatched through the query builder, never by name.

--- a/tests/Type/tests/PublicScopeAccessorVisibilityTest.phpt
+++ b/tests/Type/tests/PublicScopeAccessorVisibilityTest.phpt
@@ -18,12 +18,6 @@ class PublicScopesModel extends Model
         return $query;
     }
 
-    // Reported as PublicModelAccessor: a public legacy scopeXxx().
-    public function scopePublished(Builder $query): Builder
-    {
-        return $query;
-    }
-
     // Reported as PublicModelAccessor: a public legacy accessor.
     public function getTitleAttribute(): string
     {
@@ -34,6 +28,12 @@ class PublicScopesModel extends Model
     public function setTitleAttribute(string $value): void
     {
         $this->attributes['title'] = $value;
+    }
+
+    // Clean: a public legacy scopeXxx() is Laravel's documented idiom and is deliberately NOT reported.
+    public function scopePublished(Builder $query): Builder
+    {
+        return $query;
     }
 
     // Clean: a protected #[Scope] (the correct convention).
@@ -54,47 +54,47 @@ class PublicScopesModel extends Model
     {
     }
 
-    // Clean: a public method that only shares the `scope` prefix.
-    public function scoped(): void
+    // Clean: a public method that only shares the `get` prefix.
+    public function getter(): void
     {
     }
 }
 
-// Clean: a private scope is a separate dead-code concern, not a visibility convention one.
-class PrivateScopeFixtureModel extends Model
+// Clean: a private accessor is a separate dead-code concern, not a visibility convention one.
+class PrivateAccessorFixtureModel extends Model
 {
-    private function scopeSecret(Builder $query): Builder
+    private function getSecretAttribute(): string
     {
-        return $query;
+        return 'secret';
     }
 }
 
-// A public legacy scope on a trait is reported once (PublicModelAccessor), at the trait's own declaration.
-trait HasArchivedScope
+// A public legacy accessor on a trait is reported once (PublicModelAccessor), at the trait's own declaration.
+trait HasArchivedNameAccessor
 {
-    public function scopeArchived(Builder $query): Builder
+    public function getArchivedNameAttribute(): string
     {
-        return $query;
+        return 'archived';
     }
 }
 
-class TraitScopeModel extends Model
+class TraitAccessorModel extends Model
 {
-    use HasArchivedScope;
+    use HasArchivedNameAccessor;
 }
 
 // A second model composing the same trait does NOT add a second report (deduped on the shared storage).
-class SecondTraitScopeModel extends Model
+class SecondTraitAccessorModel extends Model
 {
-    use HasArchivedScope;
+    use HasArchivedNameAccessor;
 }
 
-// A public legacy scope on an ABSTRACT base is reported at the base's own declaration...
+// A public legacy accessor on an ABSTRACT base is reported at the base's own declaration...
 abstract class AbstractBaseModel extends Model
 {
-    public function scopeOnBase(Builder $query): Builder
+    public function getOnBaseAttribute(): string
     {
-        return $query;
+        return 'base';
     }
 }
 
@@ -109,30 +109,30 @@ class ConcreteChildModel extends AbstractBaseModel
 // the same but is omitted because the strict test config trips unrelated MissingAbstractPureAnnotation
 // noise on the interface declaration).
 
-// An override of a public parent scope.
+// An override of a public parent accessor.
 class OverridingChildModel extends PublicScopesModel
 {
     #[\Override]
-    public function scopePublished(Builder $query): Builder
+    public function getTitleAttribute(): string
     {
-        return $query;
+        return 'overridden';
     }
 }
 
-// A scope required by an abstract trait method.
-trait RequiresPublishedScope
+// An accessor required by an abstract trait method.
+trait RequiresDisplayNameAccessor
 {
-    abstract public function scopeRequiredPublished(Builder $query): Builder;
+    abstract public function getDisplayNameAttribute(): string;
 }
 
 class AbstractTraitRequiredModel extends Model
 {
-    use RequiresPublishedScope;
+    use RequiresDisplayNameAccessor;
 
     #[\Override]
-    public function scopeRequiredPublished(Builder $query): Builder
+    public function getDisplayNameAttribute(): string
     {
-        return $query;
+        return 'name';
     }
 }
 
@@ -151,8 +151,7 @@ class NotAModel
 ?>
 --EXPECTF--
 PublicModelScope on line %d: Eloquent #[Scope] method active() should be protected, not public: called statically (Model::active()) it is a runtime fatal.
-PublicModelAccessor on line %d: Eloquent query scope scopePublished() should be protected, not public; it is dispatched through the query builder, never by name.
 PublicModelAccessor on line %d: Eloquent accessor/mutator getTitleAttribute() should be protected, not public; it is dispatched via __get()/__set(), never by name.
 PublicModelAccessor on line %d: Eloquent accessor/mutator setTitleAttribute() should be protected, not public; it is dispatched via __get()/__set(), never by name.
-PublicModelAccessor on line %d: Eloquent query scope scopeArchived() should be protected, not public; it is dispatched through the query builder, never by name.
-PublicModelAccessor on line %d: Eloquent query scope scopeOnBase() should be protected, not public; it is dispatched through the query builder, never by name.
+PublicModelAccessor on line %d: Eloquent accessor/mutator getArchivedNameAttribute() should be protected, not public; it is dispatched via __get()/__set(), never by name.
+PublicModelAccessor on line %d: Eloquent accessor/mutator getOnBaseAttribute() should be protected, not public; it is dispatched via __get()/__set(), never by name.


### PR DESCRIPTION
## Issue to Solve

The `PublicScopeAccessorVisibilityHandler` rule (added in #1056) flagged every `public` legacy `scopeXxx()` query scope as `PublicModelAccessor`, recommending `protected`. But `public` is Laravel's documented idiom for local scopes (the docs write `public function scopeActive(Builder $query)`), and a scope's `$builder->active()` dispatch is unaffected by visibility. So the check lit up the framework's normal style en masse rather than a real smell. On one benchmark app it produced 129 findings, 125 of them public legacy scopes.

## Related

#1056

## Solution Description

Drop legacy `scopeXxx()` from the rule entirely. The two genuinely useful cases stay:

- `#[Scope]`-attributed methods keep emitting `PublicModelScope` (a public `#[Scope]` static call is a runtime fatal, so this one earns error-level).
- Legacy `getXxxAttribute()` / `setXxxAttribute()` accessors keep emitting `PublicModelAccessor`.

`EloquentModelMethods::isLegacyScopeMethodName()` is retained because `SuppressHandler` still uses it.

Verified: full type suite (455 tests) and unit tests green, self-Psalm clean at 100% coverage, coding style clean. Real-world benchmark (18 apps) confirms the change: `PublicModelAccessor` on ixdf-web drops 129 to 4 (only real accessors remain), and the cross-app v4.13.1 to v4.13.2-RC1 delta drops from +250 to +82, all of it now genuine accessor and `#[Scope]` findings.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)
- [x] Documentation is updated (if needed, otherwise remove this item)
