### PR TITLE
Add opt-in `ImplicitQueryBuilderCall` rule for direct model query and scope calls

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -23,9 +23,9 @@ Full config example:
         <modelProperties columnFallback="none" />
         <resolveDynamicWhereClauses value="false" />
         <resolveConfigReturnTypes value="false" />
+        <reportImplicitQueryBuilderCalls value="true" />
         <findMissingTranslations value="true" />
         <findMissingViews value="true" />
-        <reportImplicitQueryBuilderCalls value="true" />
         <findOctaneIncompatibleBinding value="true" />
         <failOnInternalError value="true" />
         <configDirectory name="app/Config" />
@@ -94,6 +94,20 @@ When you always use `Config::ineteger()`, `Config::string()` and other typed cal
 <resolveConfigReturnTypes value="false" />
 ```
 
+## `reportImplicitQueryBuilderCalls`
+
+**default**: `false`
+
+When enabled, the plugin flags query builder and local scope methods called directly on an Eloquent model (forwarded by Laravel through `__callStatic` / `__call`) and asks for the explicit `Model::query()->...` form instead. It reports query builder methods (`where`, `find`, `orderBy`, ...), custom builder methods, and local scopes (legacy `scopeXxx()` and modern `#[Scope]`). Real model methods (including a method whose name collides with a builder method) and genuinely undefined methods are left alone.
+
+See [ImplicitQueryBuilderCall](issues/ImplicitQueryBuilderCall.md) for details.
+
+### Example
+
+```xml
+<reportImplicitQueryBuilderCalls value="true" />
+```
+
 ## `configDirectory`
 
 **default**: the booted Laravel app's `config_path()`
@@ -152,20 +166,6 @@ See [MissingView](issues/MissingView.md) for details.
 
 ```xml
 <findMissingViews value="true" />
-```
-
-## `reportImplicitQueryBuilderCalls`
-
-**default**: `false`
-
-When enabled, the plugin flags query builder and local scope methods called directly on an Eloquent model (forwarded by Laravel through `__callStatic` / `__call`) and asks for the explicit `Model::query()->...` form instead. It reports query builder methods (`where`, `find`, `orderBy`, ...), custom builder methods, and local scopes (legacy `scopeXxx()` and modern `#[Scope]`). Real model methods (including a method whose name collides with a builder method) and genuinely undefined methods are left alone.
-
-See [ImplicitQueryBuilderCall](issues/ImplicitQueryBuilderCall.md) for details.
-
-### Example
-
-```xml
-<reportImplicitQueryBuilderCalls value="true" />
 ```
 
 ## `findOctaneIncompatibleBinding`

--- a/docs/config.md
+++ b/docs/config.md
@@ -158,7 +158,7 @@ See [MissingView](issues/MissingView.md) for details.
 
 **default**: `false`
 
-When enabled, the plugin flags query builder and local scope methods called directly on an Eloquent model (forwarded by Laravel through `__callStatic` / `__call`) and asks for the explicit `Model::query()->...` form instead. It reports query builder methods (`where`, `find`, `orderBy`, ...), custom builder and trait builder methods, and local scopes (legacy `scopeXxx()` and modern `#[Scope]`). Real model methods and genuinely undefined methods are left alone.
+When enabled, the plugin flags query builder and local scope methods called directly on an Eloquent model (forwarded by Laravel through `__callStatic` / `__call`) and asks for the explicit `Model::query()->...` form instead. It reports query builder methods (`where`, `find`, `orderBy`, ...), custom builder methods, and local scopes (legacy `scopeXxx()` and modern `#[Scope]`). Real model methods (including a method whose name collides with a builder method) and genuinely undefined methods are left alone.
 
 See [ImplicitQueryBuilderCall](issues/ImplicitQueryBuilderCall.md) for details.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -25,6 +25,7 @@ Full config example:
         <resolveConfigReturnTypes value="false" />
         <findMissingTranslations value="true" />
         <findMissingViews value="true" />
+        <reportImplicitQueryBuilderCalls value="true" />
         <findOctaneIncompatibleBinding value="true" />
         <failOnInternalError value="true" />
         <configDirectory name="app/Config" />
@@ -151,6 +152,20 @@ See [MissingView](issues/MissingView.md) for details.
 
 ```xml
 <findMissingViews value="true" />
+```
+
+## `reportImplicitQueryBuilderCalls`
+
+**default**: `false`
+
+When enabled, the plugin flags query builder and local scope methods called directly on an Eloquent model (forwarded by Laravel through `__callStatic` / `__call`) and asks for the explicit `Model::query()->...` form instead. It reports query builder methods (`where`, `find`, `orderBy`, ...), custom builder and trait builder methods, and local scopes (legacy `scopeXxx()` and modern `#[Scope]`). Real model methods and genuinely undefined methods are left alone.
+
+See [ImplicitQueryBuilderCall](issues/ImplicitQueryBuilderCall.md) for details.
+
+### Example
+
+```xml
+<reportImplicitQueryBuilderCalls value="true" />
 ```
 
 ## `findOctaneIncompatibleBinding`

--- a/docs/issues/ImplicitQueryBuilderCall.md
+++ b/docs/issues/ImplicitQueryBuilderCall.md
@@ -1,0 +1,47 @@
+---
+title: ImplicitQueryBuilderCall
+parent: Custom Issues
+nav_order: 10
+---
+
+# ImplicitQueryBuilderCall
+
+Opt-in. Emitted when a query builder or local scope method is invoked directly on an Eloquent model, statically (`User::where(...)`, `User::active()`) or on an instance (`$user->where(...)`), instead of through an explicit `query()` entry point.
+
+This issue is **disabled by default**. Enable it with `<reportImplicitQueryBuilderCalls value="true" />` (see [Configuration](../config.md#reportimplicitquerybuildercalls)).
+
+## Why this is a problem
+
+Calls like `User::where(...)`, `User::find(...)`, or `User::active()` do not exist on the model. Laravel forwards them through the `__callStatic` / `__call` magic methods to a freshly created query builder. Teams that prefer to minimise this magic enable this rule to require the explicit `User::query()->...` form, which keeps the entry point concrete and the call chain easy to follow for both readers and tooling.
+
+## What is flagged
+
+- **Query builder methods**, both Eloquent `Builder` methods (`where`, `find`, `create`, `first`, `get`) and `Query\Builder` methods (`orderBy`, `whereIn`), plus resolvable dynamic `where{Column}()` clauses.
+- **Custom builder methods**, declared on a model's dedicated Eloquent builder (registered via `newEloquentBuilder()` or `#[UseEloquentBuilder]`).
+- **Local scopes**, both legacy `scopeActive()` invoked by its forwarded bare name `active()`, and modern `#[Scope]` attribute methods.
+
+A real method declared on the framework `Model` base (`save()`, `all()`, `with()`, `query()`, `destroy()`, ...) and any real user-defined method are left alone, since they are genuine methods rather than magic forwarding. A genuinely undefined method is reported as `UndefinedMagicMethod` rather than mislabelled by this rule.
+
+## Examples
+
+```php
+// Bad — forwarded through magic to a new query builder
+$users = User::where('active', 1)->get();
+$user  = User::find($id);
+$recent = User::active()->latest()->get();
+```
+
+```php
+// Good — explicit query() entry point
+$users = User::query()->where('active', 1)->get();
+$user  = User::query()->find($id);
+$recent = User::query()->active()->latest()->get();
+```
+
+## How to fix
+
+Route the call through `Model::query()` (static) or `$model->newQuery()` (instance) before the builder or scope method.
+
+## Known limitation
+
+A `public` `#[Scope]` method is accessible from every call site, so its forwarded form cannot be distinguished from a legitimate direct call by visibility alone, and is therefore not flagged. Laravel's convention wants scopes `protected` (which this rule does flag when forwarded); a `public` `#[Scope]` is independently reported as [PublicModelScope](PublicModelScope.md).

--- a/docs/issues/index.md
+++ b/docs/issues/index.md
@@ -17,5 +17,6 @@ The plugin ships advanced Laravel-aware static analysis checks that extend Psalm
 - [OctaneIncompatibleBinding](OctaneIncompatibleBinding.md) — `singleton()` closure resolves a request-scoped service such as Request, Session, or Auth (auto-enabled when `laravel/octane` is installed)
 - [PublicModelScope](PublicModelScope.md) — `public` `#[Scope]` Eloquent query scope, whose static call is a runtime fatal (reported at error levels 1 to 4)
 - [PublicModelAccessor](PublicModelAccessor.md) — `public` legacy `getXxxAttribute()` / `setXxxAttribute()` accessor or mutator, a pure convention nit (reported at error level 1)
+- [ImplicitQueryBuilderCall](ImplicitQueryBuilderCall.md) — a query builder or local scope method called directly on a model instead of through an explicit `query()` entry point (opt-in)
 
 Each issue page explains what it detects, why it matters, and how to fix it.

--- a/src/Config/PluginConfig.php
+++ b/src/Config/PluginConfig.php
@@ -29,6 +29,13 @@ final readonly class PluginConfig
         public bool $findMissingTranslations,
         public bool $findMissingViews,
         /**
+         * Opt-in: when true, registers the ImplicitQueryBuilderCall rule, which flags query
+         * builder / local scope methods called directly on a model (e.g. `User::where(...)`,
+         * `User::active()`, `$user->where(...)`) and requires the explicit `Model::query()->...`
+         * form instead. Default false — the magic forwarding is idiomatic Laravel.
+         */
+        public bool $reportImplicitQueryBuilderCalls,
+        /**
          * Tri-state opt-in/out for the OctaneIncompatibleBinding rule.
          *
          *  - null  → auto-detect (rule registers when laravel/octane is installed)
@@ -59,6 +66,7 @@ final readonly class PluginConfig
         $failOnInternalError = self::xmlBoolAttr($config?->failOnInternalError, 'failOnInternalError');
         $findMissingTranslations = self::xmlBoolAttr($config?->findMissingTranslations, 'findMissingTranslations');
         $findMissingViews = self::xmlBoolAttr($config?->findMissingViews, 'findMissingViews');
+        $reportImplicitQueryBuilderCalls = self::xmlBoolAttr($config?->reportImplicitQueryBuilderCalls, 'reportImplicitQueryBuilderCalls');
         $findOctaneIncompatibleBinding = self::xmlOptionalBoolAttr($config?->findOctaneIncompatibleBinding, 'findOctaneIncompatibleBinding');
         $resolveDynamicWhereClauses = self::xmlBoolAttr($config?->resolveDynamicWhereClauses, 'resolveDynamicWhereClauses', true);
         $resolveConfigReturnTypes = self::xmlBoolAttr($config?->resolveConfigReturnTypes, 'resolveConfigReturnTypes', true);
@@ -71,6 +79,7 @@ final readonly class PluginConfig
             resolveConfigReturnTypes: $resolveConfigReturnTypes,
             findMissingTranslations: $findMissingTranslations,
             findMissingViews: $findMissingViews,
+            reportImplicitQueryBuilderCalls: $reportImplicitQueryBuilderCalls,
             findOctaneIncompatibleBinding: $findOctaneIncompatibleBinding,
             cachePath: self::resolveCachePath(),
             failOnInternalError: $failOnInternalError,

--- a/src/Config/PluginConfig.php
+++ b/src/Config/PluginConfig.php
@@ -28,12 +28,6 @@ final readonly class PluginConfig
         public bool $resolveConfigReturnTypes,
         public bool $findMissingTranslations,
         public bool $findMissingViews,
-        /**
-         * Opt-in: when true, registers the ImplicitQueryBuilderCall rule, which flags query
-         * builder / local scope methods called directly on a model (e.g. `User::where(...)`,
-         * `User::active()`, `$user->where(...)`) and requires the explicit `Model::query()->...`
-         * form instead. Default false — the magic forwarding is idiomatic Laravel.
-         */
         public bool $reportImplicitQueryBuilderCalls,
         /**
          * Tri-state opt-in/out for the OctaneIncompatibleBinding rule.

--- a/src/Config/PluginConfig.php
+++ b/src/Config/PluginConfig.php
@@ -26,9 +26,9 @@ final readonly class PluginConfig
         public array $configDirectories,
         public bool $resolveDynamicWhereClauses,
         public bool $resolveConfigReturnTypes,
+        public bool $reportImplicitQueryBuilderCalls,
         public bool $findMissingTranslations,
         public bool $findMissingViews,
-        public bool $reportImplicitQueryBuilderCalls,
         /**
          * Tri-state opt-in/out for the OctaneIncompatibleBinding rule.
          *
@@ -71,9 +71,9 @@ final readonly class PluginConfig
             configDirectories: $configDirectories,
             resolveDynamicWhereClauses: $resolveDynamicWhereClauses,
             resolveConfigReturnTypes: $resolveConfigReturnTypes,
+            reportImplicitQueryBuilderCalls: $reportImplicitQueryBuilderCalls,
             findMissingTranslations: $findMissingTranslations,
             findMissingViews: $findMissingViews,
-            reportImplicitQueryBuilderCalls: $reportImplicitQueryBuilderCalls,
             findOctaneIncompatibleBinding: $findOctaneIncompatibleBinding,
             cachePath: self::resolveCachePath(),
             failOnInternalError: $failOnInternalError,

--- a/src/Handlers/Eloquent/ModelMethodHandler.php
+++ b/src/Handlers/Eloquent/ModelMethodHandler.php
@@ -537,6 +537,32 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
         return self::$unresolvedCache[$key] = false;
     }
 
+    /**
+     * Whether a bare method name on $modelClass forwards to its query builder (default or custom):
+     * an Eloquent\Builder method reachable via the @mixin (`where`, `find`, `first`, `get`), a
+     * Query\Builder method (`orderBy`, `whereIn`), a custom builder or trait builder method, or a
+     * resolvable dynamic `where{Column}()` clause. Real methods declared on the model itself are
+     * excluded. Scopes may also report true here (the shared {@see isUnresolvedBuilderMethod}
+     * logic includes them), so a caller that must treat scopes specially should consult
+     * {@see BuilderScopeHandler::hasScopeMethod()} first.
+     *
+     * @internal Used by {@see \Psalm\LaravelPlugin\Handlers\Rules\ImplicitQueryBuilderCallHandler}
+     * to decide whether a direct model call is magic forwarding without duplicating the resolution.
+     *
+     * @param class-string<Model> $modelClass
+     * @param lowercase-string $methodNameLower
+     */
+    public static function forwardsToQueryBuilder(Codebase $codebase, string $modelClass, string $methodNameLower): bool
+    {
+        // Eloquent\Builder methods (where/find/create/first/get) resolve via Model's @mixin, so
+        // isUnresolvedBuilderMethod reports them as already-resolved (false); check them here.
+        if ($codebase->methodExists(new MethodIdentifier(Builder::class, $methodNameLower))) {
+            return true;
+        }
+
+        return self::isUnresolvedBuilderMethod($codebase, $modelClass, $methodNameLower);
+    }
+
     /** @inheritDoc */
     #[\Override]
     public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Type\Union

--- a/src/Handlers/Rules/ImplicitQueryBuilderCallHandler.php
+++ b/src/Handlers/Rules/ImplicitQueryBuilderCallHandler.php
@@ -136,9 +136,8 @@ final class ImplicitQueryBuilderCallHandler implements AfterExpressionAnalysisIn
 
         IssueBuffer::accepts(
             new ImplicitQueryBuilderCall(
-                "Avoid calling {$methodName}() directly on the {$shortName} model: the call is forwarded through "
-                . "Laravel's __callStatic/__call magic to the query builder. Use an explicit query entry point "
-                . "instead, e.g. {$shortName}::query()->{$methodName}(...).",
+                "{$shortName}::{$methodName}() is forwarded to the query builder through Laravel's "
+                . "__callStatic/__call magic. Use {$shortName}::query()->{$methodName}(...) instead.",
                 new CodeLocation($event->getStatementsSource(), $expr),
             ),
             $event->getStatementsSource()->getSuppressedIssues(),

--- a/src/Handlers/Rules/ImplicitQueryBuilderCallHandler.php
+++ b/src/Handlers/Rules/ImplicitQueryBuilderCallHandler.php
@@ -172,9 +172,11 @@ final class ImplicitQueryBuilderCallHandler implements AfterExpressionAnalysisIn
 
     /**
      * Resolve the model FQCN of an instance call's receiver, or null when the receiver type is
-     * not a single Eloquent model. A receiver typed as a Builder, Relation, or Collection is
-     * intentionally skipped — `User::query()->where()` chains the builder, not the model, and
-     * is exactly the explicit form the rule wants.
+     * not unambiguously a single Eloquent model. The receiver must resolve to exactly one model
+     * class: every atomic of the type has to be that same model. A union that mixes the model
+     * with a Builder/Relation/Collection (the call may already be on a builder — the explicit
+     * form), with `null`, or with a different model (an arbitrary class-specific suggestion) is
+     * skipped to avoid a false positive.
      *
      * @return class-string<Model>|null
      */
@@ -186,13 +188,24 @@ final class ImplicitQueryBuilderCallHandler implements AfterExpressionAnalysisIn
             return null;
         }
 
+        $modelClass = null;
+
         foreach ($receiverType->getAtomicTypes() as $atomicType) {
-            if ($atomicType instanceof TNamedObject && self::isModelSubclass($atomicType->value, $codebase)) {
-                return $atomicType->value;
+            // Any non-model atomic (a Builder/Relation/Collection object, null, a scalar) makes
+            // the receiver ambiguous — bail rather than guess.
+            if (!$atomicType instanceof TNamedObject || !self::isModelSubclass($atomicType->value, $codebase)) {
+                return null;
+            }
+
+            if ($modelClass === null) {
+                $modelClass = $atomicType->value;
+            } elseif ($modelClass !== $atomicType->value) {
+                // A union of distinct models gives no single class to name in the suggestion.
+                return null;
             }
         }
 
-        return null;
+        return $modelClass;
     }
 
     /**
@@ -242,11 +255,41 @@ final class ImplicitQueryBuilderCallHandler implements AfterExpressionAnalysisIn
             return !BuilderScopeHandler::isDirectScopeCall($codebase, $modelClass, $methodNameLower, $event->getContext());
         }
 
+        // A method genuinely declared on the model (or inherited from a non-Model ancestor or
+        // trait) is a real method, not magic forwarding — even when its name collides with a
+        // builder method (a user `public function where()` / `orderBy()`). Scopes were already
+        // handled above, so this does not swallow them. declaring_method_ids holds real declared
+        // methods only; the plugin's forwarded methods are virtual and never recorded there.
+        if (self::modelDeclaresMethod($modelClass, $methodNameLower, $codebase)) {
+            return false;
+        }
+
         // Query builder methods reached only through forwarding — Eloquent\Builder via the
-        // @mixin, Query\Builder via Builder::__call, a custom builder, a trait builder method, or
-        // a resolvable dynamic where. A typo matches none of these and is left to
-        // UndefinedMagicMethod.
+        // @mixin, Query\Builder via Builder::__call, a custom builder, or a resolvable dynamic
+        // where. A typo matches none of these and is left to UndefinedMagicMethod.
         return ModelMethodHandler::forwardsToQueryBuilder($codebase, $modelClass, $methodNameLower);
+    }
+
+    /**
+     * Whether $modelClass really declares (or inherits) a method named $methodNameLower, as
+     * opposed to resolving it through Laravel's magic forwarding. Reads `declaring_method_ids`,
+     * which Psalm populates only from genuinely declared methods — the plugin's forwarded methods
+     * are answered virtually by a method-existence provider and never recorded there.
+     *
+     * @param class-string<Model> $modelClass
+     * @param lowercase-string $methodNameLower
+     *
+     * @psalm-mutation-free
+     */
+    private static function modelDeclaresMethod(string $modelClass, string $methodNameLower, Codebase $codebase): bool
+    {
+        try {
+            $classStorage = $codebase->classlike_storage_provider->get(\strtolower($modelClass));
+        } catch (\InvalidArgumentException) {
+            return false;
+        }
+
+        return isset($classStorage->declaring_method_ids[$methodNameLower]);
     }
 
     /** @psalm-pure */

--- a/src/Handlers/Rules/ImplicitQueryBuilderCallHandler.php
+++ b/src/Handlers/Rules/ImplicitQueryBuilderCallHandler.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Rules;
+
+use Illuminate\Database\Eloquent\Model;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use Psalm\Codebase;
+use Psalm\CodeLocation;
+use Psalm\Exception\UnpopulatedClasslikeException;
+use Psalm\IssueBuffer;
+use Psalm\LaravelPlugin\Handlers\Eloquent\BuilderScopeHandler;
+use Psalm\LaravelPlugin\Handlers\Eloquent\ModelMethodHandler;
+use Psalm\LaravelPlugin\Issues\ImplicitQueryBuilderCall;
+use Psalm\Plugin\EventHandler\AfterExpressionAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterExpressionAnalysisEvent;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Union;
+
+/**
+ * Opt-in rule: flags query builder and local scope methods invoked directly on an Eloquent
+ * model — statically (`User::where(...)`, `User::active()`) or on an instance
+ * (`$user->where(...)`) — instead of through an explicit `query()` entry point.
+ *
+ * Such calls are forwarded by Laravel through `__callStatic` / `__call` to a fresh query
+ * builder. Teams that want to minimise this magic enable the rule to require the explicit
+ * `Model::query()->...` form, which keeps the call chain concrete and easy to follow.
+ *
+ * Registered only when `<reportImplicitQueryBuilderCalls value="true" />` is set (see
+ * {@see \Psalm\LaravelPlugin\Plugin::registerHandlers()}). Sibling of {@see ModelMakeHandler},
+ * which flags the single `Model::make()` case; this generalises the idea to the whole forwarded
+ * surface, while deferring `make()` itself back to that handler (its correct fix is `new Model()`,
+ * not a query).
+ *
+ * ## What is flagged
+ *
+ * The rule reuses the plugin's own forwarding-resolution logic so it flags exactly what the
+ * plugin already recognises as a forwarded call, and nothing it would report as
+ * `UndefinedMagicMethod`:
+ *
+ *  - **Query builder methods** — Eloquent `Builder` methods reached via the `@mixin`
+ *    (`where`, `find`, `create`, `first`, `get`), and `Query\Builder` methods forwarded through
+ *    `Builder::__call` (`orderBy`, `whereIn`), plus resolvable dynamic `where{Column}()` clauses.
+ *    Resolved by {@see ModelMethodHandler::forwardsToQueryBuilder()}.
+ *  - **Custom builder methods** — methods declared on a model's dedicated Eloquent builder
+ *    (registered via `newEloquentBuilder()` or `#[UseEloquentBuilder]`), and trait-provided
+ *    `@method` builder helpers on such custom-builder models. Also via
+ *    {@see ModelMethodHandler::forwardsToQueryBuilder()}. (Trait builder macros on a plain
+ *    base-`Builder` model — e.g. `SoftDeletes::withTrashed()` — are runtime macros the plugin
+ *    does not resolve as forwarded, so they are not flagged.)
+ *  - **Local scopes** — legacy `scopeActive()` invoked by its forwarded bare name `active()`,
+ *    and modern `#[Scope]` attribute methods. Detected by
+ *    {@see BuilderScopeHandler::hasScopeMethod()}; a scope call that is actually a direct,
+ *    accessible invocation passing the builder explicitly (scope composition like
+ *    `$this->other($query, ...)`) is excluded via {@see BuilderScopeHandler::isDirectScopeCall()}
+ *    so legitimate direct calls are not flagged.
+ *
+ * A real method declared on the framework `Model` base (`save()`, `all()`, `with()`, `query()`,
+ * `destroy()`, ...) and any real user-defined method are never magic forwarding and are left
+ * alone. A genuinely undefined method matches none of the above and is left to Psalm's
+ * `UndefinedMagicMethod` rather than mislabelled as a "use query()" suggestion.
+ *
+ * ### Known limitation — public `#[Scope]` methods
+ *
+ * A `public` `#[Scope]` method is accessible from every call site, so its forwarded form cannot
+ * be told apart from a direct call by accessibility alone, and is therefore not flagged here.
+ * Laravel's convention wants scopes `protected` (which the rule does flag when forwarded), and a
+ * `public` `#[Scope]` is independently reported by {@see PublicScopeAccessorVisibilityHandler} as
+ * {@see \Psalm\LaravelPlugin\Issues\PublicModelScope}.
+ *
+ * ## Hook choice — AfterExpressionAnalysis
+ *
+ * Matches {@see ModelMakeHandler}: it fires for every expression regardless of how the called
+ * method was resolved, so it sees magic-forwarded calls that a method-resolution provider hook
+ * might never be consulted for. The `instanceof` / `Identifier` / `method_exists` guards reject
+ * the vast majority of expressions before any codebase lookup.
+ */
+final class ImplicitQueryBuilderCallHandler implements AfterExpressionAnalysisInterface
+{
+    /** @inheritDoc */
+    #[\Override]
+    public static function afterExpressionAnalysis(AfterExpressionAnalysisEvent $event): ?bool
+    {
+        $expr = $event->getExpr();
+
+        // Only static (`Model::method()`) and instance (`$model->method()`) calls are in scope.
+        if (!$expr instanceof StaticCall && !$expr instanceof MethodCall) {
+            return null;
+        }
+
+        // Named methods only — `Model::$method()` / `$model->$method()` are not statically known.
+        if (!$expr->name instanceof Identifier) {
+            return null;
+        }
+
+        // PHP method names are case-insensitive; the plugin's resolution keys are lowercase and
+        // method_exists() is case-insensitive too.
+        $methodNameLower = \strtolower($expr->name->name);
+
+        // Fast reject + stub-independent correctness: a method that genuinely exists on the
+        // framework Model base (save/all/with/query/destroy/increment/...) is never magic
+        // forwarding, so it is left alone before any per-call-site codebase lookup. Resolved
+        // against the loaded real class, this holds even when the Model stub omits the method.
+        if (\method_exists(Model::class, $methodNameLower)) {
+            return null;
+        }
+
+        // `make()` is forwarded to Builder::make(), but it is a "new instance" operation, not a
+        // query — its proper fix is `new Model(...)`, which the always-on ModelMakeHandler already
+        // reports as ModelMakeDiscouraged. Suggesting `Model::query()->make(...)` here would be
+        // nonsensical and duplicate that handler, so defer to it.
+        if ($methodNameLower === 'make') {
+            return null;
+        }
+
+        $codebase = $event->getCodebase();
+
+        $modelClass = $expr instanceof StaticCall
+            ? self::staticReceiverModel($expr, $codebase)
+            : self::instanceReceiverModel($expr, $event, $codebase);
+
+        if ($modelClass === null) {
+            return null;
+        }
+
+        if (!self::isMagicForwardedCall($modelClass, $methodNameLower, $event, $codebase)) {
+            return null;
+        }
+
+        $shortName = self::shortClassName($modelClass);
+        $methodName = $expr->name->name;
+
+        IssueBuffer::accepts(
+            new ImplicitQueryBuilderCall(
+                "Avoid calling {$methodName}() directly on the {$shortName} model: the call is forwarded through "
+                . "Laravel's __callStatic/__call magic to the query builder. Use an explicit query entry point "
+                . "instead, e.g. {$shortName}::query()->{$methodName}(...).",
+                new CodeLocation($event->getStatementsSource(), $expr),
+            ),
+            $event->getStatementsSource()->getSuppressedIssues(),
+        );
+
+        return null;
+    }
+
+    /**
+     * Resolve the model FQCN named on the left of a static call, or null when the receiver
+     * is not a (resolvable) Eloquent model.
+     *
+     * @return class-string<Model>|null
+     */
+    private static function staticReceiverModel(StaticCall $expr, Codebase $codebase): ?string
+    {
+        // Only named class references (`User::`, and `self`/`static`/`parent` which the name
+        // resolver rewrites to a concrete FQCN); dynamic `$class::method()` is not known here.
+        if (!$expr->class instanceof Name) {
+            return null;
+        }
+
+        $className = $expr->class->getAttribute('resolvedName');
+
+        if (!\is_string($className) || !self::isModelSubclass($className, $codebase)) {
+            return null;
+        }
+
+        return $className;
+    }
+
+    /**
+     * Resolve the model FQCN of an instance call's receiver, or null when the receiver type is
+     * not a single Eloquent model. A receiver typed as a Builder, Relation, or Collection is
+     * intentionally skipped — `User::query()->where()` chains the builder, not the model, and
+     * is exactly the explicit form the rule wants.
+     *
+     * @return class-string<Model>|null
+     */
+    private static function instanceReceiverModel(MethodCall $expr, AfterExpressionAnalysisEvent $event, Codebase $codebase): ?string
+    {
+        $receiverType = $event->getStatementsSource()->getNodeTypeProvider()->getType($expr->var);
+
+        if (!$receiverType instanceof Union) {
+            return null;
+        }
+
+        foreach ($receiverType->getAtomicTypes() as $atomicType) {
+            if ($atomicType instanceof TNamedObject && self::isModelSubclass($atomicType->value, $codebase)) {
+                return $atomicType->value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @psalm-assert-if-true class-string<Model> $className
+     *
+     * @psalm-external-mutation-free
+     */
+    private static function isModelSubclass(string $className, Codebase $codebase): bool
+    {
+        if ($className === Model::class) {
+            return true;
+        }
+
+        if (!$codebase->classExists($className)) {
+            return false;
+        }
+
+        // classExtends (from_api: true) throws InvalidArgumentException on missing/aliased storage
+        // and UnpopulatedClasslikeException (a sibling LogicException) when storage exists but is
+        // not populated yet. Either way the subclass link can't be proven → treat as not a model.
+        // Mirrors BuilderScopeHandler::isMethodAccessibleFrom; reached on a broad receiver set here.
+        try {
+            return $codebase->classExtends($className, Model::class);
+        } catch (\InvalidArgumentException|UnpopulatedClasslikeException) {
+            return false;
+        }
+    }
+
+    /**
+     * Whether a call whose method is absent from the framework Model base is a magic-forwarded
+     * builder / scope call. Reuses the plugin's own forwarding resolution so the verdict matches
+     * what the plugin recognises as a forwarded call.
+     *
+     * @param class-string<Model> $modelClass
+     * @param lowercase-string $methodNameLower
+     */
+    private static function isMagicForwardedCall(
+        string $modelClass,
+        string $methodNameLower,
+        AfterExpressionAnalysisEvent $event,
+        Codebase $codebase,
+    ): bool {
+        // Scopes (legacy scopeXxx + modern #[Scope]) are forwarded when invoked by the bare name.
+        // A real, accessible scope method passed the builder explicitly (scope composition such
+        // as $this->other($query, ...)) is a direct call, not magic, and is left alone.
+        if (BuilderScopeHandler::hasScopeMethod($codebase, $modelClass, $methodNameLower)) {
+            return !BuilderScopeHandler::isDirectScopeCall($codebase, $modelClass, $methodNameLower, $event->getContext());
+        }
+
+        // Query builder methods reached only through forwarding — Eloquent\Builder via the
+        // @mixin, Query\Builder via Builder::__call, a custom builder, a trait builder method, or
+        // a resolvable dynamic where. A typo matches none of these and is left to
+        // UndefinedMagicMethod.
+        return ModelMethodHandler::forwardsToQueryBuilder($codebase, $modelClass, $methodNameLower);
+    }
+
+    /** @psalm-pure */
+    private static function shortClassName(string $fqcn): string
+    {
+        $pos = \strrpos($fqcn, '\\');
+
+        return $pos !== false ? \substr($fqcn, $pos + 1) : $fqcn;
+    }
+}

--- a/src/Issues/ImplicitQueryBuilderCall.php
+++ b/src/Issues/ImplicitQueryBuilderCall.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Issues;
+
+use Psalm\Issue\PluginIssue;
+
+/**
+ * Reported when a query builder or local scope method is invoked directly on an Eloquent
+ * model — statically (`User::where(...)`, `User::active()`) or on an instance
+ * (`$user->where(...)`) — instead of through an explicit `query()` entry point.
+ *
+ * Opt-in only: emitted exclusively when `<reportImplicitQueryBuilderCalls value="true" />` is set
+ * on the `<pluginClass>` element in psalm.xml. Teams enable it to forbid Laravel's
+ * `__callStatic` / `__call` magic forwarding and require the explicit `Model::query()->...`
+ * form, which keeps the call chain concrete and easy to follow for both readers and tooling.
+ */
+final class ImplicitQueryBuilderCall extends PluginIssue
+{
+    public const DOCUMENTATION_URL = 'https://psalm.github.io/psalm-plugin-laravel/issues/ImplicitQueryBuilderCall/';
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -276,6 +276,14 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Rules/UndefinedBuilderMethodHandler.php';
         $registration->registerHooksFromClass(Handlers\Rules\UndefinedBuilderMethodHandler::class);
 
+        // Opt-in: forbid Laravel's __callStatic/__call magic forwarding on models and require
+        // the explicit Model::query()->... entry point. Off by default — the forwarding is
+        // idiomatic Laravel, so this only registers when the user asks for it.
+        if ($pluginConfig->reportImplicitQueryBuilderCalls) {
+            require_once __DIR__ . '/Handlers/Rules/ImplicitQueryBuilderCallHandler.php';
+            $registration->registerHooksFromClass(Handlers\Rules\ImplicitQueryBuilderCallHandler::class);
+        }
+
         // Tri-state gate for the OctaneIncompatibleBinding rule:
         //   findOctaneIncompatibleBinding === null  → auto-detect via class_exists()
         //   findOctaneIncompatibleBinding === true  → force enabled

--- a/src/Util/IssueUrlGenerator.php
+++ b/src/Util/IssueUrlGenerator.php
@@ -86,6 +86,7 @@ final class IssueUrlGenerator
             "- modelPropertiesColumnFallback: {$pluginConfig->modelPropertiesColumnFallback->value}",
             '- resolveDynamicWhereClauses: ' . self::formatBool($pluginConfig->resolveDynamicWhereClauses),
             '- resolveConfigReturnTypes: ' . self::formatBool($pluginConfig->resolveConfigReturnTypes),
+            '- reportImplicitQueryBuilderCalls: ' . self::formatBool($pluginConfig->reportImplicitQueryBuilderCalls),
             '- findMissingTranslations: ' . self::formatBool($pluginConfig->findMissingTranslations),
             '- findMissingViews: ' . self::formatBool($pluginConfig->findMissingViews),
             '- findOctaneIncompatibleBinding: ' . self::formatOctaneFlag($pluginConfig->findOctaneIncompatibleBinding),

--- a/tests/Type/psalm-with-optin-custom-issues.xml
+++ b/tests/Type/psalm-with-optin-custom-issues.xml
@@ -20,6 +20,7 @@
             <findMissingViews value="true" />
             <findMissingTranslations value="true" />
             <findOctaneIncompatibleBinding value="true" />
+            <reportImplicitQueryBuilderCalls value="true" />
         </pluginClass>
     </plugins>
     <issueHandlers>

--- a/tests/Type/psalm-with-optin-custom-issues.xml
+++ b/tests/Type/psalm-with-optin-custom-issues.xml
@@ -16,11 +16,11 @@
 >
     <plugins>
         <pluginClass class="Psalm\LaravelPlugin\Plugin">
-            <failOnInternalError value="true" />
-            <findMissingViews value="true" />
-            <findMissingTranslations value="true" />
-            <findOctaneIncompatibleBinding value="true" />
             <reportImplicitQueryBuilderCalls value="true" />
+            <findMissingTranslations value="true" />
+            <findMissingViews value="true" />
+            <findOctaneIncompatibleBinding value="true" />
+            <failOnInternalError value="true" />
         </pluginClass>
     </plugins>
     <issueHandlers>

--- a/tests/Type/tests/ImplicitQueryBuilderCallTest.phpt
+++ b/tests/Type/tests/ImplicitQueryBuilderCallTest.phpt
@@ -135,6 +135,17 @@ function ambiguous_union_receiver_is_not_flagged(Customer|Vehicle $model): void
 }
 
 /**
+ * A model-or-builder union: the receiver may already be an explicit builder, so the call is not
+ * flagged (the Builder atomic makes the receiver ambiguous).
+ *
+ * @param Customer|Builder<Customer> $receiver
+ */
+function model_or_builder_receiver_is_not_flagged(Customer|Builder $receiver): void
+{
+    $receiver->where('active', 1);
+}
+
+/**
  * A trait builder macro on a plain base-Builder model (SoftDeletes::withTrashed on Customer) is
  * a runtime macro the plugin does not resolve as forwarded, so it is not flagged (and not a typo).
  */

--- a/tests/Type/tests/ImplicitQueryBuilderCallTest.phpt
+++ b/tests/Type/tests/ImplicitQueryBuilderCallTest.phpt
@@ -185,18 +185,18 @@ function undefined_method_is_not_mislabelled(Customer $customer): void
 }
 ?>
 --EXPECTF--
-ImplicitQueryBuilderCall on line %d: Avoid calling where() directly on the Customer model: the call is forwarded through Laravel's __callStatic/__call magic to the query builder. Use an explicit query entry point instead, e.g. Customer::query()->where(...).
-ImplicitQueryBuilderCall on line %d: Avoid calling find() directly on the Customer model: the call is forwarded through Laravel's __callStatic/__call magic to the query builder. Use an explicit query entry point instead, e.g. Customer::query()->find(...).
-ImplicitQueryBuilderCall on line %d: Avoid calling create() directly on the Customer model: the call is forwarded through Laravel's __callStatic/__call magic to the query builder. Use an explicit query entry point instead, e.g. Customer::query()->create(...).
-ImplicitQueryBuilderCall on line %d: Avoid calling first() directly on the Customer model: the call is forwarded through Laravel's __callStatic/__call magic to the query builder. Use an explicit query entry point instead, e.g. Customer::query()->first(...).
-ImplicitQueryBuilderCall on line %d: Avoid calling whereIn() directly on the Customer model: the call is forwarded through Laravel's __callStatic/__call magic to the query builder. Use an explicit query entry point instead, e.g. Customer::query()->whereIn(...).
-ImplicitQueryBuilderCall on line %d: Avoid calling active() directly on the Customer model: the call is forwarded through Laravel's __callStatic/__call magic to the query builder. Use an explicit query entry point instead, e.g. Customer::query()->active(...).
-ImplicitQueryBuilderCall on line %d: Avoid calling active() directly on the DirectScopeModel model: the call is forwarded through Laravel's __callStatic/__call magic to the query builder. Use an explicit query entry point instead, e.g. DirectScopeModel::query()->active(...).
+ImplicitQueryBuilderCall on line %d: Customer::where() is forwarded to the query builder through Laravel's __callStatic/__call magic. Use Customer::query()->where(...) instead.
+ImplicitQueryBuilderCall on line %d: Customer::find() is forwarded to the query builder through Laravel's __callStatic/__call magic. Use Customer::query()->find(...) instead.
+ImplicitQueryBuilderCall on line %d: Customer::create() is forwarded to the query builder through Laravel's __callStatic/__call magic. Use Customer::query()->create(...) instead.
+ImplicitQueryBuilderCall on line %d: Customer::first() is forwarded to the query builder through Laravel's __callStatic/__call magic. Use Customer::query()->first(...) instead.
+ImplicitQueryBuilderCall on line %d: Customer::whereIn() is forwarded to the query builder through Laravel's __callStatic/__call magic. Use Customer::query()->whereIn(...) instead.
+ImplicitQueryBuilderCall on line %d: Customer::active() is forwarded to the query builder through Laravel's __callStatic/__call magic. Use Customer::query()->active(...) instead.
+ImplicitQueryBuilderCall on line %d: DirectScopeModel::active() is forwarded to the query builder through Laravel's __callStatic/__call magic. Use DirectScopeModel::query()->active(...) instead.
 InvalidStaticInvocation on line %d: Method App\Models\DirectScopeModel::active is not static, but is called statically
-ImplicitQueryBuilderCall on line %d: Avoid calling whereElectric() directly on the Vehicle model: the call is forwarded through Laravel's __callStatic/__call magic to the query builder. Use an explicit query entry point instead, e.g. Vehicle::query()->whereElectric(...).
-ImplicitQueryBuilderCall on line %d: Avoid calling wherePaid() directly on the Invoice model: the call is forwarded through Laravel's __callStatic/__call magic to the query builder. Use an explicit query entry point instead, e.g. Invoice::query()->wherePaid(...).
-ImplicitQueryBuilderCall on line %d: Avoid calling whereId() directly on the Customer model: the call is forwarded through Laravel's __callStatic/__call magic to the query builder. Use an explicit query entry point instead, e.g. Customer::query()->whereId(...).
-ImplicitQueryBuilderCall on line %d: Avoid calling where() directly on the Customer model: the call is forwarded through Laravel's __callStatic/__call magic to the query builder. Use an explicit query entry point instead, e.g. Customer::query()->where(...).
-ImplicitQueryBuilderCall on line %d: Avoid calling find() directly on the Customer model: the call is forwarded through Laravel's __callStatic/__call magic to the query builder. Use an explicit query entry point instead, e.g. Customer::query()->find(...).
-ImplicitQueryBuilderCall on line %d: Avoid calling whereByMake() directly on the Vehicle model: the call is forwarded through Laravel's __callStatic/__call magic to the query builder. Use an explicit query entry point instead, e.g. Vehicle::query()->whereByMake(...).
+ImplicitQueryBuilderCall on line %d: Vehicle::whereElectric() is forwarded to the query builder through Laravel's __callStatic/__call magic. Use Vehicle::query()->whereElectric(...) instead.
+ImplicitQueryBuilderCall on line %d: Invoice::wherePaid() is forwarded to the query builder through Laravel's __callStatic/__call magic. Use Invoice::query()->wherePaid(...) instead.
+ImplicitQueryBuilderCall on line %d: Customer::whereId() is forwarded to the query builder through Laravel's __callStatic/__call magic. Use Customer::query()->whereId(...) instead.
+ImplicitQueryBuilderCall on line %d: Customer::where() is forwarded to the query builder through Laravel's __callStatic/__call magic. Use Customer::query()->where(...) instead.
+ImplicitQueryBuilderCall on line %d: Customer::find() is forwarded to the query builder through Laravel's __callStatic/__call magic. Use Customer::query()->find(...) instead.
+ImplicitQueryBuilderCall on line %d: Vehicle::whereByMake() is forwarded to the query builder through Laravel's __callStatic/__call magic. Use Vehicle::query()->whereByMake(...) instead.
 UndefinedMagicMethod on line %d: Magic method App\Models\Customer::undefinedbuildermethod does not exist

--- a/tests/Type/tests/ImplicitQueryBuilderCallTest.phpt
+++ b/tests/Type/tests/ImplicitQueryBuilderCallTest.phpt
@@ -10,6 +10,7 @@ use App\Models\DirectScopeModel;
 use App\Models\Invoice;
 use App\Models\Vehicle;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 
 /**
@@ -18,6 +19,26 @@ use Illuminate\Support\Collection;
  * and asks for the explicit Model::query()->... form instead. Only registered under the opt-in
  * config used by this test (see --ARGS-- above).
  */
+
+/**
+ * A model declaring real methods whose names collide with query builder methods. These are real
+ * methods, not magic forwarding, and must not be flagged.
+ */
+class ShadowingModel extends Model
+{
+    public static function find(int $id): ?self
+    {
+        return $id > 0 ? new self() : null;
+    }
+
+    public function orderBy(string $column): bool
+    {
+        return $column !== '';
+    }
+}
+
+/** Inherits the shadowing methods, so the inherited real method is also not flagged. */
+class ChildShadowingModel extends ShadowingModel {}
 
 /** Eloquent\Builder methods, a Query\Builder method, and a forwarded helper are all flagged. */
 function static_builder_calls_are_flagged(): void
@@ -91,6 +112,26 @@ function real_framework_methods_are_not_flagged(Customer $customer): void
 function non_model_calls_are_not_flagged(): void
 {
     Collection::make([1, 2, 3]);
+}
+
+/**
+ * A real method declared on (or inherited by) the model is not flagged, even when its name
+ * collides with a query builder method — it is a real method, not magic forwarding.
+ */
+function real_colliding_methods_are_not_flagged(ShadowingModel $model, ChildShadowingModel $child): void
+{
+    ShadowingModel::find(1);
+    $model->orderBy('name');
+    $child->orderBy('name');
+}
+
+/**
+ * An ambiguous union receiver (two distinct models here) gives no single class to name and may
+ * already be a builder, so it is not flagged.
+ */
+function ambiguous_union_receiver_is_not_flagged(Customer|Vehicle $model): void
+{
+    $model->where('active', 1);
 }
 
 /**

--- a/tests/Type/tests/ImplicitQueryBuilderCallTest.phpt
+++ b/tests/Type/tests/ImplicitQueryBuilderCallTest.phpt
@@ -1,0 +1,150 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm-with-optin-custom-issues.xml
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\RequireQuery;
+
+use App\Models\Customer;
+use App\Models\DirectScopeModel;
+use App\Models\Invoice;
+use App\Models\Vehicle;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+
+/**
+ * The opt-in ImplicitQueryBuilderCall rule flags query builder, custom builder, and local
+ * scope methods called directly on a model (forwarded by Laravel through __callStatic/__call)
+ * and asks for the explicit Model::query()->... form instead. Only registered under the opt-in
+ * config used by this test (see --ARGS-- above).
+ */
+
+/** Eloquent\Builder methods, a Query\Builder method, and a forwarded helper are all flagged. */
+function static_builder_calls_are_flagged(): void
+{
+    Customer::where('active', 1);
+    Customer::find(1);
+    Customer::create();
+    Customer::first();
+    Customer::whereIn('id', [1, 2]);
+}
+
+/** A legacy scopeXxx() invoked by its forwarded bare name is flagged (the User::active() case). */
+function static_legacy_scope_is_flagged(): void
+{
+    Customer::active();
+}
+
+/**
+ * A protected modern #[Scope] invoked by its forwarded bare name is flagged. The static form of
+ * a modern scope also raises InvalidStaticInvocation (an upstream Psalm limitation, see #1042 /
+ * vimeo/psalm#11876); both diagnostics agree the direct call should move to query()->active().
+ */
+function static_modern_scope_is_flagged(): void
+{
+    DirectScopeModel::active();
+}
+
+/**
+ * Custom Eloquent builder methods forwarded from the model are flagged, for both registration
+ * mechanisms: Vehicle via newEloquentBuilder(), Invoice via the #[UseEloquentBuilder] attribute.
+ */
+function static_custom_builder_method_is_flagged(): void
+{
+    Vehicle::whereElectric();
+    Invoice::wherePaid();
+}
+
+/**
+ * A dynamic where{Column}() clause the plugin resolves (Customer has @property string $id) is a
+ * forwarded builder call and is flagged. An unresolvable column would instead be a typo left to
+ * UndefinedMagicMethod.
+ */
+function dynamic_where_clause_is_flagged(): void
+{
+    Customer::whereId('cust-1');
+}
+
+/** Instance calls forwarded through __call are flagged too, including custom builder methods. */
+function instance_calls_are_flagged(Customer $customer, Vehicle $vehicle): void
+{
+    $customer->where('active', 1);
+    $customer->find(1);
+    $vehicle->whereByMake('Toyota');
+}
+
+/** The explicit query() entry point is the desired form — the builder receiver is never flagged. */
+function explicit_query_is_not_flagged(): void
+{
+    Customer::query()->where('active', 1)->orderBy('id')->first();
+}
+
+/** Real methods declared on the framework Model base are not magic forwarding — not flagged. */
+function real_framework_methods_are_not_flagged(Customer $customer): void
+{
+    Customer::all();
+    Customer::query();
+    $customer->save();
+}
+
+/** A method on a non-model class (here Collection::make) is not flagged. */
+function non_model_calls_are_not_flagged(): void
+{
+    Collection::make([1, 2, 3]);
+}
+
+/**
+ * A trait builder macro on a plain base-Builder model (SoftDeletes::withTrashed on Customer) is
+ * a runtime macro the plugin does not resolve as forwarded, so it is not flagged (and not a typo).
+ */
+function softdeletes_macro_is_not_flagged(): void
+{
+    Customer::withTrashed();
+}
+
+/**
+ * A relation receiver is skipped — `$customer->vehicles()` is a real model method (not flagged),
+ * and the `where()` chained on the resulting HasMany has a non-model receiver, so neither is
+ * flagged. Covers both the real-user-method non-flag path and the relation-receiver skip.
+ */
+function relation_receiver_is_not_flagged(Customer $customer): void
+{
+    $customer->vehicles()->where('vin', 'X');
+}
+
+/**
+ * A genuine direct scope call — a public scope passed the builder explicitly (scope composition)
+ * — invokes the real method and is not magic forwarding, so it is not flagged.
+ *
+ * @param Builder<DirectScopeModel> $query
+ */
+function direct_scope_call_is_not_flagged(DirectScopeModel $model, Builder $query): void
+{
+    $model->hasAnyName($query, ['a', 'b']);
+}
+
+/**
+ * A genuinely undefined method is left to Psalm's UndefinedMagicMethod, not mislabelled as a
+ * "use query()" suggestion: the rule only flags calls Laravel actually resolves by forwarding.
+ */
+function undefined_method_is_not_mislabelled(Customer $customer): void
+{
+    $customer->undefinedBuilderMethod();
+}
+?>
+--EXPECTF--
+ImplicitQueryBuilderCall on line %d: Avoid calling where() directly on the Customer model: the call is forwarded through Laravel's __callStatic/__call magic to the query builder. Use an explicit query entry point instead, e.g. Customer::query()->where(...).
+ImplicitQueryBuilderCall on line %d: Avoid calling find() directly on the Customer model: the call is forwarded through Laravel's __callStatic/__call magic to the query builder. Use an explicit query entry point instead, e.g. Customer::query()->find(...).
+ImplicitQueryBuilderCall on line %d: Avoid calling create() directly on the Customer model: the call is forwarded through Laravel's __callStatic/__call magic to the query builder. Use an explicit query entry point instead, e.g. Customer::query()->create(...).
+ImplicitQueryBuilderCall on line %d: Avoid calling first() directly on the Customer model: the call is forwarded through Laravel's __callStatic/__call magic to the query builder. Use an explicit query entry point instead, e.g. Customer::query()->first(...).
+ImplicitQueryBuilderCall on line %d: Avoid calling whereIn() directly on the Customer model: the call is forwarded through Laravel's __callStatic/__call magic to the query builder. Use an explicit query entry point instead, e.g. Customer::query()->whereIn(...).
+ImplicitQueryBuilderCall on line %d: Avoid calling active() directly on the Customer model: the call is forwarded through Laravel's __callStatic/__call magic to the query builder. Use an explicit query entry point instead, e.g. Customer::query()->active(...).
+ImplicitQueryBuilderCall on line %d: Avoid calling active() directly on the DirectScopeModel model: the call is forwarded through Laravel's __callStatic/__call magic to the query builder. Use an explicit query entry point instead, e.g. DirectScopeModel::query()->active(...).
+InvalidStaticInvocation on line %d: Method App\Models\DirectScopeModel::active is not static, but is called statically
+ImplicitQueryBuilderCall on line %d: Avoid calling whereElectric() directly on the Vehicle model: the call is forwarded through Laravel's __callStatic/__call magic to the query builder. Use an explicit query entry point instead, e.g. Vehicle::query()->whereElectric(...).
+ImplicitQueryBuilderCall on line %d: Avoid calling wherePaid() directly on the Invoice model: the call is forwarded through Laravel's __callStatic/__call magic to the query builder. Use an explicit query entry point instead, e.g. Invoice::query()->wherePaid(...).
+ImplicitQueryBuilderCall on line %d: Avoid calling whereId() directly on the Customer model: the call is forwarded through Laravel's __callStatic/__call magic to the query builder. Use an explicit query entry point instead, e.g. Customer::query()->whereId(...).
+ImplicitQueryBuilderCall on line %d: Avoid calling where() directly on the Customer model: the call is forwarded through Laravel's __callStatic/__call magic to the query builder. Use an explicit query entry point instead, e.g. Customer::query()->where(...).
+ImplicitQueryBuilderCall on line %d: Avoid calling find() directly on the Customer model: the call is forwarded through Laravel's __callStatic/__call magic to the query builder. Use an explicit query entry point instead, e.g. Customer::query()->find(...).
+ImplicitQueryBuilderCall on line %d: Avoid calling whereByMake() directly on the Vehicle model: the call is forwarded through Laravel's __callStatic/__call magic to the query builder. Use an explicit query entry point instead, e.g. Vehicle::query()->whereByMake(...).
+UndefinedMagicMethod on line %d: Magic method App\Models\Customer::undefinedbuildermethod does not exist

--- a/tests/Unit/PluginConfigTest.php
+++ b/tests/Unit/PluginConfigTest.php
@@ -43,6 +43,7 @@ final class PluginConfigTest extends TestCase
         $this->assertFalse($config->failOnInternalError);
         $this->assertFalse($config->findMissingTranslations);
         $this->assertFalse($config->findMissingViews);
+        $this->assertFalse($config->reportImplicitQueryBuilderCalls);
         // null = auto-detect via class_exists('Laravel\Octane\Octane') at runtime;
         // explicit true/false in XML overrides the auto-detection.
         $this->assertNull($config->findOctaneIncompatibleBinding);
@@ -226,6 +227,37 @@ final class PluginConfigTest extends TestCase
         $config = PluginConfig::fromXml($xml);
 
         $this->assertFalse($config->findMissingViews);
+    }
+
+    #[Test]
+    public function report_implicit_query_builder_calls_true(): void
+    {
+        $xml = new \SimpleXMLElement('<pluginClass><reportImplicitQueryBuilderCalls value="true" /></pluginClass>');
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertTrue($config->reportImplicitQueryBuilderCalls);
+    }
+
+    #[Test]
+    public function report_implicit_query_builder_calls_false(): void
+    {
+        $xml = new \SimpleXMLElement('<pluginClass><reportImplicitQueryBuilderCalls value="false" /></pluginClass>');
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertFalse($config->reportImplicitQueryBuilderCalls);
+    }
+
+    #[Test]
+    public function invalid_report_implicit_query_builder_calls_throws(): void
+    {
+        $xml = new \SimpleXMLElement('<pluginClass><reportImplicitQueryBuilderCalls value="yes" /></pluginClass>');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid reportImplicitQueryBuilderCalls value 'yes'");
+
+        PluginConfig::fromXml($xml);
     }
 
     #[Test]


### PR DESCRIPTION
## Issue to Solve

Some teams want to forbid Laravel's `__callStatic` / `__call` magic forwarding on Eloquent models and require an explicit `query()` entry point. Calls like `User::where(...)`, `User::active()` (a scope), or `User::find(...)` do not exist on the model; Laravel forwards them to a freshly created query builder. Teams aiming for a more explicit, statically obvious codebase want to mandate the `User::query()->...` form.

## Related

Closes #1067

## Solution Description

Adds a new **opt-in** custom issue `ImplicitQueryBuilderCall`, enabled via `<reportImplicitQueryBuilderCalls value="true" />` on `<pluginClass>` (off by default). An `AfterExpressionAnalysis` handler flags static (`User::where(...)`) and instance (`$user->where(...)`) calls of forwarded builder/scope methods on Eloquent models.

To stay consistent with the plugin's own type inference, the rule reuses the existing forwarding resolution rather than reimplementing it:

- `ModelMethodHandler::forwardsToQueryBuilder()` (new, `@internal`) — Eloquent `Builder` methods via the `@mixin`, `Query\Builder` methods, custom builder methods (both `newEloquentBuilder()` and `#[UseEloquentBuilder]`), and resolvable dynamic `where{Column}()` clauses.
- `BuilderScopeHandler::hasScopeMethod()` / `isDirectScopeCall()` — legacy `scopeXxx()` and modern `#[Scope]` scopes, while excluding a legitimate direct call that passes the builder explicitly (scope composition).

So it flags exactly what the plugin already treats as forwarded, and nothing it would report as `UndefinedMagicMethod`. Real `Model` methods (`save()`, `all()`, `query()`, ...) and any real user-defined method are left alone. `make()` defers to the existing `ModelMakeHandler` (`ModelMakeDiscouraged` → `new Model()`). A genuinely undefined method is left to Psalm's `UndefinedMagicMethod`.

**Known limitation:** a `public` `#[Scope]` is accessible everywhere, so its forwarded form cannot be told apart from a direct call by accessibility alone; it is not flagged here and remains covered by `PublicModelScope`.

Verified with a new type test `tests/Type/tests/ImplicitQueryBuilderCallTest.phpt` (flagged: builder methods, `Query\Builder` `whereIn`, legacy + modern protected scopes, custom builders, dynamic-where; not flagged: `query()` chains, real methods, non-models, relation receivers, public direct scope, undefined → `UndefinedMagicMethod`), new `PluginConfig` unit tests, `composer psalm` clean at 100% type coverage, and `composer cs`.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and unit tests in `tests/Unit/`)
- [x] Documentation is updated
