### PR TITLE
Stop false `TaintedFile`/`TaintedSSRF` on `UploadedFile` reads

### DIFF
--- a/stubs/common/Http/Concerns/InteractsWithInput.phpstub
+++ b/stubs/common/Http/Concerns/InteractsWithInput.phpstub
@@ -122,9 +122,14 @@ trait InteractsWithInput
     /**
      * Get all uploaded files for the request.
      *
-     * @return array<string, \Illuminate\Http\UploadedFile|array<\Illuminate\Http\UploadedFile>>
+     * Not a taint source, for the same reason as Request::file(): the returned
+     * UploadedFile objects only coerce to their server-controlled temp path.
+     * The user-controlled upload data is tainted at the UploadedFile accessors
+     * instead (see stubs/common/Http/UploadedFile.phpstub).
      *
-     * @psalm-taint-source input
+     * Refs: https://github.com/psalm/psalm-plugin-laravel/issues/1134
+     *
+     * @return array<string, \Illuminate\Http\UploadedFile|array<\Illuminate\Http\UploadedFile>>
      */
     public function allFiles() {}
 

--- a/stubs/common/Http/Request.phpstub
+++ b/stubs/common/Http/Request.phpstub
@@ -43,13 +43,21 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      * support. See stubs/common/Http/Concerns/InteractsWithInput.phpstub for
      * the long-form rationale and laravel/framework history.
      *
-     * Refs: https://github.com/psalm/psalm-plugin-laravel/issues/925
+     * Not a taint source: file() returns an UploadedFile object whose only
+     * string coercion is its path (via __toString()/SplFileInfo::getPathname()),
+     * i.e. the PHP-assigned temp upload path in upload_tmp_dir. That path is
+     * server-controlled (not attacker-controllable), so tainting the whole
+     * object raised false TaintedFile/TaintedSSRF when it reached a path sink
+     * such as file_get_contents(). The genuinely user-controlled data
+     * (contents, client filename, MIME type) is tainted at the UploadedFile
+     * accessors instead (see stubs/common/Http/UploadedFile.phpstub).
+     *
+     * Refs: https://github.com/psalm/psalm-plugin-laravel/issues/925,
+     *       https://github.com/psalm/psalm-plugin-laravel/issues/1134
      *
      * @param  string|null  $key
      * @param  mixed  $default
      * @return ($key is null ? array<string, \Illuminate\Http\UploadedFile|array<\Illuminate\Http\UploadedFile>> : \Illuminate\Http\UploadedFile|array<\Illuminate\Http\UploadedFile>|null)
-     *
-     * @psalm-taint-source input
      */
     public function file($key = null, $default = null) {}
 

--- a/stubs/common/Http/UploadedFile.phpstub
+++ b/stubs/common/Http/UploadedFile.phpstub
@@ -67,4 +67,16 @@ class UploadedFile
      * @psalm-taint-source input
      */
     public function get() {}
+
+    /**
+     * Returns the raw contents of the uploaded file (Symfony File parent API).
+     *
+     * Same attacker-controlled bytes as get(), so it is likewise a source. This
+     * is the contents accessor the Request::file() taint fix relies on (#1134).
+     *
+     * @return string
+     *
+     * @psalm-taint-source input
+     */
+    public function getContent(): string {}
 }

--- a/tests/Type/tests/TaintAnalysis/SafeUploadedFilePathViaAllFiles.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeUploadedFilePathViaAllFiles.phpt
@@ -1,0 +1,20 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Same as SafeUploadedFilePathViaRequestFile, for the request's other
+ * UploadedFile entry point: Request::allFiles(). It returns the same
+ * UploadedFile objects, so reading one via its temp path must not raise
+ * TaintedFile / TaintedSSRF (issue #1134). Empty EXPECTF asserts zero output;
+ * before the fix this flagged both findings.
+ */
+function readUploadFromAllFiles(\Illuminate\Http\Request $request): void {
+    $file = $request->allFiles()['avatar'] ?? null;
+    if ($file instanceof \Illuminate\Http\UploadedFile) {
+        file_get_contents((string) $file);
+    }
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeUploadedFilePathViaRequestFile.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeUploadedFilePathViaRequestFile.phpt
@@ -11,18 +11,25 @@
  * temp path (PHP-assigned, in upload_tmp_dir): server-controlled, not
  * attacker-controllable. The user controls the file contents and client name
  * (tainted at the UploadedFile accessors), never the path. So file() is no
- * longer an object-level taint source, and coercing the object to its path
- * must reach the file/SSRF sink untainted. The explicit (string) cast is the
- * type-checkable form of what file_get_contents($file) does implicitly.
+ * longer an object-level taint source, and EVERY way the object coerces to its
+ * path (all routing through __toString -> SplFileInfo::getPathname()) must
+ * reach the file/SSRF sink untainted.
  *
- * Empty EXPECTF asserts zero Psalm output. Before the fix this flagged
- * TaintedFile + TaintedSSRF (the cast carries the object's source taint), so
- * the empty block is a real regression guard, not a vacuous pass.
+ * Empty EXPECTF asserts zero Psalm output. Before the fix each line below
+ * flagged TaintedFile + TaintedSSRF (the coercions carry the object's source
+ * taint), so the empty block is a real regression guard, not a vacuous pass.
+ *
+ * Concatenation ($file . '') is intentionally omitted: it is the same taint
+ * path but Psalm adds an orthogonal ImplicitToStringCast for object-in-concat,
+ * which would pollute the zero-output assertion.
  */
 function readUpload(\Illuminate\Http\Request $request): void {
     $file = $request->file('avatar');
     if ($file instanceof \Illuminate\Http\UploadedFile) {
-        file_get_contents((string) $file);
+        file_get_contents((string) $file);       // explicit cast
+        file_get_contents("$file");               // string interpolation
+        file_get_contents(strval($file));         // strval()
+        file_get_contents(sprintf('%s', $file));  // sprintf %s
     }
 }
 ?>

--- a/tests/Type/tests/TaintAnalysis/SafeUploadedFilePathViaRequestFile.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeUploadedFilePathViaRequestFile.phpt
@@ -1,0 +1,29 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Reading an uploaded file via its path is a safe, standard Laravel idiom and
+ * must NOT raise TaintedFile / TaintedSSRF (issue #1134).
+ *
+ * Request::file() returns an UploadedFile object whose only string form is its
+ * temp path (PHP-assigned, in upload_tmp_dir): server-controlled, not
+ * attacker-controllable. The user controls the file contents and client name
+ * (tainted at the UploadedFile accessors), never the path. So file() is no
+ * longer an object-level taint source, and coercing the object to its path
+ * must reach the file/SSRF sink untainted. The explicit (string) cast is the
+ * type-checkable form of what file_get_contents($file) does implicitly.
+ *
+ * Empty EXPECTF asserts zero Psalm output. Before the fix this flagged
+ * TaintedFile + TaintedSSRF (the cast carries the object's source taint), so
+ * the empty block is a real regression guard, not a vacuous pass.
+ */
+function readUpload(\Illuminate\Http\Request $request): void {
+    $file = $request->file('avatar');
+    if ($file instanceof \Illuminate\Http\UploadedFile) {
+        file_get_contents((string) $file);
+    }
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/TaintedFileUploadedFileClientNameViaRequestFile.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedFileUploadedFileClientNameViaRequestFile.phpt
@@ -1,0 +1,23 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * The #1134 fix rests on a split: an UploadedFile's path coercion is safe, but
+ * its user-controlled accessors stay tainted. This locks in the dangerous
+ * direction so the fix can never silently become an over-broad escape: a
+ * client-supplied filename (getClientOriginalName) is a classic path-traversal
+ * vector and MUST still reach a file/SSRF sink, even though file() is no longer
+ * an object-level source.
+ */
+function readByClientName(\Illuminate\Http\Request $request): void {
+    $file = $request->file('avatar');
+    if ($file instanceof \Illuminate\Http\UploadedFile) {
+        file_get_contents($file->getClientOriginalName());
+    }
+}
+?>
+--EXPECTF--
+%ATaintedFile on line %d: Detected tainted file handling
+%ATaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlUploadedFileContentsViaRequestFile.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlUploadedFileContentsViaRequestFile.phpt
@@ -1,0 +1,24 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Dropping the object-level taint source from Request::file() (issue #1134)
+ * must NOT weaken detection of the genuinely user-controlled data: the file
+ * *contents* are still attacker-supplied. Echoing them is tainted HTML.
+ *
+ * The taint here comes from UploadedFile::get() being its own source (see
+ * stubs/common/Http/UploadedFile.phpstub), independent of how the object was
+ * obtained. This locks in that obtaining it through file() still flows.
+ */
+function renderUploadContents(\Illuminate\Http\Request $request): void {
+    $file = $request->file('avatar');
+    if ($file instanceof \Illuminate\Http\UploadedFile) {
+        echo $file->get();
+    }
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlUploadedFileGetContent.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlUploadedFileGetContent.phpt
@@ -1,0 +1,18 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * UploadedFile::getContent() (the Symfony File parent API) returns the same
+ * raw attacker-controlled bytes as Laravel's get(), so it is a taint source
+ * too. Echoing the contents is tainted HTML. Guards the source added for
+ * issue #1134 (the contents accessor the file() fix relies on).
+ */
+function renderUploadGetContent(\Illuminate\Http\UploadedFile $file): void {
+    echo $file->getContent();
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes


### PR DESCRIPTION
## Issue to Solve

`file_get_contents($request->file('x'))`, a standard Laravel idiom for reading an uploaded file, raised two false-positive taint criticals: `TaintedFile` and `TaintedSSRF`.

`Request::file()` (and `allFiles()`) were annotated `@psalm-taint-source input`, which taints the whole `UploadedFile` object. An `UploadedFile`'s only string coercion is its path (`__toString` to `SplFileInfo::getPathname()`), i.e. the PHP-assigned temp upload path in `upload_tmp_dir`. That path is server-controlled, not attacker-controllable, so feeding the object to a path sink lit up `TaintedFile`/`TaintedSSRF` even though nothing attacker-controlled reaches the path argument.

## Related

Closes #1134

## Solution Description

Remove the object-level `@psalm-taint-source input` from `Request::file()` and `Request::allFiles()`. The genuinely user-controlled data (contents, client filename/path, extension, MIME) stays tainted at the per-accessor sources in `stubs/common/Http/UploadedFile.phpstub` (`get()`, `getClientOriginalName()`, and the rest), which fire independently of how the object was obtained. The object-level source was both redundant and the cause of the false positive.

This is the issue's Option 2 (scope the source to the accessors), chosen over Option 1 (escape the path accessors):

- The path accessors are already untainted: the stub merges with reflection, so `getPathname()`/`getRealPath()`/`__toString()` resolve to the safe Symfony/SplFileInfo implementations.
- Psalm propagates the object's source taint to the sink by data-flow node, independent of `__toString` coercion, so escaping the cast would not stop the flow. Removing the source is the correct lever.

The second commit is related hardening surfaced in review: `UploadedFile::getContent()` (the Symfony `File` parent API) returns the same raw bytes as Laravel's `get()` but was not a source. It now taints like `get()`, so the "user data stays tainted at the accessors" guarantee is complete.

### Verification

5 new type tests under `tests/Type/tests/TaintAnalysis/`:

- `SafeUploadedFilePathViaRequestFile`, `SafeUploadedFilePathViaAllFiles`: reading via the temp path raises no `TaintedFile`/`TaintedSSRF` (order-independent absence assertion).
- `TaintedFileUploadedFileClientNameViaRequestFile`: a client-supplied filename into a path sink still fires, locking in that the fix is a path-only narrowing, not an over-broad escape.
- `TaintedHtmlUploadedFileContentsViaRequestFile`, `TaintedHtmlUploadedFileGetContent`: echoed contents still raise `TaintedHtml`.

Full type suite green (514), `composer psalm` reports 100% coverage with no issues, `composer cs` clean.

### Branch base

Based on `master` (Psalm 7 line). The stub lives in `stubs/common` and is shared with the 3.x (Psalm 6) line, where it arrives via the regular master to 3.x merge.

## Checklist

- [x] Tests cover the change (type tests in `tests/Type/`)
