### PR TITLE
Allow null values in __() $replace parameter

### DIFF
--- a/stubs/common/Foundation/helpers.phpstub
+++ b/stubs/common/Foundation/helpers.phpstub
@@ -359,7 +359,7 @@ function to_route($route, $parameters = [], $status = 302, $headers = []) {}
  * Translate the given message.
  *
  * @param  string|null  $key
- * @param  array<string, scalar>  $replace
+ * @param  array<string, scalar|null>  $replace
  * @param  string|null  $locale
  * @return ($key is null ? null : string|array)
  */


### PR DESCRIPTION
## Problem

`__('msg', ['name' => null])` raised a false-positive `InvalidArgument`. The `__()` stub typed the `$replace` parameter as `array<string, scalar>`, which rejects `null`.

## Why null is valid

Laravel's translator coerces null replacement values to an empty string:

```php
// Illuminate/Translation/Translator.php::makeReplacements()
$shouldReplace[':'.Str::ucfirst($key)] = Str::ucfirst($value ?? '');
$shouldReplace[':'.Str::upper($key)]   = Str::upper($value ?? '');
$shouldReplace[':'.$key] = $value;
```

So passing `null` is supported at runtime, not an error.

## Change

Widen the `__()` `$replace` param from `array<string, scalar>` to `array<string, scalar|null>` in `stubs/common/Foundation/helpers.phpstub`. This matches Larastan's stub for the same helper.

`trans()` is unaffected (not stubbed here; it falls back to Laravel's untyped `array $replace`, already permissive).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784746591&installation_id=141955579&pr_number=1151&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1151&signature=543557146724e0be22be51c7c4b46d980330db01235143183ea23d6bcceed3c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->