### PR TITLE
CI: per-PR cross-app issue delta

### DIFF
--- a/.github/workflows/psalm-delta.yml
+++ b/.github/workflows/psalm-delta.yml
@@ -1,7 +1,7 @@
 name: Psalm delta
 
 # Comment-triggered, opt-in PR check: runs the plugin on a curated set of
-# real-world Laravel apps (bin/ci/test-apps.json) for the PR base AND head, then
+# real-world Laravel apps (bin/ci/test-apps.yml) for the PR base AND head, then
 # posts a single sticky comment with the per-app issue delta + which issue types
 # moved. Informational only — it never fails the PR (a delta is often intended:
 # fixing false positives REMOVES issues; new narrowing ADDS some).
@@ -15,6 +15,15 @@ name: Psalm delta
 # The per-app runner (bin/ci/delta-app.sh) and comparator (bin/ci/delta-report.php)
 # are the SAME scripts bin/ci/delta.sh runs locally, so contributors can
 # reproduce any row with `bash bin/ci/delta.sh <pr-branch>`.
+#
+# Security posture: the `delta` job runs the PR's plugin code on the runner
+# (Testbench boots, stubs generate). It is contained by (1) the fork-PR guard in
+# `prepare` that refuses any head from a different repository, (2) the
+# MEMBER/OWNER/COLLABORATOR author check on the trigger, and (3) `contents: read`
+# only + `persist-credentials: false` on that job — no token write scope and no
+# git credentials are exposed to the executed code. The privileged `report` job
+# (pull-requests: write) never runs PR code: it checks out the trusted base and
+# processes the per-app JSON as data.
 
 on:
   issue_comment:
@@ -25,12 +34,13 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: read  # default for all jobs; each job narrows/extends explicitly below
 
 jobs:
 
   # ── Resolve refs + emit the app matrix ───────────────────────────────
   prepare:
+    name: Prepare (refs + matrix)
     if: >-
       github.event.issue.pull_request
       && startsWith(github.event.comment.body, '/psalm-delta')
@@ -38,9 +48,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: read
-      pull-requests: read
-      issues: write  # comment reaction
+      contents: read         # checkout the base ref to read the app registry
+      pull-requests: read    # github-script reads the PR's base/head SHAs
+      issues: write          # add the :rocket: reaction to the trigger comment
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       base_sha: ${{ steps.refs.outputs.base_sha }}
@@ -57,9 +67,10 @@ jobs:
       - name: React to comment
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
           COMMENT_ID: ${{ github.event.comment.id }}
         run: |
-          gh api repos/${{ github.repository }}/issues/comments/"$COMMENT_ID"/reactions \
+          gh api "repos/$REPO/issues/comments/$COMMENT_ID/reactions" \
             -f content=rocket --silent
 
       - name: Resolve PR refs (+ fork-PR security guard)
@@ -89,25 +100,31 @@ jobs:
             core.setOutput('head_label', `pr-${headSha.substring(0, 8)}`);
             core.setOutput('pr_number', String(pr.number));
 
+      # Trusted ref: base of a same-repo PR (the fork guard above already ran).
       - name: Checkout base (for the registry)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ steps.refs.outputs.base_sha }}
+          persist-credentials: false
 
       - name: Build app matrix from registry
         id: matrix
         run: |
           # yq (mikefarah v4, preinstalled on ubuntu-latest) emits the apps list
-          # as a GitHub matrix `include` array straight from the YAML registry.
-          echo "matrix=$(yq -o=json -I=0 '{\"include\": .apps}' bin/ci/test-apps.yml)" >> "$GITHUB_OUTPUT"
+          # as a GitHub matrix `include` array straight from the committed YAML
+          # registry. The value is derived only from a repo-tracked file (no
+          # workflow context / PR-author input), so it is not an injection sink.
+          matrix=$(yq -o=json -I=0 '{"include": .apps}' bin/ci/test-apps.yml)
+          printf 'matrix=%s\n' "$matrix" >> "$GITHUB_OUTPUT"
 
   # ── One job per app: install, run base + head, upload JSON ───────────
   delta:
+    name: Delta (${{ matrix.name }})
     needs: prepare
     runs-on: ubuntu-latest
     timeout-minutes: 12
     permissions:
-      contents: read
+      contents: read  # only checks out source + reads the public app repos; no token write scope
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
@@ -120,17 +137,23 @@ jobs:
       # Two plugin checkouts give base and head fully isolated source trees.
       # delta-app.sh installs each as a symlinked path repo, so the plugin's own
       # requires resolve into the per-app vendor — these checkouts need no vendor.
+      # persist-credentials: false — the executed PR code never gets git creds.
       - name: Checkout base plugin
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.prepare.outputs.base_sha }}
           path: plugin-base
+          persist-credentials: false
 
+      # Untrusted ref (PR head). Safe only because: same-repo guard passed in
+      # prepare, this job has contents:read and no credentials, and the head
+      # code's only effect is producing issue JSON consumed as data downstream.
       - name: Checkout head plugin
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.prepare.outputs.head_sha }}
           path: plugin-pr
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
@@ -153,7 +176,7 @@ jobs:
       - name: Run delta for ${{ matrix.name }}
         # All interpolated values go through env (not inline ${{ }} in run) so a
         # workflow linter can confirm no template-injection sink. Registry values
-        # are trusted (committed, read from the base checkout) but env- izing keeps
+        # are trusted (committed, read from the base checkout) but env-izing keeps
         # the pattern uniform.
         env:
           NAME: ${{ matrix.name }}
@@ -193,23 +216,27 @@ jobs:
 
   # ── Aggregate + sticky comment ───────────────────────────────────────
   report:
+    name: Report (aggregate + comment)
     needs: [prepare, delta]
     if: always() && needs.prepare.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: read
-      pull-requests: write
+      contents: read         # checkout the trusted base for the comparator + registry
+      pull-requests: write   # post / update the sticky delta comment
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
+      # Trusted ref: base of a same-repo PR. This job runs only base code
+      # (delta-report.php) over the per-app JSON, never the PR's plugin code.
       - name: Checkout base (for the comparator + registry)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.prepare.outputs.base_sha }}
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
@@ -225,44 +252,40 @@ jobs:
           merge-multiple: true  # reconstructs out/<app>/... from every artifact
           path: out
 
-      - name: Build delta report
-        id: build
+      # Build the markdown to a FILE and post it with `gh api -F body=@file`, so
+      # the (app-derived) report text never transits a shell variable, GITHUB_OUTPUT,
+      # or a heredoc — no command-injection / output-injection surface.
+      - name: Build + post sticky comment
         env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
           BASE_LABEL: ${{ needs.prepare.outputs.base_label }}
           HEAD_LABEL: ${{ needs.prepare.outputs.head_label }}
           BASE_SHA: ${{ needs.prepare.outputs.base_sha }}
           HEAD_SHA: ${{ needs.prepare.outputs.head_sha }}
         run: |
-          APPS=$(yq '.apps[].name' bin/ci/test-apps.yml | paste -sd, -)
-          REPORT=$(php bin/ci/delta-report.php out \
-            "$BASE_LABEL" "$HEAD_LABEL" \
-            --apps="$APPS" \
-            --base-sha="$BASE_SHA" \
-            --head-sha="$HEAD_SHA" \
-            --date-marker=cache)
-          {
-            echo "report<<REPORT_EOF"
-            echo "$REPORT"
-            echo ""
-            echo "<sub>Informational only — never fails the PR. Reproduce locally: \`bash bin/ci/delta.sh <pr-branch>\`.</sub>"
-            echo "REPORT_EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Post or update sticky comment
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
-          REPORT: ${{ steps.build.outputs.report }}
-        run: |
           MARKER='<!-- psalm-delta-report -->'
-          BODY="${MARKER}"$'\n'"${REPORT:-Delta failed to produce a report. Check the workflow logs.}"
-          # Find an existing delta comment (sticky) and edit it; else create one.
-          EXISTING=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" --paginate \
+          APPS=$(yq '.apps[].name' bin/ci/test-apps.yml | paste -sd, -)
+
+          {
+            printf '%s\n' "$MARKER"
+            php bin/ci/delta-report.php out "$BASE_LABEL" "$HEAD_LABEL" \
+              --apps="$APPS" --base-sha="$BASE_SHA" --head-sha="$HEAD_SHA" \
+              --date-marker=cache \
+              || echo "Delta failed to produce a report. Check the workflow logs."
+          } > comment.md
+          # Quoted heredoc: literal backticks for the inline code span, no expansion.
+          cat >> comment.md <<'FOOTER'
+
+          <sub>Informational only — never fails the PR. Reproduce locally: `bash bin/ci/delta.sh <pr-branch>`.</sub>
+          FOOTER
+
+          # Sticky: edit the existing delta comment if present, else create one.
+          EXISTING=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
             --jq "map(select(.body | startswith(\"$MARKER\"))) | .[0].id // empty")
           if [ -n "$EXISTING" ]; then
-            gh api "repos/${{ github.repository }}/issues/comments/${EXISTING}" \
-              -X PATCH -f body="$BODY" --silent
+            gh api "repos/$REPO/issues/comments/$EXISTING" -X PATCH -F body=@comment.md --silent
           else
-            gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-              -f body="$BODY" --silent
+            gh api "repos/$REPO/issues/$PR_NUMBER/comments" -F body=@comment.md --silent
           fi

--- a/.github/workflows/psalm-delta.yml
+++ b/.github/workflows/psalm-delta.yml
@@ -1,0 +1,268 @@
+name: Psalm delta
+
+# Comment-triggered, opt-in PR check: runs the plugin on a curated set of
+# real-world Laravel apps (bin/ci/test-apps.json) for the PR base AND head, then
+# posts a single sticky comment with the per-app issue delta + which issue types
+# moved. Informational only — it never fails the PR (a delta is often intended:
+# fixing false positives REMOVES issues; new narrowing ADDS some).
+#
+# Architecture (see .alies/docs/ci-psalm-delta-design.md for the full rationale):
+#   prepare  — resolve refs, fork-PR security guard, emit the app matrix
+#   delta    — ONE job per app (parallel): install app, run base + head, upload
+#              per-app issue/perf JSON. Wall time = slowest single app, not sum.
+#   report   — download all artifacts, run bin/ci/delta-report.php, sticky comment
+#
+# The per-app runner (bin/ci/delta-app.sh) and comparator (bin/ci/delta-report.php)
+# are the SAME scripts bin/ci/delta.sh runs locally, so contributors can
+# reproduce any row with `bash bin/ci/delta.sh <pr-branch>`.
+
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: psalm-delta-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+
+  # ── Resolve refs + emit the app matrix ───────────────────────────────
+  prepare:
+    if: >-
+      github.event.issue.pull_request
+      && startsWith(github.event.comment.body, '/psalm-delta')
+      && contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write  # comment reaction
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      base_sha: ${{ steps.refs.outputs.base_sha }}
+      head_sha: ${{ steps.refs.outputs.head_sha }}
+      base_label: ${{ steps.refs.outputs.base_label }}
+      head_label: ${{ steps.refs.outputs.head_label }}
+      pr_number: ${{ steps.refs.outputs.pr_number }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: React to comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          gh api repos/${{ github.repository }}/issues/comments/"$COMMENT_ID"/reactions \
+            -f content=rocket --silent
+
+      - name: Resolve PR refs (+ fork-PR security guard)
+        id: refs
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            // The delta runs the PR's plugin code on the runner (Testbench boots,
+            // stubs generate). Refuse PRs from a fork so untrusted code cannot
+            // execute with this workflow's token. Same guard as benchmark.yml.
+            const expectedRepo = `${context.repo.owner}/${context.repo.repo}`;
+            const headRepo = pr.head.repo ? pr.head.repo.full_name : null;
+            if (headRepo !== expectedRepo) {
+              core.setFailed(`Refusing to run delta on a PR from a different repository (head: ${headRepo}, expected: ${expectedRepo})`);
+              return;
+            }
+            const baseSha = pr.base.sha;
+            const headSha = pr.head.sha;
+            core.setOutput('base_sha', baseSha);
+            core.setOutput('head_sha', headSha);
+            core.setOutput('base_label', `base-${baseSha.substring(0, 8)}`);
+            core.setOutput('head_label', `pr-${headSha.substring(0, 8)}`);
+            core.setOutput('pr_number', String(pr.number));
+
+      - name: Checkout base (for the registry)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.refs.outputs.base_sha }}
+
+      - name: Build app matrix from registry
+        id: matrix
+        run: |
+          # yq (mikefarah v4, preinstalled on ubuntu-latest) emits the apps list
+          # as a GitHub matrix `include` array straight from the YAML registry.
+          echo "matrix=$(yq -o=json -I=0 '{\"include\": .apps}' bin/ci/test-apps.yml)" >> "$GITHUB_OUTPUT"
+
+  # ── One job per app: install, run base + head, upload JSON ───────────
+  delta:
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      # Two plugin checkouts give base and head fully isolated source trees.
+      # delta-app.sh installs each as a symlinked path repo, so the plugin's own
+      # requires resolve into the per-app vendor — these checkouts need no vendor.
+      - name: Checkout base plugin
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.prepare.outputs.base_sha }}
+          path: plugin-base
+
+      - name: Checkout head plugin
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.prepare.outputs.head_sha }}
+          path: plugin-pr
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+        with:
+          php-version: ${{ matrix.php }}
+          ini-values: memory_limit=-1
+          coverage: none
+          tools: composer:v2
+
+      # Cache the installed app source (clone + vendor) keyed on the IMMUTABLE
+      # ref, so steady-state runs skip the cold composer install (the dominant
+      # cost). The runner workspace path is stable across runs, so the plugin
+      # path-repo symlink inside vendor stays valid.
+      - name: Cache app source
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/app-cache/${{ matrix.name }}
+          key: psalm-delta-app-${{ matrix.name }}-${{ matrix.ref }}-php${{ matrix.php }}-v1
+
+      - name: Run delta for ${{ matrix.name }}
+        # All interpolated values go through env (not inline ${{ }} in run) so a
+        # workflow linter can confirm no template-injection sink. Registry values
+        # are trusted (committed, read from the base checkout) but env- izing keeps
+        # the pattern uniform.
+        env:
+          NAME: ${{ matrix.name }}
+          REPO: ${{ matrix.repo }}
+          REF: ${{ matrix.ref }}
+          PHP: ${{ matrix.php }}
+          PROJECT_DIR: ${{ matrix.project_dir }}
+          PRIME: ${{ matrix.prime }}
+          BASE_LABEL: ${{ needs.prepare.outputs.base_label }}
+          HEAD_LABEL: ${{ needs.prepare.outputs.head_label }}
+        run: |
+          mkdir -p out
+          args=(
+            --app "$NAME" --repo "$REPO" --ref "$REF" --php "$PHP"
+            --plugin-base "$GITHUB_WORKSPACE/plugin-base"
+            --plugin-head "$GITHUB_WORKSPACE/plugin-pr"
+            --out "$GITHUB_WORKSPACE/out"
+            --base-label "$BASE_LABEL"
+            --head-label "$HEAD_LABEL"
+            --app-src "$HOME/app-cache/$NAME"
+            --date-marker cache
+          )
+          [ -n "$PROJECT_DIR" ] && args+=(--project-dir "$PROJECT_DIR")
+          [ -n "$PRIME" ] && args+=(--prime "$PRIME")
+          # The base checkout owns the harness so the PR cannot alter measurement.
+          bash "$GITHUB_WORKSPACE/plugin-base/bin/ci/delta-app.sh" "${args[@]}"
+
+      - name: Upload per-app JSON
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: delta-${{ matrix.name }}
+          # out/ holds only <app>/<app>-<label>-cache--{issues,perf}.json
+          # (the working copies + cached source live elsewhere).
+          path: out/
+          if-no-files-found: warn
+          retention-days: 14
+
+  # ── Aggregate + sticky comment ───────────────────────────────────────
+  report:
+    needs: [prepare, delta]
+    if: always() && needs.prepare.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout base (for the comparator + registry)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.prepare.outputs.base_sha }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+        with:
+          php-version: "8.3"
+          ini-values: memory_limit=-1
+          coverage: none
+
+      - name: Download all per-app JSON
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          pattern: delta-*
+          merge-multiple: true  # reconstructs out/<app>/... from every artifact
+          path: out
+
+      - name: Build delta report
+        id: build
+        env:
+          BASE_LABEL: ${{ needs.prepare.outputs.base_label }}
+          HEAD_LABEL: ${{ needs.prepare.outputs.head_label }}
+          BASE_SHA: ${{ needs.prepare.outputs.base_sha }}
+          HEAD_SHA: ${{ needs.prepare.outputs.head_sha }}
+        run: |
+          APPS=$(yq '.apps[].name' bin/ci/test-apps.yml | paste -sd, -)
+          REPORT=$(php bin/ci/delta-report.php out \
+            "$BASE_LABEL" "$HEAD_LABEL" \
+            --apps="$APPS" \
+            --base-sha="$BASE_SHA" \
+            --head-sha="$HEAD_SHA" \
+            --date-marker=cache)
+          {
+            echo "report<<REPORT_EOF"
+            echo "$REPORT"
+            echo ""
+            echo "<sub>Informational only — never fails the PR. Reproduce locally: \`bash bin/ci/delta.sh <pr-branch>\`.</sub>"
+            echo "REPORT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post or update sticky comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
+          REPORT: ${{ steps.build.outputs.report }}
+        run: |
+          MARKER='<!-- psalm-delta-report -->'
+          BODY="${MARKER}"$'\n'"${REPORT:-Delta failed to produce a report. Check the workflow logs.}"
+          # Find an existing delta comment (sticky) and edit it; else create one.
+          EXISTING=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq "map(select(.body | startswith(\"$MARKER\"))) | .[0].id // empty")
+          if [ -n "$EXISTING" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/${EXISTING}" \
+              -X PATCH -f body="$BODY" --silent
+          else
+            gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+              -f body="$BODY" --silent
+          fi

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -24,6 +24,7 @@ return (new Config())
         (new Finder())
             ->in(__DIR__ . '/src')
             ->in(__DIR__ . '/tests')
+            ->in(__DIR__ . '/bin/ci')
             ->append([
                 __FILE__,
             ]),

--- a/bin/ci/delta-app.sh
+++ b/bin/ci/delta-app.sh
@@ -77,6 +77,33 @@ APP_SRC="${APP_SRC:-${OUT}/${APP}/src}"
 COMPOSER_FLAGS=(--no-interaction --no-progress --ignore-platform-reqs)
 export COMPOSER_MEMORY_LIMIT=-1
 
+# Copy a tree using a copy-on-write clone where the filesystem supports it
+# (APFS clonefile on macOS, btrfs/xfs reflinks on Linux): instant and low-disk,
+# yet safe — writes to the copy never touch the source, unlike `cp -al`
+# hardlinks which would write through composer.json edits into APP_SRC. Falls
+# back to a deep copy everywhere else. The first two forms exit non-zero on
+# coreutils variants that lack the flag, so the chain degrades cleanly.
+fast_copy() {
+    local src="$1" dst="$2"
+    cp -c -a "$src" "$dst" 2>/dev/null && return 0             # BSD/macOS clonefile
+    cp --reflink=auto -a "$src" "$dst" 2>/dev/null && return 0 # GNU coreutils reflink
+    cp -a "$src" "$dst"
+}
+
+# md5 of the plugin's dependency-affecting composer.json sections. Only `require`
+# and `autoload` change what gets installed into the app's vendor; if they match
+# between base and head, the head side can reuse the base install and re-point a
+# symlink instead of re-running Composer. require-dev / autoload-dev are never
+# installed, so excluding them is safe (a stray match only skips a no-op solve).
+plugin_dep_sig() {
+    php -r '
+        $d = json_decode(file_get_contents($argv[1] . "/composer.json"), true, 512, JSON_THROW_ON_ERROR);
+        $sig = ["require" => $d["require"] ?? [], "autoload" => $d["autoload"] ?? []];
+        foreach ($sig as &$s) { if (is_array($s)) { ksort($s); } }
+        echo md5(json_encode($sig));
+    ' "$1"
+}
+
 # --- 1. Clone app at the frozen commit (cache-friendly) ----------------------
 #
 # The ref is an immutable commit, so a populated APP_SRC is reusable across runs
@@ -205,7 +232,7 @@ fi
 # --- 3. Run one side: relink plugin, run Psalm, emit JSON --------------------
 
 run_side() {
-    local label="$1" plugin_dir="$2"
+    local label="$1" plugin_dir="$2" relink="$3"
     local app_dir="${OUT}/${APP}/work-${label}"
     local issues_file="${OUT}/${APP}/${APP}-${label}-${DATE_MARKER}--issues.json"
     local perf_file="${OUT}/${APP}/${APP}-${label}-${DATE_MARKER}--perf.json"
@@ -219,10 +246,37 @@ run_side() {
 
     # Fresh working copy off the source so base and head never interfere.
     rm -rf "$app_dir"
-    cp -a "$APP_SRC" "$app_dir"
-    configure_plugin_repo "$app_dir" "$plugin_dir"
-    (cd "$app_dir" && composer update psalm/plugin-laravel "${COMPOSER_FLAGS[@]}" --with-all-dependencies --quiet) \
-        || { echo "[$APP/$label] composer relink failed" >&2; rm -rf "$app_dir"; return 0; }
+    fast_copy "$APP_SRC" "$app_dir"
+
+    # Point this copy's plugin at $plugin_dir. The source install already linked
+    # vendor/psalm/plugin-laravel at PLUGIN_BASE (symlink path repo), and the
+    # PSR-4 map resolves through that symlink, so the cheapest relink is a symlink
+    # swap — no Composer solve. Only fall back to Composer when head changed the
+    # plugin's installed dependency shape (see plugin_dep_sig).
+    #
+    # Critical: `composer update psalm/plugin-laravel` does NOT re-point the path
+    # symlink when the package version string is unchanged (both checkouts carry
+    # the same dev version), so Composer alone would leave the copy linked to
+    # PLUGIN_BASE and silently analyse head with the base plugin. Every branch
+    # therefore sets the symlink explicitly; Composer runs only to pull head's
+    # new dependencies into vendor.
+    local link="$app_dir/vendor/psalm/plugin-laravel"
+    case "$relink" in
+        none)
+            : # base side: the copied vendor already symlinks to PLUGIN_BASE
+            ;;
+        symlink)
+            rm -rf "$link"
+            ln -s "$plugin_dir" "$link"
+            ;;
+        composer)
+            configure_plugin_repo "$app_dir" "$plugin_dir"
+            (cd "$app_dir" && composer update psalm/plugin-laravel "${COMPOSER_FLAGS[@]}" --with-all-dependencies --quiet) \
+                || { echo "[$APP/$label] composer relink failed" >&2; rm -rf "$app_dir"; return 0; }
+            rm -rf "$link"
+            ln -s "$plugin_dir" "$link"
+            ;;
+    esac
 
     local out_txt err_txt t0 exit_code wall coverage count
     out_txt=$(mktemp); err_txt=$(mktemp)
@@ -285,7 +339,16 @@ run_side() {
     rm -rf "$app_dir" "$out_txt" "$err_txt"
 }
 
-run_side "$BASE_LABEL" "$PLUGIN_BASE"
-run_side "$HEAD_LABEL" "$PLUGIN_HEAD"
+# Base reuses the source install verbatim (its vendor already links PLUGIN_BASE).
+# Head re-points a symlink when the plugin's dependency shape is unchanged
+# (the common case), and only re-solves with Composer when it differs.
+if [[ "$(plugin_dep_sig "$PLUGIN_BASE")" == "$(plugin_dep_sig "$PLUGIN_HEAD")" ]]; then
+    HEAD_RELINK=symlink
+else
+    HEAD_RELINK=composer
+fi
+
+run_side "$BASE_LABEL" "$PLUGIN_BASE" none
+run_side "$HEAD_LABEL" "$PLUGIN_HEAD" "$HEAD_RELINK"
 
 echo "[$APP] done" >&2

--- a/bin/ci/delta-app.sh
+++ b/bin/ci/delta-app.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+#
+# Run Psalm + plugin on ONE real-world Laravel app for two plugin checkouts
+# (base + head) and emit per-side issue/perf JSON in the layout delta-report.php
+# consumes. Portable: pure bash + git + composer + php, no GNU-only flags, no
+# local hardcoded paths. The SAME script runs locally (driven by delta.sh) and
+# on CI (one matrix job per app).
+#
+# It deliberately does NOT depend on the local Psalm fork or any of bench.sh's
+# macOS-isms. Psalm comes from Packagist (the plugin's normal `vimeo/psalm`
+# constraint).
+#
+# Usage:
+#   delta-app.sh \
+#     --app monica --repo https://github.com/monicahq/monica.git --ref e08e917 \
+#     --plugin-base /path/plugin-base --plugin-head /path/plugin-head \
+#     --out /path/output-dir --base-label base-AAAA --head-label pr-BBBB \
+#     [--php 8.3] [--project-dir app] [--date-marker cache] \
+#     [--prime 'composer update foo --no-interaction'] \
+#     [--app-src /cache/monica-src] [--mem 4G]
+#
+# Output (per side, <label> in {base-label, head-label}):
+#   <out>/<app>/<app>-<label>-<date-marker>--issues.json   (Psalm --report JSON)
+#   <out>/<app>/<app>-<label>-<date-marker>--perf.json      (wall, coverage, count)
+#
+# Exit 0 even on a per-app Psalm failure: a crash log is written and the side's
+# JSON is omitted so delta-report.php renders the app as (missing) instead of
+# blocking the whole report. Hard setup errors (bad args, clone/install failure)
+# exit non-zero.
+
+set -euo pipefail
+
+# --- Argument parsing --------------------------------------------------------
+
+APP="" REPO="" REF="" PLUGIN_BASE="" PLUGIN_HEAD="" OUT=""
+BASE_LABEL="" HEAD_LABEL="" PROJECT_DIR=""
+DATE_MARKER="cache" PRIME="" APP_SRC="" MEM="4G"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --app) APP="$2"; shift 2 ;;
+        --repo) REPO="$2"; shift 2 ;;
+        --ref) REF="$2"; shift 2 ;;
+        --plugin-base) PLUGIN_BASE="$2"; shift 2 ;;
+        --plugin-head) PLUGIN_HEAD="$2"; shift 2 ;;
+        --out) OUT="$2"; shift 2 ;;
+        --base-label) BASE_LABEL="$2"; shift 2 ;;
+        --head-label) HEAD_LABEL="$2"; shift 2 ;;
+        # --php is the caller's setup concern (setup-php on CI, system php
+        # locally); accepted for interface symmetry with the registry, ignored.
+        --php) shift 2 ;;
+        --project-dir) PROJECT_DIR="$2"; shift 2 ;;
+        --date-marker) DATE_MARKER="$2"; shift 2 ;;
+        --prime) PRIME="$2"; shift 2 ;;
+        --app-src) APP_SRC="$2"; shift 2 ;;
+        --mem) MEM="$2"; shift 2 ;;
+        *) echo "ERROR: unknown argument '$1'" >&2; exit 2 ;;
+    esac
+done
+
+for req in APP REPO REF PLUGIN_BASE PLUGIN_HEAD OUT BASE_LABEL HEAD_LABEL; do
+    if [[ -z "${!req}" ]]; then
+        # tr for the flag name: bash 3.2 (macOS default) lacks ${var,,}.
+        echo "ERROR: --$(echo "$req" | tr '[:upper:]' '[:lower:]') is required" >&2
+        exit 2
+    fi
+done
+
+# Canonicalise plugin dirs so the composer path repo records an absolute target.
+PLUGIN_BASE=$(cd "$PLUGIN_BASE" && pwd -P)
+PLUGIN_HEAD=$(cd "$PLUGIN_HEAD" && pwd -P)
+mkdir -p "$OUT/$APP"
+
+# Default app source dir — a cacheable working copy keyed on the frozen ref.
+APP_SRC="${APP_SRC:-${OUT}/${APP}/src}"
+
+COMPOSER_FLAGS=(--no-interaction --no-progress --ignore-platform-reqs)
+export COMPOSER_MEMORY_LIMIT=-1
+
+# --- 1. Clone app at the frozen commit (cache-friendly) ----------------------
+#
+# The ref is an immutable commit, so a populated APP_SRC is reusable across runs
+# and is what CI caches. Clone the branch tip then reset to the exact commit,
+# with a fetch fallback when the commit is not the tip (mirrors setup.sh).
+
+if [[ ! -d "$APP_SRC/.git" ]]; then
+    echo "[$APP] cloning $REPO @ $REF" >&2
+    rm -rf "$APP_SRC"
+    mkdir -p "$APP_SRC"
+    git clone --quiet --no-checkout "$REPO" "$APP_SRC"
+    (
+        cd "$APP_SRC"
+        git checkout --quiet "$REF" 2>/dev/null || {
+            git fetch --quiet origin "$REF"
+            git checkout --quiet "$REF"
+        }
+    )
+else
+    echo "[$APP] reusing cached source at $APP_SRC" >&2
+fi
+
+# --- 2. Configure composer + write psalm.xml on the source -------------------
+#
+# Point the plugin path-repo at PLUGIN_BASE for the source install; the head
+# copy re-points to PLUGIN_HEAD afterwards. Released psalm resolves from
+# Packagist via the plugin's own `vimeo/psalm` constraint — no psalm path repo.
+
+# Point a project's composer.json at the given plugin checkout via a symlinked
+# path repo. $full=1 also applies the one-time root tweaks (stability, require,
+# relaxed PHP constraint) needed on the source install; the per-side relink
+# only swaps the path-repo URL.
+configure_plugin_repo() {
+    local dir="$1" plugin_dir="$2" full="${3:-0}"
+    php -r '
+        $file = $argv[1] . "/composer.json";
+        $d = json_decode(file_get_contents($file), true, 512, JSON_THROW_ON_ERROR);
+        $repos = $d["repositories"] ?? [];
+        if (array_is_list($repos) === false && $repos !== []) { $repos = array_values($repos); }
+        // Drop any prior plugin path repo, prepend ours.
+        $repos = array_values(array_filter($repos, fn($r) => strpos(json_encode($r), "psalm-plugin-laravel") === false));
+        array_unshift($repos, ["name" => "psalm/plugin-laravel", "type" => "path", "url" => $argv[2], "options" => ["symlink" => true]]);
+        $d["repositories"] = $repos;
+        if ($argv[3] === "1") {
+            $d["minimum-stability"] = "dev";
+            $d["prefer-stable"] = true;
+            $d["require-dev"]["psalm/plugin-laravel"] = "*";
+            // Relax a pinned PHP constraint (e.g. "8.3.*" -> "^8.3") so install
+            // does not fail on the runner PHP; analysis runs under the real binary.
+            $php = $d["require"]["php"] ?? "";
+            if ($php !== "" && $php[0] !== "^" && $php[0] !== ">") {
+                $parts = trim(str_replace([".*", "*"], "", explode("|", $php)[0]));
+                if ($parts !== "") { $d["require"]["php"] = "^" . $parts; }
+            }
+        }
+        file_put_contents($file, json_encode($d, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    ' "$dir" "$plugin_dir" "$full"
+}
+
+write_psalm_xml() {
+    # Reuse the app project layout heuristic from setup.sh: app/ (Laravel app),
+    # packages/*/src (monorepo like filament), or src/ (library). An explicit
+    # --project-dir overrides detection.
+    local target="$APP_SRC/psalm.xml"
+    local dirs=""
+    if [[ -n "$PROJECT_DIR" ]]; then
+        dirs="<directory name=\"$PROJECT_DIR\" />"
+    elif [[ -d "$APP_SRC/app" ]]; then
+        for d in app bootstrap config database routes; do
+            [[ -d "$APP_SRC/$d" ]] && dirs="$dirs<directory name=\"$d\" />"
+        done
+    elif compgen -G "$APP_SRC/packages/*/src" >/dev/null 2>&1; then
+        for d in "$APP_SRC"/packages/*/src; do
+            dirs="$dirs<directory name=\"packages/$(basename "$(dirname "$d")")/src\" />"
+        done
+    elif [[ -d "$APP_SRC/src" ]]; then
+        dirs="<directory name=\"src\" />"
+    else
+        dirs="<directory name=\".\" />"
+    fi
+
+    cat > "$target" <<XMLEOF
+<?xml version="1.0"?>
+<psalm errorLevel="1" resolveFromConfigFile="true"
+    xmlns="https://getpsalm.org/schema/config"
+    findUnusedCode="false" findUnusedPsalmSuppress="false">
+    <projectFiles>
+        ${dirs}
+        <ignoreFiles><directory name="vendor" /></ignoreFiles>
+    </projectFiles>
+    <plugins>
+        <pluginClass class="Psalm\LaravelPlugin\Plugin">
+            <failOnInternalError>false</failOnInternalError>
+        </pluginClass>
+    </plugins>
+    <issueHandlers>
+        <PropertyNotSetInConstructor errorLevel="info" />
+        <DeprecatedMethod errorLevel="info" />
+        <DeprecatedClass errorLevel="info" />
+        <MissingOverrideAttribute errorLevel="info" />
+        <MissingImmutableAnnotation errorLevel="info" />
+        <ClassMustBeFinal errorLevel="info" />
+    </issueHandlers>
+</psalm>
+XMLEOF
+}
+
+# Run the one-time source install only if vendor is absent (cache-friendly).
+if [[ ! -f "$APP_SRC/vendor/bin/psalm" ]]; then
+    echo "[$APP] installing dependencies" >&2
+    (
+        cd "$APP_SRC"
+        if [[ -n "$PRIME" ]]; then
+            echo "[$APP] prime: $PRIME" >&2
+            eval "$PRIME"
+        fi
+    )
+    configure_plugin_repo "$APP_SRC" "$PLUGIN_BASE" 1
+    write_psalm_xml
+    (cd "$APP_SRC" && composer update "${COMPOSER_FLAGS[@]}" --quiet)
+else
+    echo "[$APP] reusing installed vendor" >&2
+    write_psalm_xml
+fi
+
+# --- 3. Run one side: relink plugin, run Psalm, emit JSON --------------------
+
+run_side() {
+    local label="$1" plugin_dir="$2"
+    local app_dir="${OUT}/${APP}/work-${label}"
+    local issues_file="${OUT}/${APP}/${APP}-${label}-${DATE_MARKER}--issues.json"
+    local perf_file="${OUT}/${APP}/${APP}-${label}-${DATE_MARKER}--perf.json"
+    local crash_log="${OUT}/${APP}/${APP}-${label}-${DATE_MARKER}--crash.log"
+
+    # Skip-if-cached: a complete side is reused verbatim on rerun.
+    if [[ -f "$issues_file" && -f "$perf_file" ]]; then
+        echo "[$APP/$label] cached, skipping" >&2
+        return 0
+    fi
+
+    # Fresh working copy off the source so base and head never interfere.
+    rm -rf "$app_dir"
+    cp -a "$APP_SRC" "$app_dir"
+    configure_plugin_repo "$app_dir" "$plugin_dir"
+    (cd "$app_dir" && composer update psalm/plugin-laravel "${COMPOSER_FLAGS[@]}" --with-all-dependencies --quiet) \
+        || { echo "[$APP/$label] composer relink failed" >&2; rm -rf "$app_dir"; return 0; }
+
+    local out_txt err_txt t0 exit_code wall coverage count
+    out_txt=$(mktemp); err_txt=$(mktemp)
+    t0=$(date +%s)
+    exit_code=0
+    (
+        cd "$app_dir"
+        php -d memory_limit="$MEM" vendor/bin/psalm -c psalm.xml \
+            --no-cache --no-diff --no-progress --no-suggestions --monochrome \
+            --report="${issues_file}" >"$out_txt" 2>"$err_txt"
+    ) || exit_code=$?
+    wall=$(( $(date +%s) - t0 ))
+
+    # Psalm exits non-zero whenever issues are found, so a non-empty report is
+    # the real success signal; treat a missing/empty report as a crash.
+    if [[ ! -s "$issues_file" ]]; then
+        echo "[$APP/$label] no report (exit $exit_code) — recording (missing)" >&2
+        { echo "=== $APP/$label exit $exit_code after ${wall}s ==="; echo "--- stderr ---"; cat "$err_txt"; echo "--- stdout ---"; cat "$out_txt"; } > "$crash_log"
+        rm -f "$issues_file"
+        rm -rf "$app_dir" "$out_txt" "$err_txt"
+        return 0
+    fi
+
+    # Normalise file_path to be relative to the working copy. Both sides run in
+    # different temp dirs (work-base-* vs work-pr-*), so Psalm's absolute
+    # file_path would differ for EVERY issue and the identity tuple
+    # (file_path, line_from, line_to, type, message) would never match across
+    # sides — making every issue look both added and removed (+N/-N, ΔNet 0).
+    # Stripping the work-dir prefix yields a stable path shared by both sides.
+    # Use the canonical (symlink-resolved) dir — Psalm reports realpath'd paths,
+    # so on macOS the report says /private/tmp/... while $app_dir is /tmp/...
+    local app_dir_real
+    app_dir_real=$(cd "$app_dir" && pwd -P)
+    php -r '
+        $file = $argv[1]; $prefix = rtrim($argv[2], "/") . "/";
+        $d = json_decode(file_get_contents($file), true, 512, JSON_THROW_ON_ERROR);
+        foreach ($d as &$i) {
+            if (isset($i["file_path"]) && str_starts_with($i["file_path"], $prefix)) {
+                $i["file_path"] = substr($i["file_path"], strlen($prefix));
+            }
+        }
+        file_put_contents($file, json_encode($d, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    ' "$issues_file" "$app_dir_real"
+
+    coverage=$(sed -n 's/.*infer types for \([0-9.]*\)%.*/\1/p' "$out_txt" | tail -1)
+    count=$(php -r '$d=json_decode(file_get_contents($argv[1]),true); echo is_array($d)?count($d):0;' "$issues_file")
+
+    php -r '
+        $cov = $argv[6];
+        file_put_contents($argv[1], json_encode([
+            "app" => $argv[2], "version" => $argv[3], "date" => $argv[4],
+            "wall_seconds" => (int) $argv[5],
+            "type_coverage_pct" => $cov === "" ? null : (float) $cov,
+            "total_issues" => (int) $argv[7], "exit_code" => (int) $argv[8],
+        ], JSON_PRETTY_PRINT));
+    ' "$perf_file" "$APP" "$label" "$DATE_MARKER" "$wall" "${coverage:-}" "${count:-0}" "$exit_code"
+
+    rm -f "$crash_log"
+    echo "[$APP/$label] $count issues, ${coverage:-?}% coverage, ${wall}s" >&2
+    rm -rf "$app_dir" "$out_txt" "$err_txt"
+}
+
+run_side "$BASE_LABEL" "$PLUGIN_BASE"
+run_side "$HEAD_LABEL" "$PLUGIN_HEAD"
+
+echo "[$APP] done" >&2

--- a/bin/ci/delta-report.php
+++ b/bin/ci/delta-report.php
@@ -1,0 +1,277 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Build a base-vs-head issue-delta report (markdown) from per-app Psalm JSON.
+ *
+ * Reads issues.json + perf.json files produced by delta-app.sh out of an
+ * OUTPUT_DIR, matches base/head pairs per app, and prints a delta-only report:
+ *
+ *   * per-app deltas (issues added/removed, net, type coverage %, wall seconds)
+ *   * top issue-type movements (added/removed by type) across all apps
+ *   * newly introduced / removed issue types
+ *
+ * PHP port of the local /psalm-delta skill's compare.py — same file layout,
+ * same identity tuple, same report shape — so CI and the local harness produce
+ * byte-comparable output. Mirrors tests/Benchmark/compare.php conventions
+ * (getopt, JSON_THROW_ON_ERROR, markdown to stdout). No Python on CI.
+ *
+ * File layout (written by delta-app.sh, identical to bench.sh):
+ *   <output_dir>/<app>/<app>-<label>-<date-marker>--issues.json
+ *   <output_dir>/<app>/<app>-<label>-<date-marker>--perf.json
+ *
+ * Issue identity uses (file_path, line_from, line_to, type, message) so churn
+ * is visible: a PR fixing 50 issues and introducing 50 new ones reports
+ * +50/-50 instead of ΔNet=0.
+ *
+ * Usage:
+ *   php delta-report.php <output_dir> <base_label> <head_label> \
+ *       --apps=monica,pixelfed,coolify \
+ *       [--base-ref=] [--head-ref=] [--base-sha=] [--head-sha=] \
+ *       [--date-marker=cache] [--top=30]
+ *
+ * Exit codes: 0 = report produced, 2 = usage error.
+ */
+
+// Psalm issues.json carry full code snippets, so a large app's report decodes
+// to >100 MB — well past the default 128 MB CLI limit. This is a throwaway
+// reporting tool (one process, exits immediately); a generous floor is safe.
+// Honour a higher pre-set limit / unlimited (-1); only raise a too-low one.
+$currentLimit = (int) ini_get('memory_limit');
+if ($currentLimit !== -1 && $currentLimit < 1024 * 1024 * 1024) {
+    ini_set('memory_limit', '1G');
+}
+
+// Manual arg parse: PHP's getopt() stops at the first non-option argument, so
+// `<positional> --opt=v` would silently drop the options. Positionals and
+// `--key=value` flags may appear in any order here.
+$options = [];
+$positional = [];
+/** @var string $arg */
+foreach (array_slice($argv, 1) as $arg) {
+    if (str_starts_with($arg, '--')) {
+        [$key, $value] = array_pad(explode('=', substr($arg, 2), 2), 2, '');
+        $options[$key] = $value;
+    } else {
+        $positional[] = $arg;
+    }
+}
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "Error: {$message}\n");
+    fwrite(STDERR, "Usage: php delta-report.php <output_dir> <base_label> <head_label> --apps=a,b,c [--base-ref=] [--head-ref=] [--base-sha=] [--head-sha=] [--date-marker=cache]\n");
+    exit(2);
+};
+
+if (count($positional) < 3) {
+    $fail('expected <output_dir> <base_label> <head_label>');
+}
+
+[$outputDir, $baseLabel, $headLabel] = $positional;
+$outputDir = rtrim($outputDir, '/');
+
+$appsRaw = $options['apps'] ?? '';
+$apps = array_values(array_filter(array_map('trim', explode(',', $appsRaw)), static fn(string $a): bool => $a !== ''));
+if ($apps === []) {
+    $fail('--apps is required (comma-separated app names, in display order)');
+}
+
+$baseRef = $options['base-ref'] ?? '';
+$headRef = $options['head-ref'] ?? '';
+$baseSha = $options['base-sha'] ?? '';
+$headSha = $options['head-sha'] ?? '';
+$dateMarker = $options['date-marker'] ?? 'cache';
+
+/**
+ * Newest file matching <app>-<label>-<date-marker>--<suffix>, or null.
+ *
+ * Mirrors compare.py's _latest: the date component anchors the match so label
+ * "v4.10.0" does not also match "v4.10.0-pr905--...". With a literal marker
+ * (e.g. "cache") there is a single deterministic name; the glob still sorts so
+ * a yyyy-mm-dd marker would pick the most recent.
+ */
+$latest = static function (string $outputDir, string $app, string $label, string $suffix, string $dateMarker): ?string {
+    if ($dateMarker === 'yyyy-mm-dd') {
+        $dateGlob = '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]';
+    } else {
+        $dateGlob = $dateMarker;
+    }
+    $pattern = "{$outputDir}/{$app}/{$app}-{$label}-{$dateGlob}--{$suffix}";
+    $matches = glob($pattern);
+    if ($matches === false || $matches === []) {
+        return null;
+    }
+    sort($matches);
+
+    return $matches[array_key_last($matches)];
+};
+
+/**
+ * @return array<array-key, mixed>|null  decoded JSON array, or null on any failure
+ */
+$loadJson = static function (?string $path): ?array {
+    if ($path === null || !is_file($path)) {
+        return null;
+    }
+    try {
+        /** @psalm-var mixed $decoded */
+        $decoded = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+
+        return is_array($decoded) ? $decoded : null;
+    } catch (\JsonException) {
+        return null;
+    }
+};
+
+/**
+ * Stable identity for an issue. NUL-joined so it is a safe array key.
+ *
+ * @param array<string, mixed> $i
+ */
+$issueKey = static function (array $i): string {
+    return implode("\x00", [
+        (string) ($i['file_path'] ?? ''),
+        (string) ($i['line_from'] ?? 0),
+        (string) ($i['line_to'] ?? 0),
+        (string) ($i['type'] ?? '?'),
+        (string) ($i['message'] ?? ''),
+    ]);
+};
+
+/**
+ * @var list<array{
+ *     app: string,
+ *     total: int,
+ *     added: int,
+ *     removed: int,
+ *     net: int,
+ *     movements: list<array{type: string, base: int, head: int, delta: int}>,
+ * }> $rows
+ */
+$rows = [];
+/** @var list<string> $missing */
+$missing = [];
+
+foreach ($apps as $app) {
+    $baseIssues = $loadJson($latest($outputDir, $app, $baseLabel, 'issues.json', $dateMarker));
+    $headIssues = $loadJson($latest($outputDir, $app, $headLabel, 'issues.json', $dateMarker));
+
+    if (!is_array($baseIssues) || !array_is_list($baseIssues)
+        || !is_array($headIssues) || !array_is_list($headIssues)) {
+        $missing[] = $app;
+        continue;
+    }
+
+    // Map issue identity -> type (type only: keeping the full issue, with its
+    // multi-line code snippet, would hold ~100 MB on a 20k-issue app). Keyed by
+    // identity so duplicates collapse and the per-type counts below reconcile
+    // with the +/- churn. The foreach @var types each decoded issue (mixed JSON).
+    $baseByKey = [];
+    /** @var array<string, mixed> $i */
+    foreach ($baseIssues as $i) {
+        $baseByKey[$issueKey($i)] = (string) ($i['type'] ?? '?');
+    }
+    $headByKey = [];
+    /** @var array<string, mixed> $i */
+    foreach ($headIssues as $i) {
+        $headByKey[$issueKey($i)] = (string) ($i['type'] ?? '?');
+    }
+    unset($baseIssues, $headIssues);
+
+    $added = count(array_diff_key($headByKey, $baseByKey));
+    $removed = count(array_diff_key($baseByKey, $headByKey));
+    $net = count($headByKey) - count($baseByKey);
+
+    // Per-type counts (deduped) for this app, base vs head, for the movement list.
+    $baseTypeCount = array_count_values(array_values($baseByKey));
+    $headTypeCount = array_count_values(array_values($headByKey));
+
+    $movements = [];
+    foreach (array_keys($baseTypeCount + $headTypeCount) as $type) {
+        $b = $baseTypeCount[$type] ?? 0;
+        $h = $headTypeCount[$type] ?? 0;
+        if ($b !== $h) {
+            $movements[] = ['type' => $type, 'base' => $b, 'head' => $h, 'delta' => $h - $b];
+        }
+    }
+    // Signed delta ascending: biggest reductions first, regressions last.
+    usort(
+        $movements,
+        /**
+         * @param array{type: string, base: int, head: int, delta: int} $x
+         * @param array{type: string, base: int, head: int, delta: int} $y
+         */
+        static fn(array $x, array $y): int => [$x['delta'], $x['type']] <=> [$y['delta'], $y['type']],
+    );
+
+    $rows[] = [
+        'app' => $app,
+        'total' => $added + $removed,
+        'added' => $added,
+        'removed' => $removed,
+        'net' => $net,
+        'movements' => $movements,
+    ];
+}
+
+// --- Header ------------------------------------------------------------------
+
+$baseDesc = $baseRef !== '' ? $baseRef : $baseLabel;
+$headDesc = $headRef !== '' ? $headRef : $headLabel;
+if ($baseSha !== '') {
+    $baseDesc = "{$baseDesc} ({$baseSha})";
+}
+if ($headSha !== '') {
+    $headDesc = "{$headDesc} ({$headSha})";
+}
+
+$out = [];
+$out[] = "# PR delta: {$baseDesc} -> {$headDesc}";
+$out[] = '';
+
+// --- Per-app delta table (changed apps only) --------------------------------
+//
+// Columns: Total (issues touched = added + removed), + (added), − (removed),
+// Δ (net = head − base). Only apps with at least one changed issue appear.
+
+$changed = array_values(array_filter($rows, static fn(array $r): bool => $r['total'] > 0));
+
+$out[] = '## Per-app delta';
+$out[] = '';
+if ($changed === []) {
+    $out[] = 'No issue changes across the benchmarked apps.';
+} else {
+    $out[] = '| App | Total | + | − | Δ |';
+    $out[] = '|-----|------:|----:|----:|-----:|';
+    $tTotal = 0;
+    $tAdded = 0;
+    $tRemoved = 0;
+    $tNet = 0;
+    foreach ($changed as $r) {
+        $out[] = sprintf('| %s | %d | %d | %d | %+d |', $r['app'], $r['total'], $r['added'], $r['removed'], $r['net']);
+        $tTotal += $r['total'];
+        $tAdded += $r['added'];
+        $tRemoved += $r['removed'];
+        $tNet += $r['net'];
+    }
+    $out[] = sprintf('| **Total** | **%d** | **%d** | **%d** | **%+d** |', $tTotal, $tAdded, $tRemoved, $tNet);
+
+    // Per-app issue-type movements: every type whose count changed, base -> head.
+    foreach ($changed as $r) {
+        $out[] = '';
+        $out[] = '### ' . $r['app'];
+        $out[] = '';
+        foreach ($r['movements'] as $m) {
+            $out[] = sprintf('- %s: %d -> %d (%+d)', $m['type'], $m['base'], $m['head'], $m['delta']);
+        }
+    }
+}
+
+if ($missing !== []) {
+    $out[] = '';
+    $out[] = '> No data (crashed or not run): ' . implode(', ', $missing) . '.';
+}
+
+echo implode("\n", $out) . "\n";
+exit(0);

--- a/bin/ci/delta-report.php
+++ b/bin/ci/delta-report.php
@@ -38,7 +38,25 @@ declare(strict_types=1);
 // to >100 MB — well past the default 128 MB CLI limit. This is a throwaway
 // reporting tool (one process, exits immediately); a generous floor is safe.
 // Honour a higher pre-set limit / unlimited (-1); only raise a too-low one.
-$currentLimit = (int) ini_get('memory_limit');
+//
+// memory_limit is a shorthand byte string ("256M", "2G", "-1"), so a naive
+// (int) cast reads "2G" as 2 and would *lower* a 2 GB limit to 1 GB. Parse the
+// K/M/G unit before comparing.
+$parseBytes = static function (string $value): int {
+    $value = trim($value);
+    if ($value === '' || $value === '-1') {
+        return -1;
+    }
+    $unit = strtolower($value[strlen($value) - 1]);
+    $number = (int) $value;
+    return match ($unit) {
+        'g' => $number * 1024 * 1024 * 1024,
+        'm' => $number * 1024 * 1024,
+        'k' => $number * 1024,
+        default => (int) $value,
+    };
+};
+$currentLimit = $parseBytes((string) ini_get('memory_limit'));
 if ($currentLimit !== -1 && $currentLimit < 1024 * 1024 * 1024) {
     ini_set('memory_limit', '1G');
 }

--- a/bin/ci/delta.sh
+++ b/bin/ci/delta.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# Local orchestrator for the CI psalm-delta. Runs the SAME per-app runner
+# (delta-app.sh) and comparator (delta-report.php) the GitHub workflow uses, so
+# a contributor can reproduce the PR delta locally with one command.
+#
+# Unlike the /psalm-delta skill it does NOT checkout refs in the working tree:
+# it spins up two throwaway git worktrees (base + head) and leaves your checkout
+# untouched. Apps come from bin/ci/test-apps.yml (requires `yq`).
+#
+# Usage:
+#   bash bin/ci/delta.sh <head-ref>                 # base = merge-base(master, head)
+#   bash bin/ci/delta.sh <base-ref> vs <head-ref>   # explicit base + head
+#   APPS="monica,coolify" bash bin/ci/delta.sh <head-ref>   # subset
+#
+# Output: markdown delta report on stdout; raw JSON cached under
+#   .cache/psalm-delta-ci/<BASE_SHA>--<HEAD_SHA>/ (gitignored, reused on rerun).
+
+set -euo pipefail
+
+PLUGIN_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
+REGISTRY="${REGISTRY:-${PLUGIN_DIR}/bin/ci/test-apps.yml}"
+cd "$PLUGIN_DIR"
+
+command -v git >/dev/null || { echo "ERROR: git is required" >&2; exit 2; }
+command -v php >/dev/null || { echo "ERROR: php is required (for delta-report.php)" >&2; exit 2; }
+command -v yq  >/dev/null || { echo "ERROR: yq (mikefarah v4) is required to read $REGISTRY" >&2; exit 2; }
+
+# --- Resolve base / head refs ------------------------------------------------
+
+if [[ $# -eq 1 ]]; then
+    HEAD_REF="$1"
+    BASE_REF=$(git merge-base master "$HEAD_REF") \
+        || { echo "ERROR: cannot compute merge-base(master, $HEAD_REF)" >&2; exit 1; }
+elif [[ $# -eq 3 && "$2" == "vs" ]]; then
+    BASE_REF="$1"; HEAD_REF="$3"
+else
+    echo "Usage: $0 <head-ref> | <base-ref> vs <head-ref>" >&2
+    exit 1
+fi
+
+BASE_SHA=$(git rev-parse --short "$BASE_REF") || exit 1
+HEAD_SHA=$(git rev-parse --short "$HEAD_REF") || exit 1
+if [[ "$BASE_SHA" == "$HEAD_SHA" ]]; then
+    echo "ERROR: base and head are the same commit ($BASE_SHA)." >&2
+    exit 1
+fi
+BASE_LABEL="base-${BASE_SHA}"
+HEAD_LABEL="pr-${HEAD_SHA}"
+
+OUT="${PLUGIN_DIR}/.cache/psalm-delta-ci/${BASE_SHA}--${HEAD_SHA}"
+mkdir -p "$OUT"
+
+echo "Base: $BASE_REF ($BASE_SHA)   Head: $HEAD_REF ($HEAD_SHA)" >&2
+echo "Output: $OUT" >&2
+
+# --- Plugin worktrees (working tree untouched) -------------------------------
+#
+# Two detached worktrees hold the base and head plugin source. They need no
+# vendor of their own: each app installs the plugin as a symlinked path repo, so
+# the plugin's requires (vimeo/psalm, testbench) resolve into the APP's vendor.
+
+WT_BASE=$(mktemp -d)
+WT_HEAD=$(mktemp -d)
+git worktree add --detach --force "$WT_BASE" "$BASE_REF" --quiet
+git worktree add --detach --force "$WT_HEAD" "$HEAD_REF" --quiet
+
+cleanup() {
+    git worktree remove --force "$WT_BASE" 2>/dev/null || rm -rf "$WT_BASE"
+    git worktree remove --force "$WT_HEAD" 2>/dev/null || rm -rf "$WT_HEAD"
+}
+trap cleanup EXIT
+
+# --- Loop apps ---------------------------------------------------------------
+
+# Optional APPS=a,b,c subset filter.
+SUBSET="${APPS:-}"
+# read loop (not mapfile) for bash 3.2 compatibility (macOS default shell).
+APP_NAMES=()
+while IFS= read -r line; do
+    [[ -n "$line" ]] && APP_NAMES+=("$line")
+done < <(yq '.apps[].name' "$REGISTRY")
+
+RUN_APPS=()
+for app in "${APP_NAMES[@]}"; do
+    if [[ -n "$SUBSET" && ",$SUBSET," != *",$app,"* ]]; then
+        continue
+    fi
+    RUN_APPS+=("$app")
+done
+
+for app in "${RUN_APPS[@]}"; do
+    # $app comes from the registry itself (trusted, filename-safe), so embedding
+    # it in the yq expression is safe. `// ""` supplies defaults for optional keys.
+    repo=$(yq ".apps[] | select(.name == \"$app\") | .repo" "$REGISTRY")
+    ref=$(yq ".apps[] | select(.name == \"$app\") | .ref" "$REGISTRY")
+    php_ver=$(yq ".apps[] | select(.name == \"$app\") | .php // \"8.3\"" "$REGISTRY")
+    pdir=$(yq ".apps[] | select(.name == \"$app\") | .project_dir // \"\"" "$REGISTRY")
+    prime=$(yq ".apps[] | select(.name == \"$app\") | .prime // \"\"" "$REGISTRY")
+
+    args=(
+        --app "$app" --repo "$repo" --ref "$ref" --php "$php_ver"
+        --plugin-base "$WT_BASE" --plugin-head "$WT_HEAD"
+        --out "$OUT" --base-label "$BASE_LABEL" --head-label "$HEAD_LABEL"
+    )
+    [[ -n "$pdir"  ]] && args+=(--project-dir "$pdir")
+    [[ -n "$prime" ]] && args+=(--prime "$prime")
+
+    echo "=== $app ===" >&2
+    bash "${PLUGIN_DIR}/bin/ci/delta-app.sh" "${args[@]}" || echo "WARN: $app runner failed" >&2
+done
+
+# --- Report ------------------------------------------------------------------
+
+echo "" >&2
+APPS_CSV=$(IFS=,; echo "${RUN_APPS[*]}")
+php "${PLUGIN_DIR}/bin/ci/delta-report.php" "$OUT" "$BASE_LABEL" "$HEAD_LABEL" \
+    --apps="$APPS_CSV" --base-ref="$BASE_REF" --head-ref="$HEAD_REF" \
+    --base-sha="$BASE_SHA" --head-sha="$HEAD_SHA" --date-marker=cache
+
+echo "" >&2
+echo "Raw data: $OUT (reused on rerun for this SHA pair; rm -rf to force clean)" >&2

--- a/bin/ci/delta.sh
+++ b/bin/ci/delta.sh
@@ -26,6 +26,33 @@ command -v git >/dev/null || { echo "ERROR: git is required" >&2; exit 2; }
 command -v php >/dev/null || { echo "ERROR: php is required (for delta-report.php)" >&2; exit 2; }
 command -v yq  >/dev/null || { echo "ERROR: yq (mikefarah v4) is required to read $REGISTRY" >&2; exit 2; }
 
+# --- Read registry + validate optional APPS= subset (before any heavy work) ---
+
+# Optional APPS=a,b,c subset filter.
+SUBSET="${APPS:-}"
+# read loop (not mapfile) for bash 3.2 compatibility (macOS default shell).
+APP_NAMES=()
+while IFS= read -r line; do
+    [[ -n "$line" ]] && APP_NAMES+=("$line")
+done < <(yq '.apps[].name' "$REGISTRY")
+
+# Validate an APPS= subset up front: an unknown name otherwise silently yields
+# an empty RUN_APPS and surfaces only later as delta-report.php's "--apps is
+# required" — after the worktrees and clones are already built. List the valid
+# names instead so the typo is obvious.
+if [[ -n "$SUBSET" ]]; then
+    valid=",$(IFS=,; echo "${APP_NAMES[*]}"),"
+    IFS=',' read -ra REQUESTED <<< "$SUBSET"
+    for req in "${REQUESTED[@]}"; do
+        [[ -z "$req" ]] && continue
+        if [[ "$valid" != *",$req,"* ]]; then
+            echo "ERROR: unknown app '$req' in APPS=. Valid apps:" >&2
+            printf '  %s\n' "${APP_NAMES[@]}" >&2
+            exit 2
+        fi
+    done
+fi
+
 # --- Resolve base / head refs ------------------------------------------------
 
 if [[ $# -eq 1 ]]; then
@@ -73,14 +100,6 @@ trap cleanup EXIT
 
 # --- Loop apps ---------------------------------------------------------------
 
-# Optional APPS=a,b,c subset filter.
-SUBSET="${APPS:-}"
-# read loop (not mapfile) for bash 3.2 compatibility (macOS default shell).
-APP_NAMES=()
-while IFS= read -r line; do
-    [[ -n "$line" ]] && APP_NAMES+=("$line")
-done < <(yq '.apps[].name' "$REGISTRY")
-
 RUN_APPS=()
 for app in "${APP_NAMES[@]}"; do
     if [[ -n "$SUBSET" && ",$SUBSET," != *",$app,"* ]]; then
@@ -88,6 +107,11 @@ for app in "${APP_NAMES[@]}"; do
     fi
     RUN_APPS+=("$app")
 done
+
+# Local PHP major.minor, for the registry-mismatch warning below. --php is the
+# caller's concern locally (delta-app.sh ignores it), so a registry app pinned to
+# a different minor than the system php can fail Composer in confusing ways.
+LOCAL_PHP=$(php -r 'echo PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION;')
 
 for app in "${RUN_APPS[@]}"; do
     # $app comes from the registry itself (trusted, filename-safe), so embedding
@@ -97,6 +121,12 @@ for app in "${RUN_APPS[@]}"; do
     php_ver=$(yq ".apps[] | select(.name == \"$app\") | .php // \"8.3\"" "$REGISTRY")
     pdir=$(yq ".apps[] | select(.name == \"$app\") | .project_dir // \"\"" "$REGISTRY")
     prime=$(yq ".apps[] | select(.name == \"$app\") | .prime // \"\"" "$REGISTRY")
+
+    # Warn (don't block) when the system php differs from the app's pinned minor:
+    # Composer installs under the local binary, so a mismatch can fail oddly.
+    if [[ "$php_ver" != "$LOCAL_PHP" ]]; then
+        echo "WARN: $app pins php $php_ver but local php is $LOCAL_PHP; install may differ from CI." >&2
+    fi
 
     args=(
         --app "$app" --repo "$repo" --ref "$ref" --php "$php_ver"

--- a/bin/ci/test-apps.yml
+++ b/bin/ci/test-apps.yml
@@ -1,0 +1,80 @@
+# Real-world Laravel apps benchmarked by the CI psalm-delta workflow and the
+# local bin/ci/delta.sh orchestrator. Shared, committed source of truth.
+#
+# Each app is pinned to an IMMUTABLE commit so:
+#   * the vendor install is reproducible, and
+#   * CI can cache vendor keyed on (name, ref, php) safely.
+#
+# This is the curated v1 set: apps that composer-install cleanly from a frozen
+# commit against Packagist Psalm (no local fork). Add an entry to grow; delete
+# one to drop a flaky app. The private codebase used by the local /psalm-delta
+# skill is intentionally absent — this file is committed (public).
+#
+# Read with mikefarah yq v4 (preinstalled on ubuntu-latest, `brew install yq`
+# locally). The CI matrix is `yq -o=json '{"include": .apps}'`.
+#
+# Fields:
+#   name         display + on-disk key (filename-safe)
+#   repo         public https clone URL
+#   ref          immutable commit SHA (the cache key; never a moving branch)
+#   php          PHP version the runner sets up for install/analysis
+#   kind         app | lib  (informational; project layout is auto-detected)
+#   project_dir  optional explicit Psalm projectFiles root (else auto-detected:
+#                app/ for Laravel apps, packages/*/src for monorepos, src/ for libs)
+#   prime        optional shell run in the app dir before `composer update`
+#                (one-off install quirks, e.g. bumping a flagged dependency)
+
+apps:
+  - name: monica
+    repo: https://github.com/monicahq/monica.git
+    ref: e08e917
+    php: "8.3"
+    kind: app
+    # Monica's lock pins laravel-lang/http-statuses at a version Packagist flags
+    # as malware; bump that one package (constraint ^3.8) before install.
+    prime: composer update laravel-lang/http-statuses --no-interaction --no-progress --ignore-platform-reqs
+
+  - name: pixelfed
+    repo: https://github.com/pixelfed/pixelfed.git
+    ref: 67606eb
+    php: "8.3"
+    kind: app
+
+  - name: coolify
+    repo: https://github.com/coollabsio/coolify.git
+    ref: ffd69c1
+    php: "8.3"
+    kind: app
+
+  - name: bookstack
+    repo: https://source.bookstackapp.com/bookstack.git
+    ref: 82ef735
+    php: "8.3"
+    kind: app
+
+  - name: solidtime
+    repo: https://github.com/solidtime-io/solidtime.git
+    ref: 797fddf
+    php: "8.3"
+    kind: app
+
+  - name: laravel-socialite
+    repo: https://github.com/laravel/socialite.git
+    ref: 40e0757
+    php: "8.3"
+    kind: lib
+    project_dir: src
+
+  - name: laravel-permission
+    repo: https://github.com/spatie/laravel-permission.git
+    ref: ef42ecb
+    php: "8.3"
+    kind: lib
+    project_dir: src
+
+  - name: laravel-excel
+    repo: https://github.com/SpartnerNL/Laravel-Excel.git
+    ref: 1854739
+    php: "8.3"
+    kind: lib
+    project_dir: src


### PR DESCRIPTION
Closes #1078.

A comment-triggered, opt-in CI check that runs the plugin against a curated corpus of real-world Laravel apps for the PR **base** and **head**, then posts one sticky comment with the per-app **issue delta** and which issue types moved. Informational only: it never fails the PR (a delta is often intended, e.g. fixing false positives removes issues).

This is the correctness counterpart to `benchmark.yml` (which measures performance, one app, count-only).

## How it works

Matrix fan-out + aggregation, so per-PR wall time is the slowest single app (~90s steady-state with the vendor cache), not the sum:

- **prepare** — resolve refs, fork-PR security guard (refuses PRs from a different repo, same as `benchmark.yml`), emit the app matrix from the committed registry.
- **delta** — one job per app (parallel): install the app at a frozen commit, run the plugin for base and head in isolated copies, upload per-app issue JSON.
- **report** — download artifacts, diff, post/update one sticky comment.

The per-app runner (`bin/ci/delta-app.sh`) and comparator (`bin/ci/delta-report.php`) are the same scripts the local orchestrator `bin/ci/delta.sh` runs, so any row reproduces locally:

```
bash bin/ci/delta.sh <pr-branch>          # all apps
APPS=monica,coolify bash bin/ci/delta.sh <pr-branch>   # subset
```

## Report shape

Per-app table (changed apps only):

| App | Total | + | − | Δ |
|-----|------:|----:|----:|-----:|

followed by a per-app list of issue-type movements (`Type: base -> head (±delta)`). Issue identity is `(file_path, line_from, line_to, type, message)`, normalised to repo-relative paths so base/head reconcile across the two work copies.

## Files

- `bin/ci/test-apps.yml` — frozen-commit app registry (8 curated apps), read with `yq`.
- `bin/ci/delta-app.sh` — portable per-app runner (no local paths, Packagist Psalm).
- `bin/ci/delta-report.php` — issue-delta comparator (markdown).
- `bin/ci/delta.sh` — local orchestrator (throwaway git worktrees; working tree untouched).
- `.github/workflows/psalm-delta.yml` — the workflow.

## Notes

- Curated v1 set = apps that install cleanly from a frozen commit against Packagist Psalm. Add an entry to grow; delete one to drop a flaky app.
- First production run will likely need to triage a flaky install or two. A follow-up can backfill the `psalm-delta` / `psalm-app-benchmark` skills to read this committed registry.