### PR TITLE
Type `Model::loadCount()` constraint closure as `Builder`

### DIFF
--- a/stubs/common/Database/Eloquent/Model.phpstub
+++ b/stubs/common/Database/Eloquent/Model.phpstub
@@ -182,7 +182,12 @@ abstract class Model implements ArrayAccess, Arrayable, CanBeEscapedWhenCastToSt
     /**
      * Eager load relation counts on the model.
      *
-     * @param  array<array-key, array|(callable(\Illuminate\Database\Eloquent\Relations\Relation): mixed)|string>|string  $relations
+     * Unlike load()/loadMissing(), the constraint closure receives a Builder, not
+     * a Relation: loadCount() -> loadAggregate() -> Builder::withAggregate() applies
+     * it via Builder::callScope(), which invokes the closure with the Builder.
+     * (Laravel's own Collection docblock mistypes this as Relation; keep Builder.)
+     *
+     * @param  array<array-key, array|(callable(\Illuminate\Database\Eloquent\Builder): mixed)|string>|string  $relations
      * @return $this
      *
      * @psalm-variadic

--- a/tests/Type/tests/Model/LoadCountConstraintClosureTest.phpt
+++ b/tests/Type/tests/Model/LoadCountConstraintClosureTest.phpt
@@ -1,0 +1,85 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Shop;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\Relation;
+
+/**
+ * Regression tests for psalm/psalm-plugin-laravel#1163.
+ *
+ * loadCount() applies its constraint closure through Builder::callScope():
+ *
+ *   // loadCount() -> loadAggregate() -> Builder::withAggregate()
+ *   // Illuminate\Database\Eloquent\Builder::callScope()
+ *   array_unshift($parameters, $this); // $this is the Builder from withAggregate()
+ *   $scope(...$parameters);
+ *
+ * So the closure receives an Eloquent\Builder, NOT a Relation, and a closure
+ * that (correctly) type-hints Builder must be accepted.
+ *
+ * Contrast with load() / loadMissing(): their eager-load path calls
+ * $constraints($relation) (Builder::eagerLoadRelation), genuinely passing a
+ * Relation — those stubs keep callable(Relation). The clean Relation-closure
+ * cases below pin both, so a later "unify the families" edit cannot silently
+ * flip them to Builder and re-break Relation-closure users.
+ *
+ * Scope: among the aggregate methods, only Model::loadCount was stubbed with a
+ * typed callable, so it was the only false positive. The rest use loose types
+ * (loadMax/loadMin/... keep Laravel's `array|string`, withCount/withAggregate
+ * use `mixed`) and Collection::loadCount is unstubbed (no false positive today)
+ * — all out of scope here. Laravel's own Collection docblock mistypes this as
+ * callable(Relation<*, *, *>); our stub deliberately diverges to Builder, so do
+ * not "sync" it back.
+ *
+ * Uses the autoloadable Shop archetype so the per-model handler is registered.
+ */
+
+/**
+ * Closure correctly type-hinting Builder — the issue's repro. Must NOT error.
+ */
+function test_load_count_accepts_builder_closure(Shop $shop): Shop
+{
+    return $shop->loadCount([
+        'workOrders' => static fn (Builder $query): Builder => $query->where('status', 'active'),
+    ]);
+}
+
+/**
+ * Contrast: load() and loadMissing() genuinely receive a Relation, so a
+ * Relation-typed closure must stay clean on both. Guards the load/loadCount
+ * asymmetry the fix introduces — a blanket "type them all as Builder" edit, or a
+ * selective flip of either method, reddens one of these cases.
+ */
+function test_load_family_accepts_relation_closure(Shop $shop): Shop
+{
+    $shop->load([
+        'workOrders' => static fn (Relation $query): Relation => $query,
+    ]);
+
+    return $shop->loadMissing([
+        'workOrders' => static fn (Relation $query): Relation => $query,
+    ]);
+}
+
+/**
+ * Plain string / variadic form — must stay clean.
+ */
+function test_load_count_accepts_string(Shop $shop): Shop
+{
+    return $shop->loadCount('workOrders');
+}
+
+/**
+ * Wrong closure param type — must still raise InvalidArgument. This proves the
+ * argument stays a typed callable(Builder) and was not loosened to mixed.
+ */
+function test_load_count_wrong_param_type_errors(Shop $shop): Shop
+{
+    return $shop->loadCount([
+        'workOrders' => static fn (string $query): string => $query,
+    ]);
+}
+?>
+--EXPECTF--
+InvalidArgument on line %d: Argument 1 of App\Models\Shop::loadCount expects %s, but %s provided


### PR DESCRIPTION
## Issue to Solve

`Model::loadCount()` stubbed each constraint closure as `callable(\Illuminate\Database\Eloquent\Relations\Relation): mixed`, but at runtime Laravel invokes the closure with an `\Illuminate\Database\Eloquent\Builder`. A closure that correctly type-hints `Builder` therefore raised a false `InvalidArgument`:

```php
$model->loadCount([
    'posts' => static fn (Builder $query): Builder => $query->where('published', true),
]);
```

Root cause: `loadCount()` calls `loadAggregate()`, which reaches `Builder::withAggregate()`. There the constraint is applied via `Builder::callScope()`, which prepends the `Builder` and invokes the closure with it:

```php
// Illuminate\Database\Eloquent\Builder::callScope()
array_unshift($parameters, $this); // $this is the Builder from withAggregate()
$scope(...$parameters);
```

`$this` is the `Builder` returned by `getRelationExistenceQuery()`, so the closure receives a `Builder`, not a `Relation`.

This differs from `load()` / `loadMissing()`, whose eager-load path calls `$constraints($relation)` (`Builder::eagerLoadRelation`) and genuinely passes a `Relation`. Those stubs are correct and stay `callable(Relation)`.

## Related

Fixes #1163

## Solution Description

* Retype the `loadCount` constraint callable in `stubs/common/Database/Eloquent/Model.phpstub` from `callable(Relation)` to `callable(Builder)`. Bare `Builder` matches the sibling `withWhereHas` stub (the related model is unknown at the call site, since the relation is a string key).
* Safe for the common case: an untyped closure (`fn ($q) => ...`, param `mixed`) stays valid by contravariance. The only newly flagged code is a closure explicitly typed `fn (Relation $q)`, which is a correct error because the runtime passes a `Builder`.
* Add `tests/Type/tests/Model/LoadCountConstraintClosureTest.phpt` (verified red before the fix, green after). It pins both sides of the distinction: `loadCount` accepts a `Builder` closure, `load()` / `loadMissing()` still accept a `Relation` closure, and a wrong-typed closure still raises `InvalidArgument` (proving the argument stays a typed `callable(Builder)`, not loosened to `mixed`).

### Scope (deliberate)

Only `Model::loadCount` is changed. The rest of the aggregate family is intentionally left as is:

* `withCount` / `withAggregate` use `mixed` today (no false positive), so they stay permissive. Typing them as `callable(Builder)` is a possible future opt-in, not part of this fix.
* `loadMax` / `loadMin` / `loadSum` / `loadAvg` / `loadAggregate` are not stubbed by the plugin and fall back to Laravel's loose `array|string` (no false positive).
* `Eloquent\Collection::loadCount` is not stubbed and is not a false positive today.

### Upstream note

The root inaccuracy also exists in Laravel itself: `Illuminate\Database\Eloquent\Collection::loadAggregate()` / `loadCount()` docblocks type the closure as `callable(Relation<*, *, *>)`, yet the runtime passes a `Builder`. A user following Laravel's own docblock with `fn (Relation $q)` would hit a runtime `TypeError`. The correct long-term layer is a `laravel/framework` docblock fix. The plugin stub is the pragmatic layer here because the plugin already overrides these signatures.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784770047&installation_id=141955579&pr_number=1164&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1164&signature=a234cd615c6f87168aa60e722c0f69636b41bb442a3345fba2a654ed0fbbfed2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->