### PR TITLE
Set persist-credentials: false on read-only workflow checkouts

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -92,12 +92,14 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           ref: ${{ steps.pr.outputs.head_sha }}
           path: plugin-pr
 
       - name: Checkout base branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           ref: ${{ steps.pr.outputs.base_sha }}
           path: plugin-base
 
@@ -223,6 +225,8 @@ jobs:
 
       - name: Checkout plugin
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -80,6 +80,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -41,6 +41,8 @@ jobs:
         run: sudo systemctl mask --now apt-news esm-cache motd-news ua-timer.timer
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Check for typos
         # Configuration lives in _typos.toml at the repo root.

--- a/.github/workflows/test-laravel-app.yml
+++ b/.github/workflows/test-laravel-app.yml
@@ -54,6 +54,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,6 +61,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
@@ -99,6 +101,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2


### PR DESCRIPTION
## Issue to Solve

`actions/checkout` persists the `GITHUB_TOKEN` in the local git config by default, where every later step can read it until post-job cleanup. For jobs that run no authenticated git operation after checkout, that token is unused attack surface: a compromised later step (a malicious Composer dependency or Psalm plugin) could reuse it to push. `lint-workflows.yml` and `psalm-delta.yml` already set `persist-credentials: false`; this extends the same hardening to the remaining read-only checkouts.

## Related

Same hardening as the generated template (#1135 on `master`, #1133 on `3.x`).

## Solution Description

Set `persist-credentials: false` on every checkout whose job does not need the token:

* `psalm.yml`, `tests.yml` (unit + type-test jobs), `spelling.yml`, `test-laravel-app.yml`, `code-style.yml` (fork `check` job): read-only analysis/test jobs, no git write.
* `benchmark.yml` both jobs. The `pr-benchmark` job only calls the GitHub API via `gh` (token from env, not git config). The `master-benchmark` job pushes to gh-pages, but `benchmark-action/github-action-benchmark` authenticates that push with its `github-token` input (it builds an `x-access-token@github.com` remote and clears the checkout `extraheader`), so it does not rely on the persisted credential. Verified in the action's `src/git.ts` at the pinned SHA.

Deliberately left unchanged: the `code-style.yml` auto-fix job, where `stefanzweifel/git-auto-commit-action` pushes the style fix using the token persisted by checkout. Setting `persist-credentials: false` there would break the push.

Verified with `actionlint`.

## Checklist
- [x] Documentation is updated (if needed, otherwise remove this item)
