### PR TITLE
fix(config): tighten Config::collection() facade closure default

### DIFF
--- a/src/Handlers/Config/ConfigRepositoryMethodHandler.php
+++ b/src/Handlers/Config/ConfigRepositoryMethodHandler.php
@@ -132,8 +132,17 @@ final class ConfigRepositoryMethodHandler implements MethodReturnTypeProviderInt
     private static function synthesizeCollectionParams(): array
     {
         $key = new Type\Union([new Type\Atomic\TString()]);
+
+        // Mirror the concrete stub's `(\Closure():(array<array-key, mixed>|null))` exactly:
+        // a zero-arg closure returning array|null. A bare TClosure() would also accept
+        // `fn () => 'scalar'`, which Laravel rejects at runtime (the resolved value must be
+        // an array), so the facade must reproduce the same return-type constraint.
+        $arrayOrNull = new Type\Union([
+            new Type\Atomic\TArray([Type::getArrayKey(), Type::getMixed()]),
+            new Type\Atomic\TNull(),
+        ]);
         $default = new Type\Union([
-            new Type\Atomic\TClosure(),
+            new Type\Atomic\TClosure(params: [], return_type: $arrayOrNull),
             new Type\Atomic\TArray([Type::getArrayKey(), Type::getMixed()]),
             new Type\Atomic\TNull(),
         ]);

--- a/tests/Type/tests/ConfigCollectionTest.phpt
+++ b/tests/Type/tests/ConfigCollectionTest.phpt
@@ -54,6 +54,16 @@ function facade_collection_rejects_scalar_default(): void
     // throw InvalidArgumentException at runtime when the key is absent.
     Config::collection('auth.defaults', 'fallback');
 }
+
+function facade_collection_rejects_scalar_returning_closure(): void
+{
+    // The closure form is tightened to `\Closure():(array|null)`, mirroring the
+    // concrete stub. A closure returning a scalar is rejected on the facade just as
+    // it is on the Repository — Laravel throws when the resolved default is not an
+    // array. A bare Closure default would wrongly accept this.
+    Config::collection('auth.defaults', fn (): string => 'fallback');
+}
 ?>
 --EXPECTF--
 InvalidArgument on line %d: Argument 2 of Illuminate\Support\Facades\Config::collection expects %s, but 'fallback' provided
+InvalidArgument on line %d: Argument 2 of Illuminate\Support\Facades\Config::collection expects %s, but %s provided


### PR DESCRIPTION
## `Config::collection()` facade accepted a scalar-returning closure

`ConfigRepositoryMethodHandler::synthesizeCollectionParams()` synthesized the closure form of `$default` as a bare `Closure`, while the concrete stub (`stubs/common/Config/Repository.phpstub`) requires `(\Closure():(array<array-key, mixed>|null))`. That let facade calls accept `Config::collection('x', fn () => 'fallback')` even though the concrete `Repository::collection()` path rejects it and Laravel throws when the default branch is used (the resolved value must be an array).

The closure is now built with zero params and an `array<array-key, mixed>|null` return type, mirroring the stub exactly. Added a facade test (`facade_collection_rejects_scalar_returning_closure`) covering the wrong-return closure.

## Verification

- `./vendor/bin/phpunit --filter='ConfigCollection' tests/Type/` passes.
- `composer psalm` self-analysis clean (100% coverage).
- `composer cs` clean.
