### PR TITLE
Resolve the configured date class for `Date` facade static calls

### DIFF
--- a/src/Handlers/Facades/DateFacadeHandler.php
+++ b/src/Handlers/Facades/DateFacadeHandler.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Facades;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\DateFactory;
+use Illuminate\Support\Facades\Date;
+use Psalm\Codebase;
+use Psalm\LaravelPlugin\Providers\FacadeMapProvider;
+use Psalm\Plugin\EventHandler\Event\MethodParamsProviderEvent;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\MethodParamsProviderInterface;
+use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\StatementsSource;
+use Psalm\Storage\MethodStorage;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Union;
+
+/**
+ * Resolves the runtime-configured date class for `Date` facade static calls
+ * (`Date::now()`, `Date::parse()`, `Date::create*()`, `Date::instance()`, ...).
+ *
+ * The facade ships hardcoded `@method static \Illuminate\Support\Carbon ...` tags,
+ * so without this handler every call infers `Illuminate\Support\Carbon` even when a
+ * project swapped the date class via `Date::use(CarbonImmutable::class)` /
+ * `Date::useClass(...)` in a service provider.
+ *
+ * Mechanism (same as {@see \Psalm\LaravelPlugin\Handlers\Helpers\NowTodayHandler}
+ * for the `now()` / `today()` helpers): the plugin has a booted Laravel app, so we
+ * call the helper at analysis time and read `get_class()` of the result — capturing
+ * whatever the project configured rather than the hardcoded default.
+ *
+ * Rather than enumerate a method list, we read each method's declared `@method`
+ * return type from the facade's pseudo-method storage and swap the `Carbon` atomic
+ * for the configured class, preserving every other atomic. This keeps nullability
+ * correct for free across Laravel versions (`createFromFormat()` is `Carbon|null` on
+ * L12+, `Carbon|false` on L11) and covers all `create*` variants without a hardcoded list.
+ * Methods whose return type does not mention `Carbon` (e.g. `useClass()`, `getLocale()`,
+ * `withTimeZone()` returning `static`) are left to Psalm's own `@method` resolution.
+ *
+ * `maxValue()` / `minValue()` carry no `@method` tag on the Laravel 12/13 facade, so
+ * there is no declared type to rewrite and they are out of scope (Larastan resolves them
+ * via the underlying factory). On Laravel 11 they DO carry a Carbon `@method` tag, and the
+ * storage-read approach picks them up there automatically — no special-casing needed.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1154
+ * @internal
+ */
+final class DateFacadeHandler implements MethodReturnTypeProviderInterface, MethodParamsProviderInterface
+{
+    /**
+     * Resolved configured date class, cached for the analysis run.
+     *
+     * @var ?class-string
+     */
+    private static ?string $configuredClass = null;
+
+    /** @var array<string, ?Union> retyped return type per method, cached for the run */
+    private static array $returnCache = [];
+
+    /**
+     * @inheritDoc
+     * @return list<string>
+     * @psalm-external-mutation-free
+     */
+    #[\Override]
+    public static function getClassLikeNames(): array
+    {
+        // Psalm dispatches return-type providers by exact FQCN, so the root-namespace
+        // alias (`\Date`) must be registered alongside the facade FQCN — otherwise
+        // `\Date::now()` falls back to the inherited `@method` tag. FacadeMapProvider
+        // maps the `date` service (a DateFactory instance) to both.
+        return [
+            Date::class,
+            ...FacadeMapProvider::getFacadeClasses(DateFactory::class),
+        ];
+    }
+
+    /** @inheritDoc */
+    #[\Override]
+    public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        return self::retypedReturn($event->getSource()->getCodebase(), $event->getMethodNameLowercase());
+    }
+
+    /**
+     * Synthesise params for the methods we retype. Psalm runs `checkMethodArgs()` —
+     * which calls `getMethodParams()` — only after a return-type provider yields a
+     * non-null type for a pseudo `@method` call; without a params provider that path
+     * fatals with "Cannot get method params" (same crash class as #454/#854). We mirror
+     * exactly the methods {@see self::getMethodReturnType()} handles and reuse the
+     * facade's own declared `@method` params.
+     *
+     * @inheritDoc
+     */
+    #[\Override]
+    public static function getMethodParams(MethodParamsProviderEvent $event): ?array
+    {
+        $source = $event->getStatementsSource();
+
+        if (!$source instanceof StatementsSource) {
+            return null;
+        }
+
+        $codebase = $source->getCodebase();
+        $methodNameLower = $event->getMethodNameLowercase();
+
+        if (!self::retypedReturn($codebase, $methodNameLower) instanceof Union) {
+            return null;
+        }
+
+        return self::pseudoMethod($codebase, $methodNameLower)?->params;
+    }
+
+    private static function retypedReturn(Codebase $codebase, string $methodNameLower): ?Union
+    {
+        if (!\array_key_exists($methodNameLower, self::$returnCache)) {
+            $declared = self::pseudoMethod($codebase, $methodNameLower)?->return_type;
+
+            self::$returnCache[$methodNameLower] = $declared instanceof Union
+                ? self::swapCarbon($declared, self::configuredClass())
+                : null;
+        }
+
+        return self::$returnCache[$methodNameLower];
+    }
+
+    /**
+     * Replace every `Illuminate\Support\Carbon` atomic in $declared with $configured,
+     * preserving all other atomics (`null`, `false`, ...). Returns null when $declared
+     * contains no `Carbon` atomic — the caller treats that as "not a date-returning
+     * method, defer to Psalm".
+     *
+     * @param class-string $configured
+     * @psalm-pure
+     */
+    public static function swapCarbon(Union $declared, string $configured): ?Union
+    {
+        $carbonLower = \strtolower(Carbon::class);
+        $hasCarbon = false;
+        $atomics = [];
+
+        foreach ($declared->getAtomicTypes() as $atomic) {
+            if ($atomic instanceof TNamedObject && \strtolower($atomic->value) === $carbonLower) {
+                $hasCarbon = true;
+                $atomics[] = new TNamedObject($configured);
+            } else {
+                $atomics[] = $atomic;
+            }
+        }
+
+        return $hasCarbon ? new Union($atomics) : null;
+    }
+
+    /** @return class-string */
+    private static function configuredClass(): string
+    {
+        if (self::$configuredClass === null) {
+            // now() delegates to Date::now(); both honour Date::use()/useClass() swaps,
+            // so get_class() yields the project's configured date class (default: Carbon).
+            $instance = \now();
+            self::$configuredClass = \get_class($instance);
+        }
+
+        return self::$configuredClass;
+    }
+
+    /** @psalm-mutation-free */
+    private static function pseudoMethod(Codebase $codebase, string $methodNameLower): ?MethodStorage
+    {
+        try {
+            $storage = $codebase->classlike_storage_provider->get(Date::class);
+        } catch (\InvalidArgumentException) {
+            // Facade storage missing — Psalm didn't scan the Date facade. Nothing to read;
+            // its `@method` tags remain the authoritative fallback for typing.
+            return null;
+        }
+
+        return $storage->pseudo_static_methods[$methodNameLower] ?? null;
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -294,6 +294,12 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Facades/AppFacadeMakeHandler.php';
         $registration->registerHooksFromClass(Handlers\Facades\AppFacadeMakeHandler::class);
 
+        // Date facade static calls (`Date::now()`, `Date::parse()`, `Date::create*()`, ...).
+        // getClassLikeNames() reads FacadeMapProvider for the `\Date` alias, so it relies on
+        // init() having run above. See https://github.com/psalm/psalm-plugin-laravel/issues/1154.
+        require_once __DIR__ . '/Handlers/Facades/DateFacadeHandler.php';
+        $registration->registerHooksFromClass(Handlers\Facades\DateFacadeHandler::class);
+
         require_once __DIR__ . '/Handlers/Rules/ModelMakeHandler.php';
         $registration->registerHooksFromClass(Handlers\Rules\ModelMakeHandler::class);
 

--- a/tests/Type/tests/Facades/DateFacadeStaticCallTest.phpt
+++ b/tests/Type/tests/Facades/DateFacadeStaticCallTest.phpt
@@ -1,0 +1,48 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Facades\Date;
+
+// Default app keeps Illuminate\Support\Carbon as the date class, so the handler's
+// Carbon -> configured-class swap is the identity here. This guards that the handler
+// reproduces the facade's `@method` return types exactly (shape + nullability) and
+// that synthesising params for the pseudo `@method` calls does not regress arg checks.
+// The configured-class swap itself (e.g. CarbonImmutable) is covered by the unit test,
+// since the handler reads the booted app's configured class, not the analysed code.
+
+// Non-null date methods.
+$_now = Date::now();
+/** @psalm-check-type-exact $_now = \Illuminate\Support\Carbon */
+
+$_today = Date::today();
+/** @psalm-check-type-exact $_today = \Illuminate\Support\Carbon */
+
+$_parse = Date::parse('2024-01-01');
+/** @psalm-check-type-exact $_parse = \Illuminate\Support\Carbon */
+
+// Call with scalar args — exercises checkMethodArgs against the synthesised params.
+$_create = Date::create(2024, 1, 1);
+/** @psalm-check-type-exact $_create = \Illuminate\Support\Carbon|null */
+
+// Call with an object arg.
+$_instance = Date::instance(new \DateTime());
+/** @psalm-check-type-exact $_instance = \Illuminate\Support\Carbon */
+
+// Nullable factory methods — the `|null` must survive the swap.
+$_make = Date::make('2024-01-01');
+/** @psalm-check-type-exact $_make = \Illuminate\Support\Carbon|null */
+
+$_testNow = Date::getTestNow();
+/** @psalm-check-type-exact $_testNow = \Illuminate\Support\Carbon|null */
+
+// Defer path: methods whose `@method` return type has no Carbon atomic are left to
+// Psalm's own `@method` resolution (the handler returns null from both providers).
+$_locale = Date::getLocale();
+/** @psalm-check-type-exact $_locale = string */
+
+// Defer path with args — guards that the params provider also defers for a method the
+// handler does not retype, so arg checking still flows through Psalm's `@method` path.
+$_hasFormat = Date::hasFormat('2024-01-01', 'Y-m-d');
+/** @psalm-check-type-exact $_hasFormat = bool */
+?>
+--EXPECTF--

--- a/tests/Unit/Handlers/Facades/DateFacadeHandlerTest.php
+++ b/tests/Unit/Handlers/Facades/DateFacadeHandlerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Facades;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Handlers\Facades\DateFacadeHandler;
+use Psalm\Type\Atomic\TFalse;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Atomic\TNull;
+use Psalm\Type\Atomic\TString;
+use Psalm\Type\Union;
+
+/**
+ * Unit tests for the Carbon -> configured-class substitution.
+ *
+ * The full handler depends on Psalm's Codebase (booted app, pseudo-method storage),
+ * which the type test {@see tests/Type/tests/Facades/DateFacadeStaticCallTest.phpt}
+ * exercises. The substitution is pure and is the part that varies with the configured
+ * date class, so it is covered here against a swapped class (CarbonImmutable) — a case
+ * the type test cannot trigger because the handler reads the booted app, not the
+ * analysed code.
+ */
+#[CoversClass(DateFacadeHandler::class)]
+final class DateFacadeHandlerTest extends TestCase
+{
+    #[Test]
+    public function swaps_carbon_for_the_configured_class(): void
+    {
+        $result = DateFacadeHandler::swapCarbon(
+            new Union([new TNamedObject(Carbon::class)]),
+            CarbonImmutable::class,
+        );
+
+        $this->assertNotNull($result);
+        $this->assertSame(CarbonImmutable::class, $result->getId());
+    }
+
+    #[Test]
+    public function preserves_nullability_through_the_swap(): void
+    {
+        // `create()` / `getTestNow()` / `make()` are `Carbon|null` on Laravel 12+.
+        $result = DateFacadeHandler::swapCarbon(
+            new Union([new TNamedObject(Carbon::class), new TNull()]),
+            CarbonImmutable::class,
+        );
+
+        $this->assertNotNull($result);
+        $this->assertTrue($result->isNullable());
+        $this->assertTrue($result->hasObjectType());
+        $this->assertSame(CarbonImmutable::class . '|null', $result->getId());
+    }
+
+    #[Test]
+    public function preserves_the_false_member_through_the_swap(): void
+    {
+        // Laravel 11 typed several `create*` methods `Carbon|false`; reading the declared
+        // type (rather than a hardcoded list) keeps that member correct after the swap.
+        $result = DateFacadeHandler::swapCarbon(
+            new Union([new TNamedObject(Carbon::class), new TFalse()]),
+            CarbonImmutable::class,
+        );
+
+        $this->assertNotNull($result);
+        $this->assertSame(CarbonImmutable::class . '|false', $result->getId());
+    }
+
+    #[Test]
+    public function returns_null_when_no_carbon_atomic_is_present(): void
+    {
+        // Methods like `getLocale(): string` or `withTimeZone(): static` have no Carbon
+        // atomic to rewrite — the handler defers to Psalm's own `@method` resolution.
+        $result = DateFacadeHandler::swapCarbon(new Union([new TString()]), CarbonImmutable::class);
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function identity_swap_reproduces_the_default_carbon_type(): void
+    {
+        // Default app: configured class is Carbon, so the swap is the identity. The handler
+        // still produces the type (no short-circuit), which is what the type test asserts.
+        $result = DateFacadeHandler::swapCarbon(
+            new Union([new TNamedObject(Carbon::class), new TNull()]),
+            Carbon::class,
+        );
+
+        $this->assertNotNull($result);
+        $this->assertSame(Carbon::class . '|null', $result->getId());
+    }
+}


### PR DESCRIPTION
## Issue to Solve

`Date` facade static calls (`Date::now()`, `Date::parse()`, `Date::create*()`, `Date::instance()`, etc.) always inferred `Illuminate\Support\Carbon`, ignoring projects that swap the date class via `Date::use(...)` / `Date::useClass(...)` (a common pattern, e.g. `Date::use(CarbonImmutable::class)` in a service provider). The facade ships hardcoded `@method static \Illuminate\Support\Carbon ...` tags, and unlike the `now()` / `today()` helpers (already handled by `NowTodayHandler`), the facade's static methods had no equivalent.

## Related

Fixes #1154

## Solution Description

New `DateFacadeHandler` (a `MethodReturnTypeProvider` + `MethodParamsProvider` registered for the `Date` facade and its root-namespace alias) resolves the runtime-configured date class the same way `NowTodayHandler` does: it calls the helper against the plugin's booted Laravel app and reads `get_class()` of the result (`now()` delegates to `Date::now()`, so both honour the swap).

Rather than enumerate a method list, it reads each method's declared `@method` return type from the facade's pseudo-method storage and swaps only the `Carbon` atomic for the configured class, preserving every other atomic. This means:

- Nullability is preserved for free across Laravel versions (`createFromFormat()` is `Carbon|null` on L12+, `Carbon|false` on L11).
- All `create*` variants are covered without a hardcoded list.
- Methods with no `Carbon` atomic (`useClass()`, `getLocale()`, `withTimeZone()` returning `static`) are left to Psalm's own `@method` resolution.

A params provider mirrors the retyped methods because Psalm runs `checkMethodArgs()` (which calls `getMethodParams()`) after a return-type provider yields non-null for a pseudo `@method` call; without it the run fatals with "Cannot get method params" (same crash class as #454 / #854). It reuses the facade's own declared `@method` params, so it tracks Laravel signature changes automatically.

Parity: matches Larastan's `DateExtension`, validated against Laravel source.

How it was verified:

- Type test `tests/Type/tests/Facades/DateFacadeStaticCallTest.phpt`: asserts the default-app types and nullability for `now` / `today` / `parse` / `create` / `make` / `getTestNow` / `instance`, plus the defer path (`getLocale()` returns `string`, `hasFormat(...)` returns `bool`, the latter exercising the params-provider defer branch with args).
- Unit test `tests/Unit/Handlers/Facades/DateFacadeHandlerTest.php`: covers the `Carbon` to configured-class swap (`CarbonImmutable`), nullability and `false`-member preservation, the no-`Carbon` defer, and the identity case.
- Psalm self-analysis clean, 100% type coverage, coding style clean.

Known limitation (matches `NowTodayHandler`): the handler reads the configured class from the plugin's booted app, not from the analyzed code, so the swap itself cannot be exercised in a `.phpt` (the test app uses the default `Carbon`). The swap transform is unit-tested instead.

## Checklist

- [x] Tests cover the change (type test in `tests/Type/` and unit test in `tests/Unit/`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784760248&installation_id=141955579&pr_number=1157&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1157&signature=878628aedb10d5a791525b16ba13986c01155d909558aadc988439fd8f911910"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->