### PR TITLE
Infer named-argument object shape for `literal()` helper

### DIFF
--- a/src/Handlers/Helpers/LiteralHandler.php
+++ b/src/Handlers/Helpers/LiteralHandler.php
@@ -67,7 +67,7 @@ final class LiteralHandler implements FunctionReturnTypeProviderInterface
         // A single *named* arg (literal(a: 1)) is not a list, so it falls through to
         // the object-shape branch below. A null type here means "unknown" — return
         // null so Psalm keeps the reflected type rather than asserting mixed.
-        if (\count($args) === 1 && $args[0]->name === null && !$args[0]->unpack) {
+        if (\count($args) === 1 && !$args[0]->name instanceof \PhpParser\Node\Identifier && !$args[0]->unpack) {
             return $node_type_provider->getType($args[0]->value);
         }
 

--- a/src/Handlers/Helpers/LiteralHandler.php
+++ b/src/Handlers/Helpers/LiteralHandler.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Helpers;
+
+use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
+use Psalm\Type;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Atomic\TObjectWithProperties;
+use Psalm\Type\Union;
+
+/**
+ * Infers the return type of Laravel's literal() helper from the call's arguments.
+ *
+ * Laravel's runtime (Illuminate\Support\helpers.php):
+ *
+ *     function literal(...$arguments) {
+ *         if (count($arguments) === 1 && array_is_list($arguments)) {
+ *             return $arguments[0];   // single positional arg → passthrough
+ *         }
+ *         return (object) $arguments; // otherwise → stdClass with those properties
+ *     }
+ *
+ * - Handler, not stub: property names come from the call's named arguments, not a
+ *   fixed signature, so a docblock cannot express the shape.
+ * - Object case returns the intersection \stdClass&object{...} (not a bare
+ *   object{...}): Psalm's own `(object) $array` cast yields a bare
+ *   TObjectWithProperties that is NOT a subtype of \stdClass, so it fails a
+ *   \stdClass parameter (ArgumentTypeCoercion). The intersection keeps both the
+ *   per-property shape AND \stdClass assignability.
+ * - Ordering is load-bearing: \stdClass must be the PRIMARY atomic, the shape the
+ *   member (\stdClass&object{...}). Psalm only consults the `&\stdClass` member for
+ *   \stdClass-assignability when \stdClass is primary; the reverse
+ *   (object{...}&\stdClass) renders fine but still fails ArgumentTypeCoercion.
+ *   Property narrowing (literal(a: 1)->a === 1) works under either ordering.
+ * - Mirrors Larastan's LiteralExtension, minus its constant-array unpack branch:
+ *   `literal(...$x)` property names depend on runtime array contents we cannot
+ *   resolve, so we bail to the reflected type.
+ */
+final class LiteralHandler implements FunctionReturnTypeProviderInterface
+{
+    /**
+     * @inheritDoc
+     * @psalm-pure
+     */
+    #[\Override]
+    public static function getFunctionIds(): array
+    {
+        return ['literal'];
+    }
+
+    /** @inheritDoc */
+    #[\Override]
+    public static function getFunctionReturnType(FunctionReturnTypeProviderEvent $event): ?Union
+    {
+        $args = $event->getCallArgs();
+        $node_type_provider = $event->getStatementsSource()->getNodeTypeProvider();
+
+        // literal() with no args → (object) [] → empty stdClass.
+        if ($args === []) {
+            return new Union([new TNamedObject(\stdClass::class)]);
+        }
+
+        // Single positional, non-unpacked arg → passthrough (the array_is_list path).
+        // A single *named* arg (literal(a: 1)) is not a list, so it falls through to
+        // the object-shape branch below. A null type here means "unknown" — return
+        // null so Psalm keeps the reflected type rather than asserting mixed.
+        if (\count($args) === 1 && $args[0]->name === null && !$args[0]->unpack) {
+            return $node_type_provider->getType($args[0]->value);
+        }
+
+        // Unpacking (literal(...$x)) makes the property names depend on the runtime
+        // array, which we cannot resolve here — fall back to the reflected type
+        // rather than risk an incorrect shape.
+        foreach ($args as $arg) {
+            if ($arg->unpack) {
+                return null;
+            }
+        }
+
+        // Build object{name|index: type, ...}&\stdClass from the call's arguments.
+        // Named args contribute their name; positional args contribute their index
+        // (mirroring (object) $arguments over a mixed-key array).
+        $properties = [];
+        foreach ($args as $index => $arg) {
+            $key = $arg->name?->name ?? (string) $index;
+            $properties[$key] = $node_type_provider->getType($arg->value) ?? Type::getMixed();
+        }
+
+        $std = new TNamedObject(\stdClass::class);
+
+        return new Union([$std->addIntersectionType(new TObjectWithProperties($properties))]);
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -250,6 +250,8 @@ final class Plugin implements PluginEntryPointInterface
         $registration->registerHooksFromClass(Handlers\Helpers\NowTodayHandler::class);
         require_once __DIR__ . '/Handlers/Helpers/PathHandler.php';
         $registration->registerHooksFromClass(Handlers\Helpers\PathHandler::class);
+        require_once __DIR__ . '/Handlers/Helpers/LiteralHandler.php';
+        $registration->registerHooksFromClass(Handlers\Helpers\LiteralHandler::class);
 
         // config() helper + Repository::get() narrowing — reflect runtime config
         // values from the booted Laravel app. See

--- a/tests/Type/tests/Helpers/LiteralHandlerTest.phpt
+++ b/tests/Type/tests/Helpers/LiteralHandlerTest.phpt
@@ -1,0 +1,95 @@
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * literal() helper return-type inference (handler: LiteralHandler).
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1153
+ *
+ * Laravel: a single positional arg is passed through; otherwise (object) $args
+ * yields a stdClass carrying those properties. The handler returns
+ * stdClass&object{...} (stdClass primary) so the value is both assignable to
+ * stdClass parameters AND keeps its per-property shape.
+ *
+ * Verifying the shape needs property reads, not just the full-intersection string:
+ * an exact-type check on stdClass&object{...} only compares the primary stdClass
+ * atomic and is blind to the object-shape member's property types (it still proves
+ * the result is an intersection-with-shape rather than a bare stdClass / passthrough).
+ * $r->a reads narrow exactly, so those are what pin the inferred property types.
+ */
+
+function literal_named_args(): void
+{
+    $_r = literal(a: 1, b: 'x');
+    /** @psalm-check-type-exact $_r = stdClass&object{a:1, b:'x'} */
+
+    // Pin the shape members exactly (the assertion above cannot — see file docblock).
+    $_a = $_r->a;
+    /** @psalm-check-type-exact $_a = 1 */
+    $_b = $_r->b;
+    /** @psalm-check-type-exact $_b = 'x' */
+}
+
+function literal_single_named_arg_is_object_not_passthrough(): void
+{
+    // array_is_list(['a' => 1]) === false, so this is the (object) cast path.
+    $_r = literal(a: 1);
+    /** @psalm-check-type-exact $_r = stdClass&object{a:1} */
+    $_a = $_r->a;
+    /** @psalm-check-type-exact $_a = 1 */
+}
+
+function literal_single_positional_arg_passthrough(string $s): void
+{
+    $_r = literal($s);
+    /** @psalm-check-type-exact $_r = string */
+}
+
+function literal_multiple_positional_args(): void
+{
+    // Positional args contribute their index as the property name.
+    $_r = literal(1, 2);
+    /** @psalm-check-type-exact $_r = stdClass&object{0:1, 1:2} */
+}
+
+function literal_mixed_positional_and_named_args(): void
+{
+    // (object) [0 => 1, 'b' => 2] — positional contributes its index, named its name.
+    $_r = literal(1, b: 2);
+    /** @psalm-check-type-exact $_r = stdClass&object{0:1, b:2} */
+    $_b = $_r->b;
+    /** @psalm-check-type-exact $_b = 2 */
+}
+
+function literal_no_args_is_empty_stdclass(): void
+{
+    $_r = literal();
+    /** @psalm-check-type-exact $_r = stdClass */
+}
+
+function consume_stdclass(stdClass $x): stdClass
+{
+    return $x;
+}
+
+/**
+ * Regression: stdClass&object{...} must satisfy a stdClass parameter (and return
+ * type) with no ArgumentTypeCoercion. Psalm's own (object) $array cast fails this
+ * because it yields a bare object{...} that is not a subtype of stdClass.
+ */
+function literal_result_is_assignable_to_stdclass(): stdClass
+{
+    return consume_stdclass(literal(a: 1, b: 'x'));
+}
+
+/**
+ * Unpacking depends on runtime array contents, which the handler cannot resolve,
+ * so it bails to the reflected (mixed) type rather than guessing a shape.
+ */
+function literal_unpack_falls_back_to_reflected_type(array $arr): void
+{
+    $_r = literal(...$arr);
+    /** @psalm-check-type-exact $_r = mixed */
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve
Laravel's `literal()` helper inferred only the reflected `mixed`/`object` fallback, so the per-property shape from named arguments was lost.

## Related
Closes #1153

## Solution Description
Adds `LiteralHandler` (a `FunctionReturnTypeProviderInterface`) that derives the return type from the call's arguments. The property names come from the call's named arguments, not a fixed signature, so a stub cannot express the shape, it has to be a handler.

- single positional, non-unpacked arg → passthrough that arg's type (Laravel's `array_is_list` fast path);
- named / multiple / mixed args → `\stdClass&object{...}`;
- no args → `\stdClass`;
- unpacking (`literal(...$x)`) → bails to the reflected type (runtime array contents are unknowable at analysis time).

The object case builds the intersection with `\stdClass` as the **primary** atomic (`\stdClass&object{...}`). This ordering is load-bearing: Psalm only honors the `&\stdClass` member for assignability to a `\stdClass` parameter when `\stdClass` is primary. The reverse ordering (`object{...}&\stdClass`) renders identically but fails with `ArgumentTypeCoercion`. Psalm's own `(object) $array` cast yields a bare `object{...}` that is not a subtype of `\stdClass`, so this is strictly more precise than the native cast. Mirrors Larastan's `LiteralExtension` (minus its constant-array unpack branch).

Verified with a new type test covering every call form. Shape member types are pinned via property reads (`$r->a`), because `@psalm-check-type-exact` on the full intersection compares only the primary `\stdClass` atomic (it is blind to the object-shape member). Self-analysis stays at 100% type coverage and `composer cs` is clean.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/tests/Helpers/LiteralHandlerTest.phpt`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784760866&installation_id=141955579&pr_number=1160&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1160&signature=32ce7427d20028b34970a189da42e740c9d457538d295a8faa5535bbf2ae7c85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->