### PR TITLE
Better `tap()` support: type no-arg `tap()` higher-order form as `HigherOrderTapProxy<T>`

### DIFF
--- a/src/Handlers/Support/TappableTapHandler.php
+++ b/src/Handlers/Support/TappableTapHandler.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Support;
+
+use Illuminate\Support\HigherOrderTapProxy;
+use Illuminate\Support\Traits\Tappable;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\Type\Atomic\TGenericObject;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Union;
+
+/**
+ * Types the no-argument higher-order form of {@see Tappable::tap()} as
+ * `HigherOrderTapProxy<static>`, the precise return the stub cannot express.
+ *
+ * The stub declares `@return $this`: correct for `tap($callback)` (Laravel runs the callback
+ * and returns the instance), but only an approximation for the no-arg `tap()`, which actually
+ * returns a {@see HigherOrderTapProxy} wrapping the instance. A conditional return type in the
+ * stub does not discriminate when it overrides a reflected trait method (Psalm collapses every
+ * call to the null branch), so this handler supplies the proxy for the no-callback case and
+ * defers to the stub's `$this` otherwise.
+ *
+ * Registered on the `Tappable` trait: Psalm dispatches a method return-type provider on the
+ * declaring class, which for a trait method is the trait, so one registration covers every host
+ * (Stringable, Http\Client\Response, Uri, Mailable, Router, the paginators, …). Eloquent
+ * Models and query builders are intentionally NOT affected: their `tap()` comes from
+ * `Illuminate\Database\Concerns\BuildsQueries` (a required callback, returns the builder), a
+ * different declaring class this handler never sees.
+ *
+ * The precise receiver type (with template params) is read from the call's left-hand side via
+ * the node type provider. The proxy is generic ({@see HigherOrderTapProxy}), so a proxied call
+ * threads the target type through `__call` without any further handler.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1110
+ */
+final class TappableTapHandler implements MethodReturnTypeProviderInterface
+{
+    /**
+     * @return list<string>
+     * @psalm-pure
+     */
+    #[\Override]
+    public static function getClassLikeNames(): array
+    {
+        // The declaring class of a trait method is the trait, and Psalm dispatches on it,
+        // so this single entry covers every class that uses Tappable.
+        return [Tappable::class];
+    }
+
+    #[\Override]
+    public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        if ($event->getMethodNameLowercase() !== 'tap') {
+            return null;
+        }
+
+        $source = $event->getSource();
+        if (! $source instanceof StatementsAnalyzer) {
+            return null;
+        }
+
+        $stmt = $event->getStmt();
+        if (! $stmt instanceof MethodCall) {
+            return null;
+        }
+
+        // A real callback → tap() returns the instance ($this); the stub's `@return $this` is
+        // correct, so defer. Only the no-callback (or explicit-null) form yields the proxy.
+        $callbackIsNull = self::callbackIsNull($source, $event->getCallArgs());
+        if ($callbackIsNull === false) {
+            return null;
+        }
+
+        $receiver = $source->getNodeTypeProvider()->getType($stmt->var);
+        if (! $receiver instanceof Union) {
+            return null;
+        }
+
+        // Strip `static` from the target before embedding it as the proxy's template argument.
+        // A literal `static` atomic inside `HigherOrderTapProxy<...>` re-binds to the proxy when
+        // read back through `__call(): TClass` (yielding a bogus `Target&HigherOrderTapProxy<...>`
+        // intersection), because a handler-built concrete type is not tracked as a template
+        // substitution the way the stub's `<static>` would be.
+        $target = [];
+        foreach ($receiver->getAtomicTypes() as $atomic) {
+            $target[] = $atomic instanceof TNamedObject ? $atomic->setIsStatic(false) : $atomic;
+        }
+
+        $proxy = new TGenericObject(HigherOrderTapProxy::class, [new Union($target)]);
+
+        // A nullable callable (`callable|null`) could go either way at runtime — union the proxy
+        // with the instance so neither terminal nor chained use is mistyped.
+        if ($callbackIsNull === null) {
+            return new Union([$proxy, ...$target]);
+        }
+
+        return new Union([$proxy]);
+    }
+
+    /**
+     * Whether the callback argument is null, in three states:
+     *  - `true`  → no argument, or an argument typed exactly `null` (→ `HigherOrderTapProxy`);
+     *  - `false` → an argument with a known, non-nullable type — the real-callback case, but also
+     *              an untyped/`mixed` one (→ defer to the stub's `$this`);
+     *  - `null`  → the type is undeterminable or nullable (→ union both branches).
+     *
+     * @param list<Arg> $args
+     */
+    private static function callbackIsNull(StatementsAnalyzer $source, array $args): ?bool
+    {
+        if ($args === []) {
+            return true;
+        }
+
+        $type = $source->getNodeTypeProvider()->getType($args[0]->value);
+        if (! $type instanceof Union) {
+            return null;
+        }
+
+        if ($type->isNull()) {
+            return true;
+        }
+
+        return $type->isNullable() ? null : false;
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -198,6 +198,9 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Support/ConditionableWhenHandler.php';
         $registration->registerHooksFromClass(Handlers\Support\ConditionableWhenHandler::class);
 
+        require_once __DIR__ . '/Handlers/Support/TappableTapHandler.php';
+        $registration->registerHooksFromClass(Handlers\Support\TappableTapHandler::class);
+
         require_once __DIR__ . '/Handlers/Console/CommandArgumentHandler.php';
         $registration->registerHooksFromClass(Handlers\Console\CommandArgumentHandler::class);
 

--- a/stubs/common/Support/HigherOrderTapProxy.phpstub
+++ b/stubs/common/Support/HigherOrderTapProxy.phpstub
@@ -1,0 +1,49 @@
+<?php
+
+namespace Illuminate\Support;
+
+/**
+ * Higher-order tap proxy: the no-argument `$value->tap()` returns this proxy, and any method
+ * called on it runs that method on the target and returns the target — `$s->tap()->foo()`
+ * yields the target, never `foo()`'s own return value.
+ *
+ * Laravel's real class is NOT generic (`@var mixed $target`, `__call(): mixed`). We re-declare
+ * it WITH a `@template TClass` so the target binding survives the chain:
+ * {@see \Psalm\LaravelPlugin\Handlers\Support\TappableTapHandler} types `Tappable::tap()` as
+ * `HigherOrderTapProxy<static>`, and `__call` returns `TClass`. Every proxied call yields the
+ * same target type, so a single `@return TClass` covers it — no proxy handler needed (the
+ * `__call` stub also satisfies `sealAllMethods`).
+ *
+ * `@template-covariant` (not invariant): `TClass` appears only in output position (`__call`'s
+ * return and the read-only `$target`), so a `HigherOrderTapProxy<Sub&static>` must satisfy a
+ * declared `HigherOrderTapProxy<Sub>` — covariance accepts it, invariance would reject. Mirrors
+ * the {@see \Illuminate\Database\Eloquent\HigherOrderBuilderProxy} variance, and the same
+ * covariance convention the relation stubs follow (see Eloquent's `HasRelationships` /
+ * `Relation`). Keep `TClass` output-only (no `__construct(TClass)` here) or the covariance
+ * becomes unsound. Laravel's real `$target` is a writable `public mixed` property; exposing it as
+ * `@property-read TClass` both narrows it to the target type and keeps `TClass` out of the
+ * writable (invariant) position.
+ *
+ * Taint limitation (lenient by design, like {@see \Illuminate\Database\Eloquent\HigherOrderBuilderProxy}):
+ * a proxied call resolves to `HigherOrderTapProxy::__call`, never to the proxied method's own
+ * signature, so a parameter-level `@psalm-taint-sink` on that method is never consulted (its
+ * arguments arrive as an opaque `array<array-key, mixed>` at the dispatch boundary) and
+ * `$value->tap()->sink($tainted)` does not flag. The gap is narrow: every sink reachable via
+ * `tap()->method()` is also reachable by calling `method()` directly, where the sink still fires;
+ * and re-dispatching per-argument sinks through `__call` is not expressible in a stub. Guarded by
+ * tests/Type/tests/TaintAnalysis/SafeTapProxySinkKnownLimitation.phpt.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1110
+ *
+ * @template-covariant TClass of object
+ *
+ * @property-read TClass $target
+ */
+class HigherOrderTapProxy
+{
+    /**
+     * @param array<array-key, mixed> $parameters
+     * @return TClass
+     */
+    public function __call(string $method, array $parameters): mixed {}
+}

--- a/stubs/common/Support/Traits/Tappable.phpstub
+++ b/stubs/common/Support/Traits/Tappable.phpstub
@@ -3,16 +3,23 @@
 namespace Illuminate\Support\Traits;
 
 /**
- * Simplify return type for Tappable::tap().
+ * Refine the return type of Tappable::tap().
  *
- * Without a stub, tap() returns `mixed` because Psalm can't resolve
- * the global tap() helper's generic return type. Stubbing as `@return $this`
- * fixes fluent chains on Builder, Stringable, and other Tappable classes.
+ * Laravel's real signature is conditional: a `null` callback returns a
+ * {@see \Illuminate\Support\HigherOrderTapProxy} that forwards every call back to the
+ * target; a real callback runs it and returns the target ($this).
  *
- * Note: Laravel's own PHPDoc uses a conditional return type that distinguishes
- * null callback → HigherOrderTapProxy vs callable → $this. This simplification
- * skips that distinction because conditional return types with $this do not
- * work in Psalm 7 trait stubs.
+ * We cannot express that split in this stub. A conditional return type
+ * (`($callback is null ? HigherOrderTapProxy<static> : static)`) does NOT discriminate when
+ * it overrides a reflected trait method — Psalm collapses every call to the null branch
+ * regardless of the argument (verified on both stubbed and un-stubbed Tappable users). So the
+ * stub declares only the safe fallback `@return $this` (the callback branch), and
+ * {@see \Psalm\LaravelPlugin\Handlers\Support\TappableTapHandler} supplies the precise
+ * `HigherOrderTapProxy<static>` for the no-argument higher-order form. The proxy is stubbed
+ * generic ({@see \Illuminate\Support\HigherOrderTapProxy}) so a proxied call threads the
+ * target type natively through `__call` — no proxy handler needed.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1110
  */
 trait Tappable
 {

--- a/tests/Type/tests/ConditionableTappableTest.phpt
+++ b/tests/Type/tests/ConditionableTappableTest.phpt
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Collection;
+use Illuminate\Support\HigherOrderTapProxy;
 use Illuminate\Support\Stringable;
 
 /**
@@ -213,16 +214,17 @@ function test_stringable_tap_with_callback(): void
 }
 
 /**
- * tap() without a callback also types as $this (stub simplification).
+ * tap() without a callback returns the higher-order proxy generic over the target.
  *
- * At runtime Laravel returns HigherOrderTapProxy for the null case.
- * The stub approximates this as $this to avoid mixed collapse — acceptable
- * because HigherOrderTapProxy proxies all calls back to the original object.
+ * TappableTapHandler supplies this (a conditional return type in the stub cannot
+ * discriminate the callback / no-callback branches when overriding a reflected trait).
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1110
  */
 function test_tap_without_callback(): void
 {
     $_result = (new Stringable('hello'))->tap();
-    /** @psalm-check-type-exact $_result = Stringable&static */
+    /** @psalm-check-type-exact $_result = HigherOrderTapProxy<Stringable> */
 }
 /**
  * tap() on Http\Client\Response (another Tappable user) confirms trait-level application

--- a/tests/Type/tests/HigherOrderTapProxySealedTest.phpt
+++ b/tests/Type/tests/HigherOrderTapProxySealedTest.phpt
@@ -1,0 +1,25 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm-sealed.xml
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\HigherOrderTapProxy;
+use Illuminate\Support\Stringable;
+
+/**
+ * Under sealAllMethods, a proxied call must resolve through HigherOrderTapProxy::__call rather
+ * than raise UndefinedMagicMethod — the generic stub carries `__call`, so no proxy handler is
+ * needed even in sealed mode.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1110
+ */
+function tap_proxy_sealed_chain(): void
+{
+    $_proxy = (new Stringable('x'))->tap();
+    /** @psalm-check-type-exact $_proxy = HigherOrderTapProxy<Stringable> */
+
+    $_target = (new Stringable('x'))->tap()->upper();
+    /** @psalm-check-type-exact $_target = Stringable */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/HigherOrderTapProxyTest.phpt
+++ b/tests/Type/tests/HigherOrderTapProxyTest.phpt
@@ -1,0 +1,98 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\HigherOrderTapProxy;
+use Illuminate\Support\Stringable;
+
+/**
+ * The no-arg higher-order form of Tappable::tap() — typed by TappableTapHandler as a generic
+ * HigherOrderTapProxy over the target, with `__call` threading the target type back.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1110
+ */
+
+/** No-arg tap() yields the proxy, generic over the target. */
+function tap_proxy_noarg(): void
+{
+    $_r = (new Stringable('x'))->tap();
+    /** @psalm-check-type-exact $_r = HigherOrderTapProxy<Stringable> */
+}
+
+/** A proxied call returns the TARGET, not the called method's own return — and never errors. */
+function tap_proxy_chained_returns_target(): void
+{
+    $_fluent = (new Stringable('x'))->tap()->upper();
+    /** @psalm-check-type-exact $_fluent = Stringable */
+
+    // isEmpty() normally returns bool; through the proxy it returns the target instead.
+    $_nonFluent = (new Stringable('x'))->tap()->isEmpty();
+    /** @psalm-check-type-exact $_nonFluent = Stringable */
+}
+
+/** The proxy exposes the target via $target. */
+function tap_proxy_target_property(): void
+{
+    $_r = (new Stringable('x'))->tap()->target;
+    /** @psalm-check-type-exact $_r = Stringable */
+}
+
+/** tap() with a callback still returns the instance — no proxy. */
+function tap_proxy_with_callback(): void
+{
+    $_r = (new Stringable('x'))->tap(static function (Stringable $s): void {
+        echo (string) $s;
+    });
+    /** @psalm-check-type-exact $_r = Stringable&static */
+}
+
+/** Works for any direct Tappable user, e.g. Http\Client\Response. */
+function tap_proxy_on_response(Response $response): void
+{
+    $_proxy = $response->tap();
+    /** @psalm-check-type-exact $_proxy = HigherOrderTapProxy<Response> */
+
+    $_target = $response->tap()->status();
+    /** @psalm-check-type-exact $_target = Response */
+}
+
+/** A nullable callable could be either branch at runtime → union of proxy and instance. */
+function tap_proxy_nullable_callback(?callable $cb): void
+{
+    $_r = (new Stringable('x'))->tap($cb);
+    /** @psalm-check-type-exact $_r = HigherOrderTapProxy<Stringable>|Stringable */
+}
+
+/** An explicit literal `null` is the same as the no-arg form — the proxy, not the instance. */
+function tap_proxy_explicit_null(): void
+{
+    $_r = (new Stringable('x'))->tap(null);
+    /** @psalm-check-type-exact $_r = HigherOrderTapProxy<Stringable> */
+}
+
+/**
+ * Regression for the load-bearing `static` strip in the handler: when the receiver is `$this`
+ * (the only call site that carries `static`), the proxy template arg must NOT keep `static`, or
+ * a chained call re-binds it to the proxy and yields a bogus `TapHost&HigherOrderTapProxy<...>`
+ * intersection instead of the target.
+ */
+class TapHost
+{
+    use \Illuminate\Support\Traits\Tappable;
+
+    public function name(): string
+    {
+        return 'x';
+    }
+
+    public function probe(): void
+    {
+        $_self = $this->tap();
+        /** @psalm-check-type-exact $_self = HigherOrderTapProxy<TapHost> */
+
+        $_target = $this->tap()->name();
+        /** @psalm-check-type-exact $_target = TapHost */
+    }
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeTapProxySinkKnownLimitation.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeTapProxySinkKnownLimitation.phpt
@@ -1,0 +1,33 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Mail\Mailable;
+
+/**
+ * Documented taint limitation of the higher-order tap proxy (issue #1110).
+ *
+ * `Mailable::to()` carries `@psalm-taint-sink header`, and a direct `$m->to($tainted)` DOES flag —
+ * the committed positive TaintedHeaderMailableTo.phpt asserts exactly that, so the source/sink
+ * wiring cannot silently regress and make this negative pass vacuously. But the no-arg `tap()`
+ * form resolves the call to HigherOrderTapProxy::__call rather than to `Mailable::to()`'s own
+ * signature, so the parameter-level sink is never consulted and `$m->tap()->to($tainted)` does
+ * NOT flag.
+ *
+ * This empty --EXPECTF-- pins that gap: if a future change re-dispatches per-argument sinks
+ * through the proxy (e.g. an AfterMethodCallAnalysis handler), this test will start reporting and
+ * must be updated. The gap is narrow — every sink reachable via `tap()->method()` is also
+ * reachable by calling `method()` directly, where the sink still fires.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1110
+ */
+function tap_proxy_sink_known_limitation(Mailable $m, Request $request): void
+{
+    $tainted = (string) $request->input('email');
+
+    $m->tap()->to($tainted);
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

The no-argument higher-order form of `Tappable::tap()` returns a `HigherOrderTapProxy` that forwards every call back to the target. The previous `@return $this` stub typed that terminal object as the target itself, so `$value->tap()` was mistyped — the proxy is not the target (it only forwards method calls to it), so the value is wrong for any non-forwarding use.

## Related

Closes #1110

## Solution Description

Two pieces, mirroring the existing `HigherOrderBuilderProxy` (stub) and `ConditionableWhenHandler` (handler) precedents:

- **Generic `HigherOrderTapProxy<TClass>` stub** (`stubs/common/Support/HigherOrderTapProxy.phpstub`). Laravel's real class is non-generic (`@var mixed $target`, `__call(): mixed`); re-declaring it with `@template-covariant TClass` lets `__call(): TClass` thread the target type natively. A proxied call returns the **target**, not the called method's own return (`$s->tap()->isEmpty()` is `Stringable`, not `bool`) — matching the runtime, where the proxy discards the method result and returns the target. No proxy handler is needed, and the `__call` stub satisfies `sealAllMethods`.
- **`TappableTapHandler`** (`MethodReturnTypeProvider`, registered on the `Tappable` trait). Returns `HigherOrderTapProxy<receiver>` for the no-callback form and defers to the stub's `@return $this` for the callback form.

**Why a handler and not just a conditional return type in the stub?** Laravel types this as `($callback is null ? HigherOrderTapProxy : $this)`. That conditional does **not** discriminate when it overrides a reflected trait method — Psalm collapses every call to the null branch regardless of the argument (verified empirically on both a stubbed user, `Stringable`, and an un-stubbed one, `Uri`). The discrimination therefore lives in the handler, exactly as `ConditionableWhenHandler` does for `when()`/`unless()`.

**Scope — direct `Tappable` users only** (`Stringable`, `Http\Client\Response`, `Uri`, `Mailable`, `Router`, the paginators, console `Event`, test helpers). Eloquent Models and query builders are intentionally **unaffected**: their `tap()` comes from `Illuminate\Database\Concerns\BuildsQueries::tap($callback)`, which **requires** a callback and returns the builder. A no-arg `$model->tap()` is a runtime `ArgumentCountError` (Psalm already, correctly, flags `TooFewArguments`). The handler registers only on the `Tappable` trait, so it never sees the builder/model `tap()`. (The issue's `$model->tap()` headline examples rest on this misunderstanding of how Model `tap()` resolves.)

**Known limitation (documented + regression-tested).** A proxied call resolves to `HigherOrderTapProxy::__call`, never to the proxied method's own signature, so a parameter-level `@psalm-taint-sink` is not consulted: `$m->tap()->sink($tainted)` does not flag. The gap is narrow — every sink reachable via `tap()->method()` is also reachable by calling `method()` directly, where the sink still fires — and matches the lenient-by-design `HigherOrderBuilderProxy` precedent. Pinned by `SafeTapProxySinkKnownLimitation.phpt` (anchored by the committed positive `TaintedHeaderMailableTo.phpt`).

**Verification:** full type suite green (incl. a `sealAllMethods` test and the taint regression), Psalm self-analysis clean at 100% type coverage, CS clean. Tests cover: no-arg proxy type, chained-returns-target (fluent + non-fluent), `$target` read, callback form, explicit `tap(null)`, nullable-callable union, a `$this`-receiver case (guards the `static`-strip in the handler), and `Http\Client\Response` as a second host.

**Follow-up (out of scope):** the global `tap()` helper still types the no-callback form as the bare value (`@return TValue`); the generic proxy added here makes that fixable later.

## Checklist
- [x] Tests cover the change (type tests in `tests/Type/`, incl. sealed-mode and taint regression)
