### PR TITLE
Narrow `random()` return type on `Enumerable` and `LazyCollection`

### DIFF
--- a/stubs/common/Support/Enumerable.phpstub
+++ b/stubs/common/Support/Enumerable.phpstub
@@ -12,6 +12,21 @@ namespace Illuminate\Support;
 interface Enumerable extends \Illuminate\Contracts\Support\Arrayable, \Illuminate\Contracts\Support\Jsonable, \Countable, \IteratorAggregate, \JsonSerializable
 {
     /**
+     * Get one or a specified number of items randomly from the collection.
+     *
+     * No argument → a single random element (TValue). With $number → a
+     * sub-collection (static<int, TValue>). Mirrors the conditional already
+     * shipped on Collection so Enumerable-typed callers keep the narrowing
+     * instead of falling back to Laravel's reflected static<int, TValue>|TValue.
+     *
+     * @param  int|null  $number
+     * @return ($number is null ? TValue : static<int, TValue>)
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function random($number = null);
+
+    /**
      * Get the sum of the given values.
      *
      * At runtime, the accumulator starts at 0 and uses the + operator,

--- a/stubs/common/Support/LazyCollection.phpstub
+++ b/stubs/common/Support/LazyCollection.phpstub
@@ -66,6 +66,26 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     public static function empty() {}
 
     /**
+     * Get one or a specified number of items randomly from the collection.
+     *
+     * No argument → a single random element (TValue). With $number → a
+     * sub-collection (static<int, TValue>). Mirrors the conditional already
+     * shipped on Collection so LazyCollection-typed callers keep the narrowing
+     * instead of falling back to Laravel's reflected static<int, TValue>|TValue.
+     *
+     * Unlike Enumerable::random, LazyCollection carries the $preserveKeys second
+     * parameter (it forwards func_get_args() to Collection::random) — matched
+     * here against Laravel source.
+     *
+     * @param  int|null  $number
+     * @param  bool  $preserveKeys
+     * @return ($number is null ? TValue : static<int, TValue>)
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function random($number = null, $preserveKeys = false) {}
+
+    /**
      * Determine if an item exists in the enumerable by key.
      *
      * Accepts an array of keys or variadic key arguments via func_get_args().

--- a/tests/Type/tests/Collection/CollectionRandomTest.phpt
+++ b/tests/Type/tests/Collection/CollectionRandomTest.phpt
@@ -4,6 +4,8 @@
 use App\Models\Customer;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Support\Enumerable;
+use Illuminate\Support\LazyCollection;
 
 /**
  * Collection::random() stub alignment with Laravel's actual signature.
@@ -24,6 +26,14 @@ use Illuminate\Support\Collection as BaseCollection;
  * non-null. That is tracked separately in
  * https://github.com/psalm/psalm-plugin-laravel/issues/903 and is out of scope
  * for this stub-signature fix.
+ *
+ * Also covers (#1149): the same no-arg narrowing on the `Enumerable` interface
+ * and `LazyCollection` receivers, which previously fell back to Laravel's
+ * reflected `static<int, TValue>|TValue` union. Receivers are bare `Enumerable`/
+ * `LazyCollection` (via `@param`) so calls route to those stubs, not Collection.
+ * Asserted only for the no-arg branch (the headline fix); the non-null branch is
+ * the #903 limitation noted above. `LazyCollection::random` also carries the
+ * `$preserveKeys` second parameter (Enumerable's does not) — guarded below.
  */
 final class CollectionRandomTest
 {
@@ -35,12 +45,11 @@ final class CollectionRandomTest
 
     /**
      * No argument: returns a single Customer.
-     *
-     * @psalm-check-type-exact $result = Customer
      */
     public function randomNoArg(): Customer
     {
         $result = $this->getCustomers()->random();
+        /** @psalm-check-type-exact $result = Customer */
 
         return $result;
     }
@@ -62,6 +71,45 @@ final class CollectionRandomTest
     public function randomWithPreserveKeys(): void
     {
         $this->getCustomers()->random(3, true);
+    }
+
+    /**
+     * #1149: bare Enumerable-interface receiver, no argument → single Customer.
+     * Routes to the interface stub (not Collection); before #1149 this fell back
+     * to the reflected static<int, TValue>|TValue union.
+     *
+     * @param  Enumerable<int, Customer>  $items
+     */
+    public function enumerableRandomNoArg(Enumerable $items): Customer
+    {
+        $result = $items->random();
+        /** @psalm-check-type-exact $result = Customer */
+
+        return $result;
+    }
+
+    /**
+     * #1149: bare LazyCollection receiver, no argument → single Customer.
+     *
+     * @param  LazyCollection<int, Customer>  $items
+     */
+    public function lazyCollectionRandomNoArg(LazyCollection $items): Customer
+    {
+        $result = $items->random();
+        /** @psalm-check-type-exact $result = Customer */
+
+        return $result;
+    }
+
+    /**
+     * #1149: LazyCollection::random carries $preserveKeys (Enumerable's does not);
+     * the two-argument form compiles without TooManyArguments.
+     *
+     * @param  LazyCollection<int, Customer>  $items
+     */
+    public function lazyCollectionRandomWithPreserveKeys(LazyCollection $items): void
+    {
+        $items->random(3, true);
     }
 }
 ?>


### PR DESCRIPTION
## Issue to Solve
`random()` infers a conditional return type on `Illuminate\Support\Collection`, but not on the `Enumerable` interface or `LazyCollection`. Code typed against either falls back to Laravel's reflected non-conditional `static<int, TValue>|TValue`, so a no-arg `$enumerable->random()` is inferred as that union instead of the precise `TValue`.

## Related
Closes #1149

## Solution Description
Borrow the conditional return `($number is null ? TValue : static<int, TValue>)` (already shipped on `Collection`) onto both surfaces:

- `Enumerable::random($number = null)` — one param, per Laravel source.
- `LazyCollection::random($number = null, $preserveKeys = false)` — keeps `$preserveKeys`. The issue body claimed Lazy takes only `$number`, but Laravel source (`Illuminate\Collections\LazyCollection::random`) has both params; matched to source per the stub-authoring rule.

Verified with a fail-first type test: bare `Enumerable`/`LazyCollection` receivers inferred the non-narrowed union before the change and exact `TValue` after; full type suite plus `composer test:app` green.

Regression coverage extends `tests/Type/tests/Collection/CollectionRandomTest.phpt` with bare `Enumerable<int, Customer>` / `LazyCollection<int, Customer>` receivers (so calls route to the new stubs, not `Collection`), asserting the no-arg branch. The non-null branch is the known #903 limitation and is intentionally not asserted. The file's pre-existing `@psalm-check-type-exact` annotations were moved inline because a method-docblock placement is dead under psalm-tester (they asserted nothing).

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784754693&installation_id=141955579&pr_number=1152&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1152&signature=e9018405ca3f1b264c39f1d74b00300f4def7ca57b56b888d537d5b59c1c4b9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->