### PR TITLE
Suppress false `PossiblyUnusedMethod` on Eloquent trait boot/initialize hooks

### DIFF
--- a/src/Handlers/SuppressHandler.php
+++ b/src/Handlers/SuppressHandler.php
@@ -404,6 +404,7 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
             self::suppressEloquentAccessorMethods($classStorage, $provider);
             self::suppressEloquentScopeMethods($classStorage, $provider);
             self::suppressLegacyEloquentScopeMethods($classStorage, $provider);
+            self::suppressEloquentTraitBootMethods($classStorage, $provider);
         }
 
         if (\in_array('Illuminate\Notifications\Notification', $parents, true)) {
@@ -536,6 +537,41 @@ final class SuppressHandler implements AfterClassLikeVisitInterface, AfterCodeba
     ): void {
         foreach (EloquentModelMethods::appearingMethods($classStorage, $provider) as $methodName => $methodStorage) {
             if (!EloquentModelMethods::isLegacyScopeMethodName($methodName, $methodStorage->cased_name)) {
+                continue;
+            }
+
+            self::suppressInternalDispatchMethod('PossiblyUnusedMethod', $methodStorage);
+            self::suppressInternalDispatchMethod('UnusedMethod', $methodStorage);
+        }
+    }
+
+    /**
+     * Suppress PossiblyUnusedMethod / UnusedMethod for trait boot/initialize hooks.
+     *
+     * Model::bootTraits()/initializeTraits() invoke `boot{Trait}`/`initialize{Trait}` by reflection, so
+     * findUnusedCode reports them as unused (#1069). Classification (incl. the static-only boot rule)
+     * lives in {@see EloquentModelMethods::isTraitBootHook()}. Routed through suppressInternalDispatchMethod()
+     * so public/protected are silenced (Laravel's convention is `protected static`) and private stays
+     * flagged. The `#[Boot]`/`#[Initialize]` attributes (Laravel 12.x+) are a deferred follow-up.
+     */
+    private static function suppressEloquentTraitBootMethods(
+        ClassLikeStorage $classStorage,
+        ClassLikeStorageProvider $provider,
+    ): void {
+        foreach (EloquentModelMethods::appearingMethods($classStorage, $provider) as $methodStorage) {
+            // defining_fqcln is original-cased for scanned classes, so isTraitBootHook()'s case-sensitive
+            // match holds (MacroHandler lowercases it, but only for synthesized macros).
+            $definingFqcln = $methodStorage->defining_fqcln;
+
+            if ($definingFqcln === null || !$provider->has($definingFqcln)) {
+                continue;
+            }
+
+            if (!$provider->get($definingFqcln)->is_trait) {
+                continue;
+            }
+
+            if (!EloquentModelMethods::isTraitBootHook($methodStorage->cased_name, $definingFqcln, $methodStorage->is_static)) {
                 continue;
             }
 

--- a/src/Util/EloquentModelMethods.php
+++ b/src/Util/EloquentModelMethods.php
@@ -149,4 +149,33 @@ final class EloquentModelMethods
         return \preg_match('/^get.+attribute$/', $lowercaseName) === 1
             || \preg_match('/^set.+attribute$/', $lowercaseName) === 1;
     }
+
+    /**
+     * Whether a method is a trait boot/initialize hook Laravel dispatches by reflection in
+     * Model::bootTraits()/initializeTraits(), which findUnusedCode wrongly flags (#1069).
+     *
+     * Matches the cased name against `boot`/`initialize` + the declaring trait's basename.
+     * Case-sensitive on purpose: bootTraits() collects via `in_array($method->getName(), [...])`, so a
+     * mis-cased hook is never booted. The `boot` prefix is static-only; `initialize` is not. Caller must
+     * confirm $definingTraitFqcn is a trait.
+     *
+     * @psalm-pure
+     */
+    public static function isTraitBootHook(?string $casedName, string $definingTraitFqcn, bool $isStatic): bool
+    {
+        if ($casedName === null) {
+            return false;
+        }
+
+        $separatorPosition = \strrpos($definingTraitFqcn, '\\');
+        $traitBasename = $separatorPosition === false
+            ? $definingTraitFqcn
+            : \substr($definingTraitFqcn, $separatorPosition + 1);
+
+        if ($casedName === 'boot' . $traitBasename) {
+            return $isStatic;
+        }
+
+        return $casedName === 'initialize' . $traitBasename;
+    }
 }

--- a/tests/Unit/Handlers/Fixtures/SuppressScopeUnusedCode/app/Concerns/HasInlineScopes.php
+++ b/tests/Unit/Handlers/Fixtures/SuppressScopeUnusedCode/app/Concerns/HasInlineScopes.php
@@ -47,6 +47,18 @@ trait HasInlineScopes
     }
 
     /**
+     * Trait boot hook: Model::bootTraits() invokes `boot` . basename(self) statically by reflection,
+     * so it has no visible caller and must be suppressed rather than reported. See #1069.
+     */
+    protected static function bootHasInlineScopes(): void {}
+
+    /**
+     * Trait initialize hook: Model::initializeTraits() invokes `initialize` . basename(self) on the
+     * instance by reflection. Same suppression requirement as the boot hook above. See #1069.
+     */
+    public function initializeHasInlineScopes(): void {}
+
+    /**
      * Private #[Scope]: never a usable scope (Eloquent cannot dispatch it), so the handler does
      * NOT suppress it. It produces no output here regardless — Psalm only emits UnusedMethod for a
      * private method when the class has no __call, and every Model declares __call. Present to

--- a/tests/Unit/Handlers/SuppressScopeUnusedCodeTest.php
+++ b/tests/Unit/Handlers/SuppressScopeUnusedCodeTest.php
@@ -11,7 +11,8 @@ use Psalm\LaravelPlugin\Handlers\SuppressHandler;
 use Symfony\Component\Process\Process;
 
 /**
- * End-to-end guard for SuppressHandler's Eloquent scope/accessor suppression under findUnusedCode.
+ * End-to-end guard for SuppressHandler's suppression of indirectly-dispatched Eloquent methods
+ * (scopes, accessors, and trait boot/initialize hooks) under findUnusedCode.
  *
  * Why a real Psalm subprocess instead of a phpt: psalm-tester always passes the snippet as an
  * explicit file argument, and Psalm only runs whole-program dead-code detection
@@ -21,10 +22,10 @@ use Symfony\Component\Process\Process;
  * project (tests/Unit/Handlers/Fixtures/SuppressScopeUnusedCode) with findUnusedCode enabled, the
  * way real applications run it, and asserts the suppression actually takes effect.
  *
- * The fixture hosts all four scope shapes (trait/direct x modern #[Scope]/legacy scopeXxx) and a
- * trait + direct legacy accessor, plus one non-scope control method. Without the trait-aware fix
- * the trait-hosted scope and accessor leak as PossiblyUnusedMethod; with it, only the control
- * remains.
+ * The fixture hosts all four scope shapes (trait/direct x modern #[Scope]/legacy scopeXxx), a
+ * trait + direct legacy accessor, and a trait boot/initialize hook pair (#1069), plus one plain
+ * control method. Without the suppressors each indirectly-dispatched method leaks as
+ * PossiblyUnusedMethod; with them, only the control remains.
  *
  * Placement note: this is the suite's only test that forks a real `vendor/bin/psalm` subprocess
  * (it boots Laravel via the plugin, ~6s), because whole-program dead-code detection cannot be
@@ -40,17 +41,19 @@ final class SuppressScopeUnusedCodeTest extends TestCase
      * no-regression controls). `secret` is deliberately NOT here: a private #[Scope] is structurally
      * unflaggable on a Model (see runtime note below), so asserting its absence would prove nothing.
      */
-    private const SUPPRESSED_SCOPE_MARKERS = [
+    private const SUPPRESSED_MARKERS = [
         '::active',               // trait #[Scope]
         '::scopeFlagged',         // trait legacy
         '::getComputedAttribute', // trait legacy accessor
+        '::bootHasInlineScopes',       // trait boot hook (#1069)
+        '::initializeHasInlineScopes', // trait initialize hook (#1069)
         '::published',            // direct #[Scope]
         '::scopeArchived',        // direct legacy
         '::getDisplayNameAttribute', // direct legacy accessor
     ];
 
     #[Test]
-    public function it_suppresses_trait_and_direct_eloquent_scopes_but_not_a_plain_unused_method(): void
+    public function it_suppresses_indirectly_dispatched_eloquent_methods_but_not_a_plain_unused_method(): void
     {
         $unusedMethodFindings = $this->runPsalmAndCollectUnusedMethodFindings();
 
@@ -60,16 +63,16 @@ final class SuppressScopeUnusedCodeTest extends TestCase
         );
         $joined = \implode("\n", $messages);
 
-        // Surgical control: the one non-scope method that is genuinely never called must stay
-        // reported, proving the suppressor narrows to real scopes rather than silencing every
+        // Surgical control: the one plain method that is genuinely never called must stay reported,
+        // proving the suppressor narrows to indirectly-dispatched methods rather than silencing every
         // unused method on the model. assertCount(1) also guarantees nothing else leaks — including
         // the private `secret` scope, which Psalm never emits for a __call class anyway.
-        $this->assertCount(1, $unusedMethodFindings, "Expected exactly one unused-method finding (the non-scope control), got:\n{$joined}");
+        $this->assertCount(1, $unusedMethodFindings, "Expected exactly one unused-method finding (the plain control), got:\n{$joined}");
         $this->assertStringContainsString('TraitScopeModel::helperNonScope', $messages[0]);
 
-        // Every dispatched scope/accessor must be suppressed rather than reported as unused.
-        foreach (self::SUPPRESSED_SCOPE_MARKERS as $marker) {
-            $this->assertStringNotContainsString($marker, $joined, "Scope/accessor method {$marker} must be suppressed, not reported as unused.");
+        // Every indirectly-dispatched method must be suppressed rather than reported as unused.
+        foreach (self::SUPPRESSED_MARKERS as $marker) {
+            $this->assertStringNotContainsString($marker, $joined, "Indirectly-dispatched method {$marker} must be suppressed, not reported as unused.");
         }
     }
 

--- a/tests/Unit/Util/EloquentModelMethodsTest.php
+++ b/tests/Unit/Util/EloquentModelMethodsTest.php
@@ -11,8 +11,9 @@ use Psalm\LaravelPlugin\Util\EloquentModelMethods;
 
 /**
  * Direct coverage for the pure name classifiers. They were promoted from private SuppressHandler helpers
- * to a shared util now consumed by three handlers, so the subtle StudlyCase gate and the `.+` accessor
- * guard get a dedicated truth table here rather than being exercised only through the full Psalm pipeline.
+ * to a shared util now consumed by three handlers, so the subtle StudlyCase gate, the `.+` accessor
+ * guard, and the trait-boot static gate get a dedicated truth table here rather than being exercised
+ * only through the full Psalm pipeline.
  */
 #[CoversClass(EloquentModelMethods::class)]
 final class EloquentModelMethodsTest extends TestCase
@@ -67,5 +68,43 @@ final class EloquentModelMethodsTest extends TestCase
         $this->assertFalse(EloquentModelMethods::isLegacyAccessorMethodName('getroutekeyname'));
         $this->assertFalse(EloquentModelMethods::isLegacyAccessorMethodName('getmorphclass'));
         $this->assertFalse(EloquentModelMethods::isLegacyAccessorMethodName('title'));
+    }
+
+    #[Test]
+    public function isTraitBootHook_recognises_conventional_hooks(): void
+    {
+        // Static `boot{Trait}` dispatched by Model::bootTraits().
+        $this->assertTrue(EloquentModelMethods::isTraitBootHook('bootHasUuid', 'App\Concerns\HasUuid', true));
+        // Instance `initialize{Trait}` dispatched by Model::initializeTraits() via `$this->{$method}()`.
+        $this->assertTrue(EloquentModelMethods::isTraitBootHook('initializeHasUuid', 'App\Concerns\HasUuid', false));
+        // initializeTraits() collects the hook regardless of the static modifier, so a static
+        // `initialize{Trait}` is matched too (unlike the boot prefix, which is static-only).
+        $this->assertTrue(EloquentModelMethods::isTraitBootHook('initializeHasUuid', 'App\Concerns\HasUuid', true));
+        // Basename is the last namespace segment; an unqualified trait name resolves to itself.
+        $this->assertTrue(EloquentModelMethods::isTraitBootHook('bootHasUuid', 'HasUuid', true));
+    }
+
+    #[Test]
+    public function isTraitBootHook_rejects_non_hooks(): void
+    {
+        // The static gate: Model::bootTraits() only invokes a `boot{Trait}` when it is static, so a
+        // non-static one is never dispatched and must stay flagged as the mis-declaration it is.
+        $this->assertFalse(EloquentModelMethods::isTraitBootHook('bootHasUuid', 'App\Concerns\HasUuid', false));
+        // Case-sensitive, mirroring Laravel's case-sensitive `in_array($method->getName(), $set)`
+        // collection: a mis-cased `boothasuuid()` is never booted by Laravel (genuinely dead), so it
+        // must stay flagged rather than be silently suppressed.
+        $this->assertFalse(EloquentModelMethods::isTraitBootHook('boothasuuid', 'App\Concerns\HasUuid', true));
+        $this->assertFalse(EloquentModelMethods::isTraitBootHook('initializehasuuid', 'App\Concerns\HasUuid', false));
+        // Precision: a boot/initialize method whose suffix is not the declaring trait's basename is
+        // never derived by Laravel from that trait, so it is genuinely dead code.
+        $this->assertFalse(EloquentModelMethods::isTraitBootHook('bootSomethingElse', 'App\Concerns\HasUuid', true));
+        $this->assertFalse(EloquentModelMethods::isTraitBootHook('initializeSomethingElse', 'App\Concerns\HasUuid', false));
+        // Bare prefixes never match — no trait has an empty basename.
+        $this->assertFalse(EloquentModelMethods::isTraitBootHook('boot', 'App\Concerns\HasUuid', true));
+        $this->assertFalse(EloquentModelMethods::isTraitBootHook('initialize', 'App\Concerns\HasUuid', false));
+        // Unrelated method.
+        $this->assertFalse(EloquentModelMethods::isTraitBootHook('handle', 'App\Concerns\HasUuid', true));
+        // Null cased name (no source spelling to match) is never treated as a hook.
+        $this->assertFalse(EloquentModelMethods::isTraitBootHook(null, 'App\Concerns\HasUuid', true));
     }
 }


### PR DESCRIPTION
## Issue to Solve

With `findUnusedCode` enabled, Psalm reports `PossiblyUnusedMethod` / `UnusedMethod` on Eloquent trait boot hooks (`boot{Trait}` / `initialize{Trait}`). Laravel invokes these by reflection in `Model::bootTraits()` / `Model::initializeTraits()`, so they have no statically visible caller and every such hook surfaces as a false positive.

## Related

Closes #1069

## Solution Description

`SuppressHandler` now silences `PossiblyUnusedMethod` / `UnusedMethod` for trait-declared `boot{Trait}` / `initialize{Trait}` hooks on Eloquent models. Detection lives in a new pure classifier `EloquentModelMethods::isTraitBootHook()` and mirrors Laravel's own dispatch precisely:

- **Self-validated against the declaring trait.** A method is a hook only when its name equals `boot`/`initialize` + the basename of the trait that declares it, so a `bootSomethingElse` on an unrelated trait stays reported.
- **Case-sensitive.** `Model::bootTraits()` collects hooks with a case-sensitive `in_array($method->getName(), ['boot' . class_basename($trait), …])`, so a mis-cased `boothasuuid()` is never booted by Laravel and stays reported (unlike legacy scopes, which dispatch case-insensitively via `$this->{'scope' . ucfirst($name)}()`).
- **Static gate on `boot`.** A non-static `boot{Trait}()` is never dispatched by `bootTraits()`, so it stays reported as the latent mis-declaration it is. `initialize{Trait}` is an instance hook and carries no static requirement.
- **Visibility.** `public` / `protected` are suppressed (Laravel's own convention is `protected static`); `private` stays flagged (and is structurally unflaggable on a `__call` model anyway).

Verified with:

- A unit truth table for the classifier (`EloquentModelMethodsTest`) covering the static gate, case sensitivity, basename mismatch, and the null cased-name path.
- End-to-end coverage folded into the existing `SuppressScopeUnusedCodeTest`, which runs a real Psalm subprocess over a `<projectFiles>` fixture with `findUnusedCode="true"` (a phpt cannot observe whole-program dead-code findings). The fixture trait now hosts a `boot`/`initialize` hook pair, asserted suppressed alongside the existing scope/accessor cases, with a plain unused control proving the suppressor stays narrow.

Out of scope: the newer `#[Boot]` / `#[Initialize]` attributes (Laravel 12.x+) for arbitrarily named hooks are deferred to an attribute-driven follow-up.

## Checklist
- [x] Tests cover the change (unit + subprocess tests in `tests/Unit/`)
