### PR TITLE
Fix `init` emitting Psalm 7-only issue handlers that break Psalm 6

### DIFF
--- a/src/Cli/InitCommand.php
+++ b/src/Cli/InitCommand.php
@@ -48,6 +48,19 @@ final class InitCommand extends Command
     /** One indent level. Matches the template heredoc's per-nesting whitespace. */
     private const TAB = '    ';
 
+    /**
+     * Laravel-tailored psalm.xml template; {{LEVEL}} and {{PROJECT_FILES}} are
+     * substituted at write time.
+     *
+     * Every issue handler listed here MUST exist in the installed Psalm's
+     * config.xsd, or Psalm rejects the generated config on startup. This is the
+     * Psalm 6 line, so the Psalm-7-only handlers MissingPureAnnotation,
+     * MissingAbstractPureAnnotation and MissingInterfaceImmutableAnnotation are
+     * intentionally absent (they belong to the 4.x/master template, which targets
+     * Psalm 7). Do not re-add them when merging master into 3.x:
+     * InitCommandTest::generated_config_validates_against_installed_psalm_schema,
+     * run under the pinned Psalm 6, is the guard that catches a reintroduction (#1115).
+     */
     private const PSALM_XML_TEMPLATE = <<<'XML'
         <?xml version="1.0"?>
         <psalm
@@ -75,12 +88,9 @@ final class InitCommand extends Command
             <issueHandlers>
                 <ClassMustBeFinal errorLevel="info"/>
                 <ImplicitToStringCast errorLevel="info"/>
-                <MissingAbstractPureAnnotation errorLevel="info"/>
                 <MissingClosureReturnType errorLevel="info"/>
                 <MissingImmutableAnnotation errorLevel="info"/>
-                <MissingInterfaceImmutableAnnotation errorLevel="info"/>
                 <MissingOverrideAttribute errorLevel="info"/>
-                <MissingPureAnnotation errorLevel="info"/>
                 <RedundantCast errorLevel="info"/>
                 <RedundantCondition errorLevel="info"/>
                 <UnnecessaryVarAnnotation errorLevel="suppress"/>

--- a/tests/Unit/Cli/InitCommandTest.php
+++ b/tests/Unit/Cli/InitCommandTest.php
@@ -108,6 +108,53 @@ final class InitCommandTest extends TestCase
         }
     }
 
+    /**
+     * The generated psalm.xml must validate against the *installed* Psalm's
+     * config.xsd. Psalm validates its config against that schema on startup and
+     * refuses to run if it fails, so a config referencing issue handlers absent
+     * from the schema is broken out of the box (#1115: the Psalm 6 line must not
+     * emit Psalm-7-only handlers such as MissingPureAnnotation).
+     *
+     * This is the real re-introduction guard: it runs under the Psalm version
+     * pinned in composer.json, so a Psalm-7-only handler creeping back in (e.g.
+     * via a master -> 3.x merge) fails here rather than in users' projects.
+     */
+    #[Test]
+    public function generated_config_validates_against_installed_psalm_schema(): void
+    {
+        $schema = \dirname(__DIR__, 3) . \DIRECTORY_SEPARATOR
+            . 'vendor' . \DIRECTORY_SEPARATOR . 'vimeo' . \DIRECTORY_SEPARATOR . 'psalm'
+            . \DIRECTORY_SEPARATOR . 'config.xsd';
+        // Fail loudly rather than skip: a silent skip would turn this regression
+        // guard into dead weight that protects nothing.
+        $this->assertFileExists($schema, 'Psalm config.xsd not found; run composer install first.');
+
+        $tester = $this->makeTester();
+        $tester->execute([]);
+
+        $contents = \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $this->assertIsString($contents);
+
+        $previous = \libxml_use_internal_errors(true);
+        try {
+            $dom = new \DOMDocument();
+            $this->assertTrue($dom->loadXML($contents), 'Generated psalm.xml must be loadable XML.');
+
+            $valid = $dom->schemaValidate($schema);
+            $errors = \array_map(
+                static fn(\LibXMLError $error): string => \trim($error->message),
+                \libxml_get_errors(),
+            );
+            $this->assertTrue(
+                $valid,
+                \sprintf("Generated psalm.xml failed config.xsd validation:\n%s", \implode("\n", $errors)),
+            );
+        } finally {
+            \libxml_clear_errors();
+            \libxml_use_internal_errors($previous);
+        }
+    }
+
     #[Test]
     public function refuses_to_overwrite_by_default_when_answered_no(): void
     {


### PR DESCRIPTION
## Issue to Solve

On the `3.x` line (Psalm 6, `vimeo/psalm: ^6.16.1`), `psalm-laravel init` generated a `psalm.xml` whose `<issueHandlers>` block listed three handlers that exist only in Psalm 7: `MissingAbstractPureAnnotation`, `MissingInterfaceImmutableAnnotation`, and `MissingPureAnnotation`.

Psalm validates its config against `config.xsd` on startup, and those elements are not defined in Psalm 6's schema, so the generated config failed validation and Psalm refused to run. A user installing v3 and running `init` got a broken, unusable config out of the box.

## Related

Fixes #1115

## Solution Description

- Remove the three Psalm-7-only handlers from `PSALM_XML_TEMPLATE` in `InitCommand`. The remaining eight handlers are all defined in Psalm 6's `config.xsd`. The same template on `master` is intentionally left untouched, since `master` targets Psalm 7 where these handlers are valid.
- Add a docblock above the template warning against re-adding them on a `master` into `3.x` merge (the likely regression path, since `3.x` periodically merges `master`).
- Add a regression test `generated_config_validates_against_installed_psalm_schema` that validates the generated `psalm.xml` against the installed `vendor/vimeo/psalm/config.xsd` via `DOMDocument::schemaValidate`.

Verified red first: against the old template the test fails with `Element '{...}MissingAbstractPureAnnotation': This element is not expected.`; after the fix the full `InitCommandTest` suite passes (13 tests, 47 assertions). Because the test reads whatever Psalm is installed (rather than a hardcoded version), it catches a Psalm-7-only handler reintroduced under the pinned Psalm 6 without any maintenance.

## Checklist
- [x] Tests cover the change (unit test in `tests/Unit/`)
