### PR TITLE
Narrow `config()->collection()` to `Collection<key, value>`

### DIFF
--- a/src/Handlers/Config/ConfigRepositoryMethodHandler.php
+++ b/src/Handlers/Config/ConfigRepositoryMethodHandler.php
@@ -14,14 +14,17 @@ use Psalm\Storage\FunctionLikeParameter;
 use Psalm\Type;
 
 /**
- * Narrows `Repository::get()` (concrete + contract) and `Config::get()` (facade)
- * to the runtime type reflected from the booted Laravel app.
+ * Narrows `Repository::get()`/`collection()` (concrete + contract) and the
+ * matching `Config` facade calls to the runtime type reflected from the booted
+ * Laravel app. `collection($key)` wraps the same reflected array as `get($key)`
+ * in `Collection<keyType, valueType>` (see {@see ConfigKeyResolver}).
  *
- * Typed accessors (`string`, `integer`, `float`, `boolean`, `array`,
- * `collection`) are not handled here — their stub return types in
+ * The other typed accessors (`string`, `integer`, `float`, `boolean`, `array`)
+ * are not handled here — their stub return types in
  * `stubs/common/Config/Repository.phpstub` are already precise.
  *
- * See https://github.com/psalm/psalm-plugin-laravel/issues/752.
+ * See https://github.com/psalm/psalm-plugin-laravel/issues/752
+ * and https://github.com/psalm/psalm-plugin-laravel/issues/1150.
  */
 final class ConfigRepositoryMethodHandler implements MethodReturnTypeProviderInterface, MethodParamsProviderInterface
 {
@@ -49,20 +52,20 @@ final class ConfigRepositoryMethodHandler implements MethodReturnTypeProviderInt
     #[\Override]
     public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Type\Union
     {
-        if ($event->getMethodNameLowercase() !== 'get') {
-            return null;
-        }
+        $nodeTypeProvider = $event->getSource()->getNodeTypeProvider();
 
-        return ConfigKeyResolver::resolveFromCallArgs(
-            $event->getCallArgs(),
-            $event->getSource()->getNodeTypeProvider(),
-        );
+        return match ($event->getMethodNameLowercase()) {
+            'get' => ConfigKeyResolver::resolveFromCallArgs($event->getCallArgs(), $nodeTypeProvider),
+            'collection' => ConfigKeyResolver::resolveCollectionFromCallArgs($event->getCallArgs(), $nodeTypeProvider),
+            default => null,
+        };
     }
 
     /**
-     * Synthesise `get()` params for the Facade FQCN (`@method`-declared only).
-     * Without this, Psalm 7 crashes with
-     * `Cannot get method params for ...::get` — same crash class as #454/#854.
+     * Synthesise `get()`/`collection()` params for the Facade FQCN
+     * (`@method`-declared only). Without this, registering a return-type
+     * provider for these pseudo-methods makes Psalm 7 crash with
+     * `Cannot get method params for ...` — same crash class as #454/#854.
      * Defers to source for the real Repository + contract so future Laravel
      * signature changes are picked up automatically.
      *
@@ -72,7 +75,9 @@ final class ConfigRepositoryMethodHandler implements MethodReturnTypeProviderInt
     #[\Override]
     public static function getMethodParams(MethodParamsProviderEvent $event): ?array
     {
-        if ($event->getMethodNameLowercase() !== 'get') {
+        $method = $event->getMethodNameLowercase();
+
+        if ($method !== 'get' && $method !== 'collection') {
             return null;
         }
 
@@ -85,7 +90,17 @@ final class ConfigRepositoryMethodHandler implements MethodReturnTypeProviderInt
             return null;
         }
 
-        // `@method static mixed get(array|string $key, mixed $default = null)`
+        return $method === 'get' ? self::synthesizeGetParams() : self::synthesizeCollectionParams();
+    }
+
+    /**
+     * `@method static mixed get(array|string $key, mixed $default = null)`
+     *
+     * @return list<FunctionLikeParameter>
+     * @psalm-pure
+     */
+    private static function synthesizeGetParams(): array
+    {
         $stringOrArray = new Type\Union([
             new Type\Atomic\TString(),
             new Type\Atomic\TArray([Type::getArrayKey(), Type::getMixed()]),
@@ -98,6 +113,38 @@ final class ConfigRepositoryMethodHandler implements MethodReturnTypeProviderInt
                 false,
                 Type::getMixed(),
                 Type::getMixed(),
+                is_optional: true,
+                default_type: Type::getNull(),
+            ),
+        ];
+    }
+
+    /**
+     * `@method static Collection collection(string $key, \Closure|array|null $default = null)`
+     *
+     * The tightened `\Closure|array|null` default mirrors the concrete stub
+     * (`stubs/common/Config/Repository.phpstub`), so a scalar default is
+     * rejected on the facade exactly as it is on the Repository.
+     *
+     * @return list<FunctionLikeParameter>
+     * @psalm-pure
+     */
+    private static function synthesizeCollectionParams(): array
+    {
+        $key = new Type\Union([new Type\Atomic\TString()]);
+        $default = new Type\Union([
+            new Type\Atomic\TClosure(),
+            new Type\Atomic\TArray([Type::getArrayKey(), Type::getMixed()]),
+            new Type\Atomic\TNull(),
+        ]);
+
+        return [
+            new FunctionLikeParameter('key', false, $key, $key, is_optional: false),
+            new FunctionLikeParameter(
+                'default',
+                false,
+                $default,
+                $default,
                 is_optional: true,
                 default_type: Type::getNull(),
             ),

--- a/src/Util/ConfigKeyResolver.php
+++ b/src/Util/ConfigKeyResolver.php
@@ -7,11 +7,14 @@ namespace Psalm\LaravelPlugin\Util;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Psalm\LaravelPlugin\Providers\ConfigRepositoryProvider;
 use Psalm\Type;
+use Psalm\Type\Atomic\TArray;
 use Psalm\Type\Atomic\TBool;
 use Psalm\Type\Atomic\TClosure;
 use Psalm\Type\Atomic\TFalse;
 use Psalm\Type\Atomic\TFloat;
+use Psalm\Type\Atomic\TGenericObject;
 use Psalm\Type\Atomic\TInt;
+use Psalm\Type\Atomic\TKeyedArray;
 use Psalm\Type\Atomic\TLiteralFloat;
 use Psalm\Type\Atomic\TLiteralInt;
 use Psalm\Type\Atomic\TLiteralString;
@@ -105,6 +108,35 @@ final class ConfigKeyResolver
     }
 
     /**
+     * `Repository::collection($key)` wraps `$this->array($key)` in a Collection
+     * (`Illuminate\Config\Repository::collection()` → `new Collection($this->array($key))`).
+     * We reuse the same reflected value as {@see resolveCallReturnType()} and
+     * collapse its array shape to `Collection<keyType, valueType>`.
+     *
+     * Returns null (caller defers to the stub's `Collection<array-key, mixed>`)
+     * when there is no sound narrowed type:
+     *   - key absent → no default arg is threaded here (see
+     *     {@see resolveCollectionFromCallArgs()}); the runtime default's shape is
+     *     not reflected, so we defer (deliberate scope cut, the case is rare).
+     *   - value is not an array → `array()` throws InvalidArgumentException at
+     *     runtime, so no Collection is ever produced.
+     *   - value is an empty array → `Collection<never, never>` is strictly less
+     *     useful than the generic stub for a mutable container.
+     */
+    public function resolveCollectionReturnType(string $key): ?Union
+    {
+        $this->warm($key);
+
+        $reflected = $this->cache[$key];
+
+        if ($reflected === null) {
+            return null;
+        }
+
+        return $this->wrapReflectedArrayInCollection($reflected);
+    }
+
+    /**
      * Shared entry point for both `config()` and `Repository::get()` handlers.
      * Returns null on non-narrowable shapes (no args, dynamic key, array
      * first-arg) so the caller defers to the stub.
@@ -120,6 +152,24 @@ final class ConfigKeyResolver
         }
 
         return self::instance()->resolveCallReturnType($key, self::readDefaultTypeAt($call_args, 1, $nodeTypeProvider));
+    }
+
+    /**
+     * `collection()` counterpart of {@see resolveFromCallArgs()}. The default
+     * argument is intentionally ignored: it only matters for the absent-key
+     * branch, which {@see resolveCollectionReturnType()} already defers.
+     *
+     * @param list<\PhpParser\Node\Arg> $call_args
+     */
+    public static function resolveCollectionFromCallArgs(array $call_args, \Psalm\NodeTypeProvider $nodeTypeProvider): ?Union
+    {
+        $key = self::extractLiteralKey($call_args, $nodeTypeProvider);
+
+        if ($key === null || $key === false) {
+            return null;
+        }
+
+        return self::instance()->resolveCollectionReturnType($key);
     }
 
     /**
@@ -275,6 +325,49 @@ final class ConfigKeyResolver
 
         // Every Union needs at least one atomic; empty input is defensive only.
         return $atomics === [] ? Type::getMixed() : new Union($atomics);
+    }
+
+    /**
+     * Collapse a reflected array type to `Collection<keyType, valueType>`. Same
+     * result as Larastan's `getIterableKeyType()`/`getIterableValueType()` wrap
+     * (PHPStan APIs); here we dispatch over `TKeyedArray`/`TArray` explicitly.
+     *
+     * The value type is already generalized by {@see ConfigValueReflector}
+     * (env-driven values collapse to a single observation); the structural key
+     * type is preserved, since config keys are static across env unlike values.
+     *
+     * Returns null (caller defers to the stub) for non-array reflections and for
+     * any array whose key or value reflects to `never` — in practice the empty
+     * array, whose `never` params make a poor mutable Collection.
+     *
+     * @psalm-mutation-free
+     */
+    private function wrapReflectedArrayInCollection(Union $reflected): ?Union
+    {
+        // ConfigValueReflector emits a single atomic for array values; anything
+        // else (a union) is unexpected, so play safe and defer.
+        if (!$reflected->isSingle()) {
+            return null;
+        }
+
+        $atomic = $reflected->getSingleAtomic();
+
+        if ($atomic instanceof TKeyedArray) {
+            $keyType = $atomic->getGenericKeyType();
+            $valueType = $atomic->getGenericValueType();
+        } elseif ($atomic instanceof TArray) {
+            [$keyType, $valueType] = $atomic->type_params;
+        } else {
+            return null;
+        }
+
+        if ($keyType->isNever() || $valueType->isNever()) {
+            return null;
+        }
+
+        return new Union([
+            new TGenericObject(\Illuminate\Support\Collection::class, [$keyType, $valueType]),
+        ]);
     }
 
     private function warm(string $key): void

--- a/tests/Type/tests/ConfigCollectionTest.phpt
+++ b/tests/Type/tests/ConfigCollectionTest.phpt
@@ -1,0 +1,59 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Config\Repository;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Config;
+
+/**
+ * Repository::collection()/Config::collection()/config()->collection() narrow
+ * to Collection<keyType, valueType> reflected from the booted config — the same
+ * resolution as get(), wrapped in a Collection. `auth.defaults` is a stable
+ * keyed array (`['guard' => ..., 'passwords' => ...]`) present in every
+ * supported Laravel version (12-13). Values are generalized to `string`
+ * (env-driven); structural keys are kept.
+ *
+ * The facade assertions also guard the @method param synthesis: without it,
+ * registering a return-type provider for the facade pseudo-method crashes Psalm
+ * (same crash class as #454/#854). The scalar-default case additionally pins the
+ * tightened `\Closure|array|null` default that synthesizeCollectionParams() sets.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1150
+ */
+
+function repo_collection(Repository $config): void
+{
+    $_result = $config->collection('auth.defaults');
+    /** @psalm-check-type-exact $_result = Collection<'guard'|'passwords', string> */
+}
+
+function facade_collection(): void
+{
+    $_result = Config::collection('auth.defaults');
+    /** @psalm-check-type-exact $_result = Collection<'guard'|'passwords', string> */
+}
+
+function helper_chained_collection(): void
+{
+    $_result = config()->collection('auth.defaults');
+    /** @psalm-check-type-exact $_result = Collection<'guard'|'passwords', string> */
+}
+
+function collection_scalar_value_defers_to_stub(Repository $config): void
+{
+    // `app.name` is a string, not an array — collection() would throw at runtime,
+    // so the handler declines and the stub's generic type wins.
+    $_result = $config->collection('app.name');
+    /** @psalm-check-type-exact $_result = Collection<array-key, mixed> */
+}
+
+function facade_collection_rejects_scalar_default(): void
+{
+    // The synthesized facade params tighten $default to \Closure|array|null, so a
+    // scalar default is rejected exactly as on the concrete Repository — it would
+    // throw InvalidArgumentException at runtime when the key is absent.
+    Config::collection('auth.defaults', 'fallback');
+}
+?>
+--EXPECTF--
+InvalidArgument on line %d: Argument 2 of Illuminate\Support\Facades\Config::collection expects %s, but 'fallback' provided

--- a/tests/Unit/Util/ConfigKeyResolverTest.php
+++ b/tests/Unit/Util/ConfigKeyResolverTest.php
@@ -234,6 +234,54 @@ final class ConfigKeyResolverTest extends TestCase
         $this->assertTrue($generalized->isMixed());
     }
 
+    #[Test]
+    public function resolveCollectionReturnType_wraps_array_in_collection(): void
+    {
+        // A list keeps the structural key (`int<0, 2>`) and a value generalized
+        // by the reflector (`int`). Keyed arrays follow the identical wrap path
+        // but intern literal string keys, which needs a bootstrapped
+        // ProjectAnalyzer the unit harness deliberately avoids — that rendering
+        // (`Collection<'guard'|'passwords', string>`) is exercised by the type
+        // tests instead.
+        $repo = $this->fakeRepository(['app.aliases' => [1, 2, 3]]);
+        $resolver = new ConfigKeyResolver($repo);
+
+        $type = $resolver->resolveCollectionReturnType('app.aliases');
+
+        $this->assertNotNull($type);
+        $this->assertSame('Illuminate\\Support\\Collection<int<0, 2>, int>', $type->getId());
+    }
+
+    #[Test]
+    public function resolveCollectionReturnType_returns_null_when_key_absent(): void
+    {
+        $repo = $this->fakeRepository(['app.name' => 'Laravel']);
+        $resolver = new ConfigKeyResolver($repo);
+
+        // Absent key → array() resolves the default, whose shape we don't reflect.
+        $this->assertNull($resolver->resolveCollectionReturnType('app.missing'));
+    }
+
+    #[Test]
+    public function resolveCollectionReturnType_returns_null_when_value_not_array(): void
+    {
+        $repo = $this->fakeRepository(['app.name' => 'Laravel']);
+        $resolver = new ConfigKeyResolver($repo);
+
+        // Scalar value → collection() throws InvalidArgumentException at runtime.
+        $this->assertNull($resolver->resolveCollectionReturnType('app.name'));
+    }
+
+    #[Test]
+    public function resolveCollectionReturnType_returns_null_for_empty_array(): void
+    {
+        $repo = $this->fakeRepository(['app.providers' => []]);
+        $resolver = new ConfigKeyResolver($repo);
+
+        // Collection<never, never> is useless for a mutable container — defer to stub.
+        $this->assertNull($resolver->resolveCollectionReturnType('app.providers'));
+    }
+
     /**
      * @param array<string, mixed> $values
      */


### PR DESCRIPTION
## Issue to Solve
`config()->collection($key)` / `Config::collection($key)` / `Repository::collection($key)` returned a generic `Collection<array-key, mixed>`, losing the value precision the plugin already provides for `get()` / `config()`.

## Related
Closes #1150

## Solution Description
Reuse the existing config value-reflection (`ConfigKeyResolver`, the same path `get()` uses) to wrap the reflected array at `$key` in `Collection<keyType, valueType>` from the booted app. All three entry points converge on the method handler (the `Config` facade and `config()` with no args both yield a `Repository`).

- `ConfigKeyResolver::resolveCollectionReturnType()` collapses the reflected array (`TKeyedArray` → `getGenericKeyType()`/`getGenericValueType()`, `TArray` → `type_params`) into a `Collection` generic.
- Defers to the stub's `Collection<array-key, mixed>` when the key is absent, the value is not an array (`collection()` throws `InvalidArgumentException` at runtime), or the array is empty (`never` params are useless for a mutable container).
- Values stay generalized (env-driven, matching the `get()` design); structural keys are preserved. Larastan keeps literal config values; we intentionally do not.
- Synthesizes the facade `collection()` params: the `@method` pseudo-method would otherwise crash the return-type provider (same class as #454 / #854).

Verified: new unit tests (`ConfigKeyResolverTest` — list wrap + all three defer branches), new type test (`ConfigCollectionTest.phpt` — all three entry points, facade `@method` param-synthesis crash guard, scalar-default rejection), psalm self-analysis (100% coverage), cs, rector, fresh-app scan.

### Follow-up (out of scope)
The common stub declares `collection()` for all versions, but `Illuminate\Config\Repository::collection()` only exists from Laravel 12.20+ (the plugin floor is `^12.4`). Version-gating that stub is a separate, pre-existing concern (the narrowing here is version-safe: it only fires when `collection()` is actually called and only produces a more precise type).

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and unit test in `tests/Unit/`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784760416&installation_id=141955579&pr_number=1159&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1159&signature=9cf818f0bac76359b4e3ea1d174177e5480540edfdcfbd624dc4d19994a1996b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->