### PR TITLE
Resolve concrete-only `Application` methods on the contract

### DIFF
--- a/src/Handlers/Application/ApplicationContractMethodHandler.php
+++ b/src/Handlers/Application/ApplicationContractMethodHandler.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Application;
+
+use Illuminate\Contracts\Foundation\Application as ApplicationContract;
+use Psalm\Codebase;
+use Psalm\LaravelPlugin\Providers\ApplicationProvider;
+use Psalm\Plugin\EventHandler\AfterCodebasePopulatedInterface;
+use Psalm\Plugin\EventHandler\Event\AfterCodebasePopulatedEvent;
+use Psalm\Storage\ClassLikeStorage;
+
+/**
+ * Declares the environment/state methods that exist on the concrete
+ * {@see \Illuminate\Foundation\Application} but NOT on its
+ * {@see \Illuminate\Contracts\Foundation\Application} contract, so calling them
+ * on a contract-typed receiver (`Command::$laravel`, `ServiceProvider::$app`, or
+ * any property/parameter typed on the interface) no longer raises
+ * `UndefinedInterfaceMethod` (psalm 181).
+ *
+ * **Why a resolution-map write and not a `.phpstub`.** Stubbing the contract to
+ * add these methods would mean restating every signature in the stub (which drifts
+ * as Laravel evolves) and re-declaring the interface — which, unless the full
+ * `extends` clause is copied verbatim, resets the interface's parent list (see the
+ * "Class declarations wipe reflected metadata" note in the contributing docs).
+ * Pointing the contract's resolution maps at the live concrete app keeps signatures
+ * version-correct and leaves the reflected interface untouched.
+ *
+ * **Why not a method-existence provider.** `MethodExistenceProviderInterface` only
+ * suppresses 181 when the receiver declares `__call` (the analyzer routes a
+ * provider-confirmed-but-storage-less method through the magic-method handler,
+ * which is `__call`-gated — see `AtomicMethodCallAnalyzer`). The contract has no
+ * `__call`, so the method must exist for real in `declaring_method_ids`; only a
+ * resolution-map entry achieves that.
+ *
+ * **Why only the resolution maps, not `$contract->methods`.** Naive
+ * `methodExists()` consults `declaring_method_ids` directly, so adding entries
+ * there (pointed at the concrete app's own declarations) is enough to resolve the
+ * call. Deliberately NOT touching `$contract->methods`: the interface-compliance
+ * check iterates `$interface->methods` at analysis time, so writing there would
+ * force every class that `implements` the contract to declare these 9 methods
+ * (spurious `UnimplementedInterfaceMethod`). Keeping them out of `methods` makes
+ * the injection invisible to compliance while still resolving the call.
+ *
+ * Runs at `AfterCodebasePopulated` (not `AfterClassLikeVisit`) so the write lands
+ * after the populator has rebuilt `declaring_method_ids`, and so the concrete
+ * app's own storage is already populated to copy ids from. Mirrors
+ * {@see \Psalm\LaravelPlugin\Handlers\Eloquent\ModelRegistrationHandler}.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1108
+ */
+final class ApplicationContractMethodHandler implements AfterCodebasePopulatedInterface
+{
+    /**
+     * Methods declared only on the concrete `Illuminate\Foundation\Application`,
+     * absent from the `Illuminate\Contracts\Foundation\Application` contract.
+     * Verified against laravel/framework across the ^12.4 floor and Laravel 13.
+     *
+     * Resolution is delegated to the concrete app's own declarations rather than
+     * restated here, so signatures stay correct as Laravel evolves. If a future
+     * Laravel promotes one of these onto the contract, the loop below leaves the
+     * real declaration untouched.
+     *
+     * @var list<lowercase-string>
+     */
+    private const CONCRETE_ONLY_METHODS = [
+        'islocal',
+        'isproduction',
+        'detectenvironment',
+        'environmentfile',
+        'environmentfilepath',
+        'environmentpath',
+        'useenvironmentpath',
+        'loadenvironmentfrom',
+        'afterloadingenvironment',
+    ];
+
+    #[\Override]
+    public static function afterCodebasePopulated(AfterCodebasePopulatedEvent $event): void
+    {
+        $codebase = $event->getCodebase();
+
+        $contract = self::getStorage($codebase, ApplicationContract::class);
+        if (!$contract instanceof \Psalm\Storage\ClassLikeStorage) {
+            return;
+        }
+
+        // The concrete application bound in the container (normally
+        // Illuminate\Foundation\Application; custom app classes are honoured too).
+        $concrete = self::getStorage($codebase, ApplicationProvider::getAppFullyQualifiedClassName());
+        if (!$concrete instanceof \Psalm\Storage\ClassLikeStorage) {
+            return;
+        }
+
+        foreach (self::CONCRETE_ONLY_METHODS as $method) {
+            // Already resolvable on the contract (a real future declaration, or a
+            // prior fire in this process) — never shadow it.
+            if (isset($contract->declaring_method_ids[$method])) {
+                continue;
+            }
+
+            // Where the concrete app declares the method. Reading declaring_method_ids
+            // (not ->methods) follows inheritance/traits, so this stays correct if a
+            // future Laravel relocates a method onto a parent or trait. Also guards a
+            // custom application class that drops one of these methods.
+            $concreteMethodId = $concrete->declaring_method_ids[$method] ?? null;
+            if ($concreteMethodId === null) {
+                continue;
+            }
+
+            // Point the contract's method resolution at the concrete implementation.
+            // naive methodExists() reads declaring_method_ids directly, so the call
+            // resolves on contract-typed receivers, and return/param lookups follow
+            // the id to the concrete's real storage (bool / string / $this).
+            $contract->declaring_method_ids[$method] = $concreteMethodId;
+            $contract->appearing_method_ids[$method] = $concrete->appearing_method_ids[$method] ?? $concreteMethodId;
+        }
+    }
+
+    /** @psalm-mutation-free */
+    private static function getStorage(Codebase $codebase, string $fqcn): ?ClassLikeStorage
+    {
+        try {
+            return $codebase->classlike_storage_provider->get(\strtolower($fqcn));
+        } catch (\InvalidArgumentException) {
+            return null;
+        }
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -86,6 +86,8 @@ final class Plugin implements PluginEntryPointInterface
         $registration->registerHooksFromClass(Handlers\Application\ContainerHandler::class);
         require_once __DIR__ . '/Handlers/Application/OffsetHandler.php';
         $registration->registerHooksFromClass(Handlers\Application\OffsetHandler::class);
+        require_once __DIR__ . '/Handlers/Application/ApplicationContractMethodHandler.php';
+        $registration->registerHooksFromClass(Handlers\Application\ApplicationContractMethodHandler::class);
 
         require_once __DIR__ . '/Handlers/Auth/AuthMethodHandler.php';
         $registration->registerHooksFromClass(Handlers\Auth\AuthMethodHandler::class);

--- a/tests/Type/tests/ApplicationContractMethodsNoLeakTest.phpt
+++ b/tests/Type/tests/ApplicationContractMethodsNoLeakTest.phpt
@@ -1,0 +1,22 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App;
+
+use Illuminate\Contracts\Foundation\Application;
+
+/**
+ * Guard: the concrete-only-method injection stays scoped to its allow-list. A
+ * method that is neither on the contract nor in ApplicationContractMethodHandler's
+ * list must STILL raise UndefinedInterfaceMethod on a contract-typed receiver —
+ * otherwise the contract would silently accept arbitrary undefined methods.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1108
+ */
+function no_leak(Application $app): void
+{
+    $app->thisMethodDoesNotExist();
+}
+?>
+--EXPECTF--
+UndefinedInterfaceMethod on line %d: Method Illuminate\Contracts\Foundation\Application::thisMethodDoesNotExist does not exist

--- a/tests/Type/tests/ApplicationContractMethodsTest.phpt
+++ b/tests/Type/tests/ApplicationContractMethodsTest.phpt
@@ -1,0 +1,84 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Concrete-only Application methods (isProduction/isLocal/environment*) must
+ * resolve on contract-typed receivers without UndefinedInterfaceMethod (181).
+ *
+ * Command::$laravel and ServiceProvider::$app are both typed as the
+ * Illuminate\Contracts\Foundation\Application contract, which does not declare
+ * these methods — only the concrete Illuminate\Foundation\Application does.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1108
+ */
+class DatabasePrune extends Command
+{
+    /** @var string */
+    protected $signature = 'db:prune';
+
+    public function handle(): int
+    {
+        // Command::$laravel is the Foundation\Application contract.
+        $_isProduction = $this->laravel->isProduction();
+        /** @psalm-check-type-exact $_isProduction = bool */
+
+        $_isLocal = $this->laravel->isLocal();
+        /** @psalm-check-type-exact $_isLocal = bool */
+
+        $_path = $this->laravel->environmentPath();
+        /** @psalm-check-type-exact $_path = string */
+
+        return 0;
+    }
+}
+
+class PruneServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        // ServiceProvider::$app is the Foundation\Application contract.
+        $_isProduction = $this->app->isProduction();
+        /** @psalm-check-type-exact $_isProduction = bool */
+
+        $_file = $this->app->environmentFile();
+        /** @psalm-check-type-exact $_file = string */
+
+        // Methods carrying parameters resolve their signature too (no arg-count
+        // false positives), proving the delegated signature keeps its params.
+        $this->app->useEnvironmentPath('/var/www');
+        $this->app->detectEnvironment(static fn(): string => 'production');
+    }
+}
+
+/**
+ * Same methods on a directly contract-typed receiver (e.g. app() widened to the
+ * contract, or any property typed on the interface).
+ */
+function on_contract_receiver(Application $app): string
+{
+    $env = $app->detectEnvironment(static fn(): string => 'local');
+    /** @psalm-check-type-exact $env = string */
+
+    $filePath = $app->environmentFilePath();
+    /** @psalm-check-type-exact $filePath = string */
+
+    // Fluent setters carry their `@return $this` through the contract receiver.
+    // Chaining off the result (rather than pinning the exact `&static`
+    // intersection, which renders differently across Psalm versions) proves the
+    // return is the receiver type and not `mixed`, engine-independently.
+    $chained = $app->loadEnvironmentFrom('.env.testing')->isProduction();
+    /** @psalm-check-type-exact $chained = bool */
+
+    $app->useEnvironmentPath('/srv/app');
+    $app->afterLoadingEnvironment(static function (): void {});
+
+    return $env . $filePath . ($chained ? '' : '');
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

Calling methods that exist only on the concrete `Illuminate\Foundation\Application` (e.g. `isProduction()`, `isLocal()`, the `environment*()` family) on a receiver typed as the `Illuminate\Contracts\Foundation\Application` contract raised `UndefinedInterfaceMethod` (psalm 181). The contract declares ~30 methods but not these 9 environment/state ones. Common receivers: `Command::$laravel`, `ServiceProvider::$app`, and `app()` when widened to the contract.

## Related

Fixes #1108

## Solution Description

After the codebase is populated, an `AfterCodebasePopulated` handler (`ApplicationContractMethodHandler`) registers the concrete app's own method ids on the contract's `declaring_method_ids` / `appearing_method_ids` resolution maps for the 9 concrete-only methods. Naive `methodExists()` reads `declaring_method_ids` directly, so the call resolves on contract-typed receivers, and return/param lookups follow the id to the concrete app's real storage. Signatures are delegated to the live concrete app, so they stay correct across Laravel 12-13 without restating them here.

The entries are deliberately **not** written to `$contract->methods`: the interface-compliance check iterates `$interface->methods` at analysis time, so writing there would force every class that `implements` the contract to declare these 9 methods (spurious `UnimplementedInterfaceMethod`). Keeping them out of `methods` makes the resolution invisible to compliance while still resolving the call.

Why not the alternatives:

- A `MethodExistenceProviderInterface` only suppresses 181 when the receiver declares `__call` (the magic-method path is `__call`-gated). The contract has no `__call`.
- A contract `.phpstub` would have to restate every signature (drifts across versions), and re-declaring the interface risks resetting its parent list unless the full `extends` clause is copied verbatim.

Verification: a red→green type test exercises all 9 methods on `Command::$laravel`, `ServiceProvider::$app`, and a contract-typed parameter (pinning `bool` / `string` returns and chaining off a fluent setter to prove `@return $this` is not `mixed`). A separate no-leak test asserts a genuinely-undefined method still raises `UndefinedInterfaceMethod`, guarding the scope. Full type suite, unit, app integration, and self-analysis (100% coverage) are green; `cs` / `rector` are clean.

Out-of-scope follow-up: `Application::path()` is also concrete-only and hits the same 181, while its seven path-siblings (`basePath()`, `configPath()`, ...) are all on the contract. Left out of this env/state-scoped fix as a candidate for a separate change.

## Checklist
- [x] Tests cover the change (type tests in `tests/Type/`)
