### PR TITLE
Fix false-positive `UndefinedMethod` on `$app->when()->needs()` chains

### DIFF
--- a/src/Handlers/Application/ContainerHandler.php
+++ b/src/Handlers/Application/ContainerHandler.php
@@ -67,9 +67,38 @@ final class ContainerHandler implements AfterClassLikeVisitInterface, FunctionRe
         ];
     }
 
+    /**
+     * Container methods carrying the `class-string<T> -> T` resolution contract: their return
+     * IS the resolved instance, so narrowing it to the first `Foo::class` argument is correct.
+     *
+     * The gate matters because this provider is registered per-class (see getClassLikeNames),
+     * so Psalm offers it EVERY method on the container — not just the resolving ones. Without
+     * the name check the resolver rewrote the return of any container method whose first
+     * argument is a class-string: `$app->when(Foo::class)` (a contextual-binding builder),
+     * `$app->bound(Foo::class)` (a bool), `$app->instance(Foo::class, $x)` (the instance), etc.
+     * all collapsed to `Foo`, and chains like `$app->when(Foo::class)->needs(...)` then reported
+     * a false-positive `UndefinedMethod` (`Foo::needs`). Regression from #1075, which added the
+     * container contracts to getClassLikeNames so make() narrows on `$this->app` too — widening
+     * the set of receivers this un-gated provider fired for.
+     *
+     * Mirrors {@see \Psalm\LaravelPlugin\Handlers\Facades\AppFacadeMakeHandler::HANDLED_METHODS}
+     * (the `App` facade analogue) — keep the two lists in sync.
+     *
+     * @var array<lowercase-string, true>
+     */
+    private const RESOLUTION_METHODS = [
+        'make' => true,
+        'makewith' => true,
+        'get' => true,
+    ];
+
     #[\Override]
     public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Type\Union
     {
+        if (!isset(self::RESOLUTION_METHODS[$event->getMethodNameLowercase()])) {
+            return null;
+        }
+
         return ContainerResolver::resolvePsalmTypeFromApplicationContainerViaArgs($event->getSource()->getNodeTypeProvider(), $event->getCallArgs());
     }
 

--- a/src/Handlers/Facades/AppFacadeMakeHandler.php
+++ b/src/Handlers/Facades/AppFacadeMakeHandler.php
@@ -55,6 +55,11 @@ final class AppFacadeMakeHandler implements MethodReturnTypeProviderInterface, M
     /**
      * Container-resolution methods carrying the `class-string<T> -> T` contract; all narrow alike.
      *
+     * Mirrors {@see \Psalm\LaravelPlugin\Handlers\Application\ContainerHandler::RESOLUTION_METHODS}
+     * (the container-instance analogue, e.g. `$this->app->make()`) — keep the two lists in sync.
+     * Note {@see \Psalm\LaravelPlugin\Handlers\Rules\OctaneIncompatibleBindingHandler} keeps an
+     * intentionally different set (it also tracks `resolve`), so it is deliberately NOT unified here.
+     *
      * @var array<lowercase-string, true>
      */
     private const HANDLED_METHODS = [

--- a/tests/Type/tests/ContainerContextualBindingTest.phpt
+++ b/tests/Type/tests/ContainerContextualBindingTest.phpt
@@ -1,0 +1,54 @@
+--FILE--
+<?php declare(strict_types=1);
+
+// Regression for the false-positive UndefinedMethod on `$app->when(Foo::class)->needs(...)`.
+//
+// ContainerHandler is a MethodReturnTypeProvider registered per-class, so Psalm offers it
+// EVERY method on the container — not only the resolving ones. It used to feed the first
+// `Foo::class` argument to ContainerResolver for any method, so `$app->when(Foo::class)`
+// (a contextual-binding builder) collapsed to `Foo`, and the chained `->needs()` reported
+// `Foo::needs does not exist`. The provider is now gated to the resolution methods
+// (make / makeWith / get) that actually carry the `class-string<T> -> T` contract; every
+// other container method keeps its real return type. Regression introduced by #1075, which
+// added the container contracts to ContainerHandler::getClassLikeNames().
+//
+// NB: the `when()` assertions below lock in the correct behaviour but do not fail in this
+// harness without the fix — the un-gated provider only mis-fired for `when()` under a full
+// real-app scan (the `$this->app` interface receiver), which the minimal psalm-tester scan
+// does not reproduce. The end-to-end proof lives in the PR description; the concrete
+// `app()->make()` guard at the bottom is the co-located check that DOES fire here and would
+// break if the gate ever dropped make() narrowing.
+
+use Illuminate\Contracts\Container\ContextualBindingBuilder;
+use Illuminate\Contracts\Foundation\Application;
+
+final class WhenService {}
+interface WhenContract {}
+
+// when() keeps its real ContextualBindingBuilder return on the idiomatic `$this->app`
+// (Application contract) receiver...
+function when_returns_contextual_binding_builder(Application $app): ContextualBindingBuilder
+{
+    $builder = $app->when(WhenService::class);
+    /** @psalm-check-type-exact $builder = ContextualBindingBuilder */
+    return $builder;
+}
+
+// ...so the full contextual-binding chain from the bug report analyses without UndefinedMethod.
+function when_needs_give_chain_resolves(Application $app): void
+{
+    $app->when(WhenService::class)
+        ->needs(WhenContract::class)
+        ->give(static fn(): WhenService => new WhenService());
+}
+
+// Guard that the gate keeps make() narrowing: on a concrete container receiver (the surface
+// that fires in this harness) a class-string argument still resolves to the named class.
+function make_still_narrows_the_resolved_class(): WhenService
+{
+    $service = app()->make(WhenService::class);
+    /** @psalm-check-type-exact $service = WhenService */
+    return $service;
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

A `MethodReturnTypeProvider` regression made the plugin report a false-positive `UndefinedMethod` on idiomatic contextual-binding chains in service providers:

```php
$this->app->when(SomeClass::class)
    ->needs(SomeContract::class)
    ->give(static fn () => ...);
// UndefinedMethod: Method SomeClass::needs does not exist (psalm.dev/022)
```

`ContainerHandler::getMethodReturnType()` is registered per-class, so Psalm offers it **every** method on the container / `Application` contracts, not only the resolving ones. It fed the first `SomeClass::class` argument to `ContainerResolver` unconditionally, so the return of any container method was rewritten to that class. `when()` (which returns a `ContextualBindingBuilder`) was inferred as `SomeClass`, and the chained `->needs()` then looked undefined. The same over-narrowing also hit `bound()` (a `bool`), `instance()`, `bind()`, `singleton()`, etc.

## Related

Regression from #1075, which added the container contracts to `ContainerHandler::getClassLikeNames()` so `make()` narrows on the interface-typed `$this->app` receiver too, widening the set of receivers the un-gated provider fired for.

## Solution Description

Gate `getMethodReturnType()` to the methods that actually carry the `class-string<T> -> T` resolution contract: `make()` / `makeWith()` / `get()`, mirroring the sibling `AppFacadeMakeHandler::HANDLED_METHODS`. Every other container method now keeps its real declared return type. `make()`/`makeWith()`/`get()` narrowing and the #1075 CWE-470 taint sink (which lives in the stub, not this provider) are preserved.

`build()` and `instance()` are intentionally excluded: `build()` is concrete-only and already narrows natively via Laravel's reflected generic, and `instance($abstract, $instance)` returns its second argument, not the abstract.

Verification:

- New type test `tests/Type/tests/ContainerContextualBindingTest.phpt` locks `when()` -> `ContextualBindingBuilder`, the `when()->needs()->give()` chain resolving, and that `make()` still narrows the resolved class.
- Validated end-to-end against a large real-world Laravel app: the false positive reproduces with the base plugin and is gone with the gate; full self-analysis (100% type coverage), the type suite, and the unit suite stay green.

> Note: the `when()` over-narrowing only manifests under a full real-app scan (the interface-typed `$this->app` receiver); the minimal `psalm-tester` scan does not fire the provider for `when()`, so the test's `when()` assertions are intent/documentation guards. The co-located `make()` assertion is the one that exercises the gate in-harness, and the real-app run above is the end-to-end proof.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
