### PR TITLE
Narrow `FilesystemAdapter` listing methods to `list<string>`

### DIFF
--- a/stubs/common/Filesystem/FilesystemAdapter.phpstub
+++ b/stubs/common/Filesystem/FilesystemAdapter.phpstub
@@ -319,7 +319,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      *
      * @param  string|null  $directory
      * @param  bool  $recursive
-     * @return array
+     * @return list<string>
      *
      * @psalm-taint-sink file $directory
      */
@@ -329,7 +329,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      * Get all of the files from the given directory (recursive).
      *
      * @param  string|null  $directory
-     * @return array
+     * @return list<string>
      *
      * @psalm-taint-sink file $directory
      */
@@ -340,7 +340,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      *
      * @param  string|null  $directory
      * @param  bool  $recursive
-     * @return array
+     * @return list<string>
      *
      * @psalm-taint-sink file $directory
      */
@@ -350,7 +350,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      * Get all the directories within a given directory (recursive).
      *
      * @param  string|null  $directory
-     * @return array
+     * @return list<string>
      *
      * @psalm-taint-sink file $directory
      */

--- a/tests/Type/tests/Facades/StorageListingReturnsListTest.phpt
+++ b/tests/Type/tests/Facades/StorageListingReturnsListTest.phpt
@@ -1,0 +1,70 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * `Storage::disk()` narrows to the concrete `FilesystemAdapter` (#802), so its
+ * directory-listing methods resolve to the adapter's own implementations. Each
+ * of `files()` / `allFiles()` / `directories()` / `allDirectories()` builds its
+ * result as `listContents(...)->filter(...)->map(fn (StorageAttributes $a) =>
+ * $a->path())->toArray()`, where `StorageAttributes::path(): string` and
+ * Flysystem's `DirectoryListing::toArray()` is `iterator_to_array(..., false)`
+ * (preserve_keys = false → sequential reindex). So the runtime value is provably
+ * `list<string>`, not the bare `array` Laravel's own docblock declares.
+ *
+ * Laravel's `@return array` (and Larastan, which does not narrow these at all)
+ * leaves the element type `mixed`, which surfaces as `MixedAssignment` /
+ * `MixedArgument` floods on `foreach (Storage::disk(...)->files() as $f)` in
+ * real apps. The `list<string>` stub kills those at the source.
+ */
+
+function test_files_returns_list_of_strings(): array
+{
+    $files = Storage::disk('local')->files();
+    /** @psalm-check-type-exact $files = list<string> */
+
+    return $files;
+}
+
+function test_all_files_returns_list_of_strings(): array
+{
+    $files = Storage::disk('local')->allFiles();
+    /** @psalm-check-type-exact $files = list<string> */
+
+    return $files;
+}
+
+function test_directories_returns_list_of_strings(): array
+{
+    $dirs = Storage::disk('local')->directories();
+    /** @psalm-check-type-exact $dirs = list<string> */
+
+    return $dirs;
+}
+
+function test_all_directories_returns_list_of_strings(): array
+{
+    $dirs = Storage::disk('local')->allDirectories();
+    /** @psalm-check-type-exact $dirs = list<string> */
+
+    return $dirs;
+}
+
+/**
+ * The element type is now `string`, so a `foreach` body no longer leaks `mixed`.
+ * The loop variable flows into a string sink with no `MixedArgument`.
+ */
+function test_foreach_over_files_yields_string(): string
+{
+    $out = '';
+    foreach (Storage::disk('local')->files() as $file) {
+        /** @psalm-check-type-exact $file = string */
+        $out .= $file;
+    }
+
+    return $out;
+}
+
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

`Storage::disk()` now resolves to the concrete `\Illuminate\Filesystem\FilesystemAdapter` (#802). Its directory-listing methods (`files()`, `allFiles()`, `directories()`, `allDirectories()`) carry Laravel's bare `@return array` docblock, which Psalm expands to `array<array-key, mixed>`. So iterating a listing leaks `mixed`:

```php
foreach (Storage::disk('ssh-mux')->files() as $file) {
    // $file is mixed -> MixedAssignment, then MixedArgument on every use
}
```

On the v4.13.2 -> v4.14.0 benchmark this surfaced as 6 new `Mixed*` findings in coolify alone (`CleanupStaleMultiplexedConnections` `$muxFile` x3, `ProductionSeeder` `$coolify_key` x3), and similar noise lands in any app that lists disk contents.

## Related

Follow-up to #802.

## Solution Description

Narrow all four listing methods in `stubs/common/Filesystem/FilesystemAdapter.phpstub` from `@return array` to `@return list<string>`.

This is provable from Laravel + Flysystem source, not a guess:

- Each method is `listContents(...)->filter(...)->map(fn (StorageAttributes $a) => $a->path())->toArray()`.
- `\League\Flysystem\StorageAttributes::path(): string` -> elements are `string`.
- `\League\Flysystem\DirectoryListing::toArray()` is `iterator_to_array($this->listing, false)` (preserve_keys = false), so keys are reindexed sequentially -> `list`.

No polymorphism risk: the only subclasses (`AwsS3V3Adapter`, `LocalFilesystemAdapter`) inherit `files()` without overriding it. Larastan does not narrow these methods at all (its Storage extensions only resolve the disk object to `FilesystemAdapter`), so `list<string>` is strictly more precise than both Laravel's own docblock and Larastan.

Verified on the frozen coolify benchmark app (plugin symlinked to this branch): the 6 `Mixed*` findings disappear. `ProductionSeeder.php:82` correctly regains a `RiskyTruthyFalsyComparison` on `null|string` (a real finding that was masked once `$coolify_key` went `mixed`).

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
