### PR TITLE
Accept uppercase `orderBy()` direction (`'ASC'`/`'DESC'`) on Laravel <13.8

### DIFF
--- a/stubs/13.8.0/Database/Query/Builder.phpstub
+++ b/stubs/13.8.0/Database/Query/Builder.phpstub
@@ -17,8 +17,10 @@ use Illuminate\Support\Traits\Macroable;
  * symfony/polyfill-php86 (which declares the enum on PHP < 8.6), and this override only
  * loads when Laravel >= 13.8 is installed.
  *
- * The common stub already types $direction as 'asc'|'desc'; this override re-states
- * those and adds the \SortDirection member (types replace, they do not merge).
+ * The common stub (Laravel 12–13.7) also accepts the uppercase literals 'ASC'|'DESC' that
+ * the runtime tolerates via strtolower. From 13.8 the \SortDirection enum is the canonical
+ * way to express a non-lowercase direction, so this override drops uppercase and restates
+ * the documented 'asc'|'desc'|\SortDirection (types replace, they do not merge).
  *
  * The full class header (use-traits + implements) and the orderBy SQL taint sink are
  * copied verbatim because re-declaring the class resets Psalm's metadata, and types

--- a/stubs/common/Database/Query/Builder.phpstub
+++ b/stubs/common/Database/Query/Builder.phpstub
@@ -413,13 +413,17 @@ class Builder implements BuilderContract
     /**
      * Add an "order by" clause to the query.
      *
-     * Typed as the canonical lowercase literals (not a bare `string`) to catch typos and
-     * keep parity with Larastan and Laravel 13.8's `'asc'|'desc'|\SortDirection`, where
-     * the new PHP enum canonicalizes to lowercase. Dynamic directions belong to the
-     * validation layer, not this signature. The 13.8 override adds the enum member.
+     * Typed as direction literals (not a bare `string`) to catch typos while still
+     * rejecting arbitrary strings. Both cases are accepted because the runtime
+     * canonicalizes via `strtolower($direction) === 'asc'|'desc'`, so `orderBy('x', 'DESC')`
+     * is valid and idiomatic on every supported version. This deliberately widens
+     * Laravel 13.8's documented `'asc'|'desc'|\SortDirection` (and Larastan's lowercase-only
+     * signal): matching upstream verbatim flags the extremely common uppercase form as a
+     * hard `InvalidArgument` on correct code. Dynamic directions belong to the validation
+     * layer, not this signature. The 13.8 override adds the enum member.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Illuminate\Contracts\Database\Query\Expression|string  $column
-     * @param  'asc'|'desc'  $direction
+     * @param  'asc'|'desc'|'ASC'|'DESC'  $direction
      * @return $this
      *
      * @psalm-taint-sink sql $column

--- a/tests/Type/tests/Builder/OrderBySortDirectionL13Test.phpt
+++ b/tests/Type/tests/Builder/OrderBySortDirectionL13Test.phpt
@@ -23,6 +23,12 @@ function test_order_by(): void {
     // the new PHP 8.6 enum is accepted
     $_enum = Customer::query()->orderBy('name', \SortDirection::Ascending);
     /** @psalm-check-type-exact $_enum = Builder<Customer>&static */
+
+    // From 13.8 the canonical non-lowercase form is the enum, so uppercase string literals
+    // are rejected (use \SortDirection or lowercase). The common stub still tolerates these
+    // on Laravel 12–13.7, which have no enum to canonicalize with.
+    Customer::query()->orderBy('name', 'DESC');
 }
 ?>
 --EXPECTF--
+%AInvalidArgument on line %d: Argument 2 of Illuminate\Database\Query\Builder::orderBy expects 'asc'|'desc'|SortDirection, but 'DESC' provided%A

--- a/tests/Type/tests/Builder/OrderByUppercaseCommonTest.phpt
+++ b/tests/Type/tests/Builder/OrderByUppercaseCommonTest.phpt
@@ -1,0 +1,28 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+\Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipFrom('13.8.0');
+--FILE--
+<?php declare(strict_types=1);
+
+// On Laravel 12–13.7 there is no \SortDirection enum, and the runtime canonicalizes the
+// direction via strtolower(), so the common stub accepts the uppercase literals 'ASC'|'DESC'
+// as well as the lowercase form. orderBy('x', 'DESC') is valid, idiomatic code and must not
+// raise InvalidArgument. From 13.8 the version override drops uppercase in favour of the
+// enum (see OrderBySortDirectionL13Test).
+
+use App\Models\Customer;
+use Illuminate\Database\Eloquent\Builder;
+
+function test_order_by_uppercase(): void {
+    $_asc = Customer::query()->orderBy('name', 'asc');
+    /** @psalm-check-type-exact $_asc = Builder<Customer>&static */
+
+    $_ASC = Customer::query()->orderBy('name', 'ASC');
+    /** @psalm-check-type-exact $_ASC = Builder<Customer>&static */
+
+    $_DESC = Customer::query()->orderBy('name', 'DESC');
+    /** @psalm-check-type-exact $_DESC = Builder<Customer>&static */
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve
Typing `Query\Builder::orderBy()`'s `$direction` as the lowercase-only literals `'asc'|'desc'` (#1103 / #1104) flagged the idiomatic uppercase form `orderBy('column', 'DESC')` as a hard `InvalidArgument` across real-world apps, even though it is valid at runtime: the query builder canonicalizes the direction via `strtolower($direction) === 'asc'|'desc'`.

App benchmark of `master` (v4.14.1-RC1) surfaced this as the entire regression versus v4.14.0: ~17 new `InvalidArgument` findings on bookstack, ixdf-web, pixelfed, filament (all on Laravel 12.x), all of the form "expects `'asc'|'desc'`, but `'DESC'` provided".

## Related
Follow-up to #1103 (the `orderBy` direction narrowing).

## Solution Description
Widen the **common** stub (Laravel 12-13.7) to `'asc'|'desc'|'ASC'|'DESC'`, the cases the runtime tolerates. The **13.8 override** is unchanged at `'asc'|'desc'|\SortDirection`: from Laravel 13.8 the PHP 8.6 `\SortDirection` enum is the canonical way to express a non-lowercase direction, so users on that version are nudged to the enum rather than uppercase strings.

Dynamic `string` / `array` directions (e.g. raw request input) stay flagged as before, since they are the validation layer's concern, not this signature.

Verified on the frozen app benchmark: pixelfed dropped from 3 to 1 `orderBy` `InvalidArgument` (the remaining one is `array<array-key, mixed>|string` request input, correctly still flagged). bookstack is unchanged because its new findings were `ArgumentTypeCoercion` on `string` variables, intentionally not loosened.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
  - `OrderByUppercaseCommonTest.phpt` (`skipFrom('13.8.0')`): asserts `'ASC'`/`'DESC'` accepted on Laravel 12-13.7
  - `OrderBySortDirectionL13Test.phpt`: asserts uppercase rejected on 13.8+ (canonical enum form)
