### PR TITLE
Type `Query\Builder::orderBy()` direction as `asc`/`desc` literals plus `SortDirection`

### DIFF
--- a/stubs/13.8.0/Database/Query/Builder.phpstub
+++ b/stubs/13.8.0/Database/Query/Builder.phpstub
@@ -1,0 +1,43 @@
+<?php
+
+namespace Illuminate\Database\Query;
+
+use Illuminate\Contracts\Database\Query\Builder as BuilderContract;
+use Illuminate\Database\Concerns\BuildsQueries;
+use Illuminate\Support\Traits\ForwardsCalls;
+use Illuminate\Support\Traits\Macroable;
+
+/**
+ * From Laravel 13.8.0+, orderBy() takes 'asc'|'desc'|\SortDirection (the PHP 8.6
+ * enum) for the direction. On Laravel 12 the enum fatals at runtime (strtolower over
+ * an enum) and the method is not version-loaded there, so this override lives in the
+ * version dir, not common.
+ *
+ * \SortDirection is always resolvable here: laravel/framework ^13.8 hard-requires
+ * symfony/polyfill-php86 (which declares the enum on PHP < 8.6), and this override only
+ * loads when Laravel >= 13.8 is installed.
+ *
+ * The common stub already types $direction as 'asc'|'desc'; this override re-states
+ * those and adds the \SortDirection member (types replace, they do not merge).
+ *
+ * The full class header (use-traits + implements) and the orderBy SQL taint sink are
+ * copied verbatim because re-declaring the class resets Psalm's metadata, and types
+ * replace while taints accumulate — both must be present in this one declaration.
+ */
+class Builder implements BuilderContract
+{
+    use BuildsQueries, ForwardsCalls, Macroable {
+        __call as macroCall;
+    }
+
+    /**
+     * Add an "order by" clause to the query.
+     *
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @param  'asc'|'desc'|\SortDirection  $direction
+     * @return $this
+     *
+     * @psalm-taint-sink sql $column
+     */
+    public function orderBy($column, $direction = 'asc') {}
+}

--- a/stubs/common/Database/Query/Builder.phpstub
+++ b/stubs/common/Database/Query/Builder.phpstub
@@ -408,8 +408,13 @@ class Builder implements BuilderContract
     /**
      * Add an "order by" clause to the query.
      *
+     * Typed as the canonical lowercase literals (not a bare `string`) to catch typos and
+     * keep parity with Larastan and Laravel 13.8's `'asc'|'desc'|\SortDirection`, where
+     * the new PHP enum canonicalizes to lowercase. Dynamic directions belong to the
+     * validation layer, not this signature. The 13.8 override adds the enum member.
+     *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Contracts\Database\Query\Expression|string  $column
-     * @param  string  $direction
+     * @param  'asc'|'desc'  $direction
      * @return $this
      *
      * @psalm-taint-sink sql $column

--- a/tests/Type/tests/Builder/BuilderTypesTest.phpt
+++ b/tests/Type/tests/Builder/BuilderTypesTest.phpt
@@ -140,7 +140,7 @@ final class EloquentBuilderCustomerRepository
 * @psalm-return Builder<Customer>
 */
 function can_call_methods_on_underlying_query_builder(Builder $builder): Builder {
-    return $builder->orderBy('id', 'ASC');
+    return $builder->orderBy('id', 'asc');
 }
 
 function test_whereDateWithDateTimeInterface(Builder $builder): Builder {

--- a/tests/Type/tests/Builder/OrderBySortDirectionL13Test.phpt
+++ b/tests/Type/tests/Builder/OrderBySortDirectionL13Test.phpt
@@ -1,0 +1,28 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+\Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipBelow('13.8.0');
+--FILE--
+<?php declare(strict_types=1);
+
+// Laravel 13.8.0+ types the orderBy() direction as 'asc'|'desc'|\SortDirection (the PHP
+// 8.6 enum). The stubs/13.8.0/ override adopts that literal verbatim and keeps the SQL
+// taint sink on $column.
+
+use App\Models\Customer;
+use Illuminate\Database\Eloquent\Builder;
+
+function test_order_by(): void {
+    // both string literals are accepted
+    $_asc = Customer::query()->orderBy('name', 'asc');
+    /** @psalm-check-type-exact $_asc = Builder<Customer>&static */
+
+    $_desc = Customer::query()->orderBy('name', 'desc');
+    /** @psalm-check-type-exact $_desc = Builder<Customer>&static */
+
+    // the new PHP 8.6 enum is accepted
+    $_enum = Customer::query()->orderBy('name', \SortDirection::Ascending);
+    /** @psalm-check-type-exact $_enum = Builder<Customer>&static */
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

`Query\Builder::orderBy()`'s `$direction` was typed as a bare `string`. Laravel 13.8 narrowed it to `'asc'|'desc'|\SortDirection` (the new PHP 8.6 enum). Typing the canonical literals catches typos, keeps parity with Larastan (which reports the same), and nudges code toward the post-upgrade form; the enum member additionally needs support on Laravel 13.8+.

## Related

Part of #1103. Surfaced by the local `laravel-watch` stub-maintenance report.

## Solution Description

- **Common (all supported versions):** type `$direction` as `'asc'|'desc'`. Laravel lowercases the direction at runtime, so the literal narrowing holds on every version; lowercase-only matches Larastan and the new PHP enum, giving dual-engine projects a consistent signal. Dynamic directions sourced from request input are the validation layer's concern, not this signature.
- **Laravel 13.8+ (`stubs/13.8.0/` override):** re-state the literals and add the `\SortDirection` member (`'asc'|'desc'|\SortDirection`). The enum fatals at runtime on Laravel 12 (`strtolower` over an enum), so it must not leak into common.

Verification:
- sig-extract against `.cache/laravel-framework`: `$direction` doc is `string` at `v13.7.0`, becomes `'asc'|'desc'|SortDirection` at `v13.8.0` (`since v13.8.0`). Resolved the enum to the PHP 8.6 global `\SortDirection`.
- `\SortDirection` is always resolvable where the override loads: `laravel/framework ^13.8` hard-requires `symfony/polyfill-php86` (verified in the framework `composer.json` at `v13.8.0`), which declares the enum on PHP < 8.6; the override only loads on Laravel >= 13.8. On Laravel 12 the override never loads, so our stubs never reference the enum there. No guard needed.
- The override copies the full class header and the `@psalm-taint-sink sql $column` annotation verbatim (re-declaring resets metadata; types replace while taints accumulate). The existing `TaintAnalysis/TaintedSqlOrderBy.phpt` exercises the override's sink on this runtime.
- Gated type test (`OrderBySortDirectionL13Test.phpt`, `skipBelow('13.8.0')`) asserts `'asc'`, `'desc'`, and `\SortDirection::Ascending` are accepted; `BuilderTypesTest.phpt` already covers the common literal path on all versions.

`Scope::apply`'s Laravel 13.7 `Builder<covariant TModel>` change was evaluated and **dropped**: Psalm 7 does not parse use-site variance in a docblock type param (reads `covariant TModel` as a class name), breaking existing scope implementations. Left as a checklist item in #1103.

Note: this narrows a high-traffic param across all versions. The only false positive is a non-`'asc'|'desc'` direction (uppercase `'ASC'`, or a dynamic `string`); these are rare for `orderBy` and align with Larastan's behavior. Broader real-app validation via `psalm-delta` is available on request.

`composer test:type`, `test:app`, `cs`, and `rector` all green.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
