### PR TITLE
ci(benchmark): keep Monica beta.5, bump malware-flagged dep instead of downgrading

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,11 +28,13 @@ permissions:
 env:
   # Pinned Monica release for reproducible benchmarks.
   # Monica is a real-world Laravel app (~700 PHP files, Laravel 12) https://github.com/monicahq/monica.
-  # Pinned to beta.4 (not the newer beta.5) because beta.5 locks the dev dependency
-  # laravel-lang/http-statuses 3.10.3, which Packagist flags as malware, so `composer install`
-  # aborts. beta.4 locks 3.8.2, which is not flagged. Revisit when a clean Monica tag ships.
+  # beta.5 is the lowest tag on Laravel 12 (the plugin requires illuminate ^12 || ^13;
+  # beta.4 and earlier ship Laravel 11). Its lock pins the dev dependency
+  # laravel-lang/http-statuses 3.10.3, which Packagist flags as malware, so a plain
+  # `composer install` aborts. The Prime step below bumps that one package to a clean
+  # release before installing (see there).
   MONICA_REPO: monicahq/monica
-  MONICA_REF: "v5.0.0-beta.4"
+  MONICA_REF: "v5.0.0-beta.5"
   PHP_VERSION: "8.3"
   HYPERFINE_RUNS: 3
 
@@ -123,14 +125,19 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /tmp/monica-source/vendor
-          key: monica-vendor-${{ env.MONICA_REF }}-php${{ env.PHP_VERSION }}-v1
+          key: monica-vendor-${{ env.MONICA_REF }}-php${{ env.PHP_VERSION }}-v2
 
       - name: Prime Monica vendor
         run: |
-          if [ ! -d /tmp/monica-source/vendor ]; then
-            cd /tmp/monica-source
-            COMPOSER_MEMORY_LIMIT=-1 composer install --no-interaction --no-progress
-          fi
+          cd /tmp/monica-source
+          # Monica's lock pins the dev dependency laravel-lang/http-statuses at a version
+          # Packagist flags as malware, so a plain `composer install` aborts. Bumping just
+          # that one package to a clean release (the constraint is ^3.8) rewrites the lock and
+          # installs the full set. Run unconditionally — not behind a `[ ! -d vendor ]` guard —
+          # because the vendor cache does not include composer.lock, so on a cache hit the lock
+          # is restored from the fresh git clone at the flagged version; the rewrite must run
+          # every time so the corrected lock is what `cp -a` copies into the base/pr projects.
+          COMPOSER_MEMORY_LIMIT=-1 composer update laravel-lang/http-statuses --no-interaction --no-progress
 
       - name: Setup benchmark projects
         run: |
@@ -238,14 +245,16 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /tmp/monica/vendor
-          key: monica-vendor-${{ env.MONICA_REF }}-php${{ env.PHP_VERSION }}-v1
+          key: monica-vendor-${{ env.MONICA_REF }}-php${{ env.PHP_VERSION }}-v2
 
       - name: Setup benchmark project
         run: |
           cd /tmp/monica
-          if [ ! -d vendor ]; then
-            COMPOSER_MEMORY_LIMIT=-1 composer install --no-interaction --no-progress
-          fi
+          # Bump Monica's malware-flagged dev dependency laravel-lang/http-statuses to a clean
+          # release (see the pr-benchmark "Prime Monica vendor" step for the full rationale).
+          # Unconditional: the vendor cache excludes composer.lock, so the flagged lock returns
+          # on every cache hit and must be rewritten before any other composer command runs.
+          COMPOSER_MEMORY_LIMIT=-1 composer update laravel-lang/http-statuses --no-interaction --no-progress
           composer config repositories.plugin \
             '{"type": "path", "url": "'"$GITHUB_WORKSPACE"'", "options": {"symlink": true}}'
           composer config minimum-stability dev


### PR DESCRIPTION
## Background

#1064 fixed the malware-flagged `laravel-lang/http-statuses 3.10.3` failure by downgrading Monica from `v5.0.0-beta.5` to `v5.0.0-beta.4`. That traded one failure for another: beta.4 ships **Laravel 11**, but the plugin requires `illuminate ^12 || ^13`, so `composer update psalm/plugin-laravel` could not resolve ([run 27529425175](https://github.com/psalm/psalm-plugin-laravel/actions/runs/27529425175/job/81363667810)):

```
psalm/plugin-laravel ... requires illuminate/config ^12.0 || ^13.0 -> found
illuminate/config[...] but these were not loaded, likely because it conflicts
with another require.
##[error]Your requirements could not be resolved to an installable set of packages.
```

beta.5 is the lowest Monica tag on Laravel 12, so a clean downgrade is not possible.

## Fix

Restore `MONICA_REF: v5.0.0-beta.5` and neutralize the malware-flagged dependency directly: before any other composer command, run

```
composer update laravel-lang/http-statuses --no-interaction --no-progress
```

`http-statuses` is a transitive **dev** dependency (via `laravel-lang/common`, constraint `^3.8`). Explicitly updating just that package lets the solver skip the flagged `3.10.3` and pick a clean release (`3.13.2`), rewrite the lock, and install the full set. Verified locally on a fresh beta.5 clone: `Upgrading laravel-lang/http-statuses (3.10.3 => 3.13.2)`, then 238 installs, no malware block.

### Why unconditional (no `[ ! -d vendor ]` guard)

The Monica vendor cache stores only `vendor/`, not `composer.lock`. On a cache hit the lock is restored from the fresh `git clone` at the flagged `3.10.3`. The rewrite must run on every job so the corrected lock is what `cp -a` copies into the base/pr projects, where `composer update psalm/plugin-laravel --with-all-dependencies` would otherwise re-hit the block. Cache keys bumped `v1 -> v2` to drop any stale flagged vendor.

Applied to both the `pr-benchmark` and `master-benchmark` jobs.
