### PR TITLE
Type `Filesystem::hash()` return as `non-empty-string|false`

### DIFF
--- a/stubs/common/Filesystem/Filesystem.phpstub
+++ b/stubs/common/Filesystem/Filesystem.phpstub
@@ -198,7 +198,7 @@ class Filesystem
      *
      * @param  string  $path
      * @param  string  $algorithm
-     * @return string
+     * @return non-empty-string|false
      *
      * @psalm-taint-sink file $path
      */


### PR DESCRIPTION
## Issue to Solve
`Filesystem::hash()` was stubbed as `@return string`, but its body is `return hash_file($algorithm, $path);` and PHP's `hash_file()` returns `non-empty-string|false` (false on failure). The stub was a false-negative: code that handles the failure branch (e.g. `Storage::hash(...) === false`) was wrongly flagged by Psalm as a redundant/impossible condition. As a `stubs/common/` stub, this affected Laravel 11/12/13.

## Related
Part of #1103

## Solution Description
Widen the return annotation `@return string` → `@return non-empty-string|false` on `Filesystem::hash()`. Verified against Laravel framework source: the `hash()` body is byte-identical (`return hash_file($algorithm, $path);`) across v11.54.0, v12.62.0, and v13.16.1, so the change is annotation-only and belongs in `stubs/common/`. The `@psalm-taint-sink file $path` annotation is preserved verbatim.

Verified with a throwaway type test asserting `hash()` resolves to `false|string` and that a subsequent `=== false` check is not flagged; the probe was removed before commit, per the project's stub-test policy for trivial additive annotation changes.

## Checklist
- [x] Tests cover the change (verified locally with a throwaway type test, not committed per stub-test policy)
