### PR TITLE
Resolve higher-order builder where proxies (`->orWhere->scope()`)

### DIFF
--- a/stubs/common/Database/Eloquent/Builder.phpstub
+++ b/stubs/common/Database/Eloquent/Builder.phpstub
@@ -9,7 +9,17 @@ use Illuminate\Support\Traits\ForwardsCalls;
 
 /**
  * @template-covariant TModel of \Illuminate\Database\Eloquent\Model
- * @property-read HigherOrderBuilderProxy $orWhere
+ *
+ * Higher-order where proxies (`$builder->orWhere->scope()`). The `<TModel>` arg is
+ * essential and threads through to `HigherOrderBuilderProxy::__call`, which returns
+ * `Builder<TModel>` — see HigherOrderBuilderProxy.phpstub.
+ * Do NOT drop it to `@property-read HigherOrderBuilderProxy` (non-generic), nor to
+ * `@property-read static`/`$this` (Larastan's form): Psalm 7 then loses TModel in the
+ * property-read (the latter collapse to `Builder&static`) and the chained scope falls
+ * to mixed. Verified empirically.
+ * @property-read HigherOrderBuilderProxy<TModel> $orWhere
+ * @property-read HigherOrderBuilderProxy<TModel> $whereNot
+ * @property-read HigherOrderBuilderProxy<TModel> $orWhereNot
  *
  * @mixin \Illuminate\Database\Query\Builder
  */

--- a/stubs/common/Database/Eloquent/HigherOrderBuilderProxy.phpstub
+++ b/stubs/common/Database/Eloquent/HigherOrderBuilderProxy.phpstub
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+/**
+ * Higher-order where proxy: `$builder->orWhere->active()` builds a where-clause on the
+ * underlying builder and returns it.
+ *
+ * Laravel's real class is NOT generic. We re-declare it WITH a `@template TModel` so the
+ * model binding survives the chain: `Builder<TModel>` threads `TModel` into this proxy via
+ * `@property-read HigherOrderBuilderProxy<TModel> $orWhere` (declared directly on Builder),
+ * and `__call` returns `Builder<TModel>`. The proxied method is itself a scope, dispatched
+ * through `__call`; type-wise every proxied call yields the same builder, so a single
+ * `@return Builder<TModel>` covers it — no handler needed.
+ *
+ * `@template-covariant` (not invariant): `TModel` appears only in output position
+ * (`__call`'s return), so when the receiver is `Builder<Model&static>` on a non-final
+ * model, the inferred `Builder<Model&static>` must satisfy a call-site `Builder<self>` —
+ * covariance accepts it, invariance would reject. Mirrors Builder's own variance and the
+ * relation-stub rule in CLAUDE.md.
+ *
+ * Do NOT drop the `@template` and type the property as `@property-read static`/`$this`
+ * (Larastan's form): Psalm 7 collapses both to `Builder&static` in a property-read and
+ * loses `TModel`, so the chained scope falls to mixed. Verified empirically.
+ *
+ * Lenient by design: any proxied call yields `Builder<TModel>`, with no check that the
+ * name is a real scope (matches Laravel's runtime and the collection proxy).
+ * @todo Validate the proxied method is a real scope and flag unknown names. A stub
+ *       cannot express this, so it means reintroducing a handler (MethodReturnType /
+ *       AfterMethodCallAnalysis) once the Model Metadata Registry owns the per-model
+ *       scope list. Deferred — see issue #1062.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1062
+ *
+ * @template-covariant TModel of \Illuminate\Database\Eloquent\Model
+ */
+class HigherOrderBuilderProxy
+{
+    /**
+     * @param array<array-key, mixed> $parameters
+     * @return Builder<TModel>
+     */
+    public function __call(string $method, array $parameters): mixed {}
+}

--- a/tests/Application/app/Models/Customer.php
+++ b/tests/Application/app/Models/Customer.php
@@ -111,6 +111,20 @@ class Customer extends Authenticatable
     }
 
     /**
+     * Variance lock for the higher-order where proxy: calling `->orWhere->scope()` inside a
+     * non-final model method whose return is typed `Builder<self>` must NOT raise
+     * InvalidReturnStatement. The proxy carries `@template-covariant TModel`, so the inferred
+     * `Builder<Customer>` (Model&static collapses to Customer) satisfies `Builder<self>`.
+     * See HigherOrderBuilderProxy.phpstub and issue #1062.
+     *
+     * @return Builder<self>
+     */
+    public function activeOrVerified(): Builder
+    {
+        return static::query()->orWhere->verified();
+    }
+
+    /**
      * Value-returning scope: ->first() returns ?self. Laravel's Builder::callScope evaluates
      * `$scope(...) ?? $this`, so the null result is swapped for the builder and a forwarded
      * call (Customer::query()->firstActive(), Customer::firstActive()) is `self | Builder<self>`,

--- a/tests/Type/tests/Builder/HigherOrderBuilderProxyTest.phpt
+++ b/tests/Type/tests/Builder/HigherOrderBuilderProxyTest.phpt
@@ -1,0 +1,76 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+
+/**
+ * Higher-order where proxies (`->orWhere->scope()`, `->whereNot->scope()`,
+ * `->orWhereNot->scope()`) must resolve to Builder<TModel> instead of collapsing to
+ * mixed, so the trailing chain (->get(), further scopes) infers correctly.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1062
+ */
+
+/** Legacy scope through the orWhere proxy. */
+function test_or_where_legacy_scope(): void
+{
+    $_result = Customer::query()->orWhere->active();
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
+
+/** #[Scope]-attributed scope through the orWhere proxy. */
+function test_or_where_attribute_scope(): void
+{
+    $_result = Customer::query()->orWhere->verified();
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
+
+/** The proxied chain stays a builder, so ->get() narrows to the eloquent collection. */
+function test_or_where_chain_to_get(): void
+{
+    $_result = Customer::query()->orWhere->active()->get();
+    /** @psalm-check-type-exact $_result = Collection<int, Customer> */
+}
+
+/** Proxy used after a static scope entry point. */
+function test_static_scope_then_proxy(): void
+{
+    $_result = Customer::active()->orWhere->verified()->get();
+    /** @psalm-check-type-exact $_result = Collection<int, Customer> */
+}
+
+/** whereNot proxy resolves the same way. */
+function test_where_not_proxy(): void
+{
+    $_result = Customer::query()->whereNot->active();
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
+
+/** orWhereNot proxy resolves the same way. */
+function test_or_where_not_proxy(): void
+{
+    $_result = Customer::query()->orWhereNot->active();
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
+
+/** A scope with args through the proxy accepts the trailing args. */
+function test_proxy_scope_with_arg(): void
+{
+    $_result = Customer::query()->orWhere->ofName('Ada');
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
+
+/**
+ * Variance: the proxy carries @template-covariant TModel, so a proxied call inside a
+ * non-final model method typed `@return Builder<self>` resolves without InvalidReturnStatement.
+ * Customer::activeOrVerified() exercises the declaration; here we assert the call-site type.
+ */
+function test_proxy_variance_self_return(): void
+{
+    $_result = (new Customer())->activeOrVerified();
+    /** @psalm-check-type-exact $_result = Builder<Customer> */
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

Higher-order builder where proxies collapsed to `mixed`:

```php
$users = User::popular()->orWhere->active()->get();
// UndefinedMagicMethod: HigherOrderBuilderProxy::active does not exist
// MixedMethodCall: ->get()
// $users: mixed
```

`->orWhere` (also `->whereNot`, `->orWhereNot`) returns a `HigherOrderBuilderProxy`; the trailing scope is proxied onto the builder via `__call`. The model binding (`TModel`) was lost at the property-read step because the proxy carried no template parameter, so the chained scope fell to `mixed`.

## Related

Closes #1062

## Solution Description

Pure stub, no handler:

- Re-declare `HigherOrderBuilderProxy` as generic (`@template-covariant TModel`) with `__call(): Builder<TModel>` (`stubs/common/Database/Eloquent/HigherOrderBuilderProxy.phpstub`).
- Type the three proxy properties directly on `Builder` as `@property-read HigherOrderBuilderProxy<TModel>`.

Psalm threads `TModel` from `Builder<TModel>` through the property read into the proxy and back out of `__call`. The proxy always returns the builder fluently, so one uniform `@return Builder<TModel>` covers every proxied scope — unlike the collection proxy (per-method return types), no handler is needed.

**Variance:** the proxy must be `@template-covariant` (TModel is output-only). A proxied call inside a non-final model method typed `@return Builder<self>` must accept the inferred `Builder<Model&static>`; covariance allows it, invariance would reject. Locked by `Customer::activeOrVerified()` + a phpt assertion.

**Why not Larastan's form:** Larastan types `@property-read static $orWhere` (no proxy class). That does not port to Psalm 7 — `static`/`$this` in a property-read collapse to `Builder&static` and drop `TModel`. Verified empirically; a guard comment on the Builder stub records it.

**Lenient by design:** any proxied call yields `Builder<TModel>` without scope-existence validation (matches Laravel runtime and the collection proxy). Strict scope-name validation is deferred to the upcoming Model Metadata Registry; since a stub cannot validate names, implementing it later means reintroducing a handler (`@todo` in the proxy stub).

Verified: new type test `tests/Type/tests/Builder/HigherOrderBuilderProxyTest.phpt` covers all three proxies, `#[Scope]` and legacy scopes, chaining to `->get()`, scope args, and the variance case. Full type suite (456 tests) passes including `sealAllMethods`, self-analysis stays clean at 100% coverage. Manual end-to-end on the #1062 repro traces `$users: Collection<int, User>`.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
