### PR TITLE
CI: pin Monica to beta.4 to avoid malware-flagged dependency

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,8 +28,11 @@ permissions:
 env:
   # Pinned Monica release for reproducible benchmarks.
   # Monica is a real-world Laravel app (~700 PHP files, Laravel 12) https://github.com/monicahq/monica.
+  # Pinned to beta.4 (not the newer beta.5) because beta.5 locks the dev dependency
+  # laravel-lang/http-statuses 3.10.3, which Packagist flags as malware, so `composer install`
+  # aborts. beta.4 locks 3.8.2, which is not flagged. Revisit when a clean Monica tag ships.
   MONICA_REPO: monicahq/monica
-  MONICA_REF: "v5.0.0-beta.5"
+  MONICA_REF: "v5.0.0-beta.4"
   PHP_VERSION: "8.3"
   HYPERFINE_RUNS: 3
 


### PR DESCRIPTION
## Problem

The `master-benchmark` job fails at the Monica `composer install` step ([run 27515015810](https://github.com/psalm/psalm-plugin-laravel/actions/runs/27515015810/job/81322000449)):

```
Package laravel-lang/http-statuses 3.10.3 (in the lock file) was not loaded,
because it was flagged as malware ... reason: malware.
...
##[error]Your requirements could not be resolved to an installable set of packages.
```

Monica `v5.0.0-beta.5` locks the dev dependency `laravel-lang/http-statuses` at `3.10.3` (via `laravel-lang/common 6.7.0`). Packagist flags that version as malware, so `composer install` aborts.

## Fix

Pin `MONICA_REF` to the lowest Monica tag whose lock resolves to a non-flagged `http-statuses`:

| Monica tag | `http-statuses` lock | Flagged? |
|---|---|---|
| v5.0.0-beta.1 / beta.2 | 3.3.1 | yes |
| v5.0.0-beta.3 | 3.4.4 | yes |
| **v5.0.0-beta.4** | **3.8.2** | **no** |
| v5.0.0-beta.5 | 3.10.3 | yes |

Downgrade `v5.0.0-beta.5` to `v5.0.0-beta.4`. The vendor cache key is derived from `MONICA_REF`, so the cache re-primes automatically.

Revisit when a clean Monica tag ships.
