### PR TITLE
Type `firstOrNew`/`updateOrCreate` closure values on Laravel 13.5+

### DIFF
--- a/stubs/13.5.0/Database/Eloquent/Builder.phpstub
+++ b/stubs/13.5.0/Database/Eloquent/Builder.phpstub
@@ -1,0 +1,51 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+use Illuminate\Contracts\Database\Eloquent\Builder as BuilderContract;
+use Illuminate\Database\Concerns\BuildsQueries;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Traits\ForwardsCalls;
+
+/**
+ * From Laravel 13.5.0+, firstOrNew() and updateOrCreate() accept a deferred-value
+ * closure for $values (12.62 still ships plain array). This override widens just
+ * those two methods; everything else merges from stubs/common/.
+ *
+ * The full class header (templates, @property-read proxies, @mixin, use-traits) is
+ * copied verbatim from common because re-declaring the class resets Psalm's
+ * interface/template metadata to whatever this declaration carries.
+ *
+ * @template-covariant TModel of \Illuminate\Database\Eloquent\Model
+ *
+ * Higher-order where proxies (`$builder->orWhere->scope()`). The `<TModel>` arg is
+ * essential and threads through to `HigherOrderBuilderProxy::__call`, which returns
+ * `Builder<TModel>` — see HigherOrderBuilderProxy.phpstub.
+ * Do NOT drop it to `@property-read HigherOrderBuilderProxy` (non-generic), nor to
+ * `@property-read static`/`$this` (Larastan's form): Psalm 7 then loses TModel in the
+ * property-read (the latter collapse to `Builder&static`) and the chained scope falls
+ * to mixed. Verified empirically.
+ * @property-read HigherOrderBuilderProxy<TModel> $orWhere
+ * @property-read HigherOrderBuilderProxy<TModel> $whereNot
+ * @property-read HigherOrderBuilderProxy<TModel> $orWhereNot
+ *
+ * @mixin \Illuminate\Database\Query\Builder
+ */
+class Builder implements BuilderContract
+{
+    use BuildsQueries, Concerns\QueriesRelationships, ForwardsCalls;
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     * @param  (\Closure(): array<string, mixed>)|array<string, mixed>  $values
+     * @return TModel
+     */
+    public function firstOrNew(array $attributes = [], \Closure|array $values = []) {}
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     * @param  (\Closure(): array<string, mixed>)|array<string, mixed>  $values
+     * @return TModel
+     */
+    public function updateOrCreate(array $attributes, \Closure|array $values = []) {}
+}

--- a/stubs/13.5.0/Database/Eloquent/Relations/BelongsToMany.phpstub
+++ b/stubs/13.5.0/Database/Eloquent/Relations/BelongsToMany.phpstub
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations;
+
+/**
+ * From Laravel 13.5.0+, firstOrNew() and updateOrCreate() accept a deferred-value
+ * closure for $values (12.62 still ships plain array). This override widens just
+ * those two methods; everything else merges from stubs/common/.
+ *
+ * The full class header (templates, @template-extends, @mixin, use-trait) is copied
+ * verbatim from common because re-declaring the class resets Psalm's
+ * interface/template metadata to whatever this declaration carries.
+ *
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * Covariant TDeclaringModel — required by #913 (see Relation.phpstub for the rationale).
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @template TPivotModel of \Illuminate\Database\Eloquent\Relations\Pivot = \Illuminate\Database\Eloquent\Relations\Pivot
+ * @template TAccessor of string = 'pivot'
+ * @template-extends Relation<TRelatedModel, TDeclaringModel, \Illuminate\Database\Eloquent\Collection<int, TRelatedModel&object{pivot: TPivotModel}>>
+ * @mixin \Illuminate\Database\Eloquent\Builder<TRelatedModel>
+ */
+class BelongsToMany extends Relation
+{
+    use Concerns\InteractsWithPivotTable;
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     * @param  (\Closure(): array<string, mixed>)|array<string, mixed>  $values
+     * @return TRelatedModel&object{pivot: TPivotModel}
+     */
+    public function firstOrNew(array $attributes = [], \Closure|array $values = []) {}
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     * @param  (\Closure(): array<string, mixed>)|array<string, mixed>  $values
+     * @param  array<string, mixed>  $joining
+     * @param  bool   $touch
+     * @return TRelatedModel&object{pivot: TPivotModel}
+     */
+    public function updateOrCreate(array $attributes, \Closure|array $values = [], array $joining = [], $touch = true) {}
+}

--- a/stubs/13.5.0/Database/Eloquent/Relations/HasOneOrMany.phpstub
+++ b/stubs/13.5.0/Database/Eloquent/Relations/HasOneOrMany.phpstub
@@ -1,0 +1,39 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Relations;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * From Laravel 13.5.0+, firstOrNew() and updateOrCreate() accept a deferred-value
+ * closure for $values (12.62 still ships plain array). This override widens just
+ * those two methods; everything else merges from stubs/common/.
+ *
+ * The full class header (templates, @template-extends, @mixin, use-imports) is copied
+ * verbatim from common because re-declaring the class resets Psalm's
+ * interface/template metadata to whatever this declaration carries.
+ *
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * Covariant TDeclaringModel — required by #913 (see Relation.phpstub for the rationale).
+ * @template-covariant TDeclaringModel of \Illuminate\Database\Eloquent\Model
+ * @template TResult
+ * @template-extends Relation<TRelatedModel, TDeclaringModel, TResult>
+ * @mixin \Illuminate\Database\Eloquent\Builder<TRelatedModel>
+ */
+abstract class HasOneOrMany extends Relation
+{
+    /**
+     * @param  array<string, mixed>  $attributes
+     * @param  (\Closure(): array<string, mixed>)|array<string, mixed>  $values
+     * @return TRelatedModel
+     */
+    public function firstOrNew(array $attributes = [], \Closure|array $values = []) {}
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     * @param  (\Closure(): array<string, mixed>)|array<string, mixed>  $values
+     * @return TRelatedModel
+     */
+    public function updateOrCreate(array $attributes, \Closure|array $values = []) {}
+}

--- a/tests/Type/tests/Eloquent/ClosureValuesL13Test.phpt
+++ b/tests/Type/tests/Eloquent/ClosureValuesL13Test.phpt
@@ -1,0 +1,50 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+\Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipBelow('13.5.0');
+--FILE--
+<?php declare(strict_types=1);
+
+// Laravel 13.5.0+ accepts a deferred-value closure for the $values argument of
+// firstOrNew()/updateOrCreate(). The stubs/13.5.0/ overrides widen $values to
+// (\Closure(): array<string, mixed>)|array<string, mixed>; this test asserts the
+// closure form is accepted (no ArgumentTypeCoercion) AND that the model/template/
+// pivot metadata still resolves through each override's copied class header.
+
+use App\Models\Customer;
+use App\Models\Part;
+use App\Models\Shop;
+use App\Models\WorkOrder;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+// Eloquent\Builder
+function test_builder(): void {
+    $_arr = Customer::query()->firstOrNew(['email' => 'a@b.c'], ['name' => 'x']);
+    /** @psalm-check-type-exact $_arr = Customer */
+
+    $_closure = Customer::query()->firstOrNew(['email' => 'a@b.c'], fn(): array => ['name' => 'x']);
+    /** @psalm-check-type-exact $_closure = Customer */
+
+    $_upd = Customer::query()->updateOrCreate(['email' => 'a@b.c'], fn(): array => ['name' => 'x']);
+    /** @psalm-check-type-exact $_upd = Customer */
+}
+
+// HasOneOrMany (via HasMany)
+function test_has_many(Shop $shop): void {
+    $_new = $shop->workOrders()->firstOrNew(['shop_id' => 1], fn(): array => ['status' => 'open']);
+    /** @psalm-check-type-exact $_new = WorkOrder */
+
+    $_upd = $shop->workOrders()->updateOrCreate(['shop_id' => 1], fn(): array => ['status' => 'open']);
+    /** @psalm-check-type-exact $_upd = WorkOrder */
+}
+
+// BelongsToMany
+function test_belongs_to_many(Shop $shop): void {
+    $_new = $shop->parts()->firstOrNew(['name' => 'bolt'], fn(): array => ['price' => 1]);
+    /** @psalm-check-type-exact $_new = Part&object{pivot: Pivot} */
+
+    $_upd = $shop->parts()->updateOrCreate(['name' => 'bolt'], fn(): array => ['price' => 1]);
+    /** @psalm-check-type-exact $_upd = Part&object{pivot: Pivot} */
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

Laravel 13.5.0 widened the `$values` argument of `firstOrNew()` and `updateOrCreate()` to accept a deferred-value closure (`(\Closure(): array)|array`). Our stubs still typed `$values` as a plain `array`, so the closure form (idiomatic on Laravel 13.5+) was rejected with `ArgumentTypeCoercion`. Laravel 12 (down to the `^12.4` floor, verified at `v12.62.0`) still ships a plain `array`, so the widening must not leak onto Laravel 12.

## Related

Part of #1103. Surfaced by the local `laravel-watch` stub-maintenance report (`v12.62.0..v13.16.1`).

## Solution Description

Add per-method overrides under `stubs/13.5.0/` (loaded only when installed Laravel `>=` 13.5.0) for `Eloquent\Builder`, `Relations\BelongsToMany`, and `Relations\HasOneOrMany`. Widening `stubs/common/` instead would be a silent false negative on Laravel 12, where the closure fatals at runtime.

- Verified the delta with the report's signature extractor against `.cache/laravel-framework` tags: `$values` is `array` at `v12.62.0` and `v13.4.0`, becomes `\Closure|array` (native) / `(\Closure(): array)|array` (doc) at `v13.5.0`, pinning `since: v13.5.0`.
- Each override copies the full class header verbatim (templates, `@template-extends`, `@mixin`, `@property-read` proxies, use-traits) so re-declaring the class does not strip Psalm's template/interface metadata.
- The `$values` docblock keeps our richer `array<string, mixed>` element type (matching the sibling `firstOrCreate`/`createOrFirst` stubs), a deliberate divergence from the bare `array` Laravel documents.
- New gated type test (`tests/Type/tests/Eloquent/ClosureValuesL13Test.phpt`) asserts the closure form is accepted and that the model/template/pivot return metadata still resolves (`Customer`, `WorkOrder`, `Part&object{pivot: Pivot}`). Gated with `LaravelVersion::skipBelow('13.5.0')` so it does not fail the `^12.4` CI matrix cell. Verified it runs (not skips) locally on Laravel 13.16.1.

`composer test:type`, `test:app`, `cs`, and `rector` all green.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)

