### PR TITLE
Surface a degraded Laravel boot instead of silently running inert

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -223,6 +223,16 @@ Set this to `true` to throw the exception instead.
 **Recommended for CI.** Without this, a misconfigured environment causes the plugin to silently disable itself — your pipeline passes but without any plugin analysis.
 With `failOnInternalError`, the Psalm run fails immediately, so you know the plugin isn't working.
 
+### Degraded boot
+
+The plugin boots your real Laravel application to read its configuration, models, and bindings. To stay crash resistant, it tolerates a `bootstrap()` failure (for example a `config/*.php` file that fatals during evaluation, such as a computation over an unset `env()` value): rather than disabling the plugin for the whole run, it keeps going on a partially booted application.
+
+That partial boot is now surfaced. A normal `psalm` run prints a `DEGRADED mode` warning that names the originating error, because the later boot stages were skipped and the partial application is missing its configured service providers, facade bindings, and migration schema, which produces false positive `Undefined*` / `Mixed*` findings and lower type coverage. Run `vendor/bin/psalm-laravel diagnose` for the full boot report.
+
+With `failOnInternalError` set to `true`, a tolerated `bootstrap()` failure is treated as an internal error and stops the run (the same as any other boot failure), instead of analysing on a half booted application.
+
+Note on `--no-progress`: that flag selects a renderer that discards plugin warnings, so a run using it is silent about a degraded boot by default. CI setups that pass `--no-progress` should also set `failOnInternalError`, which stops the run through a channel that stays visible regardless of progress mode.
+
 ### Example
 
 ```xml

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -12,6 +12,7 @@ use Psalm\LaravelPlugin\Providers\ApplicationProvider;
 use Psalm\LaravelPlugin\Providers\CarbonStubProvider;
 use Psalm\LaravelPlugin\Providers\FacadeMapProvider;
 use Psalm\LaravelPlugin\Providers\SchemaStateProvider;
+use Psalm\LaravelPlugin\Util\BootstrapDegradationReporter;
 use Psalm\LaravelPlugin\Util\InternalErrorReporter;
 use Psalm\LaravelPlugin\Util\StubFileFinder;
 use Psalm\Plugin\PluginEntryPointInterface;
@@ -33,7 +34,39 @@ final class Plugin implements PluginEntryPointInterface
         try {
             ApplicationProvider::bootApp();
 
-            if ($pluginConfig->shouldUseMigrations()) {
+            // #1096: ApplicationProvider tolerates a throwable from `bootstrap()` (so one bad
+            // config/*.php cannot disable the plugin for the whole run) by swallowing it and
+            // continuing with a partially-booted app. That degraded state — handlers running
+            // inert with no providers, model metadata, or facade bindings, yet a clean-looking
+            // run — used to be observable only via `bin/psalm-laravel diagnose`. Surface it here,
+            // where $output and $pluginConfig are in scope, before any handler is registered.
+            $bootstrapError = ApplicationProvider::getBootstrapError();
+            if ($bootstrapError instanceof \Throwable) {
+                if ($pluginConfig->failOnInternalError) {
+                    // The user opted into failing on internal errors, and a half-booted app is one.
+                    // Rethrow so the shared catch routes it through InternalErrorReporter, which —
+                    // because failOnInternalError is on — rethrows and stops the Psalm run (Psalm
+                    // wraps it as a ConfigException). Thrown before registerHandlers() so we never
+                    // half-register handlers we are about to abandon.
+                    throw $bootstrapError;
+                }
+
+                // Crash-resistant default: keep analysing on the partial app, but make the
+                // degradation loud instead of silent.
+                BootstrapDegradationReporter::warn($bootstrapError, $output);
+            }
+
+            // Skip migration-schema building on a degraded boot. It resolves the `migrator`
+            // binding, which a partial app never registered (RegisterProviders did not run),
+            // so on a degraded app it throws and re-enters the catch below as a generic
+            // "plugin disabled" InternalErrorReporter error — burying the clearer degraded
+            // signal above under a stack trace. Skipping it lets the remaining handlers still
+            // register and run (inert for model metadata) instead of disabling the plugin.
+            // The init steps below already tolerate a partial app (they use bound() guards or
+            // only touch the filesystem); a new step that resolves a binding an unbooted app
+            // lacks must guard the degraded case the same way, or it will surface here as a
+            // misleading "disabled" error rather than the degraded warning.
+            if (!$bootstrapError instanceof \Throwable && $pluginConfig->shouldUseMigrations()) {
                 $this->buildSchema($pluginConfig);
             }
 

--- a/src/Util/BootstrapDegradationReporter.php
+++ b/src/Util/BootstrapDegradationReporter.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Util;
+
+use Psalm\Progress\Progress;
+
+/**
+ * Surfaces a *tolerated* (swallowed) Laravel bootstrap failure as a loud warning.
+ *
+ * {@see \Psalm\LaravelPlugin\Providers\ApplicationProvider::doGetApp()} deliberately
+ * catches a throwable from `$consoleApp->bootstrap()` — typically a `config/*.php` file
+ * that fatals during evaluation (e.g. `parse_url(env('UNSET_VAR'))` returning null on
+ * PHP 8.1+) — so one bad config file does not disable the plugin for the whole run.
+ *
+ * The cost of that crash-resistance is that the app is left *partially booted*: the later
+ * bootstrappers (RegisterFacades, RegisterProviders, BootProviders) never ran, so the
+ * plugin has no service-provider bindings, no model metadata, and no facade map. Handlers
+ * then run effectively inert and Psalm reports a misleadingly clean run — the failure used
+ * to be observable only via `bin/psalm-laravel diagnose` (#1096).
+ *
+ * This reporter makes that degraded state visible from a normal `psalm` run without
+ * sacrificing crash-resistance. It is intentionally **warn-only**: escalating a degraded
+ * boot to a hard failure is the caller's decision, gated on
+ * {@see \Psalm\LaravelPlugin\Config\PluginConfig::$failOnInternalError} in
+ * {@see \Psalm\LaravelPlugin\Plugin::__invoke()}.
+ *
+ * Sibling of {@see InternalErrorReporter} (which handles the plugin-is-fully-disabled case);
+ * both compose {@see InternalErrorClassifier} to point the user at the most likely fix site.
+ *
+ * Visibility note: `Progress::warning()` writes to STDERR under Psalm's default progress
+ * renderer, so the message shows in a normal run. `--no-progress` swaps in `VoidProgress`,
+ * which swallows it — the same pre-existing blind spot {@see InternalErrorReporter} has.
+ * CI users who run `--no-progress` should pair it with `failOnInternalError`, which fails
+ * the run through a channel that is visible regardless of progress mode.
+ *
+ * @internal
+ */
+final class BootstrapDegradationReporter
+{
+    public static function warn(\Throwable $bootstrapError, Progress $output): void
+    {
+        $output->warning(
+            'Laravel plugin: running in DEGRADED mode. Your application booted only partially because '
+            . 'bootstrap() threw and the plugin tolerated it. Later boot stages were skipped, so configured '
+            . 'service providers, facade bindings, and migration schema can be missing, which produces '
+            . 'false-positive Undefined*/Mixed* findings and lower type coverage than a healthy boot. '
+            . 'Cause: ' . $bootstrapError->getMessage(),
+        );
+
+        // Best-effort classification — points at the most likely fix site (the user's
+        // config/provider, the framework, Testbench, or the plugin itself).
+        $hint = InternalErrorClassifier::hint($bootstrapError);
+        if ($hint !== null) {
+            $output->warning('Laravel plugin: ' . $hint);
+        }
+
+        $output->warning(
+            'Laravel plugin: run `vendor/bin/psalm-laravel diagnose` for the full boot report. '
+            . 'Set <failOnInternalError value="true" /> in your psalm.xml plugin config to fail the run '
+            . 'instead of degrading silently (recommended for CI).',
+        );
+    }
+}

--- a/tests/Unit/Fixtures/DegradedBootstrap/app/Probe.php
+++ b/tests/Unit/Fixtures/DegradedBootstrap/app/Probe.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+/**
+ * A trivial project file so Psalm has something to scan. Its findings are irrelevant —
+ * the test asserts on the plugin's degraded-boot warning (stderr), not on analysis output.
+ */
+final class Probe
+{
+    public function run(): string
+    {
+        return 'ok';
+    }
+}

--- a/tests/Unit/Fixtures/DegradedBootstrap/bootstrap/app.php
+++ b/tests/Unit/Fixtures/DegradedBootstrap/bootstrap/app.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Application;
+
+// A real bootstrap/app.php so the plugin takes the bootstrap-file branch (not the
+// Testbench fallback). The returned Application is not yet bootstrapped; the plugin's
+// $consoleApp->bootstrap() drives LoadConfiguration over config/*.php, where bad.php
+// fatals — exercising the swallowed-bootstrap path the test guards (#1096).
+return Application::configure(basePath: dirname(__DIR__))->create();

--- a/tests/Unit/Fixtures/DegradedBootstrap/config/bad.php
+++ b/tests/Unit/Fixtures/DegradedBootstrap/config/bad.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+// Simulates a config/*.php that fatals while LoadConfiguration evaluates it, aborting
+// bootstrap() (the #1096 mechanism). intdiv(1, 0) throws DivisionByZeroError on every
+// supported PHP version regardless of typing mode, so it is a deterministic stand-in for
+// the issue's real parse_url(env('UNSET')) case (which throws a TypeError only under
+// declare(strict_types=1); in coercive mode PHP 8.1+ only deprecates it instead of throwing).
+return [
+    'value' => intdiv(1, 0),
+];

--- a/tests/Unit/Fixtures/DegradedBootstrap/psalm-fail.xml
+++ b/tests/Unit/Fixtures/DegradedBootstrap/psalm-fail.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+>
+    <projectFiles>
+        <directory name="app" />
+    </projectFiles>
+    <plugins>
+        <pluginClass class="Psalm\LaravelPlugin\Plugin">
+            <failOnInternalError value="true" />
+        </pluginClass>
+    </plugins>
+</psalm>

--- a/tests/Unit/Fixtures/DegradedBootstrap/psalm.xml
+++ b/tests/Unit/Fixtures/DegradedBootstrap/psalm.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+>
+    <projectFiles>
+        <directory name="app" />
+    </projectFiles>
+    <plugins>
+        <pluginClass class="Psalm\LaravelPlugin\Plugin" />
+    </plugins>
+</psalm>

--- a/tests/Unit/PluginBootstrapDegradationTest.php
+++ b/tests/Unit/PluginBootstrapDegradationTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Plugin;
+use Psalm\LaravelPlugin\Util\BootstrapDegradationReporter;
+use Symfony\Component\Process\Process;
+
+/**
+ * End-to-end guard for #1096: a Laravel `bootstrap()` failure that {@see \Psalm\LaravelPlugin\Providers\ApplicationProvider}
+ * swallows to stay crash-resistant must not leave the plugin silently inert.
+ *
+ * Why a real Psalm subprocess instead of a phpt or an in-process unit test: the degraded
+ * state lives in {@see \Psalm\LaravelPlugin\Providers\ApplicationProvider}'s process-global
+ * boot, and the signal is a `Progress::warning()` written to STDERR — neither is observable
+ * from psalm-tester (which captures issue output) nor from an in-process call without a boot
+ * seam. This points a real `vendor/bin/psalm` at a fixture whose `config/bad.php` fatals
+ * during `LoadConfiguration`, the way the UNIT3D repro in the issue does.
+ *
+ * Progress note: the run deliberately omits `--no-progress`. Psalm swaps in `VoidProgress`
+ * for `--no-progress`, and `VoidProgress::write()` is a no-op that would swallow the warning;
+ * the default progress renderer writes warnings to STDERR, which is the "normal run" the
+ * acceptance criterion targets.
+ *
+ * Placement note: like {@see \Tests\Psalm\LaravelPlugin\Unit\Handlers\SuppressScopeUnusedCodeTest},
+ * this forks a real psalm subprocess (it boots Laravel via the plugin, a few seconds) because
+ * the behaviour cannot be observed in-process.
+ */
+#[CoversClass(Plugin::class)]
+#[CoversClass(BootstrapDegradationReporter::class)]
+final class PluginBootstrapDegradationTest extends TestCase
+{
+    #[Test]
+    public function it_surfaces_a_degraded_boot_warning_from_a_normal_run(): void
+    {
+        $process = $this->runPsalmOnFixture('psalm.xml');
+
+        $stderr = $process->getErrorOutput();
+        $combined = $process->getOutput() . "\n" . $stderr;
+
+        // Acceptance #1: the degraded state is visible without running `diagnose`.
+        $this->assertStringContainsString('DEGRADED', $stderr, "Degraded-boot warning missing from STDERR.\n{$combined}");
+        $this->assertStringContainsString('Division by zero', $stderr, 'The originating cause should be named.');
+
+        // Acceptance #3: crash-resistance preserved. A tolerated boot failure does NOT abort
+        // the run via the plugin-invoke boundary (that is the failOnInternalError path, below).
+        $this->assertStringNotContainsString('Failed to invoke plugin', $combined, "A degraded boot must not hard-fail plugin invocation when failOnInternalError is off.\n{$combined}");
+
+        // The degraded path must stay DEGRADED, not collapse into "disabled". This guards the
+        // buildSchema() skip in Plugin::__invoke: without it, building the migration schema on the
+        // partial app resolves the absent `migrator` binding, throws, and routes through
+        // InternalErrorReporter ("has been disabled for this run") instead, burying the signal.
+        $this->assertStringNotContainsString('has been disabled for this run', $combined, "Degraded boot must not collapse into the disabled path.\n{$combined}");
+    }
+
+    #[Test]
+    public function it_stops_the_run_when_fail_on_internal_error_is_enabled(): void
+    {
+        $process = $this->runPsalmOnFixture('psalm-fail.xml');
+
+        $combined = $process->getOutput() . "\n" . $process->getErrorOutput();
+
+        // Acceptance #2: with failOnInternalError, the swallowed bootstrap failure is reportable —
+        // it propagates out of the plugin and Psalm stops the run (non-zero exit) instead of
+        // analysing on a half-booted app.
+        $this->assertNotSame(0, $process->getExitCode(), "Psalm should have stopped with a non-zero exit.\n{$combined}");
+        $this->assertStringContainsString('Failed to invoke plugin', $combined, "The run should stop at plugin invocation with the bootstrap failure surfaced.\n{$combined}");
+
+        // "Reportable" means the originating cause is preserved, not a generic wrapper. Psalm
+        // prints "Failed to invoke plugin" for any plugin throwable, so assert the real cause too,
+        // guarding that __invoke rethrows the actual bootstrap error rather than something generic.
+        $this->assertStringContainsString('Division by zero', $combined, "The originating bootstrap cause should be surfaced.\n{$combined}");
+    }
+
+    private function runPsalmOnFixture(string $configFile): Process
+    {
+        $projectRoot = \dirname(__DIR__, 2);
+        $fixtureDir = __DIR__ . '/Fixtures/DegradedBootstrap';
+        $psalmBinary = $projectRoot . '/vendor/bin/psalm';
+
+        $this->assertFileExists($psalmBinary, 'Psalm binary not found — run composer install.');
+
+        // No --no-progress on purpose: it would select VoidProgress and swallow the warning.
+        $process = new Process(
+            [\PHP_BINARY, $psalmBinary, '-c', $configFile, '--no-cache', '--threads=1'],
+            $fixtureDir,
+        );
+        $process->setTimeout(300);
+        // Psalm exits non-zero when it reports issues or stops on a config error; both are
+        // expected across these cases, so do not mustRun().
+        $process->run();
+
+        return $process;
+    }
+}

--- a/tests/Unit/Util/BootstrapDegradationReporterTest.php
+++ b/tests/Unit/Util/BootstrapDegradationReporterTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Util;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Util\BootstrapDegradationReporter;
+use Psalm\LaravelPlugin\Util\InternalErrorClassifier;
+use Psalm\Progress\Phase;
+use Psalm\Progress\Progress;
+
+#[CoversClass(BootstrapDegradationReporter::class)]
+#[CoversClass(InternalErrorClassifier::class)]
+final class BootstrapDegradationReporterTest extends TestCase
+{
+    #[Test]
+    public function it_warns_with_the_cause_and_remediation_without_claiming_the_plugin_is_disabled(): void
+    {
+        $output = $this->capturingProgress();
+
+        BootstrapDegradationReporter::warn(
+            new \RuntimeException('parse_url(): Argument #1 ($url) must be of type string, null given'),
+            $output,
+        );
+
+        $joined = \implode("\n", $output->warnings);
+
+        // The signal: names the degraded mode and the originating cause.
+        $this->assertStringContainsString('DEGRADED', $joined);
+        $this->assertStringContainsString('parse_url(): Argument #1 ($url) must be of type string, null given', $joined);
+
+        // Remediation: points at diagnose and the opt-in to fail instead of degrade.
+        $this->assertStringContainsString('psalm-laravel diagnose', $joined);
+        $this->assertStringContainsString('failOnInternalError', $joined);
+
+        // Distinct from InternalErrorReporter: a degraded run keeps going, it is NOT disabled.
+        $this->assertStringNotContainsStringIgnoringCase('disabled', $joined);
+    }
+
+    #[Test]
+    public function it_includes_a_classifier_hint_pointing_at_the_fix_site(): void
+    {
+        $output = $this->capturingProgress();
+
+        // A throwable raised here carries this test file as its origin, so the classifier
+        // resolves the "application code" bucket — proving the hint line is wired in.
+        BootstrapDegradationReporter::warn(new \LogicException('boom'), $output);
+
+        $joined = \implode("\n", $output->warnings);
+        $hint = InternalErrorClassifier::hint(new \LogicException('boom'));
+
+        $this->assertNotNull($hint, 'Expected the classifier to produce a hint for this origin.');
+        $this->assertStringContainsString($hint, $joined);
+    }
+
+    /**
+     * A {@see Progress} double that records every line written through `warning()`.
+     *
+     * `warning()` is concrete on the base class and delegates to `write()`, so overriding
+     * `write()` captures the full rendered line. The remaining abstract members are no-ops.
+     *
+     * @return Progress&object{warnings: list<string>}
+     */
+    private function capturingProgress(): Progress
+    {
+        return new class extends Progress {
+            /** @var list<string> */
+            public array $warnings = [];
+
+            #[\Override]
+            public function write(string $message): void
+            {
+                $this->warnings[] = $message;
+            }
+
+            #[\Override]
+            public function debug(string $message): void {}
+
+            #[\Override]
+            public function startPhase(Phase $phase, int $threads = 1): void {}
+
+            #[\Override]
+            public function expand(int $number_of_tasks): void {}
+
+            #[\Override]
+            public function taskDone(int $level): void {}
+
+            #[\Override]
+            public function finish(): void {}
+
+            #[\Override]
+            public function alterFileDone(string $file_name): void {}
+        };
+    }
+}


### PR DESCRIPTION
## Issue to Solve

When the analyzed app's `bootstrap()` throws partway (for example a `config/*.php` that fatals during evaluation), `ApplicationProvider` catches and swallows it to stay crash resistant and returns a partially booted app. Service providers never register, so the plugin runs effectively inert (no model metadata, facade bindings, or migration schema), yet Psalm reports a clean, successful run, even with `failOnInternalError=true`. The degraded state was observable only via `bin/psalm-laravel diagnose`. The `failOnInternalError` docs even promised it catches "failing to boot the Laravel app", but this tolerated partial boot escaped it.

## Related

Closes #1096
Related: #766 (silent Testbench / degraded-boot fallback).

## Solution Description

`Plugin::__invoke()` now inspects `ApplicationProvider::getBootstrapError()` right after `bootApp()`:

- `failOnInternalError=true`: rethrow the original throwable through the existing `InternalErrorReporter` path, so Psalm stops the run (wrapped as a `ConfigException`), the same as any other boot failure. The originating cause is preserved.
- otherwise: emit a `DEGRADED mode` warning (new `BootstrapDegradationReporter`, warn only) that names the cause and the likely fix site (reusing `InternalErrorClassifier`) and points at `psalm-laravel diagnose`. Analysis continues on the partial app, so crash resistance is preserved.

Migration schema building is skipped on a degraded boot, because the `migrator` binding is absent on a partial app and would otherwise crash into a generic "disabled" error that buries the degraded signal.

Visibility: the warning uses `Progress::warning()`, which the default renderer writes to STDERR. `--no-progress` selects `VoidProgress`, which discards it (the same pre-existing blind spot `InternalErrorReporter` has), so CI runs that pass `--no-progress` should pair it with `failOnInternalError`, which stops the run through Psalm's progress independent channel. A direct STDERR write was considered and declined (it would be unsilenceable and absent from structured output).

Verified with: a unit test for the reporter, and an e2e subprocess test (`PluginBootstrapDegradationTest`) that runs real Psalm against a fixture whose `config/*.php` fatals, asserting (1) the degraded warning surfaces and the run does not collapse into "disabled", and (2) `failOnInternalError=true` stops the run with the cause preserved. Full unit and type suites plus `composer psalm` self analysis (100% coverage) pass.

Deferred (noted for a follow-up, not in this PR): on the `failOnInternalError` path the rethrow reuses `InternalErrorReporter`'s generic "report this issue" URL, which is misleading for a user config caused boot failure. This is pre-existing for any config caused boot failure, and the classifier hint already points the user at their own application code.

## Checklist
- [x] Tests cover the change (unit test in `tests/Unit/Util/`, e2e subprocess test in `tests/Unit/`)
- [x] Documentation is updated (`docs/config.md`, new "Degraded boot" section)
