### PR TITLE
Set persist-credentials: false on the Psalm workflow checkout

### DIFF
--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -25,7 +25,7 @@ A single Psalm job that, in one run, produces three outcomes:
 
 The run is a plain `./vendor/bin/psalm`, no `--taint-analysis` flag. Psalm 7 enables taint analysis by default, so one run covers both type and taint analysis and reports both. On Psalm 6.x the flag is required (and switches Psalm to a taint-only mode), which is why a separate template targets that version.
 
-The template also pins every action to a commit SHA and hardens the runner with a blocking egress policy plus an allowed-endpoints allowlist. Both are documented inline in the generated file.
+The template also pins every action to a commit SHA and hardens the runner with a blocking egress policy plus an allowed-endpoints allowlist. Checkout runs with `persist-credentials: false` so the `GITHUB_TOKEN` is not left in the git config for later steps to reuse (nothing runs a git operation after checkout, and the SARIF upload uses the Actions token, not git credentials). All are documented inline in the generated file.
 
 ## Customizing
 

--- a/resources/ci/github-actions/psalm.yml
+++ b/resources/ci/github-actions/psalm.yml
@@ -44,7 +44,13 @@ jobs:
             repo.packagist.org:443
             results-receiver.actions.githubusercontent.com:443
 
+      # No git operations run after checkout, so drop the persisted token. Defense in depth:
+      # a compromised later step (a malicious Composer dependency or Psalm plugin) cannot reuse the
+      # token to push, even though github.com is on the egress allowlist. The SARIF upload uses the
+      # Actions token (security-events: write), not git credentials.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:


### PR DESCRIPTION
## Issue to Solve

`actions/checkout` persists the `GITHUB_TOKEN` in the git config (a `$RUNNER_TEMP` file in v6+) by default, where every later step can read it until post-job cleanup. The generated workflow already pins actions to SHAs and blocks egress, but `github.com:443` is on the allowlist, so a compromised later step (a malicious Composer dependency or Psalm plugin pulled during `composer-install`) could reuse the persisted token to push to the repo.

## Related

Mirrors the same hardening applied to the Psalm 6.x template on `3.x` (#1133).

## Solution Description

Set `persist-credentials: false` on the checkout step. Nothing in the workflow runs a git operation after checkout, and the SARIF upload authenticates with the Actions token (`security-events: write`), not git credentials, so the persisted token was unused. This is the OpenSSF Scorecard / StepSecurity recommended default for workflows that do not push.

`persist-credentials` is a checkout-only input, so this is the only step it applies to.

## Checklist
- [x] Documentation is updated
