### PR TITLE
Report undefined methods on base `Builder<Model>` from `$class::query()`

### DIFF
--- a/src/Handlers/Rules/UndefinedBuilderMethodHandler.php
+++ b/src/Handlers/Rules/UndefinedBuilderMethodHandler.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Rules;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use Psalm\Codebase;
+use Psalm\CodeLocation;
+use Psalm\Internal\MethodIdentifier;
+use Psalm\Issue\UndefinedMagicMethod;
+use Psalm\IssueBuffer;
+use Psalm\LaravelPlugin\Util\DynamicWhereResolver;
+use Psalm\Plugin\EventHandler\AfterExpressionAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterExpressionAnalysisEvent;
+use Psalm\Type\Atomic\TGenericObject;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Union;
+
+/**
+ * Flags undefined method/scope calls on `$class::query()` when `$class` is a bare
+ * `class-string<\Illuminate\Database\Eloquent\Model>`.
+ *
+ * Such a `query()` resolves to the base `Builder<Model>`, whose stub
+ * `@mixin \Illuminate\Database\Query\Builder` (carrying `__call`) makes Psalm accept ANY
+ * method name permissively — so a genuinely-undefined scope/method is silently swallowed
+ * and surfaces only as a downstream `mixed`. At runtime the same call reaches
+ * `Builder::__call`, which forwards to `Query\Builder::__call`, finds no scope/macro/
+ * where-clause to route to (the base `Model` declares no scopes), and throws
+ * `BadMethodCallException`. This was the motivating bug in #1070: a renamed scope reached
+ * production via `$fqcn::query()->oldScope()`.
+ *
+ * The handler reports Psalm's built-in {@see \Psalm\Issue\UndefinedMagicMethod} — the same
+ * issue Psalm already raises for the concrete custom-builder case
+ * (`WorkOrder::query()->fake()`) — so both paths surface identically and honor existing
+ * `UndefinedMagicMethod` issue configuration.
+ *
+ * **Why the receiver is restricted to a direct `::query()` call.** A bare `Builder $q`
+ * parameter (idiomatic in filters, pipelines, and `whereHas(..., fn (Builder $q) => ...)`
+ * closures) is *type-identical* to `Builder<Model>` — Psalm fills the missing template
+ * param with the `Model` bound and there is no type-level discriminator. Such a variable
+ * usually stands in for a concrete model at runtime, where the scope is perfectly valid, so
+ * flagging it would be a false positive. Requiring the receiver to be `$class::query()`
+ * narrows reporting to the genuine `class-string<Model>` case from #1070 and leaves bare
+ * `Builder` receivers alone. The trade-off: a variable-assigned builder
+ * (`$q = $fqcn::query(); $q->oldScope();`) or a method chain
+ * (`$fqcn::query()->where(...)->oldScope()`) is not reported.
+ *
+ * Concrete-model builders (`Builder<Post>`) are excluded by the type gate: a
+ * `class-string<Post>` holder may legitimately call a scope this handler cannot enumerate,
+ * and models with custom builders already report undefined calls through the builder class
+ * ({@see \Psalm\LaravelPlugin\Handlers\Eloquent\CustomBuilderMethodHandler}).
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1070
+ * @see https://github.com/larastan/larastan EloquentBuilderForwardsCallsExtension — Larastan's always-on analogue
+ */
+// Uses AfterExpressionAnalysisInterface (fires per-expression). The instanceof MethodCall
+// check and the cheap structural "receiver is a ::query() static call" gate reject the
+// overwhelming majority of expressions before any type lookup or codebase query runs.
+final class UndefinedBuilderMethodHandler implements AfterExpressionAnalysisInterface
+{
+    /** @inheritDoc */
+    #[\Override]
+    public static function afterExpressionAnalysis(AfterExpressionAnalysisEvent $event): ?bool
+    {
+        $expr = $event->getExpr();
+
+        // Only instance calls with a literal method name. Dynamic `->{$name}()` is skipped:
+        // the name isn't statically known, so existence can't be decided.
+        if (!$expr instanceof MethodCall || !$expr->name instanceof Identifier) {
+            return null;
+        }
+
+        // Provenance gate: only report on `$class::query()->method()`. A plain-variable
+        // receiver (bare `Builder $q` param, whereHas closure) is type-identical to
+        // Builder<Model> but typically backs a concrete model at runtime, so reporting there
+        // would be a false positive. See the class docblock for the full rationale.
+        $receiver = $expr->var;
+        if (!$receiver instanceof StaticCall
+            || !$receiver->name instanceof Identifier
+            || \strtolower($receiver->name->name) !== 'query'
+        ) {
+            return null;
+        }
+
+        $source = $event->getStatementsSource();
+
+        $receiverType = $source->getNodeTypeProvider()->getType($receiver);
+        if (!$receiverType instanceof Union || !self::isBaseModelBuilder($receiverType)) {
+            return null;
+        }
+
+        $methodName = $expr->name->name;
+        /** @var lowercase-string $methodNameLc */
+        $methodNameLc = \strtolower($methodName);
+
+        if (self::isResolvableOnBaseBuilder($event->getCodebase(), $methodNameLc)) {
+            return null;
+        }
+
+        // Emit Psalm's built-in UndefinedMagicMethod — the same issue Psalm raises for the
+        // concrete custom-builder case (e.g. WorkOrder::query()->fake()), so the dynamic
+        // base-Builder case reports consistently and honors existing UndefinedMagicMethod config.
+        IssueBuffer::accepts(
+            new UndefinedMagicMethod(
+                'Magic method ' . Builder::class . "::{$methodNameLc} does not exist",
+                new CodeLocation($source, $expr->name),
+                Builder::class . '::' . $methodNameLc,
+            ),
+            $source->getSuppressedIssues(),
+        );
+
+        return null;
+    }
+
+    /**
+     * True only when the receiver is exactly base `Builder<\Illuminate\Database\Eloquent\Model>`.
+     *
+     * Custom builder subclasses (`PostBuilder<...>`) and concrete-model params
+     * (`Builder<Post>`) are excluded — the former already report undefined calls via the
+     * builder class, the latter may carry scopes this handler does not enumerate.
+     *
+     * @psalm-mutation-free
+     */
+    private static function isBaseModelBuilder(Union $receiverType): bool
+    {
+        $atomics = $receiverType->getAtomicTypes();
+        if (\count($atomics) !== 1) {
+            return false;
+        }
+
+        $atomic = $atomics[\array_key_first($atomics)];
+
+        if (!$atomic instanceof TGenericObject
+            || $atomic->value !== Builder::class
+            || \count($atomic->type_params) !== 1
+        ) {
+            return false;
+        }
+
+        $paramAtomics = $atomic->type_params[0]->getAtomicTypes();
+        if (\count($paramAtomics) !== 1) {
+            return false;
+        }
+
+        $paramAtomic = $paramAtomics[\array_key_first($paramAtomics)];
+
+        return $paramAtomic instanceof TNamedObject && $paramAtomic->value === Model::class;
+    }
+
+    /**
+     * Mirror Laravel's `Builder` / `Query\Builder` `__call` dispatch: a method on base
+     * `Builder<Model>` is resolvable (won't reach the throwing branch of `__call`) iff it is a
+     * real `Eloquent\Builder` or `Query\Builder` method, a registered macro, or a dynamic
+     * `where{Column}` form.
+     *
+     * `Model::class` is intentionally NOT consulted: `Eloquent\Builder::__call` forwards only
+     * to `$this->query` (Query\Builder), never to the Model, so Model-only methods such as
+     * `save()` / `getAttribute()` genuinely fatal on a builder and must be reported.
+     *
+     * @param lowercase-string $methodNameLc
+     */
+    private static function isResolvableOnBaseBuilder(Codebase $codebase, string $methodNameLc): bool
+    {
+        // Real methods reachable on Builder<Model>: Eloquent\Builder's own and Query\Builder's
+        // (the latter via the stub's @mixin / runtime forwardCallTo). is_used: false keeps this
+        // an existence probe, not a usage mark, so unused-code analysis is unaffected.
+        foreach ([Builder::class, QueryBuilder::class] as $class) {
+            if ($codebase->methodExists(new MethodIdentifier($class, $methodNameLc), is_used: false)) {
+                return true;
+            }
+        }
+
+        // Dynamic where{Column}: Laravel routes any `where*` name through dynamicWhere(), which
+        // builds a clause instead of throwing — so it is never an undefined-method fatal.
+        if (DynamicWhereResolver::isDynamicWhereMethod($methodNameLc)) {
+            return true;
+        }
+
+        // Runtime-registered macros (and stub @method declarations) are injected into
+        // pseudo_methods by {@see \Psalm\LaravelPlugin\Handlers\Magic\MacroHandler}; a macro
+        // call resolves through __call at runtime, so it is not undefined.
+        return self::hasPseudoMethod($codebase, Builder::class, $methodNameLc)
+            || self::hasPseudoMethod($codebase, QueryBuilder::class, $methodNameLc);
+    }
+
+    /**
+     * @param class-string $class
+     * @param lowercase-string $methodNameLc
+     * @psalm-mutation-free
+     */
+    private static function hasPseudoMethod(Codebase $codebase, string $class, string $methodNameLc): bool
+    {
+        try {
+            $storage = $codebase->classlike_storage_provider->get(\strtolower($class));
+        } catch (\InvalidArgumentException) {
+            // Builder/QueryBuilder are core classes guaranteed populated once a receiver typed
+            // as Builder<Model> exists, so this is defensive and effectively unreachable.
+            return false;
+        }
+
+        return isset($storage->pseudo_methods[$methodNameLc])
+            || isset($storage->declaring_pseudo_method_ids[$methodNameLc]);
+    }
+}

--- a/src/Handlers/Rules/UndefinedBuilderMethodHandler.php
+++ b/src/Handlers/Rules/UndefinedBuilderMethodHandler.php
@@ -76,6 +76,13 @@ final class UndefinedBuilderMethodHandler implements AfterExpressionAnalysisInte
             return null;
         }
 
+        // Respect Psalm's own gating: the core method-call analyzer only emits Undefined(Magic)Method
+        // when $context->check_methods is set. Mirror that so this rule stays silent in contexts where
+        // method checks are intentionally disabled (e.g. inside isset()/unevaluated operands).
+        if (!$event->getContext()->check_methods) {
+            return null;
+        }
+
         // Provenance gate: only report on `$class::query()->method()`. A plain-variable
         // receiver (bare `Builder $q` param, whereHas closure) is type-identical to
         // Builder<Model> but typically backs a concrete model at runtime, so reporting there
@@ -99,7 +106,7 @@ final class UndefinedBuilderMethodHandler implements AfterExpressionAnalysisInte
         /** @var lowercase-string $methodNameLc */
         $methodNameLc = \strtolower($methodName);
 
-        if (self::isResolvableOnBaseBuilder($event->getCodebase(), $methodNameLc)) {
+        if (self::isResolvableOnBaseBuilder($event->getCodebase(), $methodName, $methodNameLc)) {
             return null;
         }
 
@@ -163,22 +170,29 @@ final class UndefinedBuilderMethodHandler implements AfterExpressionAnalysisInte
      * to `$this->query` (Query\Builder), never to the Model, so Model-only methods such as
      * `save()` / `getAttribute()` genuinely fatal on a builder and must be reported.
      *
+     * Casing matters and differs per check: PHP method dispatch is case-insensitive (use the
+     * lowercased name for `methodExists`), but Laravel's `Query\Builder::__call` does a
+     * case-sensitive `str_starts_with($method, 'where')` for dynamic where, so that check uses
+     * the ORIGINAL casing — `WhereFoo()` is not dynamic-where and throws at runtime.
+     *
      * @param lowercase-string $methodNameLc
      */
-    private static function isResolvableOnBaseBuilder(Codebase $codebase, string $methodNameLc): bool
+    private static function isResolvableOnBaseBuilder(Codebase $codebase, string $methodName, string $methodNameLc): bool
     {
         // Real methods reachable on Builder<Model>: Eloquent\Builder's own and Query\Builder's
-        // (the latter via the stub's @mixin / runtime forwardCallTo). is_used: false keeps this
-        // an existence probe, not a usage mark, so unused-code analysis is unaffected.
+        // (the latter via the stub's @mixin / runtime forwardCallTo). PHP resolves these
+        // case-insensitively, so the lowercased name is correct. is_used: false keeps this an
+        // existence probe, not a usage mark, so unused-code analysis is unaffected.
         foreach ([Builder::class, QueryBuilder::class] as $class) {
             if ($codebase->methodExists(new MethodIdentifier($class, $methodNameLc), is_used: false)) {
                 return true;
             }
         }
 
-        // Dynamic where{Column}: Laravel routes any `where*` name through dynamicWhere(), which
-        // builds a clause instead of throwing — so it is never an undefined-method fatal.
-        if (DynamicWhereResolver::isDynamicWhereMethod($methodNameLc)) {
+        // Dynamic where{Column}: routed through dynamicWhere() (builds a clause, never throws) ONLY
+        // when the name starts with a lowercase `where` — Laravel's check is case-sensitive, so the
+        // original casing is required here (`WhereFoo`/`OrWhereFoo` fall through and throw).
+        if (DynamicWhereResolver::isDynamicWhereMethod($methodName)) {
             return true;
         }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -264,6 +264,8 @@ final class Plugin implements PluginEntryPointInterface
 
         require_once __DIR__ . '/Handlers/Rules/ModelMakeHandler.php';
         $registration->registerHooksFromClass(Handlers\Rules\ModelMakeHandler::class);
+        require_once __DIR__ . '/Handlers/Rules/UndefinedBuilderMethodHandler.php';
+        $registration->registerHooksFromClass(Handlers\Rules\UndefinedBuilderMethodHandler::class);
         // Tri-state gate for the OctaneIncompatibleBinding rule:
         //   findOctaneIncompatibleBinding === null  → auto-detect via class_exists()
         //   findOctaneIncompatibleBinding === true  → force enabled

--- a/tests/Type/tests/Builder/UndefinedBuilderMethodTest.phpt
+++ b/tests/Type/tests/Builder/UndefinedBuilderMethodTest.phpt
@@ -48,6 +48,31 @@ function allows_builder_macro(string $fqcn): void
 }
 
 /**
+ * Wrong-cased dynamic where: Laravel's `str_starts_with($method, 'where')` is case-sensitive,
+ * so `WhereFoo` does NOT route to dynamicWhere and throws BadMethodCallException at runtime.
+ * Must be flagged (regression guard for lowercasing before the dynamic-where check).
+ *
+ * @param class-string<Model> $fqcn
+ */
+function flags_wrong_cased_dynamic_where(string $fqcn): void
+{
+    $fqcn::query()->WhereFoo('x');
+}
+
+/**
+ * Wrong-cased macro: Psalm resolves macros case-insensitively via the lowercased pseudo-method,
+ * so `TestBuilderMacro` (macro is `testBuilderMacro`) is treated as the macro and NOT flagged —
+ * matching Psalm's own resolution and avoiding a contradictory double-signal. (At runtime Laravel's
+ * case-sensitive hasMacro would throw, but that divergence is Psalm's, not this rule's, to make.)
+ *
+ * @param class-string<Model> $fqcn
+ */
+function allows_wrong_cased_macro(string $fqcn): void
+{
+    $fqcn::query()->TestBuilderMacro();
+}
+
+/**
  * A bare `Builder<Model>` variable receiver (idiomatic in filters/pipelines and
  * `whereHas(..., fn (Builder $q) => ...)` closures) is type-identical to the dynamic-model
  * case but usually backs a concrete model at runtime — must NOT be flagged (provenance gate).
@@ -84,3 +109,4 @@ function allows_undefined_on_concrete_model_builder(string $fqcn): void
 ?>
 --EXPECTF--
 UndefinedMagicMethod on line %d: Magic method Illuminate\Database\Eloquent\Builder::thisscopedoesnotexist does not exist
+UndefinedMagicMethod on line %d: Magic method Illuminate\Database\Eloquent\Builder::wherefoo does not exist

--- a/tests/Type/tests/Builder/UndefinedBuilderMethodTest.phpt
+++ b/tests/Type/tests/Builder/UndefinedBuilderMethodTest.phpt
@@ -1,0 +1,86 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * The motivating bug (#1070): a `class-string<Model>` holder calls `query()` then an
+ * undefined scope. `$fqcn::query()` resolves to base `Builder<Model>`, whose @mixin + __call
+ * silently swallowed the name; at runtime it forwards to Builder::__call and throws. Flag it.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1070
+ *
+ * @param class-string<Model> $fqcn
+ */
+function flags_undefined_scope_on_dynamic_model_string(string $fqcn): void
+{
+    $fqcn::query()->thisScopeDoesNotExist();
+}
+
+/** Real Eloquent\Builder method — must NOT be flagged. */
+function allows_real_builder_method(string $fqcn): void
+{
+    /** @var class-string<Model> $fqcn */
+    $fqcn::query()->where('id', 1);
+}
+
+/** Query\Builder method reached via @mixin — must NOT be flagged. */
+function allows_query_builder_method(string $fqcn): void
+{
+    /** @var class-string<Model> $fqcn */
+    $fqcn::query()->whereIn('id', [1, 2, 3]);
+}
+
+/** Dynamic where{Column} — runtime dynamicWhere never fatals, must NOT be flagged. */
+function allows_dynamic_where(string $fqcn): void
+{
+    /** @var class-string<Model> $fqcn */
+    $fqcn::query()->whereSomethingDynamic('x');
+}
+
+/** Registered Builder macro (testBuilderMacro, see macro-fixtures.php) — must NOT be flagged. */
+function allows_builder_macro(string $fqcn): void
+{
+    /** @var class-string<Model> $fqcn */
+    $fqcn::query()->testBuilderMacro();
+}
+
+/**
+ * A bare `Builder<Model>` variable receiver (idiomatic in filters/pipelines and
+ * `whereHas(..., fn (Builder $q) => ...)` closures) is type-identical to the dynamic-model
+ * case but usually backs a concrete model at runtime — must NOT be flagged (provenance gate).
+ *
+ * @param Builder<Model> $builder
+ */
+function allows_undefined_on_bare_builder_param(Builder $builder): void
+{
+    $builder->anotherMissingScope();
+}
+
+/**
+ * Variable-assigned builder is the documented limitation: the provenance gate only fires on a
+ * direct `$class::query()->method()` receiver, so this is NOT flagged.
+ *
+ * @param class-string<Model> $fqcn
+ */
+function allows_undefined_on_assigned_builder(string $fqcn): void
+{
+    $query = $fqcn::query();
+    $query->thisScopeDoesNotExist();
+}
+
+/**
+ * Concrete-model builder is out of scope (the type gate requires exactly base Model), so a
+ * `class-string<Customer>` holder is NOT flagged even for a clearly-undefined name.
+ *
+ * @param class-string<Customer> $fqcn
+ */
+function allows_undefined_on_concrete_model_builder(string $fqcn): void
+{
+    $fqcn::query()->thisScopeDoesNotExistOnCustomer();
+}
+?>
+--EXPECTF--
+UndefinedMagicMethod on line %d: Magic method Illuminate\Database\Eloquent\Builder::thisscopedoesnotexist does not exist


### PR DESCRIPTION
## Issue to Solve

`$class::query()->method()` where `$class` is a `class-string<Model>` resolves to the base `Builder<Model>`. Because the `Builder` stub carries `@mixin \Illuminate\Database\Query\Builder` (and `Query\Builder` has `__call`), Psalm accepted any method name permissively, so an undefined or renamed scope passed analysis and only failed at runtime with `BadMethodCallException`. PHPStan/Larastan already catch this; Psalm did not.

## Related

Closes #1070

## Solution Description

Adds an always-on `AfterExpressionAnalysis` rule (`UndefinedBuilderMethodHandler`) that reports Psalm's **built-in `UndefinedMagicMethod`** when a method on a base `Builder<Model>` is none of: a real `Eloquent\Builder` / `Query\Builder` method, a registered macro, or a dynamic `where{Column}` form. This mirrors Laravel's `Builder::__call` / `Query\Builder::__call` dispatch, so it reports exactly the calls that throw `BadMethodCallException` at runtime — and it is the **same issue Psalm already raises for the concrete custom-builder case** (`WorkOrder::query()->fake()`), so both paths surface identically and honor existing `UndefinedMagicMethod` configuration. No new issue type is introduced.

Reporting is deliberately restricted to a direct `$class::query()->method()` receiver. A bare `Builder $q` parameter (filters, pipelines, `whereHas(..., fn (Builder $q) => ...)` closures) is type-identical to `Builder<Model>` but usually backs a concrete model at runtime, so flagging it would be a false positive. Concrete-model builders (`Builder<Post>`) and models with custom builders are also out of scope (the latter already report undefined calls via the builder class). Trade-off: a variable-assigned builder (`$q = $class::query(); $q->...`) or a longer chain (`query()->where()->...`) is not reported.

Verified with a new type test (1 positive plus 6 negative cases: real builder/query/dynamic-where methods, a registered macro, a bare `Builder<Model>` parameter, a variable-assigned builder, and a concrete-model builder), the full type suite (458 tests), self-analysis at 100% type coverage, and the fresh-app integration test.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/tests/Builder/UndefinedBuilderMethodTest.phpt`)
