### PR TITLE
Accept an `Expression` as `Query\Builder::whereRaw()` $sql

### DIFF
--- a/stubs/common/Database/Query/Builder.phpstub
+++ b/stubs/common/Database/Query/Builder.phpstub
@@ -182,7 +182,12 @@ class Builder implements BuilderContract
     /**
      * Add a raw where clause to the query.
      *
-     * @param  string  $sql
+     * Laravel documents $sql as Expression|string (the method body is unchanged across
+     * all supported versions, so this is annotation-only and safe in common). We keep
+     * `string` and add the Expression member; the literal-string Laravel 13 documents is
+     * deliberately not adopted (our taint layer guards SQLi more precisely).
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $sql
      * @param  mixed  $bindings
      * @param  string  $boolean
      * @return $this


### PR DESCRIPTION
## Issue to Solve

`Query\Builder::whereRaw()` accepts an `Expression` as `$sql`, but our stub typed it as `string` only, so `->whereRaw(DB::raw(...))` was a false-positive `ArgumentTypeCoercion`.

## Related

Part of #1103. Surfaced by the local `laravel-watch` stub-maintenance report (L13 scan, "separately and safely foldable").

## Solution Description

Add `\Illuminate\Contracts\Database\Query\Expression` to `whereRaw`'s `$sql`, keeping `string`.

- Verified with sig-extract: Laravel documents `$sql` as `Expression|string` from `v12.15.0` onward (`string` before). But the method **body is byte-identical** at `v12.4.0` and `v12.15.0` (it just stores `$sql` into `$this->wheres`), so the union is annotation-only, not a behavior change. The change therefore holds on every supported version and lives in `stubs/common/` (no version dir).
- Scoped to `whereRaw` only: checked all eight raw methods; only `whereRaw` carries the `Expression` member upstream. The siblings (`orWhereRaw`, `havingRaw`, `orHavingRaw`, `orderByRaw`, `groupByRaw`, `fromRaw`, `selectRaw`) stay `string`.
- The `@psalm-taint-sink sql $sql` annotation is preserved (the existing `TaintAnalysis/TaintedSqlWhereRaw.phpt` guards it). Laravel 13's `literal-string` tightening is deliberately **not** adopted: our taint layer guards SQLi more precisely than a literal type, which would false-positive on safe dynamic SQL.

`composer test:type`, `test:app`, `cs`, and `rector` all green.

## Checklist
- [x] Verified with a local type test (not committed — trivial additive widening; keeping CI lean per the ~5%-stub-test rule)


