### PR TITLE
Narrow `App::make()` facade calls to the resolved class

### DIFF
--- a/src/Handlers/Facades/AppFacadeMakeHandler.php
+++ b/src/Handlers/Facades/AppFacadeMakeHandler.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Facades;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use Psalm\Codebase;
+use Psalm\LaravelPlugin\Providers\ApplicationProvider;
+use Psalm\LaravelPlugin\Providers\FacadeMapProvider;
+use Psalm\Plugin\EventHandler\Event\MethodParamsProviderEvent;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\MethodParamsProviderInterface;
+use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\StatementsSource;
+use Psalm\Storage\FunctionLikeParameter;
+use Psalm\Type;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Union;
+
+/**
+ * Narrows `App::make()`, `App::makeWith()` and `App::get()` on the `Illuminate\Support\Facades\App`
+ * facade to the resolved class, mirroring the container's own conditional return type
+ * `($abstract is class-string<TClass> ? TClass : mixed)`.
+ *
+ * Why a handler and not a stub: Laravel declares these as `object|mixed` (collapses to `mixed`). A
+ * real stub method is shadowed by Laravel's reflected magic-method tag on static calls, and a
+ * class-docblock `@method` override can't express templates/conditional returns in Psalm 7.
+ *
+ * Why not {@see \Psalm\LaravelPlugin\Util\ContainerResolver}: `make` dispatches via
+ * `Facade::__callStatic`, and in `AtomicStaticCallAnalyzer` the return-type provider for that branch
+ * fires *before* arguments are analysed (a Psalm hook-ordering limitation), so `NodeTypeProvider::getType()`
+ * is null for every argument.
+ * We read the class off the AST node instead. (That resolver also probes the container, which throws
+ * for unbound user classes like a Nova action — the motivating case.)
+ *
+ * Why the params provider: once we return a non-null type, `AtomicStaticCallAnalyzer` calls
+ * `checkMethodArgs()` → `Methods::getMethodParams()`, which throws `UnexpectedValueException`
+ * ("Cannot get method params") for a magic method with no real params. {@see self::getMethodParams()}
+ * supplies them so analysis doesn't abort.
+ *
+ * Limitation: a `class-string<Foo>` *variable* first argument (vs a `Foo::class` literal) isn't
+ * narrowed — its type is unavailable at this analysis stage — so it keeps Laravel's `mixed`.
+ *
+ * @internal
+ */
+final class AppFacadeMakeHandler implements MethodReturnTypeProviderInterface, MethodParamsProviderInterface
+{
+    private const FACADE_FQCN = 'Illuminate\\Support\\Facades\\App';
+
+    /**
+     * Container-resolution methods carrying the `class-string<T> -> T` contract; all narrow alike.
+     *
+     * @var array<lowercase-string, true>
+     */
+    private const HANDLED_METHODS = [
+        'make' => true,
+        'makewith' => true,
+        'get' => true,
+    ];
+
+    /**
+     * @return list<string>
+     */
+    #[\Override]
+    public static function getClassLikeNames(): array
+    {
+        // Psalm keys providers on the exact called class, so cover the canonical facade plus
+        // its aliases (the global `\App`, project aliases) via FacadeMapProvider.
+        return [
+            self::FACADE_FQCN,
+            ...FacadeMapProvider::getFacadeClasses(ApplicationProvider::getAppFullyQualifiedClassName()),
+        ];
+    }
+
+    /** @inheritDoc */
+    #[\Override]
+    public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        if (!isset(self::HANDLED_METHODS[$event->getMethodNameLowercase()])) {
+            return null;
+        }
+
+        return self::resolveFirstArgumentClass($event);
+    }
+
+    /** @inheritDoc */
+    #[\Override]
+    public static function getMethodParams(MethodParamsProviderEvent $event): ?array
+    {
+        $method = $event->getMethodNameLowercase();
+
+        if (!isset(self::HANDLED_METHODS[$method])) {
+            return null;
+        }
+
+        // Mirror the real signatures so argument checking (incl. named args) stays faithful:
+        // get(string $id) is single-arg; make()/makeWith() use `abstract` + optional `parameters`.
+        if ($method === 'get') {
+            return [new FunctionLikeParameter('id', false, Type::getString(), is_optional: false)];
+        }
+
+        return [
+            new FunctionLikeParameter('abstract', false, Type::getString(), is_optional: false),
+            new FunctionLikeParameter('parameters', false, Type::getArray(), is_optional: true),
+        ];
+    }
+
+    private static function resolveFirstArgumentClass(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        $paramName = $event->getMethodNameLowercase() === 'get' ? 'id' : 'abstract';
+        $abstract = self::abstractArgument($event->getCallArgs(), $paramName);
+
+        // Only a `X::class` literal carries the class on the AST; a plain-string alias or a
+        // `class-string<Foo>` variable can't be narrowed here (see class docblock) — defer to mixed.
+        if (
+            !$abstract instanceof ClassConstFetch
+            || !$abstract->class instanceof Name
+            || !$abstract->name instanceof Identifier
+            || $abstract->name->toLowerString() !== 'class'
+        ) {
+            return null;
+        }
+
+        if ($abstract->class->isSpecialClassName()) {
+            return self::resolveRelativeClassName($abstract->class->toLowerString(), $event->getSource());
+        }
+
+        $fqcn = $abstract->class->getAttribute('resolvedName');
+
+        if (!\is_string($fqcn) || $fqcn === '') {
+            return null;
+        }
+
+        return new Union([new TNamedObject($fqcn)]);
+    }
+
+    /**
+     * The abstract/id expression, matched by name first so reordered named arguments
+     * (`make(parameters: [...], abstract: Foo::class)`) still narrow, then by position.
+     *
+     * @param list<Arg> $args
+     */
+    private static function abstractArgument(array $args, string $paramName): ?Expr
+    {
+        foreach ($args as $arg) {
+            if ($arg->name instanceof Identifier && $arg->name->toLowerString() === $paramName) {
+                return $arg->value;
+            }
+        }
+
+        foreach ($args as $arg) {
+            if ($arg->name === null) {
+                return $arg->value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolve `self::class` / `static::class` against the calling class (`static` keeps late static
+     * binding: `Foo&static`). `parent::class` is rare here and left to Laravel's `@method`.
+     */
+    private static function resolveRelativeClassName(string $keyword, StatementsSource $source): ?Union
+    {
+        if ($keyword !== 'self' && $keyword !== 'static') {
+            return null;
+        }
+
+        $callingClass = $source->getFQCLN();
+
+        if ($callingClass === null) {
+            return null;
+        }
+
+        // Inside a trait, `self`/`static` resolve to the consuming class at runtime, but getFQCLN()
+        // yields the trait here — so the inferred type would be the (non-instantiable) trait. Defer
+        // to mixed rather than emit a wrong type.
+        if (self::isTrait($source->getCodebase(), $callingClass)) {
+            return null;
+        }
+
+        return new Union([new TNamedObject($callingClass, is_static: $keyword === 'static')]);
+    }
+
+    /** @psalm-mutation-free */
+    private static function isTrait(Codebase $codebase, string $fqcn): bool
+    {
+        try {
+            return $codebase->classlike_storage_provider->get($fqcn)->is_trait;
+        } catch (\InvalidArgumentException) {
+            return false;
+        }
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -257,6 +257,11 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Facades/AppFacadeRegistrationHandler.php';
         $registration->registerHooksFromClass(Handlers\Facades\AppFacadeRegistrationHandler::class);
 
+        // `App::make()`/`makeWith()`/`get()` class-string narrowing. Its getClassLikeNames() reads
+        // FacadeMapProvider (for the `\App` alias), so it relies on init() having run above.
+        require_once __DIR__ . '/Handlers/Facades/AppFacadeMakeHandler.php';
+        $registration->registerHooksFromClass(Handlers\Facades\AppFacadeMakeHandler::class);
+
         require_once __DIR__ . '/Handlers/Rules/ModelMakeHandler.php';
         $registration->registerHooksFromClass(Handlers\Rules\ModelMakeHandler::class);
         // Tri-state gate for the OctaneIncompatibleBinding rule:

--- a/tests/Type/tests/Facades/AppFacadeMakeTest.phpt
+++ b/tests/Type/tests/Facades/AppFacadeMakeTest.phpt
@@ -1,0 +1,162 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Facades\App;
+
+// Laravel's `App` facade declares make()/makeWith()/get() as `object|mixed` (collapses to mixed),
+// polluting e.g. a Nova resource's `actions(): list<Action>`. The plugin narrows a class-string
+// argument to the resolved class, matching app() / resolve() / $container->make().
+
+final class SomeAction {}
+interface SomeContract {}
+
+function make_narrows_class_string(): SomeAction
+{
+    /** @psalm-check-type-exact $a = SomeAction */
+    $a = App::make(SomeAction::class);
+
+    return $a;
+}
+
+function make_with_narrows_class_string(): SomeAction
+{
+    /** @psalm-check-type-exact $a = SomeAction */
+    $a = App::makeWith(SomeAction::class, ['label' => 'x']);
+
+    return $a;
+}
+
+function get_narrows_class_string(): SomeAction
+{
+    /** @psalm-check-type-exact $a = SomeAction */
+    $a = App::get(SomeAction::class);
+
+    return $a;
+}
+
+// `make(Interface::class)` resolves to the bound implementation, which is-a Interface.
+function make_narrows_interface(): SomeContract
+{
+    /** @psalm-check-type-exact $a = SomeContract */
+    $a = App::make(SomeContract::class);
+
+    return $a;
+}
+
+// The global `\App` alias resolves identically to the canonical facade.
+function make_via_global_alias(): SomeAction
+{
+    /** @psalm-check-type-exact $a = SomeAction */
+    $a = \App::make(SomeAction::class);
+
+    return $a;
+}
+
+// Named-argument calls must keep narrowing: the params provider names make()'s first argument
+// `abstract` precisely so the named binding resolves.
+function make_named_argument_narrows(): SomeAction
+{
+    /** @psalm-check-type-exact $a = SomeAction */
+    $a = App::make(abstract: SomeAction::class);
+
+    return $a;
+}
+
+// PSR-11 `get()` names its argument `id`, not `abstract`; the params provider must mirror that
+// so `App::get(id: ...)` does not emit a false-positive InvalidNamedArgument.
+function get_named_argument_narrows(): SomeAction
+{
+    /** @psalm-check-type-exact $a = SomeAction */
+    $a = App::get(id: SomeAction::class);
+
+    return $a;
+}
+
+// Named arguments can be reordered; the abstract is matched by name, not by position.
+function make_reordered_named_arguments_narrows(): SomeAction
+{
+    /** @psalm-check-type-exact $a = SomeAction */
+    $a = App::make(parameters: [], abstract: SomeAction::class);
+
+    return $a;
+}
+
+function make_with_reordered_named_arguments_narrows(): SomeAction
+{
+    /** @psalm-check-type-exact $a = SomeAction */
+    $a = App::makeWith(parameters: [], abstract: SomeAction::class);
+
+    return $a;
+}
+
+abstract class AppMakeFactory
+{
+    // `static::class` preserves late static binding, so a `: static` factory type-checks AND
+    // the exact intersection type is pinned (a regression to bare `static` or `mixed` is caught).
+    public static function makeViaStatic(): static
+    {
+        $instance = App::make(static::class);
+        /** @psalm-check-type-exact $instance = AppMakeFactory&static */
+
+        return $instance;
+    }
+
+    // `self::class` is the lexical class, with no `&static` intersection.
+    public static function makeViaSelf(): self
+    {
+        $instance = App::make(self::class);
+        /** @psalm-check-type-exact $instance = AppMakeFactory */
+
+        return $instance;
+    }
+}
+
+// Inside a trait, self::class/static::class resolve to the consuming class at runtime, but the
+// analyser sees the trait here, so narrowing is skipped (deferred to mixed) rather than inferring
+// the non-instantiable trait type.
+trait AppMakeInTrait
+{
+    public function makeViaSelfInTrait(): void
+    {
+        $resolved = App::make(self::class);
+        /** @psalm-check-type-exact $resolved = object|mixed */
+        $resolved;
+    }
+}
+
+final class AppMakeTraitConsumer
+{
+    use AppMakeInTrait;
+}
+
+// Plain-string abstracts ('view', 'config', container aliases) are NOT class-strings, so they
+// keep Laravel's declared `object|mixed` — the resolver must not over-narrow them.
+function make_plain_string_is_not_narrowed(): void
+{
+    $service = App::make('config');
+    /** @psalm-check-type-exact $service = object|mixed */
+    $service;
+}
+
+// The params provider declares `abstract` as required, so a zero-argument call is reported
+// (and analysis must not abort with "Cannot get method params").
+function make_requires_an_abstract(): void
+{
+    App::make();
+}
+
+// get() takes a single argument; a stray second arg is reported (it must not inherit make()'s
+// optional `parameters`).
+function get_rejects_a_second_argument(): void
+{
+    App::get(SomeAction::class, []);
+}
+
+?>
+--EXPECTF--
+MixedAssignment on line %d: Unable to determine the type that $resolved is being assigned to
+UnusedVariable on line %d: $resolved is never referenced or the value is not used
+MixedAssignment on line %d: Unable to determine the type that $service is being assigned to
+UnusedVariable on line %d: $service is never referenced or the value is not used
+TooFewArguments on line %d: Too few arguments for Illuminate\Support\Facades\App::make - expecting abstract to be passed
+TooManyArguments on line %d: Too many arguments for Illuminate\Support\Facades\App::get - expecting 1 but saw 2


### PR DESCRIPTION
## Issue to Solve

`App::make(Foo::class)` on the `Illuminate\Support\Facades\App` facade infers `mixed`, unlike `app(Foo::class)`, `resolve(Foo::class)`, and `$container->make(Foo::class)`, which already resolve to `Foo`. Laravel's facade declares `make()`, `makeWith()`, and `get()` as `object|mixed`, which collapses to `mixed`. Any list or return built from such a call gets polluted (for example a Nova resource's `actions(): list<Action>` becomes `list{..., mixed, ...}`, triggering `MixedReturnTypeCoercion` / `LessSpecificReturnStatement`).

## Related

None.

## Solution Description

The obvious fix (adding the facade to `ContainerHandler::getClassLikeNames()`) does not work and actually crashes Psalm. `App::make()` is a magic static method (dispatched through `Facade::__callStatic`), so in `AtomicStaticCallAnalyzer` the return-type provider for that branch runs before the arguments are analysed (argument types are `null`), and once a non-null type is returned Psalm calls `getMethodParams()`, which throws `UnexpectedValueException("Cannot get method params")` for a method that has no real parameter storage.

This PR adds a dedicated `AppFacadeMakeHandler` that:

- Narrows `make()`, `makeWith()`, and `get()` when the first argument is a class-string, mirroring the container's conditional return type `($abstract is class-string<TClass> ? TClass : mixed)`.
- Reads the class off the AST node (`Foo::class`, `static::class`, `self::class`), since the resolved argument type is unavailable at that analysis stage.
- Supplies parameter storage through a `MethodParamsProvider` so analysis does not abort.
- Covers the canonical facade plus its aliases (the global `\App`) via `FacadeMapProvider`.

Plain-string aliases (`'view'`, `'config'`) and `class-string<Foo>` variables keep Laravel's declared `object|mixed`, so existing behaviour does not regress.

Verified with a new type test (`tests/Type/tests/Facades/AppFacadeMakeTest.phpt`) covering the narrowing cases, named arguments, `static`/`self`, the global alias, and the guard cases (plain string stays `mixed`, arity errors). The full type suite, unit tests, the fresh-app integration test, and self-analysis (100% type coverage) all pass.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
