### PR TITLE
Honor case-insensitive validation taint reads

### DIFF
--- a/src/Handlers/Validation/FormRequestPropertyHandler.php
+++ b/src/Handlers/Validation/FormRequestPropertyHandler.php
@@ -63,6 +63,12 @@ final class FormRequestPropertyHandler implements AfterCodebasePopulatedInterfac
     #[\Override]
     public static function afterCodebasePopulated(AfterCodebasePopulatedEvent $event): void
     {
+        // Psalm can run the plugin more than once in a long-lived process
+        // (language server / test harnesses). Rebuild the registry from the
+        // current populated codebase instead of carrying stale rule answers.
+        self::$formRequestClasses = [];
+        self::$cache = [];
+
         $codebase = $event->getCodebase();
         $formRequestFqcn = \strtolower(FormRequest::class);
 

--- a/src/Handlers/Validation/InlineValidateRulesCollector.php
+++ b/src/Handlers/Validation/InlineValidateRulesCollector.php
@@ -219,8 +219,7 @@ final class InlineValidateRulesCollector implements
      * Sourced from {@see ValidatedFieldReadResolver::KEYED_ACCESSOR_METHODS}
      * so the two handlers share a single definition for the same data
      * flow — the variable binding is the same flow with one extra hop.
-     * Names are in canonical Laravel casing; non-canonical casing is
-     * rejected for consistency with the sibling handler.
+     * Names are lowercase because PHP method names are case-insensitive.
      */
     private const KEYED_ACCESSOR_METHODS = ValidatedFieldReadResolver::KEYED_ACCESSOR_METHODS;
 
@@ -509,15 +508,11 @@ final class InlineValidateRulesCollector implements
             return null;
         }
 
-        // Canonical Laravel casing — direct string comparison avoids a
-        // strtolower() allocation on every MethodCall in the project. PHP
-        // method names are technically case-insensitive, but callers of
-        // these Laravel macros always write them in canonical camelCase.
-        $rawName = $expr->name->name;
+        $methodName = $expr->name->toLowerString();
 
-        if ($rawName === 'validate') {
+        if ($methodName === 'validate') {
             $rulesArgIndex = 0;
-        } elseif ($rawName === 'validateWithBag') {
+        } elseif ($methodName === 'validatewithbag') {
             $rulesArgIndex = 1;
         } else {
             return null;
@@ -737,7 +732,7 @@ final class InlineValidateRulesCollector implements
             return null;
         }
 
-        if (!\in_array($rhs->name->name, self::KEYED_ACCESSOR_METHODS, true)) {
+        if (!\in_array($rhs->name->toLowerString(), self::KEYED_ACCESSOR_METHODS, true)) {
             return null;
         }
 

--- a/src/Handlers/Validation/ValidatedFieldReadResolver.php
+++ b/src/Handlers/Validation/ValidatedFieldReadResolver.php
@@ -39,10 +39,9 @@ final class ValidatedFieldReadResolver
 {
     /**
      * Accessor methods whose single-key form selects a rule-covered field.
-     * Canonical Laravel casing only — the camelCase convention is universal in
-     * practice, and skipping `strtolower()` keeps this off the per-expression
-     * allocation path. `public` so {@see InlineValidateRulesCollector} shares
-     * one definition (same flow, one extra hop).
+     * Stored lowercase because PHP method names are case-insensitive. `public`
+     * so {@see InlineValidateRulesCollector} shares one definition (same flow,
+     * one extra hop).
      *
      * @internal shared only with {@see InlineValidateRulesCollector}.
      */
@@ -72,7 +71,7 @@ final class ValidatedFieldReadResolver
         }
 
         if ($expr instanceof MethodCall && $expr->name instanceof Identifier) {
-            return self::fromMethodCall($event, $expr, $expr->name->name);
+            return self::fromMethodCall($event, $expr, $expr->name->toLowerString());
         }
 
         return null;

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestUppercaseInputEmailEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestUppercaseInputEmailEscapesHeader.phpt
@@ -1,0 +1,40 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * PHP method names are case-insensitive. The validation return-type handler
+ * already receives lowercase method names from Psalm, but the v4.14 taint
+ * resolver originally inspected the source spelling and missed this shape.
+ */
+final class UppercaseInputEmailRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['email' => ['required', 'email']];
+    }
+
+    public function sendUserHeader(): void
+    {
+        \header('X-User: ' . $this->INPUT('email'));
+    }
+
+    public function renderUserName(): void
+    {
+        echo $this->INPUT('email');
+    }
+}
+
+function dispatch(UppercaseInputEmailRequest $request): void {
+    $request->sendUserHeader();
+    $request->renderUserName();
+}
+?>
+--EXPECTF--
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes


### PR DESCRIPTION
## Issue to Solve
The v4.14 validation taint resolver inspected validation/accessor method names using the source spelling. PHP method dispatch is case-insensitive, so unusual-but-valid calls like `$this->INPUT('email')` could miss the restored taint source/escape behavior.


## Solution Description
Normalize validation/accessor method names through `Identifier::toLowerString()` in the taint resolver and inline validation collector, keeping those paths aligned with PHP method semantics. Also clear the FormRequest property registry/cache when Psalm repopulates the codebase, avoiding stale rule answers in long-lived processes.

Verified with a new taint PHPT covering uppercase FormRequest `INPUT()` reads, plus the full type suite, unit suite, CS, and Psalm self-analysis.
