### PR TITLE
Support per-app custom Psalm CLI args in psalm-delta

### DIFF
--- a/.github/workflows/psalm-delta.yml
+++ b/.github/workflows/psalm-delta.yml
@@ -204,6 +204,7 @@ jobs:
           PHP: ${{ matrix.php }}
           PROJECT_DIR: ${{ matrix.project_dir }}
           PRIME: ${{ matrix.prime }}
+          PSALM_ARGS: ${{ matrix.psalm_args }}
           BASE_LABEL: ${{ needs.prepare.outputs.base_label }}
           HEAD_LABEL: ${{ needs.prepare.outputs.head_label }}
         run: |
@@ -220,6 +221,7 @@ jobs:
           )
           [ -n "$PROJECT_DIR" ] && args+=(--project-dir "$PROJECT_DIR")
           [ -n "$PRIME" ] && args+=(--prime "$PRIME")
+          [ -n "$PSALM_ARGS" ] && args+=(--psalm-args "$PSALM_ARGS")
           # The harness (default branch) owns measurement so the PR cannot alter it.
           bash "$GITHUB_WORKSPACE/harness/bin/ci/delta-app.sh" "${args[@]}"
 

--- a/bin/ci/delta-app.sh
+++ b/bin/ci/delta-app.sh
@@ -17,6 +17,7 @@
 #     --out /path/output-dir --base-label base-AAAA --head-label pr-BBBB \
 #     [--php 8.3] [--project-dir app] [--date-marker cache] \
 #     [--prime 'composer update foo --no-interaction'] \
+#     [--psalm-args '--php-version=8.0'] \
 #     [--app-src /cache/monica-src] [--mem 4G]
 #
 # Output (per side, <label> in {base-label, head-label}):
@@ -34,7 +35,7 @@ set -euo pipefail
 
 APP="" REPO="" REF="" PLUGIN_BASE="" PLUGIN_HEAD="" OUT=""
 BASE_LABEL="" HEAD_LABEL="" PROJECT_DIR=""
-DATE_MARKER="cache" PRIME="" APP_SRC="" MEM="4G"
+DATE_MARKER="cache" PRIME="" APP_SRC="" MEM="4G" PSALM_ARGS=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -52,6 +53,7 @@ while [[ $# -gt 0 ]]; do
         --project-dir) PROJECT_DIR="$2"; shift 2 ;;
         --date-marker) DATE_MARKER="$2"; shift 2 ;;
         --prime) PRIME="$2"; shift 2 ;;
+        --psalm-args) PSALM_ARGS="$2"; shift 2 ;;
         --app-src) APP_SRC="$2"; shift 2 ;;
         --mem) MEM="$2"; shift 2 ;;
         *) echo "ERROR: unknown argument '$1'" >&2; exit 2 ;;
@@ -76,6 +78,13 @@ APP_SRC="${APP_SRC:-${OUT}/${APP}/src}"
 
 COMPOSER_FLAGS=(--no-interaction --no-progress --ignore-platform-reqs)
 export COMPOSER_MEMORY_LIMIT=-1
+
+# Optional extra Psalm CLI args (e.g. --php-version=8.0), split on whitespace
+# into an array so each token is passed as a separate argument. `=` is not in
+# IFS, so --php-version=8.0 stays one token. `read -ra` returns 0 even on empty
+# input (set -e safe); the array is expanded with the bash-3.2-safe
+# ${arr[@]+...} guard at the call site to avoid an unbound-variable error.
+read -ra PSALM_EXTRA <<< "$PSALM_ARGS"
 
 # Copy a tree using a copy-on-write clone where the filesystem supports it
 # (APFS clonefile on macOS, btrfs/xfs reflinks on Linux): instant and low-disk,
@@ -300,6 +309,7 @@ run_side() {
         cd "$app_dir"
         php -d memory_limit="$MEM" vendor/bin/psalm -c psalm.xml \
             --no-cache --no-diff --no-progress --no-suggestions --monochrome \
+            ${PSALM_EXTRA[@]+"${PSALM_EXTRA[@]}"} \
             --report="${issues_file}" >"$out_txt" 2>"$err_txt"
     ) || exit_code=$?
     wall=$(( $(date +%s) - t0 ))

--- a/bin/ci/delta.sh
+++ b/bin/ci/delta.sh
@@ -121,6 +121,7 @@ for app in "${RUN_APPS[@]}"; do
     php_ver=$(yq ".apps[] | select(.name == \"$app\") | .php // \"8.3\"" "$REGISTRY")
     pdir=$(yq ".apps[] | select(.name == \"$app\") | .project_dir // \"\"" "$REGISTRY")
     prime=$(yq ".apps[] | select(.name == \"$app\") | .prime // \"\"" "$REGISTRY")
+    psalm_args=$(yq ".apps[] | select(.name == \"$app\") | .psalm_args // \"\"" "$REGISTRY")
 
     # Warn (don't block) when the system php differs from the app's pinned minor:
     # Composer installs under the local binary, so a mismatch can fail oddly.
@@ -135,6 +136,7 @@ for app in "${RUN_APPS[@]}"; do
     )
     [[ -n "$pdir"  ]] && args+=(--project-dir "$pdir")
     [[ -n "$prime" ]] && args+=(--prime "$prime")
+    [[ -n "$psalm_args" ]] && args+=(--psalm-args "$psalm_args")
 
     echo "=== $app ===" >&2
     bash "${PLUGIN_DIR}/bin/ci/delta-app.sh" "${args[@]}" || echo "WARN: $app runner failed" >&2

--- a/bin/ci/test-apps.yml
+++ b/bin/ci/test-apps.yml
@@ -26,6 +26,10 @@
 #                app/ for Laravel apps, packages/*/src for monorepos, src/ for libs)
 #   prime        optional shell run in the app dir before `composer update`
 #                (one-off install quirks, e.g. bumping a flagged dependency)
+#   psalm_args   optional extra CLI args appended to the Psalm invocation, split
+#                on whitespace (e.g. "--php-version=8.0" to pin the ANALYSIS php
+#                version when the app's composer.json declares a wrong/too-low
+#                minimum). Analysis-time only; does not affect install or caching.
 
 apps:
   - name: monica
@@ -81,3 +85,6 @@ apps:
     php: "8.4"
     kind: lib
     project_dir: src
+    # composer.json declares a too-low PHP minimum, so Psalm would otherwise
+    # analyse against that floor; pin the analysis target explicitly.
+    psalm_args: "--php-version=8.0"


### PR DESCRIPTION
## Issue to Solve

The `psalm-delta` harness ran every app with a fixed Psalm command line. Some apps cannot be analysed under their declared PHP floor: `laravel-excel` (`maatwebsite/excel`) declares `"php": "^7.0||^8.0"` in `composer.json`, so Psalm analyses against the 7.0 floor and **crashes** building a conditionally-loaded console trait (`Could not get class storage for illuminate\console\concerns\promptsformissinginput`). The app then shows up as `(missing)` in the delta report with no usable numbers.

## Related

#0

## Solution Description

Add an optional `psalm_args` field to the app registry (`bin/ci/test-apps.yml`) and thread it through the existing layers, mirroring how `project_dir` / `prime` already flow:

- `bin/ci/test-apps.yml` documents the field; `laravel-excel` sets `psalm_args: "--php-version=8.0"`.
- `bin/ci/delta.sh` reads it via `yq` (`// ""` default) and passes `--psalm-args` when non-empty.
- `bin/ci/delta-app.sh` parses `--psalm-args`, splits on whitespace into an array, and injects the tokens into the Psalm invocation. The empty case uses the bash-3.2-safe `${arr[@]+"${arr[@]}"}` guard so it stays `set -u` clean on the macOS default shell.
- `.github/workflows/psalm-delta.yml` threads `matrix.psalm_args` (from the committed, trusted registry) via `env:` and appends `--psalm-args` to the runner args.

The value is analysis-time only, so app install and the CI source-cache key are unaffected (correctly stays out of the cache key).

### Verification

- `yq` read + CI matrix JSON both emit `--php-version=8.0` for `laravel-excel`.
- `bash -n` clean on both scripts; tokenization verified under `set -euo pipefail` for empty / single / multi-arg inputs (`--php-version=8.0` stays one token; `=` is not in `IFS`).
- End-to-end through `delta-app.sh`: `laravel-excel` without the flag crashes (no report); with `--php-version=8.0` it runs clean at **1163 issues, 94.35% coverage**. The flag turns a `(missing)` row into a real one.

A global `PSALM_ARGS` env override was deliberately left out to keep a single source of truth (the `--psalm-args` flag); scope is per-app only.

## Checklist
- [x] Documentation is updated (registry field documented in `bin/ci/test-apps.yml` header)
