### PR TITLE
Disable findUnusedCode in app integration test

### DIFF
--- a/tests/Application/laravel-test-psalm-baseline.xml
+++ b/tests/Application/laravel-test-psalm-baseline.xml
@@ -1,83 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.1.0@827971f8bc7a28bb4f842f34bf8901521de1cea3">
+<files psalm-version="7.0.0-beta19@7e751c06a756fa64dc4c759c09fe4a173afcb433">
   <file src="app/Broadcasting/ExampleChannel.php">
     <InvalidReturnType>
       <code><![CDATA[array|bool]]></code>
     </InvalidReturnType>
-    <UnusedClass>
-      <code><![CDATA[ExampleChannel]]></code>
-    </UnusedClass>
   </file>
   <file src="app/Casts/ExampleCast.php">
     <MissingTemplateParam>
       <code><![CDATA[CastsAttributes]]></code>
     </MissingTemplateParam>
-    <UnusedClass>
-      <code><![CDATA[ExampleCast]]></code>
-    </UnusedClass>
   </file>
   <file src="app/Console/Commands/ExampleCommand.php">
     <MissingReturnType>
       <code><![CDATA[handle]]></code>
     </MissingReturnType>
   </file>
-  <file src="app/Exceptions/ExampleException.php">
-    <UnusedClass>
-      <code><![CDATA[ExampleException]]></code>
-    </UnusedClass>
-  </file>
-  <file src="app/Http/Controllers/ExampleController.php">
-    <UnusedClass>
-      <code><![CDATA[ExampleController]]></code>
-    </UnusedClass>
-  </file>
-  <file src="app/Http/Middleware/ExampleMiddleware.php">
-    <UnusedClass>
-      <code><![CDATA[ExampleMiddleware]]></code>
-    </UnusedClass>
-  </file>
-  <file src="app/Http/Requests/ExampleRequest.php">
-    <UnusedClass>
-      <code><![CDATA[ExampleRequest]]></code>
-    </UnusedClass>
-  </file>
   <file src="app/Http/Resources/ExampleResource.php">
     <MixedReturnTypeCoercion>
       <code><![CDATA[array<string, mixed>]]></code>
       <code><![CDATA[parent::toArray($request)]]></code>
     </MixedReturnTypeCoercion>
-    <UnusedClass>
-      <code><![CDATA[ExampleResource]]></code>
-    </UnusedClass>
-  </file>
-  <file src="app/Listeners/ExampleListener.php">
-    <UnusedClass>
-      <code><![CDATA[ExampleListener]]></code>
-    </UnusedClass>
-  </file>
-  <file src="app/Models/Example.php">
-    <UnusedClass>
-      <code><![CDATA[Example]]></code>
-    </UnusedClass>
-  </file>
-  <file src="app/Models/Scopes/ExampleScope.php">
-    <UnusedClass>
-      <code><![CDATA[ExampleScope]]></code>
-    </UnusedClass>
-  </file>
-  <file src="app/Observers/ExampleObserver.php">
-    <UnusedClass>
-      <code><![CDATA[ExampleObserver]]></code>
-    </UnusedClass>
-  </file>
-  <file src="app/Policies/ExamplePolicy.php">
-    <UnusedClass>
-      <code><![CDATA[ExamplePolicy]]></code>
-    </UnusedClass>
-  </file>
-  <file src="app/Rules/ExampleRule.php">
-    <UnusedClass>
-      <code><![CDATA[ExampleRule]]></code>
-    </UnusedClass>
   </file>
 </files>

--- a/tests/Application/laravel-test-psalm.xml
+++ b/tests/Application/laravel-test-psalm.xml
@@ -3,7 +3,7 @@
     xmlns="https://getpsalm.org/schema/config"
     errorLevel="1"
     findUnusedBaselineEntry="false"
-    findUnusedCode="true"
+    findUnusedCode="false"
     resolveFromConfigFile="false"
     xsi:schemaLocation="https://getpsalm.org/schema/config ../../vendor/vimeo/psalm/config.xsd"
     errorBaseline="../../tests/Application/laravel-test-psalm-baseline.xml"

--- a/tests/Application/laravel-test.sh
+++ b/tests/Application/laravel-test.sh
@@ -23,9 +23,9 @@ YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 # Default values
-UPDATE_BASELINE=false
-VERBOSE=false
-REMOVE=false
+UPDATE_BASELINE=false # --update (-u) arg
+VERBOSE=false # --verbose (-v) arg
+REMOVE=false # --remove (-r) arg
 PSALM_PASSED=false
 
 # Function to display script usage


### PR DESCRIPTION
## Issue to Solve
`findUnusedCode="true"` in the app integration test flagged every example Laravel scaffold class (`ExampleController`, `ExampleMiddleware`, `ExampleRequest`, models, policies, etc.) as `UnusedClass`. These are framework-wired stubs with no in-repo callers, so the flag produced pure noise that bloated `laravel-test-psalm-baseline.xml` and masked real findings.

## Related
Refs #0

## Solution Description
- Set `findUnusedCode="false"` in `tests/Application/laravel-test-psalm.xml`. Whole-program dead-code detection on a fresh Laravel app yields only false positives here; the app test exists to validate plugin type inference, not unused-code coverage.
- Regenerate `laravel-test-psalm-baseline.xml` (Psalm `6.1.0` -> `7.0.0-beta19`), dropping all the dead `UnusedClass` entries. Remaining baseline entries are genuine framework-shape findings unrelated to this change.
- Annotate the CLI flag vars in `laravel-test.sh` with their corresponding `--update`/`--verbose`/`--remove` arg names for readability.

No production code or stubs touched; change is scoped to the application test harness.

## Checklist
- [x] Tests cover the change (app integration test reruns clean against the regenerated baseline)
