### PR TITLE
Infer `app(Foo::class)` as `Foo` when the booted app cannot resolve it

### DIFF
--- a/src/Util/ContainerResolver.php
+++ b/src/Util/ContainerResolver.php
@@ -98,6 +98,33 @@ final class ContainerResolver
         $concrete = self::resolveFromApplicationContainer($abstract);
 
         if ($concrete === null) {
+            // Container resolution failed: either the abstract is unbound, or the
+            // plugin's booted app (Orchestra Testbench, when analysing a Laravel
+            // *package* rather than an app) lacks the provider that would register
+            // the binding, and the concrete class is not auto-wireable via reflection
+            // (protected/private constructor or provider-supplied dependencies).
+            // See #757 / umbrella #766.
+            //
+            // If the abstract is itself a loadable class name, mirror Laravel's
+            // runtime: in a real app the owning provider IS loaded, so
+            // `app(Foo::class)` returns a `Foo`. Returning the named object here is
+            // symmetrical with resolveFromClassString() (#750), which already returns
+            // a TNamedObject for `class-string<Foo>` without touching the container.
+            //
+            // `class_exists()` is both safe and sufficient as the guard: the typical
+            // failure (Container::build throwing "not instantiable" / "unresolvable
+            // dependency") only happens AFTER `new ReflectionClass($abstract)` has
+            // already succeeded, so the class is loaded and `class_exists()` is true.
+            // It also correctly excludes interfaces (returns false → mixed) — we never
+            // claim an unresolvable contract resolves to itself. We only ever return
+            // the abstract itself, a supertype of whatever the runtime would build, so
+            // this cannot introduce a false-positive on a member that genuinely exists.
+            if (\class_exists($abstract)) {
+                return new Union([
+                    new TNamedObject($abstract),
+                ]);
+            }
+
             return null;
         }
 

--- a/tests/Type/tests/ContainerUnboundClassTest.phpt
+++ b/tests/Type/tests/ContainerUnboundClassTest.phpt
@@ -1,0 +1,38 @@
+--FILE--
+<?php declare(strict_types=1);
+
+// Regression for #757 (subset of umbrella #766): `app(Foo::class)` /
+// `resolve(Foo::class)` / `make(Foo::class)` previously returned `mixed` whenever
+// the plugin's booted app could not `make()` the abstract — e.g. the class is
+// unbound and its constructor has unresolvable (scalar / provider-supplied)
+// dependencies, or a non-public constructor. The literal class-string branch now
+// falls back to a named object, mirroring Laravel's runtime: in a real app the
+// owning provider is loaded, so `app(Foo::class)` returns a Foo.
+//
+// NB: the fixture must be a *real autoloadable* class. `ContainerResolver` uses
+// PHP's `class_exists()` (the analysed project's autoloader is registered with
+// Psalm), so the fallback only fires for classes loadable in the Psalm process —
+// which every genuine package class (the issue's Spatie\Backup\Config\Config) is.
+// `Illuminate\Validation\Rules\Enum` is unbound in the booted app and its
+// constructor requires a scalar `$type`, so `make()` throws BindingResolutionException.
+
+use Illuminate\Validation\Rules\Enum;
+
+function appHelperResolvesUnboundClass(): Enum
+{
+    $rule = app(Enum::class);
+    /** @psalm-check-type-exact $rule = Illuminate\Validation\Rules\Enum */
+    return $rule;
+}
+
+function resolveHelperResolvesUnboundClass(): Enum
+{
+    return resolve(Enum::class);
+}
+
+function containerMakeResolvesUnboundClass(): Enum
+{
+    return app()->make(Enum::class);
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeRedisEvalHardcoded.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeRedisEvalHardcoded.phpt
@@ -4,7 +4,9 @@
 <?php declare(strict_types=1);
 
 function runHardcodedScript(): void {
-    /** @var \Illuminate\Redis\Connections\PhpRedisConnection $redis */
+    // The plugin infers `app(Foo::class)` as Foo even when the booted app cannot
+    // build it (PhpRedisConnection needs a $client ctor arg, unresolvable here),
+    // so the previously-required `@var` hint is now redundant (#757).
     $redis = app(\Illuminate\Redis\Connections\PhpRedisConnection::class);
     $redis->eval('return 1', 0);
     $redis->evalsha('e0e1f9fabfc9d4800c877a703b823ac0578ff8db', 1, 'mykey');


### PR DESCRIPTION
## Issue to Solve

`app(Foo::class)` / `resolve(Foo::class)` / `make(Foo::class)` degraded to `mixed` whenever the plugin's booted app could not `make()` the abstract — e.g. a class with a non-public constructor or unresolvable constructor dependencies that no registered provider binds. A single `$x = app(Foo::class)` then cascaded into `MixedAssignment`, `MixedPropertyFetch`, `MixedArgument`, and `MixedReturnStatement` across every downstream use.

This is the literal class-string branch of `ContainerResolver`. Distinct from #750 (`static::class`, the `class-string<Foo>` atomic path), which already returns a `TNamedObject` without touching the container.

## Related

Fixes #757. Subset of umbrella #766.

## Solution Description

When container resolution fails but the abstract is itself a loadable class, fall back to `new Union([new TNamedObject($abstract)])`, mirroring Laravel's runtime: in a real app the owning provider is loaded, so `app(Foo::class)` returns a `Foo`. This is symmetrical with `resolveFromClassString()` (#750).

`class_exists()` is the load-bearing guard, and it is both safe and sufficient:

- `Container::build()` only throws "not instantiable" / "unresolvable dependency" **after** `new ReflectionClass($abstract)` has already succeeded, so the class is loaded and `class_exists()` is true exactly in the failure case we target.
- Interfaces are excluded (`class_exists` returns false), so an unresolvable contract stays `mixed` rather than being wrongly claimed to resolve to itself.
- The fallback only ever returns the abstract itself, a **supertype** of whatever the runtime would build, so it cannot introduce a false positive on a member that genuinely exists.

### Verification

- New type test `tests/Type/tests/ContainerUnboundClassTest.phpt` exercises `app()` / `resolve()` / `make()` against `Illuminate\Validation\Rules\Enum` (autoloadable, unbound, scalar-ctor — `make()` throws).
- The taint fixture `SafeRedisEvalHardcoded.phpt` previously needed a `@var PhpRedisConnection` hint on `app(PhpRedisConnection::class)`; the plugin now infers that type natively, so the obsolete hint is removed.
- Full type suite (474), unit suite, and self-analysis (100% coverage) all green.
- `psalm-delta` across 18 real-world apps (master vs this branch): **zero new issues introduced on every app**, **58 issues removed** (filament −54, coolify −4), all in the Mixed family (39 `MixedArgument`, 7 `MixedReturnStatement`, 4 `MixedReturnTypeCoercion`, 3 `MixedAssignment`, etc.). No regressions; slightly faster overall.

### Note on the original repro

The issue's `spatie/laravel-backup` `app(Config::class)` example is already resolved on current `master` by #942 (`ApplicationProvider::registerDiscoveredVendorProviders()` registers the analysed package's own provider, so the `Config` binding exists). This change is a **complementary** net for the cases provider registration cannot cover: self-owned concrete classes whose binding silently fails during analysis, or classes that are simply unbound.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
