### PR TITLE
Stop guard taint warning for `SessionGuard::hashPasswordForCookie()` on Laravel 11 (remove a warning message during scanning)

### DIFF
--- a/src/Handlers/Auth/GuardTaintHandler.php
+++ b/src/Handlers/Auth/GuardTaintHandler.php
@@ -9,6 +9,7 @@ use Illuminate\Auth\TokenGuard;
 use Psalm\LaravelPlugin\Handlers\Validation\ValidationRuleAnalyzer;
 use Psalm\Plugin\EventHandler\AfterClassLikeVisitInterface;
 use Psalm\Plugin\EventHandler\Event\AfterClassLikeVisitEvent;
+use Psalm\Progress\Progress;
 use Psalm\Storage\ClassLikeStorage;
 use Psalm\Storage\MethodStorage;
 use Psalm\Type\TaintKind;
@@ -43,7 +44,10 @@ use Psalm\Type\TaintKind;
  *    user_secret`). This is defensive: the result already carries no taint to strip (the real
  *    `hash_hmac()` body breaks the flow, and a hex digest cannot carry injection taint), so the
  *    escape is a no-op today. It is kept to make the security contract explicit and to stay correct
- *    if a future Psalm ever propagates taint through the HMAC.
+ *    if a future Psalm ever propagates taint through the HMAC. This method only exists on Laravel 12+
+ *    (framework #58107); on the supported Laravel 11 line it is legitimately absent, so the branch
+ *    probes by presence and stays silent when missing — warning about a skipped no-op on every
+ *    Laravel 11 scan was pure noise (#1143). The load-bearing TokenGuard source above keeps warning.
  *
  * The deleted SessionGuard stub additionally carried `@psalm-flow ($passwordHash) -> return`, which
  * re-propagated non-secret taints through the HMAC. That is intentionally dropped: a hex digest is
@@ -54,20 +58,37 @@ final class GuardTaintHandler implements AfterClassLikeVisitInterface
     #[\Override]
     public static function afterClassLikeVisit(AfterClassLikeVisitEvent $event): void
     {
-        $storage = $event->getStorage();
+        self::annotateGuardTaints($event->getStorage(), $event->getCodebase()->progress);
+    }
 
+    /**
+     * Apply the guards' taint metadata to the matched real class storage.
+     *
+     * Split out from {@see afterClassLikeVisit} so it can be driven with a synthetic
+     * {@see ClassLikeStorage} and a capturing {@see Progress} in a unit test, without standing up a
+     * whole {@see \Psalm\Codebase}: the SessionGuard absence path (the #1143 regression) never fires
+     * against the installed Laravel, where the method exists.
+     *
+     * @internal
+     */
+    public static function annotateGuardTaints(ClassLikeStorage $storage, Progress $progress): void
+    {
         if (\strcasecmp($storage->name, TokenGuard::class) === 0) {
-            $method = self::resolveMethod($event, $storage, 'gettokenforrequest');
+            // getTokenForRequest() exists on every supported Laravel version and is a load-bearing
+            // taint *source*, so a missing method is a real regression (an invisible false negative).
+            $method = self::resolveMethod($progress, $storage, 'gettokenforrequest', warnIfMissing: true);
 
-            if ($method instanceof \Psalm\Storage\MethodStorage) {
+            if ($method instanceof MethodStorage) {
                 // Psalm 6 models a taint set as a list<string> of kind names (Psalm 7 uses an int
                 // bitmask), and has no TaintKind::ALL_INPUT constant — merge the ALL_INPUT group list.
                 $method->taint_source_types = self::mergeTaints($method->taint_source_types, ValidationRuleAnalyzer::allInputTaints());
             }
         } elseif (\strcasecmp($storage->name, SessionGuard::class) === 0) {
-            $method = self::resolveMethod($event, $storage, 'hashpasswordforcookie');
+            // hashPasswordForCookie() only exists on Laravel 12+ and carries a no-op escape (see class
+            // docblock), so its absence on Laravel 11 has zero analysis impact — stay silent.
+            $method = self::resolveMethod($progress, $storage, 'hashpasswordforcookie', warnIfMissing: false);
 
-            if ($method instanceof \Psalm\Storage\MethodStorage) {
+            if ($method instanceof MethodStorage) {
                 $method->removed_taints = self::mergeTaints($method->removed_taints, [TaintKind::USER_SECRET]);
             }
         }
@@ -88,21 +109,23 @@ final class GuardTaintHandler implements AfterClassLikeVisitInterface
     }
 
     /**
-     * Look up a method on the (already-matched) guard class, warning if it is absent.
+     * Look up a method on the (already-matched) guard class.
      *
-     * A guard taint method silently vanishing is a security regression — a missing source is an
-     * invisible false negative — so we surface it the way {@see \Psalm\LaravelPlugin\Handlers\Facades\AppFacadeRegistrationHandler}
-     * surfaces a facade root going missing: a `warning` (debug is a no-op under the default
-     * progress). It only fires for the two matched classes, so there is no per-class-visit spam.
+     * When $warnIfMissing is true, an absent method is surfaced as a `warning` (a no-op under the
+     * default progress) the way {@see \Psalm\LaravelPlugin\Handlers\Facades\AppFacadeRegistrationHandler}
+     * surfaces a facade root going missing: for a method that must exist on every supported Laravel
+     * version, a silent disappearance is a security regression — a missing taint source is an
+     * invisible false negative. Pass false for a version-optional method whose absence is expected on
+     * a supported version (the SessionGuard branch), to avoid warning about a skipped no-op (#1143).
      *
      * @param lowercase-string $method
      */
-    private static function resolveMethod(AfterClassLikeVisitEvent $event, ClassLikeStorage $storage, string $method): ?MethodStorage
+    private static function resolveMethod(Progress $progress, ClassLikeStorage $storage, string $method, bool $warnIfMissing): ?MethodStorage
     {
         $method_storage = $storage->methods[$method] ?? null;
 
-        if ($method_storage === null) {
-            $event->getCodebase()->progress->warning(
+        if ($method_storage === null && $warnIfMissing) {
+            $progress->warning(
                 "Laravel plugin: {$storage->name}::{$method}() not found — guard taint annotation skipped. "
                 . 'The Laravel method signature may have changed; please report this against psalm-plugin-laravel.',
             );

--- a/tests/Unit/Handlers/Auth/GuardTaintAnnotationTest.php
+++ b/tests/Unit/Handlers/Auth/GuardTaintAnnotationTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Auth;
+
+use Illuminate\Auth\SessionGuard;
+use Illuminate\Auth\TokenGuard;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Handlers\Auth\GuardTaintHandler;
+use Psalm\LaravelPlugin\Handlers\Validation\ValidationRuleAnalyzer;
+use Psalm\Storage\ClassLikeStorage;
+use Psalm\Storage\MethodStorage;
+use Psalm\Type\TaintKind;
+
+/**
+ * #1143: the guard taint handler must treat the two guard methods asymmetrically when absent.
+ *
+ * `SessionGuard::hashPasswordForCookie()` is a Laravel 12+ method (framework #58107), legitimately
+ * absent on the supported Laravel 11 line; it carries only a no-op `user_secret` escape, so its
+ * absence must stay silent rather than warn about a skipped no-op on every Laravel 11 scan.
+ * `TokenGuard::getTokenForRequest()` is a load-bearing taint *source* present on every supported
+ * version, so a vanished method must still warn (a missing source is an invisible false negative).
+ *
+ * Driven through {@see GuardTaintHandler::annotateGuardTaints()} with synthetic storage so the
+ * absence path is exercised deterministically regardless of the installed Laravel — where, being a
+ * 12+ release, `hashPasswordForCookie()` exists and the regression cannot reproduce.
+ */
+#[CoversClass(GuardTaintHandler::class)]
+final class GuardTaintAnnotationTest extends TestCase
+{
+    #[Test]
+    public function a_missing_session_guard_method_does_not_warn(): void
+    {
+        $progress = new RecordingProgress();
+
+        GuardTaintHandler::annotateGuardTaints(new ClassLikeStorage(SessionGuard::class), $progress);
+
+        self::assertSame(
+            [],
+            $progress->warnings,
+            'hashPasswordForCookie() is absent on Laravel 11 by design — its no-op escape must stay silent',
+        );
+    }
+
+    #[Test]
+    public function a_missing_token_guard_method_warns(): void
+    {
+        $progress = new RecordingProgress();
+
+        GuardTaintHandler::annotateGuardTaints(new ClassLikeStorage(TokenGuard::class), $progress);
+
+        self::assertCount(1, $progress->warnings, 'a vanished load-bearing taint source must surface');
+        self::assertStringContainsString('gettokenforrequest', $progress->warnings[0]);
+    }
+
+    #[Test]
+    public function a_non_guard_class_is_a_silent_no_op(): void
+    {
+        // afterClassLikeVisit fires for every class Psalm visits; only the two guard branches may act.
+        // Pins the branch boundary so a loosened if/elseif (e.g. a stray `else`) can't warn on
+        // arbitrary classes — the warning channel is otherwise unobserved by any other test.
+        $progress = new RecordingProgress();
+
+        GuardTaintHandler::annotateGuardTaints(new ClassLikeStorage(\stdClass::class), $progress);
+
+        self::assertSame([], $progress->warnings);
+    }
+
+    #[Test]
+    public function a_present_session_guard_method_gets_the_user_secret_escape(): void
+    {
+        $storage = new ClassLikeStorage(SessionGuard::class);
+        $storage->methods['hashpasswordforcookie'] = new MethodStorage();
+
+        GuardTaintHandler::annotateGuardTaints($storage, new RecordingProgress());
+
+        self::assertSame(
+            [TaintKind::USER_SECRET],
+            $storage->methods['hashpasswordforcookie']->removed_taints,
+        );
+    }
+
+    #[Test]
+    public function a_present_token_guard_method_gets_the_input_taint_source(): void
+    {
+        $storage = new ClassLikeStorage(TokenGuard::class);
+        $storage->methods['gettokenforrequest'] = new MethodStorage();
+
+        GuardTaintHandler::annotateGuardTaints($storage, new RecordingProgress());
+
+        // The source must carry exactly the all-input taint set (the contract: the token is read from
+        // request input). Canonicalizing keeps this independent of merge order/dedup.
+        self::assertEqualsCanonicalizing(
+            ValidationRuleAnalyzer::allInputTaints(),
+            $storage->methods['gettokenforrequest']->taint_source_types,
+        );
+    }
+}

--- a/tests/Unit/Handlers/Auth/GuardTaintAnnotationTest.php
+++ b/tests/Unit/Handlers/Auth/GuardTaintAnnotationTest.php
@@ -38,11 +38,7 @@ final class GuardTaintAnnotationTest extends TestCase
 
         GuardTaintHandler::annotateGuardTaints(new ClassLikeStorage(SessionGuard::class), $progress);
 
-        self::assertSame(
-            [],
-            $progress->warnings,
-            'hashPasswordForCookie() is absent on Laravel 11 by design — its no-op escape must stay silent',
-        );
+        $this->assertSame([], $progress->warnings, 'hashPasswordForCookie() is absent on Laravel 11 by design — its no-op escape must stay silent');
     }
 
     #[Test]
@@ -52,8 +48,8 @@ final class GuardTaintAnnotationTest extends TestCase
 
         GuardTaintHandler::annotateGuardTaints(new ClassLikeStorage(TokenGuard::class), $progress);
 
-        self::assertCount(1, $progress->warnings, 'a vanished load-bearing taint source must surface');
-        self::assertStringContainsString('gettokenforrequest', $progress->warnings[0]);
+        $this->assertCount(1, $progress->warnings, 'a vanished load-bearing taint source must surface');
+        $this->assertStringContainsString('gettokenforrequest', $progress->warnings[0]);
     }
 
     #[Test]
@@ -66,7 +62,7 @@ final class GuardTaintAnnotationTest extends TestCase
 
         GuardTaintHandler::annotateGuardTaints(new ClassLikeStorage(\stdClass::class), $progress);
 
-        self::assertSame([], $progress->warnings);
+        $this->assertSame([], $progress->warnings);
     }
 
     #[Test]
@@ -77,10 +73,7 @@ final class GuardTaintAnnotationTest extends TestCase
 
         GuardTaintHandler::annotateGuardTaints($storage, new RecordingProgress());
 
-        self::assertSame(
-            [TaintKind::USER_SECRET],
-            $storage->methods['hashpasswordforcookie']->removed_taints,
-        );
+        $this->assertSame([TaintKind::USER_SECRET], $storage->methods['hashpasswordforcookie']->removed_taints);
     }
 
     #[Test]
@@ -93,9 +86,6 @@ final class GuardTaintAnnotationTest extends TestCase
 
         // The source must carry exactly the all-input taint set (the contract: the token is read from
         // request input). Canonicalizing keeps this independent of merge order/dedup.
-        self::assertEqualsCanonicalizing(
-            ValidationRuleAnalyzer::allInputTaints(),
-            $storage->methods['gettokenforrequest']->taint_source_types,
-        );
+        $this->assertEqualsCanonicalizing(ValidationRuleAnalyzer::allInputTaints(), $storage->methods['gettokenforrequest']->taint_source_types);
     }
 }

--- a/tests/Unit/Handlers/Auth/RecordingProgress.php
+++ b/tests/Unit/Handlers/Auth/RecordingProgress.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Auth;
+
+use Psalm\Progress\Progress;
+
+/**
+ * A {@see Progress} that records warnings instead of writing them to STDERR, so a test can assert
+ * whether {@see \Psalm\LaravelPlugin\Handlers\Auth\GuardTaintHandler} warned about a missing guard
+ * method.
+ */
+final class RecordingProgress extends Progress
+{
+    /** @var list<string> */
+    public array $warnings = [];
+
+    #[\Override]
+    public function warning(string $message): void
+    {
+        $this->warnings[] = $message;
+    }
+}


### PR DESCRIPTION
## Issue to Solve

On every Laravel 11 scan, `GuardTaintHandler` emitted:

```text
Warning: Laravel plugin: Illuminate\Auth\SessionGuard::hashpasswordforcookie() not found — guard taint annotation skipped. The Laravel method signature may have changed; please report this against psalm-plugin-laravel.
```

`SessionGuard::hashPasswordForCookie()` is a Laravel 12+ method (framework #58107), legitimately absent on the supported Laravel 11 line (`^11.35`). The escape it carries is a documented no-op (a hex HMAC digest is injection-inert), so the warning announced a skipped no-op: pure noise that also invited bogus bug reports for a non-problem.

## Related

Fixes #1143. Residual of #1113 / #1121, which moved the guard taint metadata out of full-class stubs and into this handler.

## Solution Description

Why over what: the two guard methods are not equivalent, so their absence is not treated equally.

- `SessionGuard::hashPasswordForCookie()` is version-optional and carries a no-op escape, so its absence has zero analysis impact. The branch now probes by presence and stays silent when missing (a new `warnIfMissing` flag on `resolveMethod()`, passed `false` here). This mirrors how Laravel's own Sanctum guards the call with `method_exists()`.
- `TokenGuard::getTokenForRequest()` is a load-bearing taint source present on every supported version, so it keeps `warnIfMissing: true` — a vanished source is an invisible false negative worth surfacing.

The handler logic is extracted into an `@internal annotateGuardTaints(ClassLikeStorage, Progress)` seam so the absence path can be tested deterministically.

Verification:

- New unit test `GuardTaintAnnotationTest` drives `annotateGuardTaints()` with synthetic storage. A phpt cannot guard this: the warning goes to stderr (not matched by `--EXPECTF--`), and the method is present on the entire Laravel 12+ type-test matrix, so a phpt would be vacuous.
- Empirically confirmed on Laravel 11.54.0: the warning fires before the change and is gone after.
- `composer psalm` (Psalm 6, no errors, 100% type coverage), full unit suite (791 tests), and `composer cs` all pass.

Base is `3.x`: master supports Laravel 12-13 only, where the method always exists, so master is unaffected.

## Checklist
- [x] Tests cover the change (unit test in `tests/Unit/`)
