### PR TITLE
Narrow `Command::hasArgument()`/`hasOption()` to literal bool and fix `hasOption()` shortcut/negation semantics

### DIFF
--- a/src/Handlers/Console/CommandArgumentHandler.php
+++ b/src/Handlers/Console/CommandArgumentHandler.php
@@ -20,9 +20,16 @@ use Symfony\Component\Console\Input\InputOption;
  *
  * @see \Illuminate\Console\Concerns\InteractsWithIO::argument()
  * @see \Illuminate\Console\Concerns\InteractsWithIO::option()
+ * @see \Illuminate\Console\Concerns\InteractsWithIO::hasArgument()
+ * @see \Illuminate\Console\Concerns\InteractsWithIO::hasOption()
  *
- * Also emits {@see InvalidConsoleArgumentName} / {@see InvalidConsoleOptionName}
- * when the requested name is not defined.
+ * argument()/option(): narrows the value type, and emits {@see InvalidConsoleArgumentName} /
+ * {@see InvalidConsoleOptionName} when the requested name is not defined.
+ *
+ * hasArgument()/hasOption(): narrows to a literal true/false for a known signature and a literal
+ * name. No undefined-name issue is emitted here — existence-testing is the method's purpose; a
+ * definitely-absent name narrows to false, letting Psalm's own RedundantCondition surface the
+ * resulting dead branch (parity with Larastan's HasArgument/HasOption extensions).
  */
 final class CommandArgumentHandler implements MethodReturnTypeProviderInterface
 {
@@ -46,7 +53,7 @@ final class CommandArgumentHandler implements MethodReturnTypeProviderInterface
         $methodName = $event->getMethodNameLowercase();
 
         // @todo Narrow arguments()/options() to a constant array shape with per-key types
-        if ($methodName !== 'argument' && $methodName !== 'option') {
+        if (!\in_array($methodName, ['argument', 'option', 'hasargument', 'hasoption'], true)) {
             return null;
         }
 
@@ -75,7 +82,32 @@ final class CommandArgumentHandler implements MethodReturnTypeProviderInterface
             return self::resolveArgumentType($commandClass, $key, $event);
         }
 
-        return self::resolveOptionType($commandClass, $key, $event);
+        if ($methodName === 'option') {
+            return self::resolveOptionType($commandClass, $key, $event);
+        }
+
+        if ($methodName === 'hasargument') {
+            return self::existenceToType(CommandDefinitionAnalyzer::hasArgument($commandClass, $key));
+        }
+
+        // hasoption — the only remaining name allowed by the guard above
+        return self::existenceToType(CommandDefinitionAnalyzer::hasOption($commandClass, $key));
+    }
+
+    /**
+     * Map the analyzer's existence result to a literal-bool return type for
+     * hasArgument()/hasOption(). A null result (signature unavailable) leaves the
+     * declared bool in place; otherwise narrows to literal true/false.
+     *
+     * @psalm-pure
+     */
+    private static function existenceToType(?bool $exists): ?Type\Union
+    {
+        if ($exists === null) {
+            return null; // definition unavailable — cannot narrow
+        }
+
+        return $exists ? Type::getTrue() : Type::getFalse();
     }
 
     /**

--- a/src/Handlers/Console/CommandDefinitionAnalyzer.php
+++ b/src/Handlers/Console/CommandDefinitionAnalyzer.php
@@ -369,7 +369,9 @@ final class CommandDefinitionAnalyzer
     /**
      * Check if an option exists in the command's definition.
      *
-     * Also checks option shortcuts (e.g., 'F' for {--F|force}).
+     * Mirrors Symfony's Input::hasOption() — a name matches a long option OR a negation
+     * (e.g. 'no-ansi' for the negatable '--ansi'). Shortcuts are NOT valid hasOption()
+     * names: Input::hasOption('F') is false even when -F is a defined shortcut.
      *
      * @param class-string $commandClass
      */
@@ -381,11 +383,6 @@ final class CommandDefinitionAnalyzer
             return null; // cannot determine — definition unavailable
         }
 
-        if ($definition->hasOption($name)) {
-            return true;
-        }
-
-        // Check if the name matches a shortcut
-        return $definition->hasShortcut($name);
+        return $definition->hasOption($name) || $definition->hasNegation($name);
     }
 }

--- a/tests/Type/tests/ConsoleCommandHasArgumentOptionTest.phpt
+++ b/tests/Type/tests/ConsoleCommandHasArgumentOptionTest.phpt
@@ -1,0 +1,77 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class HasInputCommand extends Command
+{
+    /** @var string */
+    protected $signature = 'example:has
+        {email : The user email}
+        {--F|force : Force flag}
+    ';
+
+    public function handle(): int
+    {
+        // Defined argument → literal true
+        $_hasEmail = $this->hasArgument('email');
+        /** @psalm-check-type-exact $_hasEmail = true */
+
+        // Undefined argument → literal false (no InvalidConsoleArgumentName: existence-testing is valid)
+        $_hasMissingArg = $this->hasArgument('missing');
+        /** @psalm-check-type-exact $_hasMissingArg = false */
+
+        // Defined option (long name) → literal true
+        $_hasForce = $this->hasOption('force');
+        /** @psalm-check-type-exact $_hasForce = true */
+
+        // A shortcut ('F') is NOT a valid hasOption() name — Symfony's Input::hasOption()
+        // matches long names and negations only, never shortcuts → literal false
+        $_hasForceShortcut = $this->hasOption('F');
+        /** @psalm-check-type-exact $_hasForceShortcut = false */
+
+        // Inherited global option (--verbose) → literal true
+        $_hasVerbose = $this->hasOption('verbose');
+        /** @psalm-check-type-exact $_hasVerbose = true */
+
+        // Negation of the inherited negatable --ansi (--no-ansi is a valid name) → literal true
+        $_hasNoAnsi = $this->hasOption('no-ansi');
+        /** @psalm-check-type-exact $_hasNoAnsi = true */
+
+        // Undefined option → literal false (no InvalidConsoleOptionName emitted)
+        $_hasMissingOpt = $this->hasOption('missing');
+        /** @psalm-check-type-exact $_hasMissingOpt = false */
+
+        // Dynamic (non-literal) name → cannot narrow → declared bool
+        $dynamic = $this->argument('email');
+        $_hasDynamic = $this->hasArgument($dynamic);
+        /** @psalm-check-type-exact $_hasDynamic = bool */
+
+        return 0;
+    }
+}
+
+/**
+ * Legacy-style command with no parseable $signature → the definition is unavailable, so
+ * hasArgument()/hasOption() gracefully degrade to the declared bool (no narrowing, no issue).
+ */
+class NoSignatureCommand extends Command
+{
+    /** @var string */
+    protected $name = 'example:nosig';
+
+    public function handle(): int
+    {
+        $_hasArg = $this->hasArgument('whatever');
+        /** @psalm-check-type-exact $_hasArg = bool */
+
+        $_hasOpt = $this->hasOption('whatever');
+        /** @psalm-check-type-exact $_hasOpt = bool */
+
+        return 0;
+    }
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/ConsoleCommandHasArgumentRedundantConditionTest.phpt
+++ b/tests/Type/tests/ConsoleCommandHasArgumentRedundantConditionTest.phpt
@@ -1,0 +1,34 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class HasInputGuardCommand extends Command
+{
+    /** @var string */
+    protected $signature = 'example:guard {email}';
+
+    public function handle(): int
+    {
+        // Defined argument → always-true guard. Literal-bool narrowing makes Psalm
+        // report the redundant condition. This is the deliberately accepted trade-off
+        // of full narrowing (parity with Larastan); kept here to lock in the behavior.
+        if ($this->hasArgument('email')) {
+            echo 'always runs';
+        }
+
+        // Undefined argument → always-false guard. Documents the false-direction issue
+        // Psalm raises, so the "Both" trade-off is visible in deltas on real apps.
+        if ($this->hasArgument('missing')) {
+            echo 'never runs';
+        }
+
+        return 0;
+    }
+}
+?>
+--EXPECTF--
+RedundantCondition on line %d: Operand of type true is always truthy
+TypeDoesNotContainType on line %d: Operand of type false is always falsy


### PR DESCRIPTION
## Issue to Solve
`Command::hasArgument(string)` / `hasOption(string)` always inferred a bare `bool`, even when the command's `$signature` and the argument/option name are both statically known. The plugin already reflects the merged command definition (used for `argument()`/`option()` narrowing), so a literal `true`/`false` is derivable.

## Related
Closes #1155

## Solution Description
Extends the existing `CommandArgumentHandler` (`MethodReturnTypeProvider`) to also handle `hasArgument()`/`hasOption()`, reusing `CommandDefinitionAnalyzer`. Both methods are declared on the `Illuminate\Console\Concerns\InteractsWithIO` trait the handler already hooks, so no separate registration target is needed (the issue assumed Symfony's `Command` base).

- Narrows **both directions** (parity with Larastan): a present name to literal `true`, an absent name to literal `false`. No `InvalidConsoleArgumentName`/`InvalidConsoleOptionName` is emitted for these calls, since existence-testing is the method's purpose.
- Corrects `CommandDefinitionAnalyzer::hasOption()` to mirror Symfony's `Input::hasOption()` (long name or negation such as `--no-ansi`), never shortcuts: `hasOption('F')` is `false` at runtime even when `-F` is a defined shortcut. This also removes a pre-existing false positive where `option('no-ansi')` wrongly emitted `InvalidConsoleOptionName`.
- Trade-off (deliberate): a literal bool surfaces `RedundantCondition` (always-true guard) and `TypeDoesNotContainType` (always-false guard) on checks over known names. Accepted for full Larastan parity, and locked in by a type test.

Verified against `symfony/console` source, plus new type tests, the existing console tests, the analyzer unit tests, and `composer psalm` self-analysis (clean).

### Follow-up (out of scope)
`CommandDefinitionAnalyzer::getOption()` still resolves shortcuts and ignores negations on the value path, so `option('F')` is mis-narrowed (runtime throws) and `option('no-ansi')` does not narrow. Pre-existing, left for a separate change.

## Checklist
- [x] Tests cover the change (type tests in `tests/Type/`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784761402&installation_id=141955579&pr_number=1161&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1161&signature=f5570559eed2435fbd94b0677e24e393504e350bf622570f0aaa1fdb36896178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->