### PR TITLE
fix(ci): keep psalm-delta app cache from crossing Psalm majors

### DIFF
--- a/.github/workflows/psalm-delta.yml
+++ b/.github/workflows/psalm-delta.yml
@@ -187,11 +187,24 @@ jobs:
       # ref, so steady-state runs skip the cold composer install (the dominant
       # cost). The runner workspace path is stable across runs, so the plugin
       # path-repo symlink inside vendor stays valid.
+      #
+      # hashFiles(plugin-base/composer.json) namespaces the key by the measured
+      # plugin's dependency declaration — the superset of delta-app.sh's
+      # plugin_dep_sig (require + autoload), which is what actually determines the
+      # installed vendor. The 3.x and 4.x lines pin the same app refs, so a key
+      # without it lets both lines collide on one entry and poison each other with
+      # an incompatible vendor (e.g. the installed AddTaintsInterface return type
+      # mismatches every handler and fatals at class-load). The hash differs
+      # whenever ANY dependency does — a Psalm major or minor bump, an added
+      # runtime dep — which is exactly when a reinstall is warranted. delta-app.sh
+      # re-validates the same signature on reuse, so an already-poisoned cache
+      # self-heals even when this key happens to hit. Native expression: no
+      # parsing step, no shell, nothing written to an output.
       - name: Cache app source
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/app-cache/${{ matrix.name }}
-          key: psalm-delta-app-${{ matrix.name }}-${{ matrix.ref }}-php${{ matrix.php }}-v1
+          key: psalm-delta-app-${{ matrix.name }}-${{ matrix.ref }}-php${{ matrix.php }}-${{ hashFiles('plugin-base/composer.json') }}-v1
 
       - name: Run delta for ${{ matrix.name }}
         # All interpolated values go through env (not inline ${{ }} in run) so a

--- a/bin/ci/delta-app.sh
+++ b/bin/ci/delta-app.sh
@@ -220,8 +220,40 @@ write_psalm_xml() {
 XMLEOF
 }
 
-# Run the one-time source install only if vendor is absent (cache-friendly).
+# Records the base plugin dependency signature the cached vendor was solved
+# against. Lives inside the cached app-src so a later run can prove the vendor
+# still matches the plugin shape under test.
+PLUGIN_SIG_FILE="$APP_SRC/.plugin-dep-sig"
+
+# Reuse the cached vendor only when it provably matches the base plugin's
+# dependency shape. A cached app-src is keyed on the app ref, NOT on the plugin
+# under test, so a vendor solved for one plugin line can be restored for another
+# (e.g. a Psalm 7 line on 4.x feeding a Psalm 6 line on 3.x and vice versa).
+# Reusing a mismatched vendor loads the wrong dependency set — most visibly an
+# `AddTaintsInterface` whose `addTaints()` return type differs (array in 6, int
+# in 7), fataling every handler at class-load before analysis even starts.
+#
+# `plugin_dep_sig` (require + autoload — the only sections that change what gets
+# installed) is the same signature the head/base relink already trusts, so ANY
+# dependency drift triggers a reinstall: a Psalm major OR minor constraint bump,
+# an added runtime dependency, an autoload change. A missing or unreadable
+# signature means we cannot prove compatibility, so we also reinstall — a
+# self-healing guard must never reuse an unverifiable vendor. The reinstall is a
+# clean `composer update` that honours the plugin's constraints.
+want_sig="$(plugin_dep_sig "$PLUGIN_BASE")"
+need_install=0
 if [[ ! -f "$APP_SRC/vendor/bin/psalm" ]]; then
+    need_install=1
+elif [[ -z "$want_sig" ]]; then
+    echo "[$APP] cannot compute base plugin dependency signature; reinstalling to stay safe" >&2
+    need_install=1
+elif [[ ! -f "$PLUGIN_SIG_FILE" || "$(cat "$PLUGIN_SIG_FILE")" != "$want_sig" ]]; then
+    echo "[$APP] cached vendor was solved for a different plugin dependency shape; reinstalling" >&2
+    need_install=1
+fi
+
+# Run the one-time source install only when needed (cache-friendly otherwise).
+if [[ "$need_install" == 1 ]]; then
     echo "[$APP] installing dependencies" >&2
     (
         cd "$APP_SRC"
@@ -239,6 +271,8 @@ if [[ ! -f "$APP_SRC/vendor/bin/psalm" ]]; then
     # written into composer.json, so the per-side COW copies inherit it.
     (cd "$APP_SRC" && composer config --no-interaction policy.advisories.block false 2>/dev/null || true)
     (cd "$APP_SRC" && composer update "${COMPOSER_FLAGS[@]}" --quiet)
+    # Stamp what this vendor was solved against, so a future run can verify reuse.
+    printf '%s' "$want_sig" > "$PLUGIN_SIG_FILE"
 else
     echo "[$APP] reusing installed vendor" >&2
     write_psalm_xml


### PR DESCRIPTION
## Problem

The `/psalm-delta` run on #1146 (a 3.x / Psalm 6 PR) crashed on **every** app with:

> Declaration of `...ValidationTaintHandler::addTaints(...): array` must be compatible with `...AddTaintsInterface::addTaints(...)`

`AddTaintsInterface::addTaints()` returns `array` in Psalm 6 and `int` in Psalm 7. The 3.x handlers correctly return `array`, so the only way this conflicts is if **Psalm 7 was loaded** into the app vendor while measuring a Psalm 6 plugin line.

## Root cause

The cached app source (`~/app-cache/<name>`) is keyed on the app ref, PHP version, and a `-v1` namespace, but **not** on the measured plugin's Psalm major. The 3.x (Psalm 6) and 4.x (Psalm 7) lines pin the same app refs, so both lines resolve to one cache entry. Whichever line installs first wins; the other restores that vendor and, because `delta-app.sh` reuses any vendor with a `vendor/bin/psalm` present, runs the wrong Psalm major against a plugin built for the other. The interface return-type mismatch then fatals at class-load, before analysis starts.

A fresh `^6` solve can never yield `7.0.0-beta` (composer's upper bound excludes it) and `configure_plugin_repo` forces the plugin into the solve, so a clean install is always correct. The bug is purely cache reuse.

## Fix

- **`bin/ci/delta-app.sh`**: reuse the cached vendor only when its installed Psalm major matches the plugin constraint. On mismatch, force a clean `composer update` re-solve (honours the plugin's `^6`/`^7`). Self-heals local runs and any already-poisoned cache entry, independent of the cache key.
- **`.github/workflows/psalm-delta.yml`**: add the measured plugin's Psalm major (read off the base checkout) to the cache key, so the two lines keep separate entries instead of poisoning each other.

## Notes

Informational delta report only; never failed the PR. The cache-key change cold-invalidates every app cache once, so the first post-merge run does a full install per app (heavy apps may run close to the 12 min timeout on that one cold run).