### PR TITLE
Support version-gated type tests for version-specific stubs

### DIFF
--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -125,6 +125,21 @@ Authoring an override:
 
 **Common vs version dir.** Return narrowing that holds across all versions (Laravel only improved its annotation) goes in `common`. A parameter widened by behavior present only in a newer Laravel (e.g. `firstOrNew`'s `values` taking `\Closure|array` only on 13) must go in the version dir: widening `common` would tell Psalm a call is valid that fatals at runtime on older versions (silent false negative).
 
+### Testing version-specific stubs
+
+A type test that asserts a `stubs/<version>/` override would fail on the lower cells of the CI matrix (`.github/workflows/tests.yml` runs `test:type` over `^13.0` and `^12.4`, including `prefer-lowest`), because the override does not load on the older Laravel. Gate such a test with a `--SKIPIF--` section so it runs only where the stub applies:
+
+```
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+\Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipBelow('12.42.0');
+--FILE--
+... assertion of the version-specific behavior ...
+```
+
+`LaravelVersion::skipBelow($version)` skips when the installed Laravel is older than the stub dir (`skipFrom($version)` does the reverse for behavior only on older lines). The `--SKIPIF--` script runs in a bare process from the project root, so it requires the autoloader via `getcwd()`. See `tests/Type/tests/Http/PendingRequestTest.phpt` for a worked example (the async HTTP client types are 12.42+).
+
 ## How to add a handler
 
 Handlers implement Psalm event interfaces to override type inference.

--- a/tests/Type/LaravelVersion.php
+++ b/tests/Type/LaravelVersion.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Type;
+
+use Illuminate\Foundation\Application;
+
+/**
+ * Laravel-version gate for version-specific stub tests, called from a phpt `--SKIPIF--` section.
+ *
+ * Stubs under `stubs/<version>/` load only when the installed Laravel is `>=` that version
+ * (see `StubFileFinder::stubsForLaravelVersion`). A phpt asserting such a stub must skip when the
+ * installed Laravel is older, otherwise it fails on the lower cells of the CI matrix
+ * (`.github/workflows/tests.yml` runs `test:type` over `^13.0` and `^12.4`, including `prefer-lowest`).
+ *
+ * The `--SKIPIF--` script runs in a bare `php` process from the project-root working directory with
+ * no autoloader preloaded, so require it via `getcwd()`:
+ *
+ *   --SKIPIF--
+ *   <?php
+ *   require getcwd() . '/vendor/autoload.php';
+ *   \Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipBelow('12.42.0');
+ *
+ * Each method echoes a `skip ...` message (which the runner detects) when the test must not run.
+ */
+final class LaravelVersion
+{
+    /** Skip when the installed Laravel is older than $version (the stub dir does not load there). */
+    public static function skipBelow(string $version): void
+    {
+        if (\version_compare(Application::VERSION, $version, '<')) {
+            echo 'skip needs Laravel >= ' . $version . ' (installed ' . Application::VERSION . ')';
+        }
+    }
+
+    /** Skip when the installed Laravel is $version or newer (for behavior only present on older lines). */
+    public static function skipFrom(string $version): void
+    {
+        if (\version_compare(Application::VERSION, $version, '>=')) {
+            echo 'skip needs Laravel < ' . $version . ' (installed ' . Application::VERSION . ')';
+        }
+    }
+}

--- a/tests/Type/tests/Http/PendingRequestTest.phpt
+++ b/tests/Type/tests/Http/PendingRequestTest.phpt
@@ -1,3 +1,7 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+\Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipBelow('12.42.0');
 --FILE--
 <?php declare(strict_types=1);
 


### PR DESCRIPTION
## Issue to Solve

There was no way to write a type test for a version-specific stub. Stubs under `stubs/<version>/` load only when the installed Laravel is that version or newer (`StubFileFinder::stubsForLaravelVersion`), but `test:type` runs across a CI matrix of `^13.0` and `^12.4` (including `prefer-lowest`). A `.phpt` asserting such a stub passes on the newer cell and fails on the older one, where the override does not load.

Concretely, `tests/Type/tests/Http/PendingRequestTest.phpt` asserts `async()` returns `AsyncPendingRequest` and the async HTTP methods return `LazyPromise`, both introduced in Laravel 12.42 (`stubs/12.42.0/`). It was ungated, so it would fail on the `^12.4` cell.

## Related

None.

## Solution Description

- Add `Tests\Psalm\LaravelPlugin\Type\LaravelVersion` with `skipBelow($version)` and `skipFrom($version)`, called from a phpt `--SKIPIF--` section. The runner (`PsalmTest::getSkipReason`) already honors `--SKIPIF--`; the helper makes the Laravel-version check a one-liner. The `--SKIPIF--` script runs in a bare process from the project root, so it requires the autoloader via `getcwd()`.
- Gate `tests/Type/tests/Http/PendingRequestTest.phpt` with `skipBelow('12.42.0')`, so its 12.42+ async assertions run only where the stub loads.
- Document the pattern under "Testing version-specific stubs" in the contributing docs.

Verified: the gated test runs and passes on Laravel 13.16.1; forcing the gate to an impossible version marks it skipped in the runner (`Skipped: 1`). Full type suite green (498 tests).

This unblocks type-testing the version-specific stub overrides described in `docs/contributing/README.md`.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
- [x] Documentation is updated
