### PR TITLE
test(cli): align workflow-template assertions to single-job psalm.yml

### DIFF
--- a/tests/Unit/Cli/AddCommandTest.php
+++ b/tests/Unit/Cli/AddCommandTest.php
@@ -48,8 +48,9 @@ final class AddCommandTest extends TestCase
         $contents = \file_get_contents($workflow);
         $this->assertIsString($contents);
         $this->assertStringContainsString('name: Psalm', $contents);
-        $this->assertStringContainsString('types:', $contents);
-        $this->assertStringContainsString('security:', $contents);
+        // Single-job workflow (#1132): one `psalm:` job, SARIF-driven Code Scanning.
+        $this->assertStringContainsString('psalm:', $contents);
+        $this->assertStringContainsString('security-events: write', $contents);
     }
 
     #[Test]

--- a/tests/Unit/Cli/Integrations/Ci/GitHubActionsTargetTest.php
+++ b/tests/Unit/Cli/Integrations/Ci/GitHubActionsTargetTest.php
@@ -86,11 +86,13 @@ final class GitHubActionsTargetTest extends TestCase
         // Assert structural contents rather than whole file equality so doc
         // tweaks to the template don't break the test.
         $this->assertStringContainsString('name: Psalm', $plan->contents);
-        $this->assertStringContainsString('types:', $plan->contents);
-        $this->assertStringContainsString('security:', $plan->contents);
+        // Single-job workflow (#1132): one `psalm:` job runs type + taint in one
+        // pass, uploads SARIF, and feeds Code Scanning via security-events: write.
+        $this->assertStringContainsString('psalm:', $plan->contents);
+        $this->assertStringContainsString('security-events: write', $plan->contents);
         $this->assertStringContainsString('shivammathur/setup-php', $plan->contents);
         $this->assertStringContainsString('github/codeql-action/upload-sarif', $plan->contents);
-        $this->assertStringContainsString('--taint-analysis', $plan->contents);
+        $this->assertStringContainsString('--report=psalm.sarif', $plan->contents);
     }
 
     #[Test]


### PR DESCRIPTION
## Problem

`GitHubActionsTargetTest` and `AddCommandTest` fail on `master`. Both still assert the **two-job** workflow template (`types:`, `security:`, `--taint-analysis`), but #1132 collapsed the generated `psalm.yml` into a **single `psalm:` job** that runs type + taint in one pass (Psalm 7 runs taint by default, so `--taint-analysis` is gone) and drives Code Scanning via a SARIF upload.

```
1) ...AddCommandTest::writes_workflow_when_target_is_github
Failed asserting that '...' contains "types:".

2) ...GitHubActionsTargetTest::plan_reads_contents_from_bundled_template
Failed asserting that '...' contains "types:".
```

## Why it merged green

`tests.yml` only runs on `**.php` / `composer.json` changes. #1132 touched only `.yml` + `.md`, so the unit suite never ran on it and the latent break slipped through. It fires on the next PR that touches any `.php` file.

## Fix

Re-point the two tests' substring assertions at the single-job template:

- `types:` / `security:` -> `psalm:` (the single job key) + `security-events: write` (the Code Scanning permission)
- `--taint-analysis` -> `--report=psalm.sarif` (the actual `Run Psalm` command, not the baseline-noise comment)

Test-only change. `master`-only: #1133 already carries the correct two-job assertions for the 3.x line.
