### PR TITLE
Add `$visible` and `knownProperties()` to the model metadata registry

### DIFF
--- a/src/Providers/ModelMetadata/ModelMetadata.php
+++ b/src/Providers/ModelMetadata/ModelMetadata.php
@@ -13,11 +13,8 @@ use Illuminate\Database\Eloquent\Model;
  *
  * {@see \Psalm\LaravelPlugin\Providers\ModelMetadataRegistry} populates all
  * public-readonly fields plus the `schema()`, `casts()`, `accessors()`, `mutators()`,
- * `scopes()`, and `relations()` accessors. All return pre-computed data; lazy memoization was not
- * required because the compute cost per model is small.
- *
- * `knownProperties()` is part of the stable API shape so later handler migrations don't change
- * the contract, but throws {@see \LogicException} until Phase 3 lands.
+ * `scopes()`, `relations()`, and `knownProperties()` accessors. All return pre-computed data; lazy
+ * memoization was not required because the compute cost per model is small.
  *
  * Immutability: every field is `readonly` and the class exposes no setters; the
  * object is fully populated by the builder at construction.
@@ -30,8 +27,8 @@ use Illuminate\Database\Eloquent\Model;
 final readonly class ModelMetadata
 {
     /**
-     * Attribute-name fields (`fillable` / `guarded` / `appends` / `hidden`) preserve the
-     * exact case the user declared — Eloquent's `isFillable` / `isGuarded` / `getHidden`
+     * Attribute-name fields (`fillable` / `guarded` / `appends` / `hidden` / `visible`) preserve the
+     * exact case the user declared — Eloquent's `isFillable` / `isGuarded` / `getHidden` / `getVisible`
      * do case-sensitive string comparisons, and lowercasing would diverge from runtime.
      * Same reason the `castsData` map is keyed by original-case column name.
      *
@@ -42,6 +39,7 @@ final readonly class ModelMetadata
      * @param list<string>                                  $with      Eager-load relation names from `$with`.
      * @param list<string>                                  $withCount Eager-load-count relation names from `$withCount`.
      * @param list<non-empty-string>                        $hidden
+     * @param list<non-empty-string>                        $visible   Serialization allow-list from `$visible`; when non-empty it limits `toArray()`/`toJson()` to these keys (consumed by #923).
      * @param class-string<Builder>|null                    $customBuilder    Detected via #[UseEloquentBuilder] / newEloquentBuilder() / $builder; non-templated because detection cannot recover the model type param.
      * @param class-string<EloquentCollection>|null         $customCollection Detected via #[CollectedBy] / newCollection() / $collectionClass.
      * @param array<non-empty-string, CastInfo>             $castsData Pre-computed cast map (column → CastInfo).
@@ -49,6 +47,7 @@ final readonly class ModelMetadata
      * @param array<non-empty-lowercase-string, MutatorInfo>  $mutatorsData  Pre-computed mutator map, keyed by snake_case property name; the write side of accessors (legacy `setXxxAttribute` may exist write-only).
      * @param array<non-empty-lowercase-string, ScopeInfo>    $scopesData    Pre-computed scope map, keyed by the normalized scope name (`scopePublished`/`#[Scope] published` → `published`); full-callable. Identity only — call-site `self`/`static` pinning stays in {@see \Psalm\LaravelPlugin\Handlers\Eloquent\BuilderScopeHandler}.
      * @param array<non-empty-lowercase-string, RelationInfo> $relationsData Pre-computed relation map, keyed by the lowercased relation method name. OWN-CLASS only (the AST parser resolves a relation factory call only in the receiver's own body), mirroring how the relation handlers call the parser; inherited/trait relations are served by those handlers' `getMethodReturnType` tiers.
+     * @param array<non-empty-lowercase-string, PropertyOrigins> $knownPropertiesData Pre-computed union of known property names tagged by origin; see {@see knownProperties()}.
      */
     public function __construct(
         public string $fqcn,
@@ -60,6 +59,7 @@ final readonly class ModelMetadata
         public array $with,
         public array $withCount,
         public array $hidden,
+        public array $visible,
         public ?string $connection,
         public ?string $morphAlias,
         public ?string $customBuilder,
@@ -70,6 +70,7 @@ final readonly class ModelMetadata
         private array $mutatorsData,
         private array $scopesData,
         private array $relationsData,
+        private array $knownPropertiesData,
     ) {}
 
     public function schema(): TableSchema
@@ -141,17 +142,30 @@ final readonly class ModelMetadata
     }
 
     /**
-     * Union of all "known" property names the model exposes, each tagged with
-     * its origin(s). Consumed by the #699 unknown-key detector.
+     * Union of the "known" property names the model exposes, each tagged with its origin(s) so a
+     * consumer decides per context which origins count (the #699 unknown-key detector is the first).
+     *
+     * Keys are normalized through {@see \Psalm\LaravelPlugin\Util\EloquentModelMethods::accessorPropertyKey()}
+     * (separators stripped, lowercased), so a `full_name` column and a `fullName()` accessor merge into
+     * one `fullname` entry carrying both {@see PropertyOrigin::SchemaColumn} and {@see PropertyOrigin::Accessor}.
+     * Sources: schema columns, casts, accessors, mutators (incl. write-only), relations, and `$appends`.
+     * `$fillable` / `$guarded` are deliberately NOT sources — they are a guard-list over columns, not an
+     * independent supply of attribute names — and docblock `@property` names are not parsed yet.
+     *
+     * The set is not exhaustive in two known ways, so a consumer must not treat a single model's set as
+     * complete: (1) with migrations disabled
+     * ({@see \Psalm\LaravelPlugin\Providers\SchemaStateProvider::getSchema()} is null) the schema-column
+     * origins are absent, so an unknown-key check must not treat the column set as authoritative in that
+     * mode (it would flag valid column keys as unknown); (2) the `relations` source is OWN-CLASS only
+     * (see {@see relations()}), so a relation inherited from a parent or trait is absent here even though
+     * it is a readable property — unlike the accessor / mutator / scope sources, which are full-callable.
+     * A consumer needing inherited relations must supplement via the relation handlers' inheritance-aware
+     * `getMethodReturnType` tiers.
      *
      * @return array<non-empty-lowercase-string, PropertyOrigins>
-     * @psalm-pure
-     * @throws \LogicException until Phase 3 lands — see the ModelMetadataRegistry design doc §7.
      */
     public function knownProperties(): array
     {
-        throw new \LogicException(
-            'ModelMetadata::knownProperties() is not yet implemented — deferred to Phase 3 of the registry migration.',
-        );
+        return $this->knownPropertiesData;
     }
 }

--- a/src/Providers/ModelMetadata/ModelMetadataRegistryBuilder.php
+++ b/src/Providers/ModelMetadata/ModelMetadataRegistryBuilder.php
@@ -253,6 +253,11 @@ final class ModelMetadataRegistryBuilder
         // storage-only method metadata above — so they are computed separately, not in the walk.
         $relations = self::computeRelations($codebase, $modelFqcn, $storage);
 
+        // Casts and appends are each needed twice — as their own field AND as a knownProperties()
+        // source — so compute each once into a local rather than re-deriving for the second use.
+        $casts = self::computeCasts($codebase, $modelFqcn, $instance, $traits, $tableSchema);
+        $appends = self::filterStringList($instance->getAppends());
+
         return new ModelMetadata(
             fqcn: $modelFqcn,
             primaryKey: self::computePrimaryKey($instance, $traits),
@@ -262,27 +267,31 @@ final class ModelMetadataRegistryBuilder
             // initializeModelAttributes(), so these getters reflect property declarations only. A future
             // phase that wires a consumer for these fields must run those initializers first.
             //
-            // Preserve case — Laravel's isFillable / isGuarded / getHidden do exact-string
+            // Preserve case — Laravel's isFillable / isGuarded / getHidden / getVisible do exact-string
             // comparisons, so lowercasing would diverge from runtime semantics.
             fillable: self::filterStringList($instance->getFillable()),
             // asArray() guards Laravel's `$guarded = false` ("guard nothing") idiom — getGuarded()
             // then returns a bool, not an array, and would TypeError filterStringList()'s array param,
             // crashing warm-up for the whole model (e.g. laravel/passport's models). #591.
             guarded: self::filterStringList(self::asArray($instance->getGuarded())),
-            appends: self::filterStringList($instance->getAppends()),
+            appends: $appends,
             with: self::readStringList($instance, 'with'),
             withCount: self::readStringList($instance, 'withCount'),
             hidden: self::filterStringList($instance->getHidden()),
+            // getVisible() always returns an array (no `$visible = false` idiom, unlike $guarded), so
+            // it needs no asArray() guard. Non-empty $visible is Eloquent's serialization allow-list.
+            visible: self::filterStringList($instance->getVisible()),
             connection: $instance->getConnectionName(),
             morphAlias: self::computeMorphAlias($modelFqcn),
             customBuilder: $customBuilder,
             customCollection: $customCollection,
             schemaData: $tableSchema,
-            castsData: self::computeCasts($codebase, $modelFqcn, $instance, $traits, $tableSchema),
+            castsData: $casts,
             accessorsData: $accessors,
             mutatorsData: $mutators,
             scopesData: $scopes,
             relationsData: $relations,
+            knownPropertiesData: self::computeKnownProperties($tableSchema, $casts, $accessors, $mutators, $relations, $appends),
         );
     }
 
@@ -321,6 +330,13 @@ final class ModelMetadataRegistryBuilder
         // a concrete model (AST + storage, no instantiation).
         $relations = self::computeRelations($codebase, $modelFqcn, $storage);
 
+        // Schema and casts are instance-derived — empty for an abstract base (no instance, no table).
+        // Hoist the empty schema + the declared $appends so both the fields AND knownProperties()
+        // read the same values (knownProperties is still meaningful here: accessors/relations/appends
+        // declared on the abstract base populate it).
+        $schema = new TableSchema([]);
+        $appends = self::stringListDefault($defaults, 'appends');
+
         return new ModelMetadata(
             fqcn: $modelFqcn,
             primaryKey: self::computePrimaryKeyFromDefaults($defaults),
@@ -329,21 +345,23 @@ final class ModelMetadataRegistryBuilder
             // Laravel's base Model defaults $guarded to ['*'] (guard-all); the default-property
             // read returns exactly that, so no special-casing is needed here.
             guarded: self::stringListDefault($defaults, 'guarded'),
-            appends: self::stringListDefault($defaults, 'appends'),
+            appends: $appends,
             with: self::stringListDefault($defaults, 'with'),
             withCount: self::stringListDefault($defaults, 'withCount'),
             hidden: self::stringListDefault($defaults, 'hidden'),
+            visible: self::stringListDefault($defaults, 'visible'),
             // Instance-derived — empty for an abstract base (no instance, no table).
             connection: null,
             morphAlias: self::computeMorphAlias($modelFqcn),
             customBuilder: $customBuilder,
             customCollection: $customCollection,
-            schemaData: new TableSchema([]),
+            schemaData: $schema,
             castsData: [],
             accessorsData: $accessors,
             mutatorsData: $mutators,
             scopesData: $scopes,
             relationsData: $relations,
+            knownPropertiesData: self::computeKnownProperties($schema, [], $accessors, $mutators, $relations, $appends),
         );
     }
 
@@ -739,6 +757,76 @@ final class ModelMetadataRegistryBuilder
         }
 
         return false;
+    }
+
+    /**
+     * Build the origin-tagged union of known property names. See {@see ModelMetadata::knownProperties()}
+     * for the contract (key normalization, the source list, and the `$fillable`/`$guarded`/`@property`
+     * exclusions). The schema, casts, accessors, mutators, and relations passed here are the very maps
+     * stored on the same {@see ModelMetadata}, so this is a pure fold over already-derived data — no
+     * reflection or Codebase access.
+     *
+     * @param array<non-empty-string, CastInfo>               $casts
+     * @param array<non-empty-lowercase-string, AccessorInfo> $accessors
+     * @param array<non-empty-lowercase-string, MutatorInfo>  $mutators
+     * @param array<non-empty-lowercase-string, RelationInfo> $relations
+     * @param list<non-empty-string>                          $appends
+     * @return array<non-empty-lowercase-string, PropertyOrigins>
+     */
+    private static function computeKnownProperties(
+        TableSchema $schema,
+        array $casts,
+        array $accessors,
+        array $mutators,
+        array $relations,
+        array $appends,
+    ): array {
+        /** @var array<non-empty-lowercase-string, PropertyOrigins> $known */
+        $known = [];
+
+        foreach (\array_keys($schema->all()) as $column) {
+            self::tagKnownProperty($known, $column, PropertyOrigin::SchemaColumn);
+        }
+
+        foreach (\array_keys($casts) as $column) {
+            self::tagKnownProperty($known, $column, PropertyOrigin::Cast);
+        }
+
+        foreach (\array_keys($accessors) as $property) {
+            self::tagKnownProperty($known, $property, PropertyOrigin::Accessor);
+        }
+
+        foreach (\array_keys($mutators) as $property) {
+            self::tagKnownProperty($known, $property, PropertyOrigin::Mutator);
+        }
+
+        foreach (\array_keys($relations) as $relation) {
+            self::tagKnownProperty($known, $relation, PropertyOrigin::Relation);
+        }
+
+        foreach ($appends as $appended) {
+            self::tagKnownProperty($known, $appended, PropertyOrigin::Appended);
+        }
+
+        return $known;
+    }
+
+    /**
+     * Merge one raw property name into the known-property accumulator under its normalized key,
+     * adding $origin to the (possibly new) {@see PropertyOrigins} set. A name that normalizes to the
+     * empty string is dropped. Mirrors {@see insertAccessor}'s by-ref accumulator convention.
+     *
+     * @param array<non-empty-lowercase-string, PropertyOrigins> $known
+     * @param-out array<non-empty-lowercase-string, PropertyOrigins> $known
+     */
+    private static function tagKnownProperty(array &$known, string $rawName, PropertyOrigin $origin): void
+    {
+        $key = EloquentModelMethods::accessorPropertyKey($rawName);
+        if ($key === null) {
+            return;
+        }
+
+        $known[$key] = ($known[$key] ?? new PropertyOrigins([]))->with($origin);
     }
 
     /** @psalm-mutation-free */

--- a/tests/Unit/Fixtures/Models/ScalarFieldsModel.php
+++ b/tests/Unit/Fixtures/Models/ScalarFieldsModel.php
@@ -23,6 +23,13 @@ final class ScalarFieldsModel extends Model
 
     protected $hidden = ['Password'];
 
+    // Non-empty $visible is Eloquent's serialization allow-list, applied BEFORE $hidden:
+    // getArrayableItems() intersects on $visible, then subtracts $hidden, so for a key in BOTH lists
+    // $hidden still wins. The registry captures the raw declared list verbatim; resolving
+    // visible-vs-hidden is the serialization-shape consumer's job (#923), so the case is preserved
+    // like the other lists.
+    protected $visible = ['Name', 'EMAIL'];
+
     protected $appends = ['FullName'];
 
     // Mixed-case cast key locks the case-preservation invariant on the cast map.

--- a/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
+++ b/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
@@ -47,6 +47,7 @@ use Psalm\LaravelPlugin\Providers\ModelMetadata\ModelMetadata;
 use Psalm\LaravelPlugin\Providers\ModelMetadata\ModelMetadataRegistryBuilder;
 use Psalm\LaravelPlugin\Providers\ModelMetadata\PrimaryKeyInfo;
 use Psalm\LaravelPlugin\Providers\ModelMetadata\PrimaryKeyType;
+use Psalm\LaravelPlugin\Providers\ModelMetadata\PropertyOrigin;
 use Psalm\LaravelPlugin\Providers\ModelMetadata\RelationInfo;
 use Psalm\LaravelPlugin\Providers\ModelMetadata\TableSchema;
 use Psalm\LaravelPlugin\Providers\ModelMetadata\TraitFlags;
@@ -373,6 +374,11 @@ final class ModelMetadataRegistryTest extends TestCase
         ModelMetadataRegistryBuilder::warmUp($codebase, AbstractDocument::class);
 
         $this->assertArrayHasKey('referencecode', $this->metadataFor(AbstractDocument::class)->accessors());
+        // The abstract path feeds the same storage-derived accessor into knownProperties() — no
+        // instance required — so an abstract base exposes a populated, origin-tagged property set too.
+        $this->assertTrue(
+            $this->metadataFor(AbstractDocument::class)->knownProperties()['referencecode']->has(PropertyOrigin::Accessor),
+        );
     }
 
     #[Test]
@@ -648,6 +654,7 @@ final class ModelMetadataRegistryTest extends TestCase
         $this->assertSame(['Name', 'EMAIL'], $metadata->fillable);
         $this->assertSame(['Id'], $metadata->guarded);
         $this->assertSame(['Password'], $metadata->hidden);
+        $this->assertSame(['Name', 'EMAIL'], $metadata->visible);
         $this->assertSame(['FullName'], $metadata->appends);
         $this->assertSame(['primaryAuthor'], $metadata->with);
         $this->assertSame(['approvedComments'], $metadata->withCount);
@@ -937,12 +944,57 @@ final class ModelMetadataRegistryTest extends TestCase
     }
 
     #[Test]
-    public function phase_3_known_properties_throws_logic_exception(): void
+    public function known_properties_merge_and_collapse_origins_across_sources(): void
     {
-        $metadata = $this->makeStubMetadata(WorkOrder::class);
+        // `full_name` is named three independent ways — a schema column, a legacy accessor, and a
+        // $appends entry — and accessorPropertyKey() collapses every spelling to the same `fullname`
+        // key, so the three origins must land on ONE entry rather than fragmenting into
+        // full_name / fullname / FullName. The remaining sources (cast, write-only mutator) each
+        // contribute their own key + origin.
+        $this->seedSchema('scalar_fields_models', [
+            new SchemaColumn('id', SchemaColumn::TYPE_INT),
+            new SchemaColumn('full_name', SchemaColumn::TYPE_STRING),
+        ]);
+        $codebase = $this->makeCodebase();
+        $storage = $this->registerStorage(ScalarFieldsModel::class);
+        $this->defineAppearingMethod($storage, 'getFullNameAttribute', Type::getString());
+        $this->defineAppearingMethod($storage, 'setNicknameAttribute', Type::getVoid());
 
-        $this->expectException(\LogicException::class);
-        $metadata->knownProperties();
+        ModelMetadataRegistryBuilder::warmUp($codebase, ScalarFieldsModel::class);
+        $known = $this->metadataFor(ScalarFieldsModel::class)->knownProperties();
+
+        // Triple merge onto one collapsed key — no fragmentation into the un-collapsed spelling.
+        $this->assertArrayHasKey('fullname', $known);
+        $this->assertTrue($known['fullname']->has(PropertyOrigin::SchemaColumn));
+        $this->assertTrue($known['fullname']->has(PropertyOrigin::Accessor));
+        $this->assertTrue($known['fullname']->has(PropertyOrigin::Appended));
+        $this->assertArrayNotHasKey('full_name', $known);
+
+        // Each remaining source contributes its own origin.
+        $this->assertArrayHasKey('id', $known);
+        $this->assertTrue($known['id']->has(PropertyOrigin::SchemaColumn));
+        $this->assertArrayHasKey('createdat', $known);            // from $casts ['CreatedAt' => ...]
+        $this->assertTrue($known['createdat']->has(PropertyOrigin::Cast));
+        $this->assertArrayHasKey('nickname', $known);             // write-only setNicknameAttribute()
+        $this->assertTrue($known['nickname']->has(PropertyOrigin::Mutator));
+    }
+
+    #[Test]
+    public function known_properties_excludes_fillable_only_names(): void
+    {
+        // No schema seeded and no accessor/relation wired: only $casts (CreatedAt) and $appends
+        // (FullName) supply names. $fillable (Name / EMAIL) is a guard-list over columns, not an
+        // independent name source, so its entries must NOT surface as known properties.
+        $codebase = $this->makeCodebase();
+        $this->registerStorage(ScalarFieldsModel::class);
+
+        ModelMetadataRegistryBuilder::warmUp($codebase, ScalarFieldsModel::class);
+        $known = $this->metadataFor(ScalarFieldsModel::class)->knownProperties();
+
+        $this->assertArrayHasKey('createdat', $known);
+        $this->assertArrayHasKey('fullname', $known);
+        $this->assertArrayNotHasKey('name', $known);
+        $this->assertArrayNotHasKey('email', $known);
     }
 
     // ---------------------------------------------------------------------
@@ -1104,6 +1156,7 @@ final class ModelMetadataRegistryTest extends TestCase
             with: [],
             withCount: [],
             hidden: [],
+            visible: [],
             connection: null,
             morphAlias: null,
             customBuilder: null,
@@ -1114,6 +1167,7 @@ final class ModelMetadataRegistryTest extends TestCase
             mutatorsData: [],
             scopesData: [],
             relationsData: $relations,
+            knownPropertiesData: [],
         );
     }
 }


### PR DESCRIPTION
## Issue to Solve

The Eloquent handlers' Phase 3 consumers need two pieces of per-model metadata that the registry did not yet expose. This PR adds them as groundwork. It ships no new diagnostics or handlers; those land in follow-up PRs.

## Related

Part of #591. Groundwork for #923 (`$visible`) and #699 (`knownProperties()`). Stacked on #1081, and should merge after it.

## Solution Description

Two additions to the registry's per-model metadata surface.

1. A `visible` field on `ModelMetadata`, populated from `getVisible()` (and from the declared default on abstract bases), mirroring how `hidden` is read. This is groundwork for #923, which infers a precise `toArray()` / `attributesToArray()` shape that must honor a non-empty `$visible` allow-list. `getVisible()` always returns an array (there is no `$visible = false` idiom, unlike `$guarded`), so it needs no `asArray()` guard.

2. `ModelMetadata::knownProperties()`, previously a throwing stub, now returns the origin-tagged union of known property names. This is groundwork for #699 (unknown-key detection in `create()` / `fill()` / `update()`). It folds schema columns, casts, accessors, mutators (including write-only), relations, and `$appends`, each tagged by `PropertyOrigin`. `$fillable` and `$guarded` are excluded, because they are guard-lists over existing columns rather than an independent supply of attribute names.

Design notes:

* `knownProperties()` is eager-stored. It is computed once in the builder during warm-up (parent process, copy-on-write shared to workers) and returned from a readonly field, matching the sibling getters (`casts()`, `accessors()`, `relations()`, and so on). This keeps `ModelMetadata` `final readonly` / `@psalm-immutable`. The fold is a cheap pass over maps the builder already derived, so eager computation costs little.
* Keys normalize through `EloquentModelMethods::accessorPropertyKey()` (separators stripped, lowercased), so a `full_name` column and a `fullName()` accessor merge under one origin-tagged `fullname` entry. The collapse errs toward false negatives, which is the safe direction for an unknown-key detector.
* The set is documented as non-exhaustive in two ways (migrations disabled hides column origins, and `relations()` is own-class only), so the future #699 consumer does not treat a single model's set as authoritative.

Verification: the full unit suite (843), the type suite (494), Psalm self-analysis at 100% type coverage, coding style, Rector, and the fresh-app integration test all pass. Reviewed via `/psalm-review` (two rounds). A `/psalm-delta` against the #1081 base across 18 real-world apps showed zero attributable issue movement (the only delta, two fewer issues on filament, is the documented multi-thread flakiness on that app, not a PR effect). This confirms warm-up reads `getVisible()` and computes `knownProperties()` for every model without dropping any registry entry.

## Checklist

- [x] Tests cover the change (unit tests in `tests/Unit/Providers/ModelMetadata/`)
