### PR TITLE
Stop `init` from silently disabling type analysis on Psalm 6

### DIFF
--- a/resources/ci/github-actions/psalm.yml
+++ b/resources/ci/github-actions/psalm.yml
@@ -6,9 +6,13 @@
 #   * taint-analysis  - taint/security analysis. Uploads SARIF to Code Scanning and fails on findings.
 #
 # Add your release branches under `push:` so Code Scanning builds the default-branch baseline it diffs PRs against.
-# Reduce existing-finding noise with separate baselines:
+# Baseline existing type issues so only new ones fail the type job:
 #   ./vendor/bin/psalm --set-baseline=psalm-baseline.xml
-#   ./vendor/bin/psalm --taint-analysis --set-baseline=psalm-taint-baseline.xml
+# That writes errorBaseline into psalm.xml; the taint job below runs --ignore-baseline so the
+# type baseline does not surface as UnusedBaselineEntry (taint mode skips type analysis, so a
+# type baseline matches nothing and every entry reads as "unused"). Psalm 6 has a single
+# errorBaseline attribute, so a per-job taint baseline is not wired here: --set-baseline under
+# --taint-analysis would overwrite that single errorBaseline pointer.
 
 name: Psalm
 
@@ -106,8 +110,11 @@ jobs:
       # generated_report_options + $_SERVER['GITHUB_WORKFLOW']), so the run step succeeds and CI is
       # failed from the SARIF after upload, not from the exit code. A real crash exits non-zero,
       # fails this step and skips the rest.
+      # --ignore-baseline keeps a type baseline (errorBaseline in psalm.xml) from reporting as
+      # UnusedBaselineEntry here: taint mode skips type analysis, so the baseline matches none
+      # and each entry would otherwise count as "unused" and fail the job (#1139).
       - name: Run Psalm (taint analysis)
-        run: ./vendor/bin/psalm --taint-analysis --report=psalm.sarif --report-show-info=false
+        run: ./vendor/bin/psalm --taint-analysis --ignore-baseline --report=psalm.sarif --report-show-info=false
 
       - name: Upload SARIF to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/src/Cli/InitCommand.php
+++ b/src/Cli/InitCommand.php
@@ -60,6 +60,15 @@ final class InitCommand extends Command
      * Psalm 7). Do not re-add them when merging master into 3.x:
      * InitCommandTest::generated_config_validates_against_installed_psalm_schema,
      * run under the pinned Psalm 6, is the guard that catches a reintroduction (#1115).
+     *
+     * The runTaintAnalysis attribute is intentionally absent too: on Psalm 6 it
+     * switches Psalm to a taint-only mode that skips type analysis, so a plain
+     * `vendor/bin/psalm` (and the `add` workflow's type job) would silently check
+     * no types. Taint runs per-job via the `--taint-analysis` flag instead (#1139).
+     * Harmless on Psalm 7 (4.x/master runs type and taint in one pass), so do not
+     * re-add it when merging master in. Unlike the handlers above, the schema test
+     * cannot catch a re-add (the attribute is valid Psalm 6 config); the explicit
+     * guard is InitCommandTest::generated_config_omits_run_taint_analysis.
      */
     private const PSALM_XML_TEMPLATE = <<<'XML'
         <?xml version="1.0"?>
@@ -70,7 +79,6 @@ final class InitCommand extends Command
             errorLevel="{{LEVEL}}"
             findUnusedCode="false"
             ensureOverrideAttribute="false"
-            runTaintAnalysis="true"
         >
             <projectFiles>
         {{PROJECT_FILES}}

--- a/tests/Unit/Cli/InitCommandTest.php
+++ b/tests/Unit/Cli/InitCommandTest.php
@@ -88,6 +88,23 @@ final class InitCommandTest extends TestCase
     }
 
     #[Test]
+    public function generated_config_omits_run_taint_analysis(): void
+    {
+        // Regression guard for #1139. On Psalm 6, runTaintAnalysis="true" switches Psalm to a
+        // taint-only mode that skips type analysis, so a plain `vendor/bin/psalm` (and the `add`
+        // workflow's type job) would silently check no types. Taint runs per-job via the
+        // --taint-analysis flag instead. The attribute is valid Psalm 6 config, so the
+        // schema-validation test cannot catch a re-add (e.g. from a master merge); asserting the
+        // bare token is absent is the only guard, and trips on any form (true or false).
+        $tester = $this->makeTester();
+        $tester->execute([]);
+
+        $contents = \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $this->assertIsString($contents);
+        $this->assertStringNotContainsString('runTaintAnalysis', $contents);
+    }
+
+    #[Test]
     public function generated_xml_is_well_formed(): void
     {
         $tester = $this->makeTester();

--- a/tests/Unit/Cli/Integrations/Ci/GitHubActionsTargetTest.php
+++ b/tests/Unit/Cli/Integrations/Ci/GitHubActionsTargetTest.php
@@ -94,6 +94,14 @@ final class GitHubActionsTargetTest extends TestCase
         $this->assertStringContainsString('shivammathur/setup-php', $plan->contents);
         $this->assertStringContainsString('github/codeql-action/upload-sarif', $plan->contents);
         $this->assertStringContainsString('--report=psalm.sarif', $plan->contents);
+        // #1139: the type job must run plain psalm (no --taint-analysis), or it runs taint-only
+        // and skips type analysis. End-anchored so the taint job's `run:` line (same prefix,
+        // trailing flags) cannot satisfy it.
+        $this->assertMatchesRegularExpression('~run: \./vendor/bin/psalm$~m', $plan->contents);
+        // #1139: the taint job must ignore a type baseline, or every errorBaseline entry reports
+        // as UnusedBaselineEntry (taint mode skips type analysis, so the baseline matches none).
+        // Anchored to the `run:` line so a comment mentioning the flags cannot satisfy it.
+        $this->assertStringContainsString('run: ./vendor/bin/psalm --taint-analysis --ignore-baseline', $plan->contents);
     }
 
     #[Test]


### PR DESCRIPTION
## Issue to Solve

On the 3.x / Psalm 6 line, `psalm-laravel init` generated a `psalm.xml` with `runTaintAnalysis="true"`. On Psalm 6 that attribute switches Psalm into a taint-only mode that skips type analysis, so a plain `vendor/bin/psalm` reported zero type issues and the type gate was silently dead. It also contradicted the two-job `add` workflow (whose type job runs plain `./vendor/bin/psalm`, assuming the config carries no `runTaintAnalysis`), and once a type baseline was wired in, the taint job loaded it but never recomputed type issues, surfacing every entry as `UnusedBaselineEntry`.

This is v3.x / Psalm 6 specific. On Psalm 7 / 4.x (master) type and taint run in a single pass, so the attribute is harmless there and master is intentionally left unchanged.

## Related

Fixes #1139

## Solution Description

- `InitCommand`: drop `runTaintAnalysis="true"` from the generated `psalm.xml` template. Taint is driven per job by the `--taint-analysis` flag instead, so a plain `vendor/bin/psalm` (and the workflow's type job) performs type analysis again. A docblock note plus a new string-absence unit test guard against a master to 3.x merge re-adding the attribute. The existing schema-validation test cannot catch that, since `runTaintAnalysis` is valid Psalm 6 config.
- `add` workflow (`resources/ci/github-actions/psalm.yml`): the taint job runs `--ignore-baseline`, so a type baseline no longer surfaces as `UnusedBaselineEntry` (taint mode skips type analysis, so a type baseline matches nothing). The misleading dual-baseline comment is rewritten: Psalm 6 exposes a single `errorBaseline` attribute, so a per-job taint baseline is not wired.
- Tests: `GitHubActionsTargetTest` now asserts the type job runs plain psalm (end anchored, so the taint job cannot satisfy it) and that the taint job carries `--ignore-baseline`.

Verified locally: the two affected unit-test files pass (23 tests), `composer psalm` reports 100% coverage with no issues, `composer cs` and `composer rector` are clean. The reporter independently verified both fixes end to end on a real app (type gate green with a baseline applied, taint gate green).

## Checklist
- [x] Tests cover the change (unit tests in `tests/Unit/`)
- [x] Documentation is updated (workflow comments and the `InitCommand` docblock)
