### PR TITLE
Gate `#[Scope]` detection on Laravel 12+ so Laravel 11 isn't mis-analyzed

### DIFF
--- a/src/Util/EloquentModelMethods.php
+++ b/src/Util/EloquentModelMethods.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Psalm\LaravelPlugin\Util;
 
 use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Foundation\Application;
 use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
 use Psalm\Internal\Provider\ClassLikeStorageProvider;
 use Psalm\Storage\ClassLikeStorage;
@@ -94,6 +95,18 @@ final class EloquentModelMethods
      */
     public static function hasScopeAttribute(MethodStorage $methodStorage): bool
     {
+        // The #[Scope] attribute ships with Laravel 12. On Laravel 11 the attribute class
+        // does not exist, so a method written with #[Scope] is not a usable scope there —
+        // Psalm already reports UndefinedAttributeClass on the declaration. The check below
+        // matches by attribute name only and cannot tell a defined attribute from an
+        // undefined one, so without this version gate the scope handlers (unused-method
+        // suppression, call-site resolution, PublicModelScope) would treat a non-functional
+        // Laravel 11 attribute as a real scope. Application::VERSION reflects the booted app
+        // the plugin analyses (same gate Plugin/StubFileFinder use for version-specific stubs).
+        if (\version_compare(Application::VERSION, '12.0.0', '<')) {
+            return false;
+        }
+
         if ($methodStorage->visibility === ClassLikeAnalyzer::VISIBILITY_PRIVATE) {
             return false;
         }

--- a/tests/Type/tests/Builder/InstanceScopeCallTest.phpt
+++ b/tests/Type/tests/Builder/InstanceScopeCallTest.phpt
@@ -1,3 +1,10 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// Skip on Laravel < 12: this test asserts #[Scope]-attributed scope resolution.
+// The #[Scope] attribute is Laravel 12+, so on Laravel 11 the plugin correctly does
+// not resolve such methods as scopes (see EloquentModelMethods::hasScopeAttribute).
+\Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipBelow('12.0.0');
 --FILE--
 <?php declare(strict_types=1);
 

--- a/tests/Type/tests/Builder/ProtectedScopeSurfacesTest.phpt
+++ b/tests/Type/tests/Builder/ProtectedScopeSurfacesTest.phpt
@@ -1,3 +1,10 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// Skip on Laravel < 12: this test asserts #[Scope]-attributed scope resolution.
+// The #[Scope] attribute is Laravel 12+, so on Laravel 11 the plugin correctly does
+// not resolve such methods as scopes (see EloquentModelMethods::hasScopeAttribute).
+\Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipBelow('12.0.0');
 --FILE--
 <?php declare(strict_types=1);
 

--- a/tests/Type/tests/Builder/ScopeVariadicNamedArgTest.phpt
+++ b/tests/Type/tests/Builder/ScopeVariadicNamedArgTest.phpt
@@ -1,3 +1,10 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// Skip on Laravel < 12: this test asserts #[Scope]-attributed scope resolution.
+// The #[Scope] attribute is Laravel 12+, so on Laravel 11 the plugin correctly does
+// not resolve such methods as scopes (see EloquentModelMethods::hasScopeAttribute).
+\Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipBelow('12.0.0');
 --FILE--
 <?php declare(strict_types=1);
 

--- a/tests/Type/tests/Builder/StaticBuilderMethodsTest.phpt
+++ b/tests/Type/tests/Builder/StaticBuilderMethodsTest.phpt
@@ -1,3 +1,10 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// Skip on Laravel < 12: this test asserts #[Scope]-attributed scope resolution.
+// The #[Scope] attribute is Laravel 12+, so on Laravel 11 the plugin correctly does
+// not resolve such methods as scopes (see EloquentModelMethods::hasScopeAttribute).
+\Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipBelow('12.0.0');
 --FILE--
 <?php declare(strict_types=1);
 

--- a/tests/Type/tests/Builder/ValueReturningScopeTest.phpt
+++ b/tests/Type/tests/Builder/ValueReturningScopeTest.phpt
@@ -1,3 +1,10 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// Skip on Laravel < 12: this test asserts #[Scope]-attributed scope resolution.
+// The #[Scope] attribute is Laravel 12+, so on Laravel 11 the plugin correctly does
+// not resolve such methods as scopes (see EloquentModelMethods::hasScopeAttribute).
+\Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipBelow('12.0.0');
 --FILE--
 <?php declare(strict_types=1);
 

--- a/tests/Type/tests/Model/AbstractModelScopeResolutionTest.phpt
+++ b/tests/Type/tests/Model/AbstractModelScopeResolutionTest.phpt
@@ -1,3 +1,10 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// Skip on Laravel < 12: this test asserts #[Scope]-attributed scope resolution.
+// The #[Scope] attribute is Laravel 12+, so on Laravel 11 the plugin correctly does
+// not resolve such methods as scopes (see EloquentModelMethods::hasScopeAttribute).
+\Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipBelow('12.0.0');
 --FILE--
 <?php declare(strict_types=1);
 

--- a/tests/Type/tests/Model/DirectScopeCallTest.phpt
+++ b/tests/Type/tests/Model/DirectScopeCallTest.phpt
@@ -1,3 +1,10 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// Skip on Laravel < 12: this test asserts #[Scope]-attributed scope resolution.
+// The #[Scope] attribute is Laravel 12+, so on Laravel 11 the plugin correctly does
+// not resolve such methods as scopes (see EloquentModelMethods::hasScopeAttribute).
+\Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipBelow('12.0.0');
 --FILE--
 <?php declare(strict_types=1);
 

--- a/tests/Type/tests/Model/ScopeAttributeLaravel11Test.phpt
+++ b/tests/Type/tests/Model/ScopeAttributeLaravel11Test.phpt
@@ -1,0 +1,34 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// Inverse of the Laravel-12 #[Scope] tests (skipBelow('12.0.0')): this asserts the
+// Laravel-11 behavior. The #[Scope] attribute class ships with Laravel 12, so on
+// Laravel 11 it does not exist. The plugin must report only UndefinedAttributeClass
+// and must NOT additionally treat the method as a scope (no PublicModelScope), proving
+// EloquentModelMethods::hasScopeAttribute() is version-gated. skipFrom() runs this only
+// on Laravel 11.
+\Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipFrom('12.0.0');
+--FILE--
+<?php declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Sandbox;
+
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class ScopeAttributeL11Model extends Model
+{
+    // A public #[Scope] would be reported PublicModelScope on Laravel 12. On Laravel 11
+    // the attribute does not exist, so only UndefinedAttributeClass must fire. The exact
+    // (no-%A) EXPECTF asserts PublicModelScope is absent: it is name-matched, so it would
+    // reappear here if the version gate in EloquentModelMethods::hasScopeAttribute() regressed.
+    #[Scope]
+    public function active(Builder $query): Builder
+    {
+        return $query;
+    }
+}
+?>
+--EXPECTF--
+UndefinedAttributeClass on line %d: Attribute class Illuminate\Database\Eloquent\Attributes\Scope does not exist

--- a/tests/Type/tests/Relation/RelationChainScopeTest.phpt
+++ b/tests/Type/tests/Relation/RelationChainScopeTest.phpt
@@ -1,3 +1,10 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// Skip on Laravel < 12: this test asserts #[Scope]-attributed scope resolution.
+// The #[Scope] attribute is Laravel 12+, so on Laravel 11 the plugin correctly does
+// not resolve such methods as scopes (see EloquentModelMethods::hasScopeAttribute).
+\Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipBelow('12.0.0');
 --FILE--
 <?php declare(strict_types=1);
 


### PR DESCRIPTION
## Issue to Solve

The `#[Scope]` attribute (`Illuminate\Database\Eloquent\Attributes\Scope`) is Laravel 12+. `EloquentModelMethods::hasScopeAttribute()` — the single chokepoint all `#[Scope]` detection routes through (used by `SuppressHandler::suppressEloquentScopeMethods` and `BuilderScopeHandler::getScopeParams`) — matched it **by attribute name only** (`$attribute->fq_class_name === Scope::class`, a compile-time string that doesn't require the class to exist).

So on **Laravel 11**, where the attribute class is absent, the scope handlers still fired for a `#[Scope]`-attributed method: unused-method suppression, scope **call-site resolution**, and `PublicModelScope`. The real declaration error (`UndefinedAttributeClass`) was still surfaced, but the plugin additionally treated a non-functional attribute as a usable scope — hiding that `Model::query()->scopeName()` would `BadMethodCallException` at runtime on Laravel 11.

`#[UseEloquentBuilder]` does **not** have this problem: it resolves via runtime reflection + `try/catch`, so on Laravel 11 it fails to instantiate and degrades to `Builder<Model>`.

## Related

Follow-up to #1119 (which gated the Laravel-11-incompatible type tests). This fixes the underlying handler behaviour that #1119's tests skipped over.

## Solution Description

- Gate `hasScopeAttribute()` on `\version_compare(Application::VERSION, '12.0.0', '<')` (the same version signal `Plugin`/`StubFileFinder` already use for version-specific stubs). On Laravel 11 it returns early, so every `#[Scope]` handler no-ops and `UndefinedAttributeClass` is the sole, correct signal; unused `#[Scope]` methods are correctly flagged and scope call sites correctly fail.
- Add `ScopeAttributeLaravel11Test` (`LaravelVersion::skipFrom('12.0.0')`, runs only on Laravel 11): a public `#[Scope]` method emits **only** `UndefinedAttributeClass`, no `PublicModelScope`. Verified red-first — without the gate, `PublicModelScope` reappears and the exact-match `--EXPECTF--` fails.
- Gate 8 existing `#[Scope]`-dependent scope-resolution tests on `skipBelow('12.0.0')`. They were green on Laravel 11 *only because of the bug this fixes* (the plugin resolved their `#[Scope]` calls there); after the fix their Laravel-11 output correctly differs (`UndefinedMagicMethod`/`mixed`), so their Laravel-12-captured expected can no longer be shared.

Verified green on **Laravel 11, 12 and 13**; psalm self-analysis EXIT 0 at 100% coverage; unit tests pass; cs + rector clean.

## Checklist
- [x] Tests cover the change (new Laravel-11 regression test + version-gated existing tests)
