### PR TITLE
Allow `null` option shortcut in `Command::getOptions()`

### DIFF
--- a/stubs/common/Console/Concerns/HasParameters.phpstub
+++ b/stubs/common/Console/Concerns/HasParameters.phpstub
@@ -1,0 +1,42 @@
+<?php
+
+namespace Illuminate\Console\Concerns;
+
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Completion\Suggestion;
+use Symfony\Component\Console\Input\InputOption;
+
+trait HasParameters
+{
+    /**
+     * Get the console command options.
+     *
+     * Adds `|null` to element index 1 (the option shortcut).
+     *
+     * Laravel's native return type declares index 1 as `string|non-empty-array<string>`,
+     * but Symfony's `InputOption::__construct(string $name, string|array|null $shortcut = null, ...)`
+     * accepts (and defaults to) `null` for the "no shortcut" case, which is the common default.
+     * The missing `|null` produces a false-positive InvalidReturnType/InvalidReturnStatement on
+     * every getOptions() override returning the typical `['name', null, ...]` element (issue #1165).
+     *
+     * Kept in common/ because the getOptions() contract (an array of InputOption objects or
+     * `addOption(...$option)` argument tuples) is identical across all supported Laravel versions.
+     * Laravel only added this array-shape docblock in v12.50.0; 11.x and 12.0 to 12.49 declared a
+     * looser `@return array`, so on those versions this stub also tightens getOptions() to the same
+     * precise shape (the runtime contract is unchanged). Remove it once Laravel ships `|null` upstream.
+     *
+     * @return (InputOption|array{
+     *    0: non-empty-string,
+     *    1?: string|non-empty-array<string>|null,
+     *    2?: int-mask-of<InputOption::VALUE_*>,
+     *    3?: string,
+     *    4?: mixed,
+     *    5?: list<string|Suggestion>|\Closure(CompletionInput, CompletionSuggestions): list<string|Suggestion>
+     * })[]
+     */
+    protected function getOptions()
+    {
+        return [];
+    }
+}

--- a/tests/Type/tests/ConsoleCommandGetOptionsNullShortcutTest.phpt
+++ b/tests/Type/tests/ConsoleCommandGetOptionsNullShortcutTest.phpt
@@ -1,0 +1,52 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+// Regression for https://github.com/psalm/psalm-plugin-laravel/issues/1165.
+// A null option shortcut (the "no shortcut" case, which is the common default) must not
+// trigger a false-positive InvalidReturnType/InvalidReturnStatement on a getOptions() override.
+// Laravel's native return type declares element index 1 as `string|non-empty-array<string>`,
+// omitting the `|null` that Symfony's InputOption constructor (`string|array|null $shortcut = null`)
+// accepts. Fixed by stubs/common/Console/Concerns/HasParameters.phpstub.
+final class NullShortcutCommand extends Command
+{
+    /** @inheritDoc */
+    #[\Override]
+    protected function getOptions(): array
+    {
+        return [
+            // index 1 = null shortcut (the reported bug): must be accepted
+            ['nullShortcut', null, InputOption::VALUE_REQUIRED, 'desc', 'default'],
+            // a real shortcut still resolves
+            ['withShortcut', 's', InputOption::VALUE_NONE],
+            // an InputOption object element still resolves
+            new InputOption('asObject'),
+        ];
+    }
+
+    // The stub re-declares the HasParameters trait with getOptions() only. Overriding the sibling
+    // getArguments() guards that the partial re-declaration still MERGES with the reflected trait:
+    // a wiped trait would raise InvalidOverride here. Uses a valid mode (not null); getArguments
+    // index 1 is the mode, which does not reproduce #1165.
+    /** @inheritDoc */
+    #[\Override]
+    protected function getArguments(): array
+    {
+        return [['argName', InputArgument::REQUIRED, 'desc']];
+    }
+
+    // Guards that the trait's internal consumer (which reads getArguments()/getOptions()) also
+    // survives the merge; a wiped trait would surface as UndefinedMagicMethod on this call
+    // (Command is Macroable, so a missing method routes through __call under sealAllMethods).
+    public function probeMerge(): void
+    {
+        $this->specifyParameters();
+    }
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

Overriding `getOptions()` on a console command with a `null` option shortcut (the common "no shortcut" case) produced a false-positive `InvalidReturnType` / `InvalidReturnStatement`:

```php
protected function getOptions(): array
{
    return [['name', null, InputOption::VALUE_REQUIRED, 'desc', 'default']];
}
```

`Illuminate\Console\Concerns\HasParameters::getOptions()` types the return element index 1 (the shortcut) as `string|non-empty-array<string>`, omitting `|null`. Symfony's `InputOption::__construct(string $name, string|array|null $shortcut = null, ...)` accepts (and defaults to) `null`, so a null shortcut is valid and common.

## Related

Closes #1165

## Solution Description

The root cause is upstream in laravel/framework; the cleanest fix is to add `|null` there. This PR ships a plugin-side stub so users do not have to baseline the false positive in the meantime.

`stubs/common/Console/Concerns/HasParameters.phpstub` re-declares the trait's `getOptions()` with `|null` added at index 1, otherwise identical to Laravel's shape.

Kept in `common/` because the `getOptions()` contract (an array of `InputOption` objects or `addOption(...$option)` argument tuples) is identical across all supported Laravel versions. Laravel only added the array-shape docblock in v12.50.0; 11.x and 12.0 to 12.49 declared a looser `@return array`, so on those versions the stub also tightens `getOptions()` to the same precise shape (the runtime contract is unchanged).

`getArguments()` is intentionally not stubbed: its index 1 is the mode (`int-mask-of<...>`), which Psalm checks leniently and does not reproduce the false positive.

Verified with a new type test `tests/Type/tests/ConsoleCommandGetOptionsNullShortcutTest.phpt`: it fails with the exact #1165 errors when the stub is removed, and passes with it. The test covers a null shortcut, a real shortcut, and an `InputOption` object element, and also guards the partial-trait merge invariant (the stub re-declares only `getOptions()`, so the test confirms `getArguments()` and `specifyParameters()` survive via reflection merge).

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
