### PR TITLE
ci(tests): gate PHPT type tests on `--EXPECTF--` and %d line numbers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,7 @@ on:
       - '**.phpt'
       - 'composer.json'
       - '.github/workflows/tests.yml'
+      - 'bin/ci/check-phpt-conventions.sh'
   pull_request:
     paths:
       - '**.php'
@@ -17,6 +18,7 @@ on:
       - '**.phpt'
       - 'composer.json'
       - '.github/workflows/tests.yml'
+      - 'bin/ci/check-phpt-conventions.sh'
   schedule:
     # Weekly on Friday at 06:00 UTC
     - cron: "0 6 * * 5"
@@ -30,6 +32,23 @@ permissions:
   contents: read
 
 jobs:
+
+  phpt_conventions:
+    name: PHPT conventions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Check PHPT type-test conventions
+        run: bash bin/ci/check-phpt-conventions.sh
 
   unit_tests:
     name: Unit tests

--- a/bin/ci/check-phpt-conventions.sh
+++ b/bin/ci/check-phpt-conventions.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Enforce PHPT authoring conventions for the type-test suite (tests/Type/tests).
+# See tests/Type/CLAUDE.local.md for the rationale.
+#
+# Rules:
+#   1. Use the `--EXPECTF--` section, never `--EXPECT--`. EXPECTF supports the
+#      `%d` / `%s` / `%A` format specifiers we rely on for line numbers and
+#      version-dependent output; EXPECT does exact matching and breaks on any
+#      drift.
+#   2. Never hardcode `on line <number>`. Line numbers shift whenever the
+#      fixture above the expectation changes; use `on line %d` instead.
+#
+# Exits non-zero (and prints file:line) on the first kind of violation found.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TESTS_DIR="${ROOT}/tests/Type/tests"
+
+status=0
+
+# Rule 1: --EXPECT-- marker (a line that is exactly "--EXPECT--").
+if expect_hits="$(grep -rnE '^--EXPECT--$' "${TESTS_DIR}")"; then
+    echo "ERROR: PHPT files must use '--EXPECTF--', not '--EXPECT--':"
+    echo "${expect_hits}"
+    echo
+    status=1
+fi
+
+# Rule 2: hardcoded line number in expectations ("on line 34" -> "on line %d").
+if line_hits="$(grep -rnE 'on line [0-9]' "${TESTS_DIR}")"; then
+    echo "ERROR: PHPT expectations must use 'on line %d', not a hardcoded number:"
+    echo "${line_hits}"
+    echo
+    status=1
+fi
+
+if [ "${status}" -eq 0 ]; then
+    echo "PHPT conventions OK (tests/Type/tests)."
+fi
+
+exit "${status}"

--- a/composer.json
+++ b/composer.json
@@ -110,6 +110,7 @@
         "test:app": "./tests/Application/laravel-test.sh",
         "test:type": [
             "Composer\\Config::disableProcessTimeout",
+            "./bin/ci/check-phpt-conventions.sh",
             "phpunit --testsuite=type"
         ],
         "test:unit": "phpunit --testsuite=unit --display-deprecations --display-notices --display-phpunit-notices"

--- a/tests/Type/tests/Auth/AuthTest.phpt
+++ b/tests/Type/tests/Auth/AuthTest.phpt
@@ -183,4 +183,4 @@ $_authUnknown = auth('nonexistent-guard');
 // unknown guard name — falls back to the stub-declared union
 /** @psalm-check-type-exact $_authUnknown = \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard */
 ?>
---EXPECT--
+--EXPECTF--

--- a/tests/Type/tests/Builder/QueryOverrideTest.phpt
+++ b/tests/Type/tests/Builder/QueryOverrideTest.phpt
@@ -57,4 +57,4 @@ function test_unshadowed_pseudo_preserved(): void
     /** @psalm-check-type-exact $_result = \Illuminate\Database\Eloquent\Builder */
 }
 ?>
---EXPECT--
+--EXPECTF--

--- a/tests/Type/tests/CollectionFilterTest.phpt
+++ b/tests/Type/tests/CollectionFilterTest.phpt
@@ -143,4 +143,4 @@ final class CollectionFilterTest
     }
 }
 ?>
---EXPECT--
+--EXPECTF--

--- a/tests/Type/tests/CollectionFlattenTest.phpt
+++ b/tests/Type/tests/CollectionFlattenTest.phpt
@@ -137,4 +137,4 @@ final class CollectionFlattenTest
     }
 }
 ?>
---EXPECT--
+--EXPECTF--

--- a/tests/Type/tests/CollectionHelpersTest.phpt
+++ b/tests/Type/tests/CollectionHelpersTest.phpt
@@ -80,4 +80,4 @@ function if_first_value_arg_is_not_closure_then_mixed_expected(): mixed
     );
 }
 ?>
---EXPECT--
+--EXPECTF--

--- a/tests/Type/tests/CollectionMethodsTest.phpt
+++ b/tests/Type/tests/CollectionMethodsTest.phpt
@@ -267,4 +267,4 @@ foreach ($collection as $key => $value) {
 }
 
 ?>
---EXPECT--
+--EXPECTF--

--- a/tests/Type/tests/CollectionWhereCallbackTest.phpt
+++ b/tests/Type/tests/CollectionWhereCallbackTest.phpt
@@ -297,4 +297,4 @@ final class CollectionWhereCallbackTestAccount
     public int $id = 0;
 }
 ?>
---EXPECT--
+--EXPECTF--

--- a/tests/Type/tests/CollectionWhereNotNullTest.phpt
+++ b/tests/Type/tests/CollectionWhereNotNullTest.phpt
@@ -126,4 +126,4 @@ final class CollectionWhereNotNullTest
     }
 }
 ?>
---EXPECT--
+--EXPECTF--

--- a/tests/Type/tests/ConsoleCommandTest.phpt
+++ b/tests/Type/tests/ConsoleCommandTest.phpt
@@ -69,4 +69,4 @@ class ExampleCommand extends Command
     }
 }
 ?>
---EXPECT--
+--EXPECTF--

--- a/tests/Type/tests/CookieJarTest.phpt
+++ b/tests/Type/tests/CookieJarTest.phpt
@@ -18,4 +18,4 @@ final class CookieJarTest
     }
 }
 ?>
---EXPECT--
+--EXPECTF--

--- a/tests/Type/tests/CursorPaginatorSetCollectionTest.phpt
+++ b/tests/Type/tests/CursorPaginatorSetCollectionTest.phpt
@@ -35,4 +35,4 @@ final class CursorPaginatorSetCollectionTest
 }
 
 ?>
---EXPECT--
+--EXPECTF--

--- a/tests/Type/tests/Foundation/AppBoundUnknownAbstractTest.phpt
+++ b/tests/Type/tests/Foundation/AppBoundUnknownAbstractTest.phpt
@@ -32,4 +32,4 @@ function test_negated_app_bound_supports_early_return(): void
 }
 
 ?>
---EXPECT--
+--EXPECTF--

--- a/tests/Type/tests/Foundation/NowTodayHelpersTest.phpt
+++ b/tests/Type/tests/Foundation/NowTodayHelpersTest.phpt
@@ -25,4 +25,4 @@ $_todayTz = today('UTC');
 $_todayDtz = today(new \DateTimeZone('UTC'));
 /** @psalm-check-type-exact $_todayDtz = \Illuminate\Support\Carbon */
 ?>
---EXPECT--
+--EXPECTF--

--- a/tests/Type/tests/Foundation/TranslateHelperTest.phpt
+++ b/tests/Type/tests/Foundation/TranslateHelperTest.phpt
@@ -38,4 +38,4 @@ $_nullable = __($maybeKey);
 $_translator = trans();
 /** @psalm-check-type-exact $_translator = \Illuminate\Contracts\Translation\Translator */
 ?>
---EXPECT--
+--EXPECTF--

--- a/tests/Type/tests/Helpers/StubReturnTypeTest.phpt
+++ b/tests/Type/tests/Helpers/StubReturnTypeTest.phpt
@@ -122,4 +122,4 @@ function test_builder_with_callback(): Builder
     });
 }
 ?>
---EXPECT--
+--EXPECTF--

--- a/tests/Type/tests/Macros/BuilderMacroTest.phpt
+++ b/tests/Type/tests/Macros/BuilderMacroTest.phpt
@@ -45,4 +45,4 @@ function test_builder_macro_resolves_through_relation_chain(Customer $customer):
     return $_;
 }
 ?>
---EXPECT--
+--EXPECTF--

--- a/tests/Type/tests/Model/IncrementDecrementTest.phpt
+++ b/tests/Type/tests/Model/IncrementDecrementTest.phpt
@@ -71,4 +71,4 @@ function test_decrement_each_with_extra(Customer $customer): void
     /** @psalm-check-type-exact $_result = int */
 }
 ?>
---EXPECT--
+--EXPECTF--

--- a/tests/Type/tests/Model/LegacyScopeUnusedMethodTest.phpt
+++ b/tests/Type/tests/Model/LegacyScopeUnusedMethodTest.phpt
@@ -48,4 +48,4 @@ final class LegacyScopeModel extends Model
 
 new LegacyScopeModel();
 ?>
---EXPECT--
+--EXPECTF--

--- a/tests/Type/tests/Model/ScopeAttributeUnusedMethodTest.phpt
+++ b/tests/Type/tests/Model/ScopeAttributeUnusedMethodTest.phpt
@@ -46,5 +46,5 @@ final class ScopeAttributeModel extends Model
 
 new ScopeAttributeModel();
 ?>
---EXPECT--
-PublicModelScope on line 34: Eloquent #[Scope] method publicPublished() should be protected, not public: called statically (Model::publicPublished()) it is a runtime fatal.
+--EXPECTF--
+PublicModelScope on line %d: Eloquent #[Scope] method publicPublished() should be protected, not public: called statically (Model::publicPublished()) it is a runtime fatal.

--- a/tests/Type/tests/PaginationTest.phpt
+++ b/tests/Type/tests/PaginationTest.phpt
@@ -51,4 +51,4 @@ function cursor_paginator_items(CursorPaginator $paginator): void
     $_collection = $paginator->getCollection();
     /** @psalm-check-type-exact $_collection = Collection<int, string> */
 }
---EXPECT--
+--EXPECTF--

--- a/tests/Type/tests/RouteMiddlewareTest.phpt
+++ b/tests/Type/tests/RouteMiddlewareTest.phpt
@@ -58,4 +58,4 @@ function pass_to_route_collection_add(RouteCollectionInterface $routes): Route
     );
 }
 ?>
---EXPECT--
+--EXPECTF--

--- a/tests/Type/tests/RouteResourceRegistrationTest.phpt
+++ b/tests/Type/tests/RouteResourceRegistrationTest.phpt
@@ -31,4 +31,4 @@ function except_variadic(PendingSingletonResourceRegistration $reg): void
     /** @psalm-check-type-exact $_c = \Illuminate\Routing\PendingSingletonResourceRegistration&static */
 }
 ?>
---EXPECT--
+--EXPECTF--

--- a/tests/Type/tests/Schema/ColumnDefinitionTest.phpt
+++ b/tests/Type/tests/Schema/ColumnDefinitionTest.phpt
@@ -90,4 +90,4 @@ Schema::create('damage_reports', function (Blueprint $table) {
     $table->foreign('team_id')->references('id')->on('teams')->lock('none');
 });
 ?>
---EXPECT--
+--EXPECTF--

--- a/tests/Type/tests/StubInterfaceTest.phpt
+++ b/tests/Type/tests/StubInterfaceTest.phpt
@@ -241,4 +241,4 @@ final class StubInterfaceTest
     }
 }
 ?>
---EXPECT--
+--EXPECTF--

--- a/tests/Type/tests/ValidationTypeNarrowingTest.phpt
+++ b/tests/Type/tests/ValidationTypeNarrowingTest.phpt
@@ -341,4 +341,4 @@ function testOptionalParentGroupWithChildren(OptionalParentGroupRequest $request
     /** @psalm-check-type-exact $_all = array{settings?: array{theme: string}} */
 }
 ?>
---EXPECT--
+--EXPECTF--


### PR DESCRIPTION
## What

Adds a CI gate that enforces the PHPT authoring conventions already documented in `tests/Type/CLAUDE.local.md` but never machine-checked.

`bin/ci/check-phpt-conventions.sh` scans `tests/Type/tests` and fails on:

1. The exact-match `--EXPECT--` section (must be `--EXPECTF--`). EXPECTF supports the `%d` / `%s` / `%A` specifiers the suite relies on; EXPECT does literal matching and breaks on any drift.
2. A hardcoded line number in expectations (`on line 34`). Line numbers shift whenever the fixture above the expectation changes, so `on line %d` is required.

Wired as a standalone `PHPT conventions` job in `tests.yml`. The script path is added to the workflow's `paths` filters so edits to the gate itself re-run it.

## Existing violations fixed

The repo already had 25 files that would have failed the gate:

- 24 files with an empty `--EXPECT--` block, converted to `--EXPECTF--` (functionally identical for empty expectations).
- `Model/ScopeAttributeUnusedMethodTest.phpt`, which also hardcoded `on line 34`, now uses `on line %d`.

## Verification

- Gate passes clean on the current tree and fails (exit 1) on an injected `--EXPECT--` / `on line 12` fixture, reporting both rule kinds with `file:line`.
- `ScopeAttributeUnusedMethodTest` plus a sample of the renamed empty-block tests pass under the type-test runner.
- Workflow YAML validates.