### PR TITLE
Support Carbon 2 alongside Carbon 3 (Better support for Laravel 11)

### DIFF
--- a/src/Providers/CarbonStubProvider.php
+++ b/src/Providers/CarbonStubProvider.php
@@ -36,6 +36,21 @@ use Psalm\Progress\Progress;
  */
 final class CarbonStubProvider
 {
+    /**
+     * Carbon major 3: CarbonPeriod `extends DatePeriodBase` and the WeekDay/Month enums exist.
+     * The CI matrix only ever resolves Carbon 3, so this boundary is exercised by a unit test
+     * ({@see \Tests\Psalm\LaravelPlugin\Unit\Providers\CarbonStubProviderTest}) rather than the
+     * type suite.
+     */
+    public const CARBON_3_CONSTRAINT = '>=3.0';
+
+    /**
+     * Dual-purpose getter/setter narrowings apply to Carbon 3.0-3.11: they type params as the
+     * Carbon-3 `WeekDay` enum (absent on Carbon 2), and Carbon 3.12 supersedes them with its own
+     * inline conditional (#1059).
+     */
+    public const DUAL_PURPOSE_NARROWINGS_CONSTRAINT = '>=3.0 <3.12';
+
     public static function register(RegistrationInterface $registration, Progress $output): void
     {
         if (!InstalledVersions::isInstalled('nesbot/carbon')) {
@@ -48,18 +63,31 @@ final class CarbonStubProvider
             return;
         }
 
+        $versionParser = new VersionParser();
+        // Carbon 3 reshaped CarbonPeriod (`extends DatePeriodBase`) and added the WeekDay/Month
+        // enums; Carbon 2 has neither. The stubs below are gated on this major so a fully supported
+        // Laravel 11 + Carbon 2 install (illuminate ^11.35 resolves nesbot/carbon ^2.72 || ^3) no
+        // longer hits MissingDependency / UndefinedClass (#1142).
+        $isCarbon3 = InstalledVersions::satisfies($versionParser, 'nesbot/carbon', self::CARBON_3_CONSTRAINT);
+
         $translatorVariant = self::symfonyTranslatorHasReturnType() ? 'Strong' : 'Weak';
         $formatterVariant = self::symfonyMessageFormatterFirstParamHasType() ? 'Strong' : 'Weak';
 
+        // Translator / MessageFormatter lazy splits exist in both Carbon 2 and 3.
         $lazyStubs = [
-            // Carbon\DatePeriodBase — picked at CarbonPeriod.php:50 via `PHP_VERSION < 8.2`.
-            // Plugin requires PHP 8.2+ (composer.json), so Unprotected is always correct.
-            $carbonRoot . '/lazy/Carbon/UnprotectedDatePeriod.php',
-
             $carbonRoot . "/lazy/Carbon/Translator{$translatorVariant}Type.php",
 
             $carbonRoot . "/lazy/Carbon/MessageFormatter/MessageFormatterMapper{$formatterVariant}Type.php",
         ];
+
+        if ($isCarbon3) {
+            // Carbon\DatePeriodBase is declared only by this lazy file, and only on Carbon 3.
+            // CarbonPeriod.php:50 picks Unprotected vs Protected via `PHP_VERSION < 8.2`; the plugin
+            // requires PHP 8.2+ (composer.json), so Unprotected is always correct. Carbon 2 has no
+            // DatePeriodBase split (CarbonPeriod implements Iterator directly), so the file is absent
+            // there — registering it would fail realpath() and warn for nothing (#1142).
+            $lazyStubs[] = $carbonRoot . '/lazy/Carbon/UnprotectedDatePeriod.php';
+        }
 
         foreach ($lazyStubs as $stub) {
             $realPath = \realpath($stub);
@@ -91,14 +119,20 @@ final class CarbonStubProvider
         // a package the consumer does not actually use.
         //
         // The directory is split by load condition:
-        //   - shared/   — version-independent stubs (the CarbonPeriod lazy-collect helper
-        //                 and the Constants/* interfaces). Always registered.
-        //   - pre-3.12/ — conditional-return narrowings for Carbon's dual-purpose
-        //                 getter/setter methods. Registered ONLY for nesbot/carbon < 3.12
-        //                 (see the version gate below).
+        //   - shared/   — version-independent stubs (the Constants/* interfaces). Always registered.
+        //   - 2/ , 3/   — the Carbon-major-specific CarbonPeriod shape. Exactly one is registered,
+        //                 keyed on $isCarbon3: Carbon 3 `extends DatePeriodBase` + `@implements
+        //                 IteratorAggregate`, Carbon 2 `implements Iterator` directly. Shipping the
+        //                 wrong shape breaks every CarbonPeriod consumer with MissingDependency (#1142).
+        //   - pre-3.12/ — conditional-return narrowings for Carbon's dual-purpose getter/setter
+        //                 methods. Registered ONLY for nesbot/carbon >=3.0 <3.12 (see the gate below).
         $integrationStubsDir = \dirname(__DIR__, 2) . '/stubs/integrations/carbon';
 
         foreach (StubFileFinder::findIn($integrationStubsDir . '/shared', $output) as $stub) {
+            $registration->addStubFile($stub);
+        }
+
+        foreach (StubFileFinder::findIn($integrationStubsDir . ($isCarbon3 ? '/3' : '/2'), $output) as $stub) {
             $registration->addStubFile($stub);
         }
 
@@ -134,7 +168,13 @@ final class CarbonStubProvider
         //     conditional on BOTH the Localization trait and CarbonInterface (plus a variadic
         //     tail param). That is an upstream Carbon/Psalm interaction the plugin cannot fix by
         //     gating.
-        if (InstalledVersions::satisfies(new VersionParser(), 'nesbot/carbon', '<3.12')) {
+        //
+        // The gate's lower bound is >=3.0, not "everything below 3.12": these stubs type the
+        // dual-purpose params as Carbon\WeekDay, an enum added in Carbon 3.0 that does not exist on
+        // Carbon 2. Registering them on Carbon 2 injects a dangling Carbon\WeekDay reference and
+        // forces a Carbon-3 signature onto Carbon 2's untyped methods (UndefinedClass at WeekDay
+        // use-sites, #1142). Carbon 2 keeps its own `@return static|int` instead.
+        if (InstalledVersions::satisfies($versionParser, 'nesbot/carbon', self::DUAL_PURPOSE_NARROWINGS_CONSTRAINT)) {
             foreach (StubFileFinder::findIn($integrationStubsDir . '/pre-3.12', $output) as $stub) {
                 $registration->addStubFile($stub);
             }

--- a/stubs/integrations/carbon/2/CarbonPeriod.phpstub
+++ b/stubs/integrations/carbon/2/CarbonPeriod.phpstub
@@ -1,0 +1,43 @@
+<?php
+
+namespace Carbon;
+
+use Carbon\Traits\IntervalRounding;
+use Carbon\Traits\Mixin;
+use Carbon\Traits\Options;
+use Carbon\Traits\ToStringFormat;
+use Countable;
+use Iterator;
+use JsonSerializable;
+
+/**
+ * Carbon 2 shape of CarbonPeriod (`implements Iterator` directly, no DatePeriodBase).
+ * The Carbon 3 variant (`extends DatePeriodBase`) lives in `../3/CarbonPeriod.phpstub`;
+ * `CarbonStubProvider` registers exactly one, keyed on the installed Carbon major (#1142).
+ *
+ * Carbon 2's `CarbonPeriod::current()` is `?CarbonInterface` and `key()` is `?int`, but
+ * the class carries no iterable template, so Psalm widens `collect(CarbonPeriod::create(...))`
+ * to `Collection<int, mixed>`. `@implements Iterator<int, CarbonInterface>` binds the value
+ * type for the `iterable<TKey, TValue>` reads (`collect()`, `iterator_to_array()`), narrowing
+ * it to `Collection<int, CarbonInterface>`. A direct `foreach` still reads the reflected
+ * `current(): ?CarbonInterface`, so the loop var is nullable there — we keep that rather than
+ * pin `current()` non-null, which would hide the real null on a standalone `current()` call
+ * (the Carbon 3 variant leaves `current()` nullable too, narrowing only via `getIterator()`).
+ *
+ * `Iterator` MUST appear in the explicit `implements` clause for the `@implements` template to
+ * bind: Psalm's `ClassLikeNodeScanner::implementTemplatedType()` validates `@implements` against
+ * `class_implements` at scan time, and a class declaration wipes the reflected `class_implements`
+ * (CLAUDE.md). So the `implements` / `use` clauses are copied verbatim from Carbon 2 source;
+ * methods not redeclared here continue to come from reflection of the real class.
+ *
+ * @implements Iterator<int, CarbonInterface>
+ */
+class CarbonPeriod implements Iterator, Countable, JsonSerializable
+{
+    use IntervalRounding;
+    use Mixin {
+        Mixin::mixin as baseMixin;
+    }
+    use Options;
+    use ToStringFormat;
+}

--- a/stubs/integrations/carbon/3/CarbonPeriod.phpstub
+++ b/stubs/integrations/carbon/3/CarbonPeriod.phpstub
@@ -12,6 +12,10 @@ use Countable;
 use JsonSerializable;
 
 /**
+ * Carbon 3 shape of CarbonPeriod (`extends DatePeriodBase`). The Carbon 2 variant
+ * (`implements Iterator` directly, no DatePeriodBase) lives in `../2/CarbonPeriod.phpstub`;
+ * `CarbonStubProvider` registers exactly one, keyed on the installed Carbon major (#1142).
+ *
  * Real signature in vendor/nesbot/carbon/src/Carbon/CarbonPeriod.php:329 is
  * `public function getIterator(): Generator` with no template — Psalm widens
  * the yield to `mixed`, which collapses `collect(CarbonPeriod::create(...))`

--- a/tests/Type/CarbonVersion.php
+++ b/tests/Type/CarbonVersion.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Type;
+
+use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
+
+/**
+ * Carbon-version gate for version-specific stub tests, called from a phpt `--SKIPIF--` section.
+ *
+ * `CarbonStubProvider` registers different stub sets per installed Carbon major:
+ * the `CarbonPeriod` / `DatePeriodBase` stubs and the `WeekDay`-typed dual-purpose
+ * narrowings only exist on Carbon 3 (see `CarbonStubProvider::register()`). A phpt
+ * asserting Carbon-3 shapes must skip on Carbon 2, and a phpt asserting the Carbon-2
+ * baseline must skip on Carbon 3, otherwise it fails on the other cell of the test matrix.
+ *
+ * Unlike {@see LaravelVersion} (which reads `Application::VERSION`), Carbon exposes no version
+ * constant usable across both majors, so the version is resolved from Composer with the same
+ * `InstalledVersions::satisfies()` call `CarbonStubProvider` gates on. The `--SKIPIF--` script
+ * runs in a bare `php` process from the project root with no autoloader preloaded, so require it
+ * via `getcwd()`:
+ *
+ *   --SKIPIF--
+ *   <?php
+ *   require getcwd() . '/vendor/autoload.php';
+ *   \Tests\Psalm\LaravelPlugin\Type\CarbonVersion::skipBelow('3.0.0');
+ *
+ * Each method echoes a `skip ...` message (which the runner detects) when the test must not run.
+ */
+final class CarbonVersion
+{
+    /** Skip when the installed Carbon is older than $version (the Carbon-3 stubs do not load there). */
+    public static function skipBelow(string $version): void
+    {
+        if (InstalledVersions::satisfies(new VersionParser(), 'nesbot/carbon', '<' . $version)) {
+            echo 'skip needs Carbon >= ' . $version
+                . ' (installed ' . InstalledVersions::getPrettyVersion('nesbot/carbon') . ')';
+        }
+    }
+
+    /** Skip when the installed Carbon is $version or newer (for the Carbon-2 baseline only). */
+    public static function skipFrom(string $version): void
+    {
+        if (InstalledVersions::satisfies(new VersionParser(), 'nesbot/carbon', '>=' . $version)) {
+            echo 'skip needs Carbon < ' . $version
+                . ' (installed ' . InstalledVersions::getPrettyVersion('nesbot/carbon') . ')';
+        }
+    }
+}

--- a/tests/Type/tests/CarbonIsoWeekdayCarbon2Test.phpt
+++ b/tests/Type/tests/CarbonIsoWeekdayCarbon2Test.phpt
@@ -1,0 +1,26 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// Carbon-2 counterpart of CarbonIsoWeekdayTest: the dual-purpose narrowing stubs type their
+// params as Carbon\WeekDay (a Carbon 3 enum) and are NOT registered on Carbon 2, so isoWeekday()
+// must resolve via Carbon 2's own untyped `static|int` with no Carbon\WeekDay reference leaking.
+// Skip on Carbon 3, where CarbonIsoWeekdayTest covers the narrowed shape instead.
+\Tests\Psalm\LaravelPlugin\Type\CarbonVersion::skipFrom('3.0.0');
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Guards the `>=3.0` lower bound of the pre-3.12 narrowing gate (#1142). Before the gate fix the
+ * plugin registered the Carbon\WeekDay-typed redeclarations on Carbon 2 too, producing
+ * `UndefinedClass: Carbon\WeekDay`. With the gate, Carbon 2 keeps its native dual-purpose
+ * `isoWeekday($value = null): static|int` (un-narrowed: the setter is NOT collapsed to `static`).
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1142
+ */
+
+use Carbon\Carbon;
+
+$_set = Carbon::now()->isoWeekday(1);
+/** @psalm-check-type-exact $_set = \Carbon\Carbon&static|int */
+?>
+--EXPECTF--

--- a/tests/Type/tests/CarbonIsoWeekdayInterfaceTest.phpt
+++ b/tests/Type/tests/CarbonIsoWeekdayInterfaceTest.phpt
@@ -1,3 +1,9 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// Asserts the Carbon 3 dual-purpose isoWeekday() narrowing (plugin stub registered only on
+// Carbon >= 3.0). On Carbon 2 the method resolves to Carbon's own wider `static|int`. Skip.
+\Tests\Psalm\LaravelPlugin\Type\CarbonVersion::skipBelow('3.0.0');
 --FILE--
 <?php declare(strict_types=1);
 

--- a/tests/Type/tests/CarbonIsoWeekdayTest.phpt
+++ b/tests/Type/tests/CarbonIsoWeekdayTest.phpt
@@ -1,3 +1,9 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// Carbon\WeekDay (used below) is a Carbon 3 enum, and the dual-purpose narrowing stub that
+// drives the asserted setter type is registered only on Carbon >= 3.0. Skip on Carbon 2.
+\Tests\Psalm\LaravelPlugin\Type\CarbonVersion::skipBelow('3.0.0');
 --FILE--
 <?php declare(strict_types=1);
 

--- a/tests/Type/tests/CarbonLazyStubsTest.phpt
+++ b/tests/Type/tests/CarbonLazyStubsTest.phpt
@@ -1,3 +1,9 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// Exercises Carbon\DatePeriodBase, declared by a lazy stub that only exists on Carbon 3.
+// Carbon 2's CarbonPeriod implements Iterator directly (no DatePeriodBase). Skip on Carbon 2.
+\Tests\Psalm\LaravelPlugin\Type\CarbonVersion::skipBelow('3.0.0');
 --FILE--
 <?php declare(strict_types=1);
 

--- a/tests/Type/tests/CarbonPeriodCollectTest.phpt
+++ b/tests/Type/tests/CarbonPeriodCollectTest.phpt
@@ -2,21 +2,22 @@
 <?php declare(strict_types=1);
 
 /**
- * Regression for issue #922 — two related defects covered in one expression:
+ * Cross-version regression (#922, #1142) — runs on BOTH Carbon majors (no SKIPIF) so the two
+ * `CarbonStubProvider` CarbonPeriod variants stay in lockstep on the one observable result:
  *
- *  1. `MissingDependency` cascade: `Carbon\DatePeriodBase` is declared via
- *     runtime `require` from `vendor/nesbot/carbon/lazy/`, outside Carbon's
- *     composer autoload. `CarbonStubProvider` registers Carbon's own lazy
- *     file as a stub; without it `CarbonPeriod::create()` collapses to
- *     `never` and every consumer surfaces as dead code.
+ *  1. `MissingDependency` cascade: a CarbonPeriod whose parent is unresolved collapses
+ *     `CarbonPeriod::create()` to `never`. On Carbon 3 the parent is `Carbon\DatePeriodBase`,
+ *     declared via a runtime `require` from `vendor/nesbot/carbon/lazy/` (outside Carbon's
+ *     composer autoload) that `CarbonStubProvider` registers as a stub; on Carbon 2 there is no
+ *     DatePeriodBase, and shipping the Carbon-3 stub there was the original cause of #1142.
  *
- *  2. `Collection<int, mixed>` widening: Carbon's `CarbonPeriod::getIterator()`
- *     returns untemplated `Generator`, so Psalm cannot resolve the iterable
- *     yield type. `stubs/common/Carbon/CarbonPeriod.phpstub` pins
- *     `@implements IteratorAggregate<int, CarbonInterface>` so `collect()`
- *     binds `TValue = CarbonInterface`.
+ *  2. `Collection<int, mixed>` widening: CarbonPeriod carries no iterable template, so Psalm
+ *     widens the yield to `mixed`. The plugin's per-major CarbonPeriod stub pins the value type
+ *     (`@implements IteratorAggregate<int, CarbonInterface>` on Carbon 3, `@implements
+ *     Iterator<int, CarbonInterface>` on Carbon 2) so `collect()` binds `TValue = CarbonInterface`.
  *
  * @see https://github.com/psalm/psalm-plugin-laravel/issues/922
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1142
  */
 
 use Carbon\CarbonPeriod;

--- a/tests/Unit/Providers/CarbonStubProviderTest.php
+++ b/tests/Unit/Providers/CarbonStubProviderTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Providers;
+
+use Composer\Semver\Semver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Providers\CarbonStubProvider;
+
+#[CoversClass(CarbonStubProvider::class)]
+final class CarbonStubProviderTest extends TestCase
+{
+    /**
+     * Locks the Carbon-major boundaries that decide which stub set the provider registers.
+     * The CI matrix only ever resolves Carbon 3, so without this the Carbon-2 and <3.12 branches
+     * (the #1142 fix) are never exercised by an automated check. `Semver::satisfies` here mirrors
+     * the `InstalledVersions::satisfies` calls in {@see CarbonStubProvider::register()} against the
+     * same constraint constants.
+     *
+     * @see https://github.com/psalm/psalm-plugin-laravel/issues/1142
+     */
+    #[Test]
+    #[DataProvider('carbonVersionProvider')]
+    public function it_gates_stub_sets_by_carbon_major(
+        string $carbonVersion,
+        bool $expectedIsCarbon3,
+        bool $expectedDualPurposeNarrowings,
+    ): void {
+        $this->assertSame($expectedIsCarbon3, Semver::satisfies($carbonVersion, CarbonStubProvider::CARBON_3_CONSTRAINT), 'CarbonPeriod / DatePeriodBase stub selection');
+        $this->assertSame($expectedDualPurposeNarrowings, Semver::satisfies($carbonVersion, CarbonStubProvider::DUAL_PURPOSE_NARROWINGS_CONSTRAINT), 'dual-purpose narrowing stub selection');
+    }
+
+    /** @return iterable<string, array{string, bool, bool}> */
+    public static function carbonVersionProvider(): iterable
+    {
+        // Carbon 2: Iterator-shaped CarbonPeriod, no DatePeriodBase, no WeekDay enum.
+        yield 'Carbon 2.72 (Laravel 11 floor)' => ['2.72.0', false, false];
+        yield 'Carbon 2.73 (latest 2.x)' => ['2.73.0', false, false];
+
+        // Carbon 3.0-3.11: DatePeriodBase shape plus the dual-purpose narrowings.
+        yield 'Carbon 3.0 (enums + DatePeriodBase land)' => ['3.0.0', true, true];
+        yield 'Carbon 3.11.4 (last before the 3.12 conditional)' => ['3.11.4', true, true];
+
+        // Carbon 3.12+: narrowings superseded by Carbon's own inline conditional (#1059).
+        yield 'Carbon 3.12 (narrowings superseded)' => ['3.12.0', true, false];
+        yield 'Carbon 3.13 (current)' => ['3.13.0', true, false];
+
+        // Hypothetical Carbon 4 is outside the supported matrix, but documents that >=3.0 keeps
+        // selecting the Carbon-3 shape (matches the prior unconditional behavior).
+        yield 'Carbon 4.0 (out of matrix, Carbon-3 shape)' => ['4.0.0', true, false];
+    }
+}


### PR DESCRIPTION
## Summary

`CarbonStubProvider` registered Carbon-3-only stubs unconditionally, so a fully supported Laravel 11 + Carbon 2 install broke with hard analysis errors. Laravel 11 (`illuminate/support: ^11.35`) resolves `nesbot/carbon: ^2.72.6 || ^3.8.4`, so Carbon 2 is inside the supported matrix, but the plugin assumed the Carbon 3 shape everywhere.

Fixes #1142.

## The bug on Carbon 2

- `CarbonPeriod`'s stub and the `DatePeriodBase` lazy stub assume the Carbon 3 shape (`CarbonPeriod extends DatePeriodBase`). Carbon 2's `CarbonPeriod implements Iterator` directly and has no `DatePeriodBase`, so every `CarbonPeriod` use surfaced `MissingDependency`.
- The dual-purpose getter/setter narrowings type their params as `Carbon\WeekDay`, an enum added in Carbon 3.0 that does not exist on Carbon 2, so they surfaced `UndefinedClass`.

## Fix

Gate the Carbon-3-only stubs on the installed Carbon major:

- The `DatePeriodBase` lazy stub registers only on Carbon `>=3` (the file is absent on Carbon 2).
- `CarbonPeriod` is split into `stubs/integrations/carbon/2/` (Iterator shape) and `3/` (DatePeriodBase shape); exactly one registers per major. The Carbon 2 variant pins `@implements Iterator<int, CarbonInterface>` so `collect(CarbonPeriod::create(...))` still narrows to `Collection<int, CarbonInterface>`.
- The dual-purpose narrowings now register on `>=3.0 <3.12` (was `<3.12`), excluding Carbon 2.

## Why this targets 3.x

Carbon 2 is reachable only through Laravel 11. Laravel 12 and 13 require `nesbot/carbon: ^3.8.4`, so master (Laravel 12 and 13) can never install Carbon 2. This is the Laravel-11-only analogue of the Psalm-6-only fixes that target 3.x directly.

## Tests

- New `tests/Type/CarbonVersion.php` SKIPIF helper (mirrors `LaravelVersion`), resolving the installed Carbon version from Composer.
- The three Carbon-3-specific type tests skip on Carbon 2. A new `CarbonIsoWeekdayCarbon2Test` covers the Carbon-2 baseline. `CarbonPeriodCollectTest` runs on both majors as a cross-version guard (both stub shapes narrow `collect()` to the same type).
- New `tests/Unit/Providers/CarbonStubProviderTest.php` locks the version-gating boundaries via the provider's own constraint constants.

## Verification

Carbon type and unit tests pass on both Carbon 2.73.0 and Carbon 3.13.0 (Psalm 6.16.1). `composer psalm` is clean at 100% type coverage and `composer cs` is clean.

## Coverage note

The CI matrix has no Carbon-2 cell. The Laravel 11 cell already carries pre-existing failures unrelated to Carbon (Laravel-12-feature tests on Laravel 11), so a full-suite Carbon-2 cell is not viable here. The Carbon-2 type tests therefore run locally and skip in CI; the version-gating boundaries (the core of the fix) are unit-tested as the compensating control and run on every cell.
