### PR TITLE
Detect user-controlled container resolution as unsafe reflection (CWE-470)

### DIFF
--- a/docs/contributing/taint-analysis.md
+++ b/docs/contributing/taint-analysis.md
@@ -163,6 +163,34 @@ Multiple parameters can be sinks:
 public function jsonp($callback, $data = []) {}
 ```
 
+#### Unsafe reflection (CWE-470) — container resolution
+
+A user-controlled class name resolved through the container lets an attacker
+instantiate arbitrary classes (constructor side effects, gadget chains). The
+container entry points reuse the built-in `callable` kind, the same kind Psalm
+applies to `new $var()` and dynamic invocation:
+
+- `app($abstract)` / `resolve($name)` — `stubs/common/Foundation/helpers.phpstub`
+- `Container::make($abstract)` / `Container::makeWith($abstract)` — `stubs/common/Container/Container.phpstub`
+
+```php
+/**
+ * @psalm-taint-sink callable $abstract
+ */
+public function make($abstract, array $parameters = []) {}
+```
+
+The helper stubs (`app`, `resolve`) carry the sink only; their return type is
+still produced by `ContainerHandler`. The bare `new $var()`, `$callback()`, and
+`call_user_func()` forms in the issue are already caught by Psalm core's
+`callable` sink combined with the plugin's `Request` taint sources, so no stub
+is needed for those.
+
+The `App::make(...)` facade form does **not** propagate taint — see
+[Known limitation: Facade static calls](#known-limitation-facade-static-calls).
+Use the `app()` / `resolve()` helpers or an instance typed as
+`Illuminate\Container\Container` for analyzable code.
+
 ### Escape stubs (with flow)
 
 Mark functions that sanitize specific taint kinds. **Always pair with `@psalm-flow`**:

--- a/src/Handlers/Application/ContainerHandler.php
+++ b/src/Handlers/Application/ContainerHandler.php
@@ -55,7 +55,16 @@ final class ContainerHandler implements AfterClassLikeVisitInterface, FunctionRe
     #[\Override]
     public static function getClassLikeNames(): array
     {
-        return [ApplicationProvider::getAppFullyQualifiedClassName()];
+        return [
+            ApplicationProvider::getAppFullyQualifiedClassName(),
+            // Container contracts: callers idiomatically type on the interface
+            // (e.g. `$this->app` is the Application contract), so the make()
+            // return must be narrowed for these receivers too — otherwise the
+            // `@return mixed` on the contract stub (which hosts the CWE-470
+            // taint sink) would surface as mixed at every `->make()` call site.
+            \Illuminate\Contracts\Container\Container::class,
+            \Illuminate\Contracts\Foundation\Application::class,
+        ];
     }
 
     #[\Override]

--- a/stubs/common/Container/Container.phpstub
+++ b/stubs/common/Container/Container.phpstub
@@ -26,4 +26,31 @@ class Container implements ArrayAccess, ContainerContract
      * @psalm-variadic
      */
     public function tag($abstracts, $tags) {}
+
+    /**
+     * Resolve the given type from the container.
+     *
+     * $abstract is an unsafe-reflection taint sink (CWE-470): a user-controlled
+     * class name lets an attacker instantiate arbitrary classes. Reuses the
+     * built-in `callable` taint kind. The return type is supplied by
+     * {@see \Psalm\LaravelPlugin\Handlers\Application\ContainerHandler}.
+     *
+     * @param  string|class-string  $abstract
+     * @param  array  $parameters
+     * @return mixed
+     *
+     * @psalm-taint-sink callable $abstract
+     */
+    public function make($abstract, array $parameters = []) {}
+
+    /**
+     * Resolve the given type with the given parameters.
+     *
+     * @param  string|class-string  $abstract
+     * @param  array  $parameters
+     * @return mixed
+     *
+     * @psalm-taint-sink callable $abstract
+     */
+    public function makeWith($abstract, array $parameters = []) {}
 }

--- a/stubs/common/Contracts/Container.phpstub
+++ b/stubs/common/Contracts/Container.phpstub
@@ -37,4 +37,26 @@ interface Container extends ContainerInterface, \ArrayAccess
      * @psalm-variadic
      */
     public function tag($abstracts, $tags);
+
+    /**
+     * Resolve the given type from the container.
+     *
+     * Declared on the contract so the sink also fires for the idiomatic
+     * interface-typed receivers — `Illuminate\Contracts\Container\Container`
+     * and `Illuminate\Contracts\Foundation\Application` (which extends it),
+     * e.g. `$this->app->make(...)` in a service provider. Taint sinks
+     * propagate parent → child, so a sink only on the concrete class would
+     * miss these. $abstract is an unsafe-reflection sink (CWE-470).
+     *
+     * `@return mixed` is harmless: ContainerHandler's MethodReturnTypeProvider
+     * is registered for this contract (see ContainerHandler::getClassLikeNames)
+     * and narrows the return from the literal $abstract, overriding it.
+     *
+     * @param  string|class-string  $abstract
+     * @param  array  $parameters
+     * @return mixed
+     *
+     * @psalm-taint-sink callable $abstract
+     */
+    public function make($abstract, array $parameters = []);
 }

--- a/stubs/common/Foundation/helpers.phpstub
+++ b/stubs/common/Foundation/helpers.phpstub
@@ -48,7 +48,23 @@ function abort_unless($boolean, $code, $message = '', array $headers = []) {}
  */
 function action($name, $parameters = [], $absolute = true) {}
 
-// app: processed by Psalm handlers
+/**
+ * Get the available container instance, or resolve the given abstract.
+ *
+ * The return type is provided by {@see \Psalm\LaravelPlugin\Handlers\Application\ContainerHandler};
+ * this stub exists only to mark $abstract as an unsafe-reflection taint sink (CWE-470).
+ * A user-controlled class name flowing into the container lets an attacker instantiate
+ * arbitrary classes (constructor side effects, gadget chains). Reuses the built-in
+ * `callable` taint kind, which Psalm also applies to `new $var()` / dynamic invocation.
+ *
+ * @param  string|null  $abstract
+ * @param  array  $parameters
+ * @return mixed
+ *
+ * @psalm-taint-sink callable $abstract
+ */
+function app($abstract = null, array $parameters = []) {}
+
 // app_path: processed by Psalm handlers
 // asset: nothing to stub
 // auth: processed by Psalm handlers
@@ -259,6 +275,21 @@ function redirect($to = null, $status = 302, $headers = [], $secure = null) {}
  * @psalm-taint-source input
  */
 function request($key = null, $default = null) {}
+
+/**
+ * Resolve a service from the container.
+ *
+ * The return type is provided by {@see \Psalm\LaravelPlugin\Handlers\Application\ContainerHandler};
+ * this stub exists only to mark $name as an unsafe-reflection taint sink (CWE-470),
+ * mirroring app(). Reuses the built-in `callable` taint kind.
+ *
+ * @param  string  $name
+ * @param  array  $parameters
+ * @return mixed
+ *
+ * @psalm-taint-sink callable $name
+ */
+function resolve($name, array $parameters = []) {}
 
 /**
  * Catch a potential exception and return a default value.

--- a/tests/Type/tests/TaintAnalysis/CWE470/SafeCallableContainerConstantClass.phpt
+++ b/tests/Type/tests/TaintAnalysis/CWE470/SafeCallableContainerConstantClass.phpt
@@ -1,0 +1,24 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+// CWE-470 negative case. A constant class-string carries no user input, so
+// resolving it through the container must NOT raise TaintedCallable. Guards the
+// container sinks (see TaintedCallableContainerResolution.phpt) against false
+// positives on the ubiquitous, safe app(Foo::class) / make(Foo::class) form.
+// Empty --EXPECTF-- asserts zero findings, so a regression that wrongly tainted
+// a constant would surface here.
+final class TrustedService {}
+
+function safeAppConstant(): mixed
+{
+    return app(TrustedService::class);
+}
+
+function safeMakeConstant(\Illuminate\Contracts\Foundation\Application $app): mixed
+{
+    return $app->make(TrustedService::class);
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/CWE470/TaintedCallableContainerResolution.phpt
+++ b/tests/Type/tests/TaintAnalysis/CWE470/TaintedCallableContainerResolution.phpt
@@ -1,0 +1,46 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+// CWE-470 — unsafe reflection via the container. A user-controlled class name
+// resolved through Laravel's container lets an attacker instantiate arbitrary
+// classes (constructor side effects, gadget chains). Every container entry
+// point marks its $abstract/$name argument as a `callable` taint sink — the
+// same built-in kind Psalm applies to `new $var()` / dynamic invocation.
+//
+// Sinks live in:
+//   - stubs/common/Foundation/helpers.phpstub      (app, resolve)
+//   - stubs/common/Container/Container.phpstub      (make, makeWith — concrete)
+//   - stubs/common/Contracts/Container.phpstub      (make — contract; covers the
+//     idiomatic interface-typed `$this->app->make(...)` receiver)
+//
+// The bare `new $var()`, `$callback()`, and `call_user_func()` forms are NOT
+// re-tested here: Psalm core's `callable` sink already catches them once the
+// plugin supplies the Request taint source.
+
+function unsafeAppHelper(\Illuminate\Http\Request $request): mixed
+{
+    return app($request->input('handler'));
+}
+
+function unsafeResolveHelper(\Illuminate\Http\Request $request): mixed
+{
+    return resolve($request->input('service'));
+}
+
+// Contract-typed receiver — the common dependency-injection form, e.g.
+// `$this->app->make(...)` in a service provider.
+function unsafeContractMake(\Illuminate\Http\Request $request, \Illuminate\Contracts\Foundation\Application $app): mixed
+{
+    return $app->make($request->input('service'));
+}
+
+// Concrete container, makeWith().
+function unsafeConcreteMakeWith(\Illuminate\Http\Request $request, \Illuminate\Container\Container $container): mixed
+{
+    return $container->makeWith($request->input('service'), []);
+}
+?>
+--EXPECTF--
+%ATaintedCallable on line %d: Detected tainted text%ATaintedCallable on line %d: Detected tainted text%ATaintedCallable on line %d: Detected tainted text%ATaintedCallable on line %d: Detected tainted text%A


### PR DESCRIPTION
## Issue to Solve
When a class name comes from user input, resolving it through Laravel's container lets an attacker instantiate arbitrary classes, triggering `__construct` side effects or gadget chains (CWE-470, unsafe reflection). Psalm + the plugin already flagged the raw `new $var()`, `$callback()`, and `call_user_func()` forms (core's `callable` taint sink combined with the plugin's `Request` taint sources), but the container entry points were a blind spot.

## Related
Closes #572

## Solution Description
Mark the `$abstract` / `$name` argument of the container resolution APIs as a `callable` taint sink (the same built-in kind Psalm applies to dynamic instantiation), reusing the existing `Request` sources. No new taint kind, no handler-emitted issue: just docblock annotations on stubs.

Sinks added:
- `app()` / `resolve()` helpers (`stubs/common/Foundation/helpers.phpstub`)
- `Container::make()` / `makeWith()` on the concrete class (`stubs/common/Container/Container.phpstub`)
- `Container::make()` on the **contract** interface (`stubs/common/Contracts/Container.phpstub`), so the idiomatic interface-typed `$this->app->make(...)` path (the common DI form) is covered too. Taint sinks propagate parent to child, so a sink only on the concrete class would miss contract-typed receivers.

The contract `make()` stub carries `@return mixed` to host the sink. To prevent that from widening `$app->make(Foo::class)` to `mixed` at every call site, `ContainerHandler` now registers its return-type provider for the two container contracts as well, so the literal-argument narrowing still applies (regression guarded by `OctaneIncompatibleBindingTest`).

The bare `new $var()`, `$callback()`, and `call_user_func()` forms are intentionally left to core's existing `callable` sink. The `App::make(...)` facade form does not propagate taint (the documented `__callStatic` limitation); use the helpers or a contract-typed instance.

Verification: 4 new taint type tests (app helper, resolve helper, concrete + contract make/makeWith fire `TaintedCallable`; a constant class-string fires nothing). Full type suite (477) green, self-analysis at 100%, `test:app` green on Laravel 12.12.2.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)
- [x] Documentation is updated (if needed, otherwise remove this item)
