### PR TITLE
Resolve concrete-only contract methods via a general bridge

### DIFF
--- a/src/Handlers/Application/ContractMethodBridgeHandler.php
+++ b/src/Handlers/Application/ContractMethodBridgeHandler.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Application;
+
+use Illuminate\Contracts\Container\Container;
+use Psalm\Codebase;
+use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
+use Psalm\Internal\MethodIdentifier;
+use Psalm\LaravelPlugin\Providers\ApplicationProvider;
+use Psalm\Plugin\EventHandler\AfterCodebasePopulatedInterface;
+use Psalm\Plugin\EventHandler\Event\AfterCodebasePopulatedEvent;
+use Psalm\Storage\ClassLikeStorage;
+use Psalm\Storage\MethodStorage;
+
+/**
+ * Bridges a Laravel service's public concrete-only methods onto the
+ * `Illuminate\Contracts\*` interface it implements, so a concrete-only call on a
+ * contract-typed receiver stops raising `UndefinedInterfaceMethod` (psalm 181).
+ *
+ * Motivating case (#1108): `Command::$laravel` / `ServiceProvider::$app` / `app()`
+ * are typed on `Contracts\Foundation\Application`, but `isProduction()`,
+ * `isLocal()`, `environmentPath()`, ... live only on the concrete app.
+ *
+ * Mechanism:
+ * - Copy the concrete's `MethodIdentifier`s into the contract's
+ *   `declaring_method_ids` + `appearing_method_ids`. `methodExists()` reads those
+ *   directly → calls resolve and return/param lookups follow to real storage
+ *   (version-correct, no restated signatures).
+ * - Never `$contract->methods`: the compliance check iterates it at analysis time
+ *   → would force implementors to declare bridged methods (`UnimplementedInterfaceMethod`).
+ * - Skip magic + non-public methods (see {@see self::bridgeConcreteMethods()}).
+ *
+ * Scope — allow-list, not a blind contract walk. Sound only for a contract with a
+ * fixed framework-owned implementation the app never swaps (container can only
+ * return that one concrete). `Foundation\Application` qualifies. Excluded:
+ * - `Queue\Queue`, `Filesystem\Filesystem`: resolved class varies by driver.
+ * - `Cache\Repository`: single concrete, but an extension point (config swaps the
+ *   inner `Store`; apps bind custom repositories) — extra surface isn't contract.
+ * Bridging any would hide real bugs. {@see self::CONTRACT_CONCRETES}.
+ *
+ * Alternatives rejected:
+ * - `MethodExistenceProviderInterface`: only suppresses 181 when the receiver has
+ *   `__call` (magic-method path is `__call`-gated); the contract has none.
+ * - Contract `.phpstub`: restates every signature (drifts) and re-declaring the
+ *   interface resets its parent list unless `extends` is copied verbatim.
+ *
+ * Hook `AfterCodebasePopulated`: `declaring_method_ids` is rebuilt and the
+ * concrete's storage populated by then. Deliberately general counterpart to the
+ * hand-listed #1130; maintainer picks either.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1108
+ */
+final class ContractMethodBridgeHandler implements AfterCodebasePopulatedInterface
+{
+    /**
+     * Contract => sole framework concrete. Add only contracts with a fixed,
+     * framework-owned implementation the app never swaps (see class docblock).
+     *
+     * KEY must be an interface/abstract: the gate relies on `make()` throwing for
+     * an unfulfilled contract, but the container auto-builds an instantiable
+     * concrete even when unbound, making the gate vacuous.
+     *
+     * @var array<class-string, class-string>
+     */
+    private const CONTRACT_CONCRETES = [
+        \Illuminate\Contracts\Foundation\Application::class => \Illuminate\Foundation\Application::class,
+    ];
+
+    #[\Override]
+    public static function afterCodebasePopulated(AfterCodebasePopulatedEvent $event): void
+    {
+        $codebase = $event->getCodebase();
+        $container = ApplicationProvider::getApp();
+
+        foreach (self::CONTRACT_CONCRETES as $contractFqcn => $concreteFqcn) {
+            $contract = self::getClassLikeStorage($codebase, $contractFqcn);
+            $concrete = self::getClassLikeStorage($codebase, $concreteFqcn);
+
+            if (!$contract instanceof \Psalm\Storage\ClassLikeStorage || !$concrete instanceof \Psalm\Storage\ClassLikeStorage) {
+                continue;
+            }
+
+            // Widen only a contract the running container fulfils with the mapped
+            // concrete. Skips an app that rebinds it; also the unit-test seam.
+            if (!self::containerResolvesConcrete($container, $contractFqcn, $concreteFqcn)) {
+                continue;
+            }
+
+            self::bridgeConcreteMethods($codebase, $contract, $concrete);
+        }
+    }
+
+    /**
+     * True if `$container->make($contract)` resolves to a `$concrete` instance.
+     * Catches every Throwable (unbound / partial boot / provider error) and treats
+     * a non-object resolution as unfulfilled → don't widen.
+     *
+     * @param class-string $concrete
+     *
+     * @internal seam for unit-testing the resolution gate
+     */
+    public static function containerResolvesConcrete(Container $container, string $contract, string $concrete): bool
+    {
+        try {
+            return self::isInstanceOf($container->make($contract), $concrete);
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    /**
+     * `make()` is untyped: routing its result through a `mixed` param keeps
+     * type-coverage at 100% (params aren't "mixed expressions") and avoids a
+     * `RedundantCondition` if a stub narrows the return.
+     *
+     * @param class-string $concrete
+     *
+     * @psalm-pure
+     */
+    private static function isInstanceOf(mixed $value, string $concrete): bool
+    {
+        return $value instanceof $concrete;
+    }
+
+    private static function bridgeConcreteMethods(
+        Codebase $codebase,
+        ClassLikeStorage $contract,
+        ClassLikeStorage $concrete,
+    ): void {
+        foreach ($concrete->declaring_method_ids as $methodName => $concreteMethodId) {
+            // Never bridge magic methods: copying __call would re-enable the
+            // magic-method path and silently swallow UndefinedInterfaceMethod
+            // (Foundation\Application has __call via Macroable, __get/__set via Container).
+            if (\str_starts_with($methodName, '__')) {
+                continue;
+            }
+
+            // Don't shadow a method already on the contract (own/inherited/prior fire).
+            if (isset($contract->declaring_method_ids[$methodName])) {
+                continue;
+            }
+
+            // Public surface only: bridging a protected/private method turns a clear
+            // UndefinedInterfaceMethod into a misleading InaccessibleMethod.
+            $methodStorage = self::getMethodStorage($codebase, $concreteMethodId);
+            if (!$methodStorage instanceof \Psalm\Storage\MethodStorage || $methodStorage->visibility !== ClassLikeAnalyzer::VISIBILITY_PUBLIC) {
+                continue;
+            }
+
+            // Point resolution maps at the concrete's ids → calls resolve and
+            // return/param lookups hit real storage.
+            $contract->declaring_method_ids[$methodName] = $concreteMethodId;
+            $contract->appearing_method_ids[$methodName] = $concrete->appearing_method_ids[$methodName] ?? $concreteMethodId;
+        }
+    }
+
+    /**
+     * @param class-string $fqcn
+     *
+     * @psalm-mutation-free
+     */
+    private static function getClassLikeStorage(Codebase $codebase, string $fqcn): ?ClassLikeStorage
+    {
+        try {
+            return $codebase->classlike_storage_provider->get(\strtolower($fqcn));
+        } catch (\InvalidArgumentException) {
+            return null;
+        }
+    }
+
+    /**
+     * Mirrors {@see \Psalm\LaravelPlugin\Handlers\Eloquent\ModelRegistrationHandler::getMethodStorage()}
+     * — same getStorage() throw contract (InvalidArgumentException: unknown class;
+     * UnexpectedValueException: missing method). Keep the catch set in sync.
+     *
+     * @psalm-mutation-free
+     */
+    private static function getMethodStorage(Codebase $codebase, MethodIdentifier $methodId): ?MethodStorage
+    {
+        try {
+            return $codebase->methods->getStorage($methodId);
+        } catch (\InvalidArgumentException|\UnexpectedValueException) {
+            return null;
+        }
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -86,6 +86,8 @@ final class Plugin implements PluginEntryPointInterface
         $registration->registerHooksFromClass(Handlers\Application\ContainerHandler::class);
         require_once __DIR__ . '/Handlers/Application/OffsetHandler.php';
         $registration->registerHooksFromClass(Handlers\Application\OffsetHandler::class);
+        require_once __DIR__ . '/Handlers/Application/ContractMethodBridgeHandler.php';
+        $registration->registerHooksFromClass(Handlers\Application\ContractMethodBridgeHandler::class);
 
         require_once __DIR__ . '/Handlers/Auth/AuthMethodHandler.php';
         $registration->registerHooksFromClass(Handlers\Auth\AuthMethodHandler::class);

--- a/tests/Type/tests/ContractMethodBridgeNoLeakTest.phpt
+++ b/tests/Type/tests/ContractMethodBridgeNoLeakTest.phpt
@@ -1,0 +1,20 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App;
+
+use Illuminate\Contracts\Foundation\Application;
+
+/**
+ * Guard: a method on neither contract nor concrete still raises
+ * UndefinedInterfaceMethod. Also pins the magic-method skip — if __call were
+ * bridged (Foundation\Application has it via Macroable) this would route through
+ * the magic path and the error would vanish. #1108.
+ */
+function no_leak(Application $app): void
+{
+    $app->thisMethodDoesNotExist();
+}
+?>
+--EXPECTF--
+UndefinedInterfaceMethod on line %d: Method Illuminate\Contracts\Foundation\Application::thisMethodDoesNotExist does not exist

--- a/tests/Type/tests/ContractMethodBridgeParamCheckTest.phpt
+++ b/tests/Type/tests/ContractMethodBridgeParamCheckTest.phpt
@@ -1,0 +1,24 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App;
+
+use Illuminate\Contracts\Foundation\Application;
+
+/**
+ * Guard: a bridged method keeps the CONCRETE's real param signature — arg-checking
+ * stays live. useEnvironmentPath() with no arg (required $path) must raise
+ * TooFewArguments naming the CONCRETE, proving the bridged id resolves to real
+ * concrete storage, not a widened/empty signature.
+ *
+ * Psalm double-reports TooFewArguments for any interface call (contract receiver +
+ * resolved declarer) — native behaviour, not a bridge artifact (setLocale() does
+ * the same). %A absorbs the contract-named line; we pin only the concrete one. #1108.
+ */
+function param_check(Application $app): void
+{
+    $app->useEnvironmentPath();
+}
+?>
+--EXPECTF--
+%ATooFewArguments on line %d: Too few arguments for method Illuminate\Foundation\Application::useenvironmentpath saw 0%A

--- a/tests/Type/tests/ContractMethodBridgeScopeTest.phpt
+++ b/tests/Type/tests/ContractMethodBridgeScopeTest.phpt
@@ -1,0 +1,20 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App;
+
+use Illuminate\Contracts\Container\Container;
+
+/**
+ * Guard: allow-list scoped, not a blind contract walk. The Container contract is
+ * off the allow-list (and is a parent of the Application contract), so its
+ * concrete-only wrap() must still raise UndefinedInterfaceMethod — proving methods
+ * don't leak onto arbitrary contracts. #1108.
+ */
+function scope_guard(Container $container): void
+{
+    $container->wrap(static fn(): null => null);
+}
+?>
+--EXPECTF--
+UndefinedInterfaceMethod on line %d: Method Illuminate\Contracts\Container\Container::wrap does not exist

--- a/tests/Type/tests/ContractMethodBridgeTest.phpt
+++ b/tests/Type/tests/ContractMethodBridgeTest.phpt
@@ -1,0 +1,79 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Concrete-only Application methods resolve on contract-typed receivers without
+ * UndefinedInterfaceMethod (181), with return types and params preserved.
+ * Command::$laravel / ServiceProvider::$app / a contract param are all typed on
+ * the Contracts\Foundation\Application interface, which declares none of these.
+ * #1108.
+ */
+class DatabasePrune extends Command
+{
+    /** @var string */
+    protected $signature = 'db:prune';
+
+    public function handle(): int
+    {
+        // Command::$laravel is the contract.
+        $_isProduction = $this->laravel->isProduction();
+        /** @psalm-check-type-exact $_isProduction = bool */
+
+        $_isLocal = $this->laravel->isLocal();
+        /** @psalm-check-type-exact $_isLocal = bool */
+
+        $_path = $this->laravel->environmentPath();
+        /** @psalm-check-type-exact $_path = string */
+
+        return 0;
+    }
+}
+
+class PruneServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        // ServiceProvider::$app is the contract.
+        $_isProduction = $this->app->isProduction();
+        /** @psalm-check-type-exact $_isProduction = bool */
+
+        $_file = $this->app->environmentFile();
+        /** @psalm-check-type-exact $_file = string */
+
+        // Param-carrying methods keep their signature (no arg-count false positives).
+        $this->app->useEnvironmentPath('/var/www');
+        $this->app->detectEnvironment(static fn(): string => 'production');
+    }
+}
+
+function on_contract_receiver(Application $app): string
+{
+    $env = $app->detectEnvironment(static fn(): string => 'local');
+    /** @psalm-check-type-exact $env = string */
+
+    $filePath = $app->environmentFilePath();
+    /** @psalm-check-type-exact $filePath = string */
+
+    // Fluent `@return $this` survives the bridge: chain instead of pinning the
+    // version-dependent `&static` intersection.
+    $chained = $app->loadEnvironmentFrom('.env.testing')->isProduction();
+    /** @psalm-check-type-exact $chained = bool */
+
+    $app->useEnvironmentPath('/srv/app');
+    $app->afterLoadingEnvironment(static function (): void {});
+
+    // Generality: every public concrete-only method is bridged, not a fixed list.
+    // path() is concrete-only too (#1130's out-of-scope sibling) and resolves here;
+    // not pinned because the plugin's path helpers narrow it to the resolved path.
+    $appPath = $app->path('routes');
+
+    return $env . $filePath . $appPath . ($chained ? '' : '');
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/ContractMethodBridgeVisibilityTest.phpt
+++ b/tests/Type/tests/ContractMethodBridgeVisibilityTest.phpt
@@ -1,0 +1,20 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App;
+
+use Illuminate\Contracts\Foundation\Application;
+
+/**
+ * Guard: public surface only. markAsRegistered() is protected on the concrete and
+ * absent from the contract, so it must still raise UndefinedInterfaceMethod —
+ * the visibility filter must not expose protected/private methods (which would
+ * surface as a misleading InaccessibleMethod). #1108.
+ */
+function visibility_guard(Application $app): void
+{
+    $app->markAsRegistered(new \stdClass());
+}
+?>
+--EXPECTF--
+UndefinedInterfaceMethod on line %d: Method Illuminate\Contracts\Foundation\Application::markAsRegistered does not exist

--- a/tests/Unit/Handlers/Application/ContractMethodBridgeHandlerTest.php
+++ b/tests/Unit/Handlers/Application/ContractMethodBridgeHandlerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Application;
+
+use Illuminate\Container\Container;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Handlers\Application\ContractMethodBridgeHandler;
+
+/**
+ * Unit guard for the resolution gate in {@see ContractMethodBridgeHandler}.
+ * A throwing / unbound / non-object / wrong-concrete binding must NOT count as
+ * fulfilled — that's what stops the handler bridging methods onto a contract the
+ * app doesn't back with the mapped concrete.
+ */
+#[CoversClass(ContractMethodBridgeHandler::class)]
+final class ContractMethodBridgeHandlerTest extends TestCase
+{
+    #[Test]
+    public function it_treats_a_throwing_binding_as_unresolved(): void
+    {
+        $container = new Container();
+        $container->bind('service', static function (): never {
+            throw new \RuntimeException('cannot build');
+        });
+
+        $this->assertFalse(ContractMethodBridgeHandler::containerResolvesConcrete($container, 'service', \stdClass::class));
+    }
+
+    #[Test]
+    public function it_treats_an_unbound_abstract_as_unresolved(): void
+    {
+        $container = new Container();
+
+        // make() on an unbound, non-instantiable abstract throws inside the handler
+        // and is swallowed — nothing gets widened.
+        $this->assertFalse(ContractMethodBridgeHandler::containerResolvesConcrete($container, 'not.bound', \stdClass::class));
+    }
+
+    #[Test]
+    public function it_rejects_a_non_object_resolution(): void
+    {
+        $container = new Container();
+        $container->instance('scalar', 'a string, not an object');
+
+        $this->assertFalse(ContractMethodBridgeHandler::containerResolvesConcrete($container, 'scalar', \stdClass::class));
+    }
+
+    #[Test]
+    public function it_rejects_an_object_of_the_wrong_concrete(): void
+    {
+        $container = new Container();
+        $container->instance('contract', new \stdClass());
+
+        $this->assertFalse(ContractMethodBridgeHandler::containerResolvesConcrete($container, 'contract', Container::class));
+    }
+
+    #[Test]
+    public function it_accepts_an_object_of_the_expected_concrete(): void
+    {
+        $container = new Container();
+        $container->instance('contract', new \stdClass());
+
+        $this->assertTrue(ContractMethodBridgeHandler::containerResolvesConcrete($container, 'contract', \stdClass::class));
+    }
+}


### PR DESCRIPTION
Alternative to #1130. Fixes #1108.

## Problem
- Concrete-only `Illuminate\Foundation\Application` methods (`isProduction()`, `isLocal()`, `environmentPath()`/`environmentFile()`/`path()`, ...) raise `UndefinedInterfaceMethod` (181) when the receiver is typed on the `Contracts\Foundation\Application` interface.
- Hits `Command::$laravel`, `ServiceProvider::$app`, `app()`.

## Fix
- `ContractMethodBridgeHandler` (`AfterCodebasePopulated`): copies the concrete's public method ids into the contract's `declaring_method_ids` + `appearing_method_ids`.
- Signatures delegate to real concrete storage → version-correct, no restated/hardcoded method list.
- Never writes `$contract->methods` → no spurious `UnimplementedInterfaceMethod` on implementors.
- Skips magic (`__*`) and non-public methods.

## Scope (soundness)
- Allow-list `contract => concrete`, seeded with `Foundation\Application` only — not a blind `Illuminate\Contracts\*` walk.
- Safe only for a fixed framework-owned impl the app never swaps. Excluded: `Queue`/`Filesystem` (driver-varying concrete), `Cache\Repository` (extension point).
- Container-gated: widens only if `make($contract)` resolves to the mapped concrete.

## vs #1130
- #1130 hand-lists 9 methods; this bridges every public concrete-only method.
- Trade-off: broader contract surface (sound — single impl) for zero maintenance + an extension seam. Also fixes `path()`.

## Tests
- Type: positive (returns/params/chaining/`path()`), param-check (`TooFewArguments` via the bridged id), no-leak (missing method still 181 + `__*` skip), scope (`Container` contract still 181), visibility (protected not bridged).
- Unit: resolution gate (throw / unbound / non-object / wrong-concrete / right-concrete).
- Full type suite (514) + unit + self-psalm (100% coverage) + `cs` + `rector` green.
- psalm-delta, 18 real apps: net **-5** — false 181 removed in monica/solidtime/one private app; filament ±2 is known flaky noise (`HasBulkActions.php:120-121`), unrelated.
