### PR TITLE
Fix `MissingTemplateParam` on in-body `belongsToMany()`/`morphToMany()` pivot chains

### DIFF
--- a/stubs/common/Database/Eloquent/Concerns/HasRelationships.phpstub
+++ b/stubs/common/Database/Eloquent/Concerns/HasRelationships.phpstub
@@ -122,7 +122,11 @@ trait HasRelationships
      * @param  string  $parentKey
      * @param  string  $relatedKey
      * @param  string  $relation
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<TRelatedModel, static>
+     *
+     * All 4 params filled: Psalm 7 ignores @template defaults (vimeo/psalm#5407), so a
+     * 2-of-4 return trips MissingTemplateParam on in-body chains (#1088). `->using()` /
+     * `->as()` re-narrow the pivot/accessor slots; `static` avoids the #913 collapse.
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<TRelatedModel, static, \Illuminate\Database\Eloquent\Relations\Pivot, 'pivot'>
      */
     public function belongsToMany($related, $table = null, $foreignPivotKey = null, $relatedPivotKey = null,
                                   $parentKey = null, $relatedKey = null, $relation = null) {}
@@ -140,7 +144,10 @@ trait HasRelationships
      * @param  string  $relatedKey
      * @param  string  $relation
      * @param  bool  $inverse
-     * @return \Illuminate\Database\Eloquent\Relations\MorphToMany<TRelatedModel, static>
+     *
+     * 4 params filled like belongsToMany() (Psalm ignores @template defaults, #1088);
+     * MorphToMany's pivot default is MorphPivot.
+     * @return \Illuminate\Database\Eloquent\Relations\MorphToMany<TRelatedModel, static, \Illuminate\Database\Eloquent\Relations\MorphPivot, 'pivot'>
      */
     public function morphToMany($related, $name, $table = null, $foreignPivotKey = null,
                                 $relatedPivotKey = null, $parentKey = null,
@@ -158,7 +165,9 @@ trait HasRelationships
      * @param  string  $parentKey
      * @param  string  $relatedKey
      * @param  string  $relation
-     * @return \Illuminate\Database\Eloquent\Relations\MorphToMany<TRelatedModel, static>
+     *
+     * 4 params filled like belongsToMany() (#1088); MorphToMany pivot default is MorphPivot.
+     * @return \Illuminate\Database\Eloquent\Relations\MorphToMany<TRelatedModel, static, \Illuminate\Database\Eloquent\Relations\MorphPivot, 'pivot'>
      */
     public function morphedByMany($related, $name, $table = null, $foreignPivotKey = null,
                                   $relatedPivotKey = null, $parentKey = null,

--- a/stubs/common/Database/Eloquent/Relations/BelongsToMany.phpstub
+++ b/stubs/common/Database/Eloquent/Relations/BelongsToMany.phpstub
@@ -18,17 +18,27 @@ class BelongsToMany extends Relation
     /**
      * Specify the custom pivot model to use for the relationship.
      *
-     * The @psalm-this-out annotation is intended to narrow TPivotModel on the
-     * returned instance. Full generic-param narrowing via @psalm-this-out is
-     * a known Psalm 7 limitation; the annotation is included for forward
-     * compatibility as Psalm's support matures.
+     * `@return static<...>` re-parameterizes TPivotModel so `->using(X::class)` narrows the
+     * pivot slot through a chain (#1088); an `@psalm-this-out` here did not thread through
+     * chained calls in Psalm 7.
      *
      * @template TNewPivotModel of \Illuminate\Database\Eloquent\Relations\Pivot
      * @param  class-string<TNewPivotModel>  $class
-     * @psalm-this-out static<TRelatedModel, TDeclaringModel, TNewPivotModel, TAccessor>
-     * @return $this
+     * @return static<TRelatedModel, TDeclaringModel, TNewPivotModel, TAccessor>
      */
     public function using($class) {}
+
+    /**
+     * Specify the custom pivot accessor to use for the relationship.
+     *
+     * `@return static<...>` re-parameterizes TAccessor so `->as('name')` narrows the
+     * accessor slot through a chain (#1088).
+     *
+     * @template TNewAccessor of string
+     * @param  TNewAccessor  $accessor
+     * @return static<TRelatedModel, TDeclaringModel, TPivotModel, TNewAccessor>
+     */
+    public function as($accessor) {}
 
     /**
      * @template T

--- a/tests/Type/tests/Relation/BelongsToManyPivotTest.phpt
+++ b/tests/Type/tests/Relation/BelongsToManyPivotTest.phpt
@@ -64,19 +64,21 @@ function test_create_infers_pivot_intersection(BelongsToMany $relation): void
     /** @psalm-check-type-exact $_ = MechanicSpecialization&object{pivot: SpecializationPivot} */
 }
 
-// --- using() is callable and accepts a class-string<TPivotModel> ---
+// --- using() narrows TPivotModel on the returned relation ---
 
 /**
- * using() must accept a class-string of a Pivot subclass.
- * The @psalm-this-out annotation is present for future Psalm narrowing support;
- * in Psalm 7, TPivotModel narrowing via @psalm-this-out is not yet fully
- * propagated through generic params.
+ * using() accepts a class-string of a Pivot subclass and re-narrows TPivotModel via the
+ * stub's `@return static<...>` (#1088). The related/declaring models and the 'pivot'
+ * accessor are preserved; only the pivot slot changes.
  *
  * @param BelongsToMany<MechanicSpecialization, Mechanic, Pivot, 'pivot'> $relation
  */
-function test_using_accepts_pivot_class(BelongsToMany $relation): BelongsToMany
+function test_using_narrows_pivot_class(BelongsToMany $relation): BelongsToMany
 {
-    return $relation->using(SpecializationPivot::class);
+    $narrowed = $relation->using(SpecializationPivot::class);
+    /** @psalm-check-type-exact $narrowed = BelongsToMany<MechanicSpecialization, Mechanic, SpecializationPivot, 'pivot'>&static */
+
+    return $narrowed;
 }
 
 /**

--- a/tests/Type/tests/Relation/Issue1088PivotChainInBodyTest.phpt
+++ b/tests/Type/tests/Relation/Issue1088PivotChainInBodyTest.phpt
@@ -1,0 +1,124 @@
+--FILE--
+<?php declare(strict_types=1);
+
+// Dedicated sub-namespace: psalm-tester batches every .phpt into one analysis, so the
+// fixture class names must not collide with the other Relation tests.
+namespace Tests\Psalm\LaravelPlugin\Sandbox\PivotInBody;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphPivot;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+/**
+ * Regression for https://github.com/psalm/psalm-plugin-laravel/issues/1088.
+ *
+ * After #1055 replaced `$this` with `static` in the relation-factory returns, a pivot
+ * chain inside a relation method body (`belongsToMany(...)->withPivot()->withTimestamps()`)
+ * resolved to the stub's 2-of-4 `BelongsToMany<TRelated, static>` and tripped
+ * MissingTemplateParam on the RETURN STATEMENT — even when the method's own `@return` was
+ * already a complete 4-param type. That is an inferred in-body expression, so the user
+ * cannot fix it by annotating the method.
+ *
+ * Fix (stubs only): the factory returns fill all 4 params (Pivot/MorphPivot + 'pivot'),
+ * and `->using()` / `->as()` re-narrow TPivotModel / TAccessor via `@return static<...>`
+ * so custom-pivot/accessor methods stay sound (no InvalidReturnStatement). The empty
+ * `--EXPECTF--` block is the oracle: every relation method below must analyse clean.
+ */
+class Tag extends Model
+{
+}
+
+class Membership extends Pivot
+{
+}
+
+class Post extends Model
+{
+    // Issue reproducer: common pivot chain, no using()/as().
+    /** @return BelongsToMany<Tag, self, Pivot, 'pivot'> */
+    public function tags(): BelongsToMany
+    {
+        return $this->belongsToMany(Tag::class, 'post_tag', 'post_id', 'tag_id')
+            ->withPivot('role')
+            ->wherePivotNull('deleted_at')
+            ->withTimestamps();
+    }
+
+    // ->as() WITHOUT ->using(): the exact shape that previously regressed to
+    // InvalidReturnStatement when the factory pinned 'pivot' — the accessor must
+    // re-narrow to 'membership' on its own.
+    /** @return BelongsToMany<Tag, self, Pivot, 'membership'> */
+    public function asOnly(): BelongsToMany
+    {
+        return $this->belongsToMany(Tag::class)->as('membership')->withPivot('role');
+    }
+
+    // ->using() only: TPivotModel narrows, accessor keeps the 'pivot' default.
+    /** @return BelongsToMany<Tag, self, Membership, 'pivot'> */
+    public function usingOnly(): BelongsToMany
+    {
+        return $this->belongsToMany(Tag::class)->using(Membership::class);
+    }
+
+    // ->using() AND ->as(): both pivot slots re-narrow through the chain.
+    /** @return BelongsToMany<Tag, self, Membership, 'membership'> */
+    public function customPivotAndAccessor(): BelongsToMany
+    {
+        return $this->belongsToMany(Tag::class)
+            ->using(Membership::class)
+            ->as('membership')
+            ->withPivot('role');
+    }
+
+    // A @mixin Builder method (where()) chained AFTER ->using()/->as(): the narrowed
+    // `static<...>` must survive a Builder-forwarded call (guards against a Builder&static
+    // collapse, a recurring failure mode in this plugin).
+    /** @return BelongsToMany<Tag, self, Membership, 'membership'> */
+    public function customThenBuilder(): BelongsToMany
+    {
+        return $this->belongsToMany(Tag::class)
+            ->using(Membership::class)
+            ->as('membership')
+            ->where('active', true)
+            ->withPivot('role');
+    }
+
+    // morphToMany: per-relation pivot default is MorphPivot.
+    /** @return MorphToMany<Tag, self, MorphPivot, 'pivot'> */
+    public function morphTags(): MorphToMany
+    {
+        return $this->morphToMany(Tag::class, 'taggable')->withTimestamps();
+    }
+
+    // morphToMany with a custom pivot + accessor.
+    /** @return MorphToMany<Tag, self, Membership, 'meta'> */
+    public function morphCustom(): MorphToMany
+    {
+        return $this->morphToMany(Tag::class, 'taggable')
+            ->using(Membership::class)
+            ->as('meta');
+    }
+
+    // morphedByMany: per-relation pivot default is MorphPivot.
+    /** @return MorphToMany<Tag, self, MorphPivot, 'pivot'> */
+    public function taggedThings(): MorphToMany
+    {
+        return $this->morphedByMany(Tag::class, 'taggable')->withPivot('x');
+    }
+}
+
+// External call sites still resolve through ModelRelationReturnTypeHandler; the in-body
+// fix and the handler agree on the 4-param shape (handler emission wins at the call site).
+function probe_external(Post $post): void
+{
+    $_common = $post->tags();
+    /** @psalm-check-type-exact $_common = BelongsToMany<Tag, Post, Pivot, 'pivot'> */
+
+    $_custom = $post->customPivotAndAccessor();
+    /** @psalm-check-type-exact $_custom = BelongsToMany<Tag, Post, Membership, 'membership'> */
+}
+
+?>
+--EXPECTF--

--- a/tests/Type/tests/Relation/RelationFactoryChainCollapseFamilyTest.phpt
+++ b/tests/Type/tests/Relation/RelationFactoryChainCollapseFamilyTest.phpt
@@ -11,23 +11,20 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
+use Illuminate\Database\Eloquent\Relations\MorphPivot;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 
 /**
  * @see https://github.com/psalm/psalm-plugin-laravel/issues/913
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1088
  *
  * Companion to BelongsToChainSelfTemplateCollapseTest, widening regression coverage from
- * belongsTo() to the WHOLE relation-factory family. The #913 fix is live on this branch
- * (`$this` -> `static` in the HasRelationships factory returns + covariant TDeclaringModel),
- * so chaining a Builder/Relation method directly off a raw factory call no longer collapses to
- * `mixed`. Every non-pivot factory below resolves cleanly (zero output).
- *
- * Two relations still emit one diagnostic each: the pivot factories belongsToMany() and
- * morphToMany() resolve to the stub's 2-arg BelongsToMany/MorphToMany, but those classes declare
- * 4 templates with the last two (TPivotModel/TAccessor) defaulted, and Psalm 7 does not honor
- * @template defaults for a partial generic -> MissingTemplateParam. This is the documented pivot
- * limitation (tracked upstream: vimeo/psalm#5407 and PR vimeo/psalm#11790); it is intentionally
- * reported rather than silently completed, since pinning the accessor would break ->as() overrides.
+ * belongsTo() to the WHOLE relation-factory family. The #913 fix in PR #1055 (`$this` -> `static`
+ * in the HasRelationships factory returns + covariant TDeclaringModel) stops a chained factory
+ * call from collapsing to `mixed`; the #1088 fix fills the pivot factories' returns to the full
+ * 4-param shape, so belongsToMany()/morphToMany() no longer trip MissingTemplateParam either.
+ * Every factory below now resolves cleanly (zero output).
  */
 class Tag extends Model
 {
@@ -83,13 +80,13 @@ class Garage extends Model
         return $this->hasManyThrough(Car::class, Mechanic::class)->withoutGlobalScopes();
     }
 
-    /** @return BelongsToMany<Tag, self> */
+    /** @return BelongsToMany<Tag, self, Pivot, 'pivot'> */
     public function tags(): BelongsToMany
     {
         return $this->belongsToMany(Tag::class)->withoutGlobalScopes();
     }
 
-    /** @return MorphToMany<Tag, self> */
+    /** @return MorphToMany<Tag, self, MorphPivot, 'pivot'> */
     public function tagsMorph(): MorphToMany
     {
         return $this->morphToMany(Tag::class, 'taggable')->withoutGlobalScopes();
@@ -98,5 +95,3 @@ class Garage extends Model
 
 ?>
 --EXPECTF--
-MissingTemplateParam on line %d: Illuminate\Database\Eloquent\Relations\BelongsToMany has missing template params, expecting 4
-MissingTemplateParam on line %d: Illuminate\Database\Eloquent\Relations\MorphToMany has missing template params, expecting 4

--- a/tests/Type/tests/Relation/RelationStubKnownLimitationsTest.phpt
+++ b/tests/Type/tests/Relation/RelationStubKnownLimitationsTest.phpt
@@ -6,43 +6,23 @@
 namespace Tests\Psalm\LaravelPlugin\Sandbox\RelationLimits;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 /**
- * Pins the two known Psalm-7 limitations that the #913 fix exposes. Both used to be hidden behind
- * the `mixed` collapse; once relation chains resolve to real types, Psalm type-checks the relation
- * method return expressions and these surface. Neither is a plugin bug. This test asserts the
- * CURRENT (limited) output so it flips loudly when the upstream fix lands.
+ * Pins the morphTo() related-type limitation that the #913 fix exposes. It used to be hidden
+ * behind the `mixed` collapse; once relation chains resolve to real types, Psalm type-checks the
+ * morphTo() return expression and this surfaces. It is NOT a plugin bug. This test asserts the
+ * CURRENT (limited) output so it flips loudly when a future morph-map-aware resolver lands.
  *
- * Limitation 1 (pivot relations, MissingTemplateParam): belongsToMany()/morphToMany() resolve to
- * the stub's 2-arg BelongsToMany<TRelated, static>, but the class declares 4 templates (the last
- * two, TPivotModel/TAccessor, defaulted). Psalm 7 does not honor @template defaults for a partial
- * generic, so a chained pivot relation trips MissingTemplateParam. Laravel itself ships under-filled
- * @returns (3-of-4) that pass under PHPStan/Larastan, which honor the defaults. The return must NOT
- * be "completed" to 4 args: pinning TAccessor='pivot' false-positives legitimate ->as('name')
- * overrides (Psalm's @psalm-this-out generic narrowing is also inert). Tracked upstream:
- * vimeo/psalm#5407 (support template default types) and PR vimeo/psalm#11790.
+ * (The sibling pivot limitation — belongsToMany()/morphToMany() chains tripping
+ * MissingTemplateParam — is fixed as of #1088; see Issue1088PivotChainInBodyTest.)
  *
- * Limitation 2 (morphTo narrowed related type): morphTo()'s target is resolved at runtime via the
- * morph map, so the stub can only return MorphTo<Model, static>. An app @return that narrows the
- * related side (a union or intersection) is more specific than the stub can prove, so it mismatches.
- * Inherent to polymorphic relations; resolvable app-side (widen the annotation) or by a future
- * morph-map-aware resolver in the plugin, not by a stub or Psalm variance change.
+ * morphTo()'s target is resolved at runtime via the morph map, so the stub can only return
+ * MorphTo<Model, static>. An app @return that narrows the related side (a union or intersection)
+ * is more specific than the stub can prove, so it mismatches. Inherent to polymorphic relations;
+ * resolvable app-side (widen the annotation) or by a future morph-map-aware resolver in the
+ * plugin, not by a stub or Psalm variance change.
  */
-class Tag extends Model
-{
-}
-
-class Post extends Model
-{
-    /** @return BelongsToMany<Tag, self> */
-    public function tags(): BelongsToMany
-    {
-        return $this->belongsToMany(Tag::class)->withTimestamps();
-    }
-}
-
 class Comment extends Model
 {
 }
@@ -62,7 +42,5 @@ class Reaction extends Model
 
 ?>
 --EXPECTF--
-MissingTemplateParam on line %d: Illuminate\Database\Eloquent\Relations\BelongsToMany has missing template params, expecting 4
-MissingTemplateParam on line %d: Illuminate\Database\Eloquent\Relations\BelongsToMany has missing template params, expecting 4
 MoreSpecificReturnType on line %d: The declared return type 'Illuminate\Database\Eloquent\Relations\MorphTo<Tests\Psalm\LaravelPlugin\Sandbox\RelationLimits\Article|Tests\Psalm\LaravelPlugin\Sandbox\RelationLimits\Comment, Tests\Psalm\LaravelPlugin\Sandbox\RelationLimits\Reaction>' for Tests\Psalm\LaravelPlugin\Sandbox\RelationLimits\Reaction::target is more specific than the inferred return type 'Illuminate\Database\Eloquent\Relations\MorphTo<Illuminate\Database\Eloquent\Model, Tests\Psalm\LaravelPlugin\Sandbox\RelationLimits\Reaction&static>'
 LessSpecificReturnStatement on line %d: The type 'Illuminate\Database\Eloquent\Relations\MorphTo<Illuminate\Database\Eloquent\Model, Tests\Psalm\LaravelPlugin\Sandbox\RelationLimits\Reaction&static>' is more general than the declared return type 'Illuminate\Database\Eloquent\Relations\MorphTo<Tests\Psalm\LaravelPlugin\Sandbox\RelationLimits\Article|Tests\Psalm\LaravelPlugin\Sandbox\RelationLimits\Comment, Tests\Psalm\LaravelPlugin\Sandbox\RelationLimits\Reaction>' for Tests\Psalm\LaravelPlugin\Sandbox\RelationLimits\Reaction::target


### PR DESCRIPTION
## Issue to Solve

After #1055 replaced `$this` with `static` in the relation factory stub returns, a pivot relation chain written inside a relation method body (for example `belongsToMany(...)->withPivot()->wherePivotNull()->withTimestamps()`) tripped `MissingTemplateParam` on the return statement, even when the method's own `@return` was already a complete 4 parameter type. The diagnostic fires on the inferred in-body expression, so a user cannot fix it by annotating the method.

Root cause: the factory stubs returned a 2 of 4 `BelongsToMany` / `MorphToMany`, but those classes declare 4 templates (the last two defaulted). Psalm 7 does not honor `@template` defaults for a partial generic (vimeo/psalm#5407), so the 2 of 4 in-body expression is flagged.

## Related

Fixes #1088. Follow up to #913 and #1055.

## Solution Description

Pure stub fix, no handler.

- `HasRelationships` factory returns now fill all four template params. `belongsToMany()` returns `BelongsToMany<TRelatedModel, static, Pivot, 'pivot'>`; `morphToMany()` and `morphedByMany()` return `MorphToMany<TRelatedModel, static, MorphPivot, 'pivot'>`.
- `BelongsToMany::using()` and a new `BelongsToMany::as()` stub use `@return static<...>` to re-narrow `TPivotModel` / `TAccessor` through a chain, so methods that customize the pivot or accessor (`->using(CustomPivot::class)`, `->as('membership')`) stay sound instead of regressing to `InvalidReturnStatement` (the failure mode observed and reverted during #1055).

Why `@return static<...>` rather than `@psalm-this-out`: the latter did not thread the narrowing through chained calls in Psalm 7, whereas the templated `static` return does (and `MorphToMany` inherits it correctly, staying `MorphToMany<...>`).

Verified:

- New type test `Issue1088PivotChainInBodyTest` covers the common chain, `->as()` without `->using()` (the shape that previously regressed when the accessor was pinned), `->using()` only, `->using()->as()`, a Builder method chained after the pivot mutators, and the `morphToMany` / `morphedByMany` variants, plus external call `@psalm-check-type-exact` pins.
- Three existing limitation pinning tests updated: the pivot `MissingTemplateParam` expectations are removed (now fixed), and the `morphTo()` related type limitation is kept.
- Full type suite green (493 tests), self analysis at 100% type coverage, unit suite green, `cs` and `rector` clean.

Known limitation (pre-existing, not introduced here): a model that sets a custom pivot at runtime via `protected $using` or a trait, without chaining `->using()` / `->as()`, will infer the default `Pivot` / `'pivot'`, because a stub cannot see runtime pivot config. Every chained (expressed) case is covered.

## Checklist

- [x] Tests cover the change (type test in `tests/Type/`)
