### PR TITLE
Fix false `UndefinedMethod` on forwarded `Query\Builder` methods in custom builder subclasses

### DIFF
--- a/src/Handlers/Eloquent/BuilderSubclassQueryMixinHandler.php
+++ b/src/Handlers/Eloquent/BuilderSubclassQueryMixinHandler.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Eloquent;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Psalm\Plugin\EventHandler\AfterCodebasePopulatedInterface;
+use Psalm\Plugin\EventHandler\Event\AfterCodebasePopulatedEvent;
+use Psalm\Type\Atomic\TNamedObject;
+
+/**
+ * Restores the `@mixin Query\Builder` that Psalm drops on user Eloquent\Builder subclasses
+ * which declare their own `@mixin` (typically `@mixin <Model>`).
+ *
+ * Eloquent\Builder forwards Query\Builder methods (whereNotNull, orWhereNull, orderBy, ...)
+ * through a stub `@mixin \Illuminate\Database\Query\Builder`. A subclass normally inherits that
+ * mixin, so those methods resolve on, e.g., a plain VehicleBuilder. But when the subclass adds
+ * its own `@mixin Model` (a common pattern to expose model attributes/scopes on builder
+ * instances), Psalm does NOT merge the child's mixins with the parent's — its populator
+ * REPLACES the inherited list with the child's own (Populator::populateDataFromParentClass,
+ * the `if (!$storage->namedMixins)` guard). The inherited `@mixin Query\Builder` is lost, so
+ * forwarded methods surface as false UndefinedMethod on the builder (and, once resolution
+ * descends through `@mixin Model`, on the model itself).
+ *
+ * Upstream layer: the non-merging behavior is a vimeo/psalm limitation, not a Laravel one — a
+ * child's own `@mixin` should extend, not shadow, the inherited mixins. Until that is fixed,
+ * we compensate at the plugin level by re-appending Query\Builder to the subclass's named
+ * mixins so native mixin resolution (existence, params, return types, visibility) works again.
+ *
+ * Not to be confused with {@see ModelBuilderMixinHandler}, which works the inverse direction —
+ * a Model's `@mixin Builder<static>` — and at analysis time rather than after population.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1140
+ */
+final class BuilderSubclassQueryMixinHandler implements AfterCodebasePopulatedInterface
+{
+    #[\Override]
+    public static function afterCodebasePopulated(AfterCodebasePopulatedEvent $event): void
+    {
+        $codebase = $event->getCodebase();
+        $builderLower = \strtolower(Builder::class);
+        $queryBuilderLower = \strtolower(QueryBuilder::class);
+
+        foreach ($codebase->classlike_storage_provider::getAll() as $storage) {
+            // Only classes that transitively extend Eloquent\Builder.
+            if (!isset($storage->parent_classes[$builderLower])) {
+                continue;
+            }
+
+            // Query\Builder already reachable as a named mixin → nothing was shadowed.
+            // This is the no-own-`@mixin` case: Psalm inherited the parent's
+            // `@mixin Query\Builder`, so namedMixins already carries it. Skip — and avoid
+            // appending a duplicate.
+            foreach ($storage->namedMixins as $mixin) {
+                if (\strtolower($mixin->value) === $queryBuilderLower) {
+                    continue 2;
+                }
+            }
+
+            // The subclass shadowed the inherited mixin with its own. Re-add Query\Builder.
+            // from_docblock mirrors a scanner-parsed `@mixin` tag — this restores the stub
+            // `@mixin Query\Builder` the subclass would otherwise have inherited.
+            $storage->namedMixins[] = new TNamedObject(QueryBuilder::class, from_docblock: true);
+
+            // handleRegularMixins() only iterates namedMixins when mixin_declaring_fqcln is set.
+            // The scanner already sets it on any class that declares its own `@mixin` (and the
+            // populator copies a value from the parent otherwise), so reaching here with null is
+            // not expected; keep the coalesce as a guard for that invariant.
+            $storage->mixin_declaring_fqcln ??= $storage->name;
+        }
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -121,6 +121,7 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Eloquent/FactoryCountTypeProvider.php';
         require_once __DIR__ . '/Handlers/Eloquent/ModelPropertyAccessorHandler.php';
         require_once __DIR__ . '/Handlers/Eloquent/ModelAttributeSubsetHandler.php';
+        require_once __DIR__ . '/Handlers/Eloquent/BuilderSubclassQueryMixinHandler.php';
         // ModelPropertyHandler is loaded unconditionally because BuilderAggregateHandler
         // calls ModelPropertyHandler::resolveColumnType() to narrow aggregate returns
         // even when migrations are disabled (the @property branch still applies).
@@ -131,6 +132,7 @@ final class Plugin implements PluginEntryPointInterface
         }
 
         $registration->registerHooksFromClass(Handlers\Eloquent\ModelRegistrationHandler::class);
+        $registration->registerHooksFromClass(Handlers\Eloquent\BuilderSubclassQueryMixinHandler::class);
         $registration->registerHooksFromClass(Handlers\Eloquent\ModelFactoryMethodTypeProvider::class);
         $registration->registerHooksFromClass(Handlers\Eloquent\FactoryCountTypeProvider::class);
 

--- a/tests/Application/app/Builders/AppointmentBuilder.php
+++ b/tests/Application/app/Builders/AppointmentBuilder.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Builders;
+
+use App\Models\Appointment;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Custom builder that exposes its model's surface via `@mixin Appointment`.
+ *
+ * Archetype for issue #1140: a user `@mixin <Model>` on an Eloquent\Builder subclass shadows
+ * the inherited `@mixin Query\Builder`. Psalm does not merge a child's own mixins with the
+ * parent's (Populator replaces, not merges), so Query\Builder-forwarded methods
+ * (whereNotNull, orWhereNull, ...) stop resolving on the builder without a compensating
+ * re-injection of the Query\Builder mixin.
+ *
+ * The incomplete()/inThePast() bodies mirror the reported reproduction; the regression is
+ * asserted in BuilderSubclassMixinForwardingTest (the type suite reflects these fixtures but
+ * does not analyze their method bodies, so the assertions drive a builder-typed receiver).
+ *
+ * @extends Builder<Appointment>
+ * @mixin Appointment
+ */
+final class AppointmentBuilder extends Builder
+{
+    public function incomplete(): self
+    {
+        $this->where(function (AppointmentBuilder $query): void {
+            $query->where('scheduled_at', '>=', 'now')
+                ->orWhereNull('completed_at');
+        });
+
+        return $this;
+    }
+
+    public function inThePast(): self
+    {
+        $this->where('scheduled_at', '<=', 'now')
+            ->whereNotNull('completed_at');
+
+        return $this;
+    }
+}

--- a/tests/Application/app/Models/Appointment.php
+++ b/tests/Application/app/Models/Appointment.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Builders\AppointmentBuilder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Garage service appointment.
+ *
+ * Archetype for issue #1140: a model whose dedicated custom builder declares
+ * `@mixin Appointment` to surface model attributes on builder instances. The builder is
+ * registered via newEloquentBuilder(), mirroring the common custom-query-builder pattern.
+ *
+ * @see AppointmentBuilder
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1140
+ *
+ * @property string      $scheduled_at Appointment time
+ * @property string|null $completed_at Completion time, null while pending
+ *
+ * @method static AppointmentBuilder incomplete()
+ * @method static AppointmentBuilder inThePast()
+ */
+final class Appointment extends Model
+{
+    protected $table = 'appointments';
+
+    #[\Override]
+    public function newEloquentBuilder($query): AppointmentBuilder
+    {
+        return new AppointmentBuilder($query);
+    }
+}

--- a/tests/Type/tests/Builder/BuilderSubclassMixinForwardingTest.phpt
+++ b/tests/Type/tests/Builder/BuilderSubclassMixinForwardingTest.phpt
@@ -1,0 +1,78 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Builders\AppointmentBuilder;
+use App\Models\Appointment;
+
+/**
+ * Issue #1140: a user Eloquent\Builder subclass that declares its own `@mixin <Model>`
+ * (here AppointmentBuilder `@mixin Appointment`) must still resolve Query\Builder-forwarded
+ * methods (whereNotNull, orWhereNull, orderBy, ...).
+ *
+ * Psalm replaces — rather than merges — a child's mixins with the parent's, so the
+ * `@mixin Query\Builder` inherited from Eloquent\Builder is shadowed by the subclass's own
+ * `@mixin Appointment`. BuilderSubclassQueryMixinHandler re-injects Query\Builder so resolution
+ * (existence + return type) works as it does on a builder without an own `@mixin`.
+ *
+ * The receiver-typed-as-builder form below is the analysis equivalent of the `$this->...`
+ * calls inside AppointmentBuilder's own methods — the receiver type is identical.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1140
+ */
+
+/** Forwarded Query\Builder methods resolve on the custom builder and preserve its type. */
+function appt_forwarded_on_builder(AppointmentBuilder $b): void
+{
+    $_whereNotNull = $b->whereNotNull('completed_at');
+    /** @psalm-check-type-exact $_whereNotNull = AppointmentBuilder */
+
+    $_orWhereNull = $b->orWhereNull('completed_at');
+    /** @psalm-check-type-exact $_orWhereNull = AppointmentBuilder */
+
+    $_orderBy = $b->orderBy('scheduled_at');
+    /** @psalm-check-type-exact $_orderBy = AppointmentBuilder */
+}
+
+/**
+ * The re-injected Query\Builder mixin must NOT displace the user's `@mixin Appointment`:
+ * model attributes must still resolve on builder instances (the reason the user added the
+ * mixin). Guards against a fix that resolves query methods by dropping the model mixin.
+ */
+function appt_model_surface_preserved(AppointmentBuilder $b): void
+{
+    $_attr = $b->scheduled_at;
+    /** @psalm-check-type-exact $_attr = string */
+}
+
+/** Chaining a forwarded method into a builder-only method keeps the custom builder type. */
+function appt_chain_preserves_builder(AppointmentBuilder $b): void
+{
+    $_result = $b->whereNotNull('completed_at')->incomplete();
+    /** @psalm-check-type-exact $_result = AppointmentBuilder */
+}
+
+/** Forwarded method resolves on the builder returned from Model::query(). */
+function appt_forwarded_via_query(): void
+{
+    $_result = Appointment::query()->whereNotNull('completed_at');
+    /** @psalm-check-type-exact $_result = AppointmentBuilder */
+}
+
+/** Negative: a genuinely undefined method on the builder must still be reported. */
+function appt_undefined_method_still_reported(AppointmentBuilder $b): void
+{
+    $b->completelyFakeMethod();
+}
+
+/**
+ * Negative on the model surface: resolution that descends through `@mixin Appointment` must
+ * still reject a fake method on the model (the issue's symptom was reported on the model).
+ */
+function appt_undefined_method_on_model_still_reported(Appointment $m): void
+{
+    $m->completelyFakeMethod();
+}
+?>
+--EXPECTF--
+UndefinedMagicMethod on line %d: Magic method App\Builders\AppointmentBuilder::completelyfakemethod does not exist
+UndefinedMagicMethod on line %d: Magic method App\Models\Appointment::completelyfakemethod does not exist


### PR DESCRIPTION
## Issue to Solve
A user-defined subclass of `Illuminate\Database\Eloquent\Builder` that declares its own
`@mixin <Model>` (a common pattern for exposing model attributes/scopes on builder
instances) triggers false `UndefinedMethod` on forwarded `Query\Builder` methods
(`whereNotNull`, `orWhereNull`, `orderBy`, ...). The error surfaces on the model once
resolution descends through `@mixin <Model>`.

## Related
Fixes #1140

## Solution Description
Root cause is an upstream Psalm limitation, not Laravel: when a child class declares its
own `@mixin`, Psalm's populator (`populateDataFromParentClass`) replaces rather than merges
the inherited mixin list (the `if (!$storage->namedMixins)` guard). `Eloquent\Builder`
carries `@mixin Query\Builder`, so a subclass with `@mixin <Model>` silently loses the
Query\Builder forwarding.

`BuilderSubclassQueryMixinHandler` (an `AfterCodebasePopulated` hook) re-appends
`Query\Builder` to the named mixins of any `Eloquent\Builder` subclass whose own mixin
shadowed it, restoring native mixin resolution (existence, params, return types, visibility)
without displacing the user's `@mixin <Model>`. The append is guarded (skipped when
`Query\Builder` is already present) and idempotent.

Verified with a type test (`BuilderSubclassMixinForwardingTest.phpt`) using registered app
fixtures (`Appointment` + `AppointmentBuilder`): forwarded methods resolve to the custom
builder, chaining preserves the builder type, the model surface (`$b->scheduled_at`) still
resolves, and genuinely-undefined methods are still reported on both builder and model.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
