### PR TITLE
Return the concrete paginator from `paginate()` and preserve the related-model template through relations

### DIFF
--- a/stubs/common/Database/Eloquent/Builder.phpstub
+++ b/stubs/common/Database/Eloquent/Builder.phpstub
@@ -529,11 +529,11 @@ class Builder implements BuilderContract
      * without an UndefinedInterfaceMethod. The concrete implements the contract, so
      * code typed on the contract still accepts the result.
      *
-     * @param  int|null|\Closure  $perPage
+     * @param  int|null|(\Closure(int): int)  $perPage
      * @param  list<non-empty-string>  $columns
      * @param  string  $pageName
      * @param  int|null  $page
-     * @param  \Closure|int|null  $total
+     * @param  (\Closure(): int)|int|null  $total
      * @return \Illuminate\Pagination\LengthAwarePaginator<int, TModel>
      *
      * @throws \InvalidArgumentException

--- a/stubs/common/Database/Eloquent/Builder.phpstub
+++ b/stubs/common/Database/Eloquent/Builder.phpstub
@@ -529,15 +529,16 @@ class Builder implements BuilderContract
      * without an UndefinedInterfaceMethod. The concrete implements the contract, so
      * code typed on the contract still accepts the result.
      *
-     * @param  int  $perPage
+     * @param  int|null|\Closure  $perPage
      * @param  list<non-empty-string>  $columns
      * @param  string  $pageName
      * @param  int|null  $page
+     * @param  \Closure|int|null  $total
      * @return \Illuminate\Pagination\LengthAwarePaginator<int, TModel>
      *
      * @throws \InvalidArgumentException
      */
-    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null) {}
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, $total = null) {}
 
     /**
      * @param  int|null  $perPage

--- a/stubs/common/Database/Eloquent/Builder.phpstub
+++ b/stubs/common/Database/Eloquent/Builder.phpstub
@@ -522,11 +522,18 @@ class Builder implements BuilderContract
     public function pluck($column, $key = null) {}
 
     /**
+     * Returns the concrete Illuminate\Pagination class, not the contract. Laravel's
+     * own Eloquent\Builder docblock and runtime both produce the concrete paginator
+     * (`new LengthAwarePaginator(...)`); typing the concrete class lets callers reach
+     * its concrete-only surface (getCollection(), through(), withQueryString(), …)
+     * without an UndefinedInterfaceMethod. The concrete implements the contract, so
+     * code typed on the contract still accepts the result.
+     *
      * @param  int  $perPage
      * @param  list<non-empty-string>  $columns
      * @param  string  $pageName
      * @param  int|null  $page
-     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator<int, TModel>
+     * @return \Illuminate\Pagination\LengthAwarePaginator<int, TModel>
      *
      * @throws \InvalidArgumentException
      */
@@ -537,7 +544,7 @@ class Builder implements BuilderContract
      * @param  list<non-empty-string>  $columns
      * @param  string  $pageName
      * @param  int|null  $page
-     * @return \Illuminate\Contracts\Pagination\Paginator<int, TModel>
+     * @return \Illuminate\Pagination\Paginator<int, TModel>
      */
     public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null) {}
 

--- a/stubs/common/Database/Eloquent/Relations/HasOneOrManyThrough.phpstub
+++ b/stubs/common/Database/Eloquent/Relations/HasOneOrManyThrough.phpstub
@@ -64,7 +64,7 @@ abstract class HasOneOrManyThrough extends Relation
      * @param  list<non-empty-string>  $columns
      * @param  string  $pageName
      * @param  int|null  $page
-     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator<int, TRelatedModel>
+     * @return \Illuminate\Pagination\LengthAwarePaginator<int, TRelatedModel>
      */
     public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null) {}
 
@@ -73,7 +73,7 @@ abstract class HasOneOrManyThrough extends Relation
      * @param  list<non-empty-string>  $columns
      * @param  string  $pageName
      * @param  int|null  $page
-     * @return \Illuminate\Contracts\Pagination\Paginator<int, TRelatedModel>
+     * @return \Illuminate\Pagination\Paginator<int, TRelatedModel>
      */
     public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null) {}
 
@@ -82,7 +82,7 @@ abstract class HasOneOrManyThrough extends Relation
      * @param  list<non-empty-string>  $columns
      * @param  string  $cursorName
      * @param  string|null  $cursor
-     * @return \Illuminate\Contracts\Pagination\CursorPaginator<int, TRelatedModel>
+     * @return \Illuminate\Pagination\CursorPaginator<int, TRelatedModel>
      */
     public function cursorPaginate($perPage = null, $columns = ['*'], $cursorName = 'cursor', $cursor = null) {}
 }

--- a/stubs/common/Database/Eloquent/Relations/Relation.phpstub
+++ b/stubs/common/Database/Eloquent/Relations/Relation.phpstub
@@ -95,15 +95,21 @@ abstract class Relation implements BuilderContract
      * Subclasses that narrow the value (BelongsToMany's pivot variant, the Through
      * relations) override these.
      *
-     * @param  int|null  $perPage
+     * The signature mirrors Eloquent\Builder::paginate (the __call forwarding target),
+     * including the Closure $perPage and the fifth $total argument. BelongsToMany and
+     * HasOneOrManyThrough declare their OWN narrower paginate() in Laravel (no $total),
+     * so they keep the four-argument override — passing $total there errors at runtime.
+     *
+     * @param  int|null|\Closure  $perPage
      * @param  list<non-empty-string>  $columns
      * @param  string  $pageName
      * @param  int|null  $page
+     * @param  \Closure|int|null  $total
      * @return \Illuminate\Pagination\LengthAwarePaginator<int, TRelatedModel>
      *
      * @throws \InvalidArgumentException
      */
-    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null) {}
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, $total = null) {}
 
     /**
      * @param  int|null  $perPage

--- a/stubs/common/Database/Eloquent/Relations/Relation.phpstub
+++ b/stubs/common/Database/Eloquent/Relations/Relation.phpstub
@@ -100,11 +100,11 @@ abstract class Relation implements BuilderContract
      * HasOneOrManyThrough declare their OWN narrower paginate() in Laravel (no $total),
      * so they keep the four-argument override — passing $total there errors at runtime.
      *
-     * @param  int|null|\Closure  $perPage
+     * @param  int|null|(\Closure(int): int)  $perPage
      * @param  list<non-empty-string>  $columns
      * @param  string  $pageName
      * @param  int|null  $page
-     * @param  \Closure|int|null  $total
+     * @param  (\Closure(): int)|int|null  $total
      * @return \Illuminate\Pagination\LengthAwarePaginator<int, TRelatedModel>
      *
      * @throws \InvalidArgumentException

--- a/stubs/common/Database/Eloquent/Relations/Relation.phpstub
+++ b/stubs/common/Database/Eloquent/Relations/Relation.phpstub
@@ -83,6 +83,47 @@ abstract class Relation implements BuilderContract
     }
 
     /**
+     * Paginate the query (forwarded to the related model's Builder).
+     *
+     * Declared here (not just on Builder) for the same reason as get()/first():
+     * Psalm's templated @mixin Builder<TRelatedModel> resolution fails to substitute
+     * TRelatedModel into a *nested* generic on a non-fluent return, so the inferred
+     * value collapses to the `Model` bound (LengthAwarePaginator<int, TRelatedModel as Model>).
+     * MethodForwardingHandler skips these via isInDeclaringMethodIds, so this stub type
+     * is used directly. The concrete Illuminate\Pagination class is returned (see Builder
+     * stub) so the concrete-only surface (getCollection(), …) resolves on the result.
+     * Subclasses that narrow the value (BelongsToMany's pivot variant, the Through
+     * relations) override these.
+     *
+     * @param  int|null  $perPage
+     * @param  list<non-empty-string>  $columns
+     * @param  string  $pageName
+     * @param  int|null  $page
+     * @return \Illuminate\Pagination\LengthAwarePaginator<int, TRelatedModel>
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null) {}
+
+    /**
+     * @param  int|null  $perPage
+     * @param  list<non-empty-string>  $columns
+     * @param  string  $pageName
+     * @param  int|null  $page
+     * @return \Illuminate\Pagination\Paginator<int, TRelatedModel>
+     */
+    public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null) {}
+
+    /**
+     * @param  int|null  $perPage
+     * @param  list<non-empty-string>  $columns
+     * @param  string  $cursorName
+     * @param  \Illuminate\Pagination\Cursor|string|null  $cursor
+     * @return \Illuminate\Pagination\CursorPaginator<int, TRelatedModel>
+     */
+    public function cursorPaginate($perPage = null, $columns = ['*'], $cursorName = 'cursor', $cursor = null) {}
+
+    /**
      * Set the columns to be selected.
      *
      * Declared here because @psalm-variadic on Query\Builder::select does not

--- a/tests/Type/tests/Builder/BuilderTypesTest.phpt
+++ b/tests/Type/tests/Builder/BuilderTypesTest.phpt
@@ -203,6 +203,19 @@ function test_scopes_on_builder_contract_preserves_concrete_builder_surface(Buil
     /** @psalm-check-type-exact $_result = Builder<Model>&static */
     return $_result;
 }
+
+/**
+ * paginate() accepts a Closure $perPage and the fifth $total argument (Laravel v13).
+ * These named-argument forms must type-check without TooManyArguments / InvalidArgument.
+ */
+function test_paginate_accepts_total_and_closure(): void
+{
+    $_total = Customer::query()->paginate(total: fn (): int => 100);
+    /** @psalm-check-type-exact $_total = LengthAwarePaginator<int, Customer> */
+
+    $_closure = Customer::query()->paginate(perPage: fn (int $total): int => $total, total: 100);
+    /** @psalm-check-type-exact $_closure = LengthAwarePaginator<int, Customer> */
+}
 ?>
 --EXPECTF--
 InvalidArgument on line %d: Argument 3 of Illuminate\Database\Eloquent\Builder::whereDate expects DateTimeInterface|null|string, but 1 provided

--- a/tests/Type/tests/Builder/BuilderTypesTest.phpt
+++ b/tests/Type/tests/Builder/BuilderTypesTest.phpt
@@ -5,6 +5,10 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Contracts\Database\Eloquent\Builder as BuilderContract;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Pagination\CursorPaginator;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
+use Illuminate\Support\Collection as SupportCollection;
 use App\Models\Customer;
 use App\Models\Vehicle;
 
@@ -75,22 +79,39 @@ final class EloquentBuilderCustomerRepository
             });
     }
 
-    /** @return \Illuminate\Contracts\Pagination\LengthAwarePaginator<int, Customer> */
-    public function testPaginate(): \Illuminate\Contracts\Pagination\LengthAwarePaginator
+    /**
+     * paginate() resolves to the concrete Illuminate\Pagination class (issue #1052),
+     * so the concrete-only getCollection() resolves on the result (subsumes #978).
+     *
+     * @return LengthAwarePaginator<int, Customer>
+     */
+    public function testPaginate(): LengthAwarePaginator
     {
-        return Customer::query()->paginate();
+        $paginator = Customer::query()->paginate();
+        /** @psalm-check-type-exact $paginator = LengthAwarePaginator<int, Customer> */
+
+        $_collection = $paginator->getCollection();
+        /** @psalm-check-type-exact $_collection = SupportCollection<int, Customer> */
+
+        return $paginator;
     }
 
-    /** @return \Illuminate\Contracts\Pagination\Paginator<int, Customer> */
-    public function testSimplePaginate(): \Illuminate\Contracts\Pagination\Paginator
+    /** @return Paginator<int, Customer> */
+    public function testSimplePaginate(): Paginator
     {
-        return Customer::query()->simplePaginate();
+        $paginator = Customer::query()->simplePaginate();
+        /** @psalm-check-type-exact $paginator = Paginator<int, Customer> */
+
+        return $paginator;
     }
 
-    /** @return \Illuminate\Pagination\CursorPaginator<int, Customer> */
-    public function testCursorPaginate(Builder $builder): \Illuminate\Pagination\CursorPaginator
+    /** @return CursorPaginator<int, Customer> */
+    public function testCursorPaginate(Builder $builder): CursorPaginator
     {
-        return Customer::query()->cursorPaginate();
+        $paginator = Customer::query()->cursorPaginate();
+        /** @psalm-check-type-exact $paginator = CursorPaginator<int, Customer> */
+
+        return $paginator;
     }
 
     /** @return Builder<Customer> */

--- a/tests/Type/tests/Relation/RelationPaginateTemplateTest.phpt
+++ b/tests/Type/tests/Relation/RelationPaginateTemplateTest.phpt
@@ -1,0 +1,96 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use App\Models\Mechanic;
+use App\Models\MechanicSpecialization;
+use App\Models\Part;
+use App\Models\Supplier;
+use App\Models\Vehicle;
+use App\Models\WorkOrder;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Pagination\CursorPaginator;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
+use Illuminate\Support\Collection;
+
+/**
+ * Regression for https://github.com/psalm/psalm-plugin-laravel/issues/1051
+ * and https://github.com/psalm/psalm-plugin-laravel/issues/1052.
+ *
+ * #1051: paginate() forwarded through a relation must keep the related-model
+ * template (HasMany<Vehicle, …>::paginate() => LengthAwarePaginator<int, Vehicle>),
+ * not collapse it to the `Model` bound of TRelatedModel.
+ *
+ * #1052: the paginator must be the concrete Illuminate\Pagination class, so the
+ * concrete-only surface (getCollection(), …) resolves on the result.
+ */
+
+function relation_paginate_keeps_template(Customer $customer): void
+{
+    $_paginator = $customer->vehicles()->paginate();
+    /** @psalm-check-type-exact $_paginator = LengthAwarePaginator<int, Vehicle> */
+
+    // #1052/#978 — getCollection() lives on the concrete AbstractPaginator only.
+    $_collection = $customer->vehicles()->paginate()->getCollection();
+    /** @psalm-check-type-exact $_collection = Collection<int, Vehicle> */
+}
+
+function relation_simple_paginate_keeps_template(Customer $customer): void
+{
+    $_paginator = $customer->vehicles()->simplePaginate();
+    /** @psalm-check-type-exact $_paginator = Paginator<int, Vehicle> */
+}
+
+function relation_cursor_paginate_keeps_template(Customer $customer): void
+{
+    $_paginator = $customer->vehicles()->cursorPaginate();
+    /** @psalm-check-type-exact $_paginator = CursorPaginator<int, Vehicle> */
+}
+
+function has_many_through_paginate_keeps_template(Customer $customer): void
+{
+    $_paginator = $customer->workOrders()->paginate();
+    /** @psalm-check-type-exact $_paginator = LengthAwarePaginator<int, WorkOrder> */
+
+    $_simple = $customer->workOrders()->simplePaginate();
+    /** @psalm-check-type-exact $_simple = Paginator<int, WorkOrder> */
+
+    $_cursor = $customer->workOrders()->cursorPaginate();
+    /** @psalm-check-type-exact $_cursor = CursorPaginator<int, WorkOrder> */
+}
+
+function belongs_to_many_paginate_keeps_pivot(Mechanic $mechanic): void
+{
+    $_paginator = $mechanic->specializations()->paginate();
+    /** @psalm-check-type-exact $_paginator = LengthAwarePaginator<int, MechanicSpecialization&object{pivot: Pivot}> */
+}
+
+/**
+ * BelongsTo extends Relation directly (not HasOneOrMany), so this pins the fix to the
+ * BASE Relation class. If paginate() were ever moved down to HasOneOrMany, every case
+ * above would still pass while this one would regress — that is exactly what it guards.
+ */
+function belongs_to_paginate_keeps_template(Part $part): void
+{
+    $_paginator = $part->supplier()->paginate();
+    /** @psalm-check-type-exact $_paginator = LengthAwarePaginator<int, Supplier> */
+}
+
+/**
+ * HasOneThrough is the OTHER subclass of HasOneOrManyThrough (alongside HasManyThrough),
+ * so this guards the contract->concrete change on that stub for the has-one branch.
+ */
+function has_one_through_paginate_keeps_template(Mechanic $mechanic): void
+{
+    $_paginator = $mechanic->vehicleOwner()->paginate();
+    /** @psalm-check-type-exact $_paginator = LengthAwarePaginator<int, Customer> */
+
+    $_simple = $mechanic->vehicleOwner()->simplePaginate();
+    /** @psalm-check-type-exact $_simple = Paginator<int, Customer> */
+
+    $_cursor = $mechanic->vehicleOwner()->cursorPaginate();
+    /** @psalm-check-type-exact $_cursor = CursorPaginator<int, Customer> */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Relation/RelationPaginateTemplateTest.phpt
+++ b/tests/Type/tests/Relation/RelationPaginateTemplateTest.phpt
@@ -92,5 +92,19 @@ function has_one_through_paginate_keeps_template(Mechanic $mechanic): void
     $_cursor = $mechanic->vehicleOwner()->cursorPaginate();
     /** @psalm-check-type-exact $_cursor = CursorPaginator<int, Customer> */
 }
+
+/**
+ * The base Relation forwards to Eloquent\Builder::paginate via __call, so its paginate()
+ * carries the Closure $perPage and the fifth $total argument. These named-argument calls
+ * must type-check (no TooManyArguments / InvalidArgument) and keep the template.
+ */
+function relation_paginate_accepts_total_and_closure(Customer $customer): void
+{
+    $_total = $customer->vehicles()->paginate(total: 100);
+    /** @psalm-check-type-exact $_total = LengthAwarePaginator<int, Vehicle> */
+
+    $_closure = $customer->vehicles()->paginate(perPage: fn (int $total): int => $total, total: fn (): int => 100);
+    /** @psalm-check-type-exact $_closure = LengthAwarePaginator<int, Vehicle> */
+}
 ?>
 --EXPECTF--


### PR DESCRIPTION
## Issue to Solve

`Builder::paginate()` / `simplePaginate()` / `cursorPaginate()` were stubbed to return the **contract** interfaces (`Illuminate\Contracts\Pagination\*`), but Laravel always constructs the **concrete** `Illuminate\Pagination\*` classes. Code that type-hints the concrete class (the common convention, since the concrete class exposes `getCollection()`, `through()`, `withQueryString()`, … that the contract lacks) got `MoreSpecificReturnType` / `LessSpecificReturnStatement`, and `getCollection()` on a `paginate()` result raised `UndefinedInterfaceMethod`.

Separately, `paginate()` forwarded through an Eloquent **relation** dropped the related-model template: `$user->posts()->paginate()` resolved to `LengthAwarePaginator<int, Model>` instead of `LengthAwarePaginator<int, Post>`, even though `->get()` resolved correctly.

## Related

Closes #1051
Closes #1052

Subsumes #978 (`LengthAwarePaginator` contract missing `getCollection()`) — once `paginate()` returns the concrete class, the concrete-only surface resolves with no extra work.

## Solution Description

**Concrete return types (#1052).** Narrowed `paginate()` / `simplePaginate()` on `Builder.phpstub` (and all three on `HasOneOrManyThrough.phpstub`) from the `Illuminate\Contracts\Pagination\*` interfaces to the concrete `Illuminate\Pagination\*` classes; `cursorPaginate()` was already concrete. This matches Laravel's own Eloquent `Builder` docblock and the runtime (`BuildsQueries` constructs `LengthAwarePaginator::class` / `Paginator::class` / `CursorPaginator::class`). The concrete classes implement the contracts, so callers typed on the contract still accept the result — strictly a precision gain, no new false positives.

**Relation template (#1051).** `@mixin Builder<TRelatedModel>` cannot substitute the related-model template into a *nested* generic on a *non-fluent* return, so the value collapsed to the `Model` bound of `TRelatedModel`. Declaring `paginate()` / `simplePaginate()` / `cursorPaginate()` directly on the base `Relation` stub — the same pattern the file already uses for `get()` / `first()` / `sole()` — threads `TRelatedModel` correctly. `MethodForwardingHandler` already skips methods present in `declaring_method_ids`, so it defers to these stub types. `BelongsToMany` (pivot-narrowed) and the `*Through` relations keep their own overrides.

**Verification.** New type test `RelationPaginateTemplateTest.phpt` was confirmed to **fail against the unmodified stubs** (showing the buggy `LengthAwarePaginator<int, TRelatedModel:HasMany as Model>` and the contract type) and pass after the fix. It covers `HasMany`, `HasManyThrough`, `HasOneThrough`, `BelongsTo` (pins the fix to the base `Relation` class, not `HasOneOrMany`), and `BelongsToMany` (guards the pivot-narrowed override), plus `getCollection()` chains for the #1052/#978 acceptance criterion. `BuilderTypesTest.phpt` updated to assert the concrete types. Full type suite 490/490, plugin self-analysis and the fresh-app integration test all green.

## Checklist
- [x] Tests cover the change (type tests in `tests/Type/`)
