### PR TITLE
List auto-discovered service providers in `diagnose`

### DIFF
--- a/src/Cli/Diagnose/Diagnostics.php
+++ b/src/Cli/Diagnose/Diagnostics.php
@@ -63,7 +63,31 @@ class Diagnostics
             bootPath: ApplicationProvider::getBootPath(),
             bootstrapErrors: $bootstrapErrors,
             hardFailures: $hardFailures,
+            loadedProviders: $this->collectLoadedProviders(),
         );
+    }
+
+    /**
+     * Service providers the booted kernel registered, sorted for stable output.
+     *
+     * Includes framework core providers plus anything package discovery (and, in
+     * package-source boots, {@see ApplicationProvider::registerDiscoveredVendorProviders()})
+     * registered. Returns an empty list when the app never resolved — `getApp()`
+     * throws in that case, and a failed boot has no providers to report.
+     *
+     * @return list<string>
+     */
+    private function collectLoadedProviders(): array
+    {
+        try {
+            $providers = \array_keys(ApplicationProvider::getApp()->getLoadedProviders());
+        } catch (\Throwable) {
+            return [];
+        }
+
+        \sort($providers);
+
+        return $providers;
     }
 
     /**

--- a/src/Cli/Diagnose/Report.php
+++ b/src/Cli/Diagnose/Report.php
@@ -21,6 +21,7 @@ final readonly class Report
      * @param 'runtime'|'psalm.xml' $phpAnalysisSource
      * @param list<string> $bootstrapErrors
      * @param list<string> $hardFailures
+     * @param list<string> $loadedProviders Service provider class names the booted kernel registered, sorted. Empty when boot failed.
      */
     public function __construct(
         public ?string $pluginVersion,
@@ -34,5 +35,6 @@ final readonly class Report
         public ?string $bootPath,
         public array $bootstrapErrors,
         public array $hardFailures,
+        public array $loadedProviders,
     ) {}
 }

--- a/src/Cli/DiagnoseCommand.php
+++ b/src/Cli/DiagnoseCommand.php
@@ -57,6 +57,13 @@ final class DiagnoseCommand extends Command
             'Show the Tips section. Use --no-tips to suppress it.',
             false,
         );
+
+        $this->addOption(
+            'providers',
+            null,
+            InputOption::VALUE_NONE,
+            'List every service provider the booted kernel registered (the default report shows only the count).',
+        );
     }
 
     #[\Override]
@@ -66,7 +73,7 @@ final class DiagnoseCommand extends Command
         $tips = (bool) $input->getOption('tips') ? ($this->tipsProvider ?? new TipsProvider())->collect() : [];
         $io = new SymfonyStyle($input, $output);
 
-        $this->renderReport($io, $report, $tips);
+        $this->renderReport($io, $report, $tips, (bool) $input->getOption('providers'));
 
         return $report->hardFailures === [] ? Command::SUCCESS : Command::FAILURE;
     }
@@ -74,7 +81,7 @@ final class DiagnoseCommand extends Command
     /**
      * @param list<string> $tips
      */
-    private function renderReport(SymfonyStyle $io, Report $report, array $tips): void
+    private function renderReport(SymfonyStyle $io, Report $report, array $tips, bool $listProviders): void
     {
         $io->writeln('<comment>Psalm Laravel Plugin Diagnostics</comment>');
         $io->newLine();
@@ -121,6 +128,8 @@ final class DiagnoseCommand extends Command
             $io->newLine();
         }
 
+        $this->renderProviders($io, $report->loadedProviders, $listProviders);
+
         if ($tips !== []) {
             $io->writeln('<info>Tips</info>');
             foreach ($tips as $tip) {
@@ -129,6 +138,33 @@ final class DiagnoseCommand extends Command
 
             $io->newLine();
         }
+    }
+
+    /**
+     * Renders the service-provider section. The default report stays compact —
+     * just the count plus a hint — because the full list runs to ~30 lines on a
+     * stock Laravel app. `--providers` expands it into the complete sorted list.
+     *
+     * @param list<string> $providers
+     */
+    private function renderProviders(SymfonyStyle $io, array $providers, bool $listProviders): void
+    {
+        $count = \count($providers);
+
+        if (!$listProviders) {
+            $this->renderSection($io, 'Providers', [
+                'Loaded' => $count . ' (use --providers to list them)',
+            ]);
+            return;
+        }
+
+        $io->writeln('<info>Providers</info>');
+        $io->writeln('  Loaded  ' . $count);
+        foreach ($providers as $provider) {
+            $io->writeln('    - ' . $provider);
+        }
+
+        $io->newLine();
     }
 
     /**

--- a/tests/Unit/Cli/DiagnoseCommandTest.php
+++ b/tests/Unit/Cli/DiagnoseCommandTest.php
@@ -51,6 +51,7 @@ final class DiagnoseCommandTest extends TestCase
             bootPath: null,
             bootstrapErrors: ['synthetic'],
             hardFailures: ['Application boot failed: synthetic'],
+            loadedProviders: [],
         );
 
         $tester = $this->testerFor($this->fixtureProvider($failing));
@@ -79,6 +80,7 @@ final class DiagnoseCommandTest extends TestCase
             bootPath: $base->bootPath,
             bootstrapErrors: ['Call to a member function bar() on null in config/app.php:42'],
             hardFailures: [],
+            loadedProviders: $base->loadedProviders,
         );
 
         $tester = $this->testerFor($this->fixtureProvider($warned));
@@ -137,6 +139,33 @@ final class DiagnoseCommandTest extends TestCase
     }
 
     #[Test]
+    public function provider_count_renders_by_default_without_the_full_list(): void
+    {
+        $tester = $this->testerFor($this->fixtureProvider($this->okReport()));
+
+        $exit = $tester->execute([]);
+        $display = $tester->getDisplay();
+
+        $this->assertSame(Command::SUCCESS, $exit, $display);
+        $this->assertStringContainsString('Providers', $display);
+        $this->assertStringContainsString('2 (use --providers to list them)', $display);
+        $this->assertStringNotContainsString('Illuminate\\Auth\\AuthServiceProvider', $display);
+    }
+
+    #[Test]
+    public function providers_flag_lists_every_provider(): void
+    {
+        $tester = $this->testerFor($this->fixtureProvider($this->okReport()));
+
+        $exit = $tester->execute(['--providers' => true]);
+        $display = $tester->getDisplay();
+
+        $this->assertSame(Command::SUCCESS, $exit, $display);
+        $this->assertStringContainsString('Illuminate\\Auth\\AuthServiceProvider', $display);
+        $this->assertStringContainsString('Illuminate\\Database\\DatabaseServiceProvider', $display);
+    }
+
+    #[Test]
     public function real_diagnostics_collect_returns_well_formed_report(): void
     {
         $report = (new Diagnostics())->collect();
@@ -145,6 +174,12 @@ final class DiagnoseCommandTest extends TestCase
         $this->assertNotEmpty($report->phpAnalysisVersion);
         $this->assertContains($report->phpAnalysisSource, ['runtime', 'psalm.xml']);
         $this->assertContains($report->bootMode, ['bootstrap', 'testbench_fallback', null]);
+        // A successful boot registers Laravel's core providers; assert the list is
+        // populated and sorted so the diagnose output is deterministic.
+        $this->assertNotEmpty($report->loadedProviders);
+        $sorted = $report->loadedProviders;
+        \sort($sorted);
+        $this->assertSame($sorted, $report->loadedProviders);
     }
 
 
@@ -201,6 +236,10 @@ final class DiagnoseCommandTest extends TestCase
             bootPath: '/app/bootstrap/app.php',
             bootstrapErrors: [],
             hardFailures: [],
+            loadedProviders: [
+                'Illuminate\\Auth\\AuthServiceProvider',
+                'Illuminate\\Database\\DatabaseServiceProvider',
+            ],
         );
     }
 }


### PR DESCRIPTION
## Issue to Solve
`diagnose` reports versions and boot mode but gives no visibility into which service providers the booted kernel (real `bootstrap/app.php` or Testbench fallback) actually registered. When debugging missing Facade or container binding support, the loaded provider set is the fastest signal.

## Related
Closes #1123

## Solution Description
Add a `Providers` section to `diagnose`.

- Default output stays compact: just the loaded count plus a hint (`34 (use --providers to list them)`), so the report does not balloon by ~30 lines on a stock app.
- `--providers` expands the full sorted list of provider class names.

Source is the booted app's `getLoadedProviders()` via `ApplicationProvider::getApp()`, collected once in `Diagnostics::collect()` and carried on the immutable `Report` as `loadedProviders`. `getApp()` throws when boot failed, so the collector catches and returns an empty list (a failed boot has no providers to report). The list is sorted in the collector for deterministic output.

Verified with new unit tests in `DiagnoseCommandTest` (compact-by-default, `--providers` lists all, real-collect populates a sorted list), plus `composer psalm` (clean) and a manual run of `bin/psalm-laravel diagnose` in both modes.

## Checklist
- [x] Tests cover the change (unit tests in `tests/Unit/Cli/DiagnoseCommandTest.php`)
