### PR TITLE
Remap value type in `Paginator::through()` to use updated template types

### DIFF
--- a/stubs/common/Pagination/Pagination.phpstub
+++ b/stubs/common/Pagination/Pagination.phpstub
@@ -37,6 +37,21 @@ abstract class AbstractPaginator implements CanBeEscapedWhenCastToString, \Illum
     public function setCollection(\Illuminate\Support\Collection $collection) {}
 
     /**
+     * Transform each item using a callback. Laravel's source returns `$this`
+     * but mutates the value template via `@phpstan-this-out` (which Psalm
+     * ignores). Type the return directly so inline `return $p->through(...)`
+     * remaps the value param; pair `@psalm-this-out` for the assigned-variable
+     * case (`$p->through(...)` then read `$p`), mirroring `setCollection()`.
+     *
+     * @template TMapValue
+     *
+     * @param  callable(TValue, TKey): TMapValue  $callback
+     * @psalm-this-out static<TKey, TMapValue>
+     * @return static<TKey, TMapValue>
+     */
+    public function through(callable $callback) {}
+
+    /**
      * @return \ArrayIterator<TKey, TValue>
      */
     public function getIterator(): \Traversable {}
@@ -111,6 +126,21 @@ abstract class AbstractCursorPaginator implements \Illuminate\Contracts\Support\
      * @return $this
      */
     public function setCollection(\Illuminate\Support\Collection $collection) {}
+
+    /**
+     * Transform each item using a callback. Laravel's source returns `$this`
+     * but mutates the value template via `@phpstan-this-out` (which Psalm
+     * ignores). Type the return directly so inline `return $p->through(...)`
+     * remaps the value param; pair `@psalm-this-out` for the assigned-variable
+     * case (`$p->through(...)` then read `$p`), mirroring `setCollection()`.
+     *
+     * @template TMapValue
+     *
+     * @param  callable(TValue, TKey): TMapValue  $callback
+     * @psalm-this-out static<TKey, TMapValue>
+     * @return static<TKey, TMapValue>
+     */
+    public function through(callable $callback) {}
 
     /**
      * @return \ArrayIterator<TKey, TValue>

--- a/tests/Type/tests/PaginatorThroughTest.phpt
+++ b/tests/Type/tests/PaginatorThroughTest.phpt
@@ -1,0 +1,45 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Pagination\CursorPaginator;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
+
+/** @param LengthAwarePaginator<int, string> $paginator */
+function length_aware_through_inline(LengthAwarePaginator $paginator): LengthAwarePaginator
+{
+    // Inline return: value template remapped via @return static<...>.
+    return $paginator->through(fn (string $value): int => (int) $value);
+}
+
+/** @param LengthAwarePaginator<int, string> $paginator */
+function length_aware_through_remaps_value(LengthAwarePaginator $paginator): void
+{
+    $_mapped = $paginator->through(fn (string $value): array => [$value, (int) $value]);
+    /** @psalm-check-type-exact $_mapped = LengthAwarePaginator<int, list{string, int}>&static */
+}
+
+/** @param Paginator<int, string> $paginator */
+function paginator_through_remaps_value(Paginator $paginator): void
+{
+    $_mapped = $paginator->through(fn (string $value): int => (int) $value);
+    /** @psalm-check-type-exact $_mapped = Paginator<int, int>&static */
+}
+
+/** @param CursorPaginator<int, string> $paginator */
+function cursor_through_remaps_value(CursorPaginator $paginator): void
+{
+    $_mapped = $paginator->through(fn (string $value): int => (int) $value);
+    /** @psalm-check-type-exact $_mapped = CursorPaginator<int, int>&static */
+}
+
+/** @param LengthAwarePaginator<int, string> $paginator */
+function length_aware_through_this_out(LengthAwarePaginator $paginator): void
+{
+    // Assigned-variable case: @psalm-this-out mutates the receiver in place.
+    $paginator->through(fn (string $value): int => (int) $value);
+    $_collection = $paginator->getCollection();
+    /** @psalm-check-type-exact $_collection = Illuminate\Support\Collection<int, int> */
+}
+
+--EXPECTF--


### PR DESCRIPTION
## Problem

`AbstractPaginator::through()` and `AbstractCursorPaginator::through()` were not declared in `stubs/common/Pagination/Pagination.phpstub`, so Psalm fell back to Laravel's reflected source. That source carries only:

```php
/**
 * @template TMapValue
 * @param  callable(TValue, TKey): TMapValue  $callback
 * @return $this
 * @phpstan-this-out static<TKey, TMapValue>
 */
public function through(callable $callback)
```

Psalm ignores `@phpstan-this-out` and reads only `@return $this`, so the value template parameter is never remapped. After `$paginator->through(fn (User $u): array => ...)` Psalm still inferred the original `LengthAwarePaginator<int, TModel>` instead of the mapped value type, producing false `InvalidReturnType` / `InvalidReturnStatement` at inline `return` call sites.

## Fix

Declare `through()` in the stub for both abstract bases, mirroring the existing `setCollection()` pattern. Unlike `setCollection()`, the call site is commonly used inline (`return $p->through(...)`), so `@psalm-this-out` alone is not enough (it mutates the variable, not the returned expression). The return is typed directly as `static<TKey, TMapValue>`, with `@psalm-this-out` retained for the assigned-variable case.

```php
/**
 * @template TMapValue
 * @param  callable(TValue, TKey): TMapValue  $callback
 * @psalm-this-out static<TKey, TMapValue>
 * @return static<TKey, TMapValue>
 */
public function through(callable $callback) {}
```

## Tests

New `tests/Type/tests/PaginatorThroughTest.phpt` covers inline-return remapping, assigned-variable `@psalm-this-out` narrowing, and all three concrete paginators (`LengthAwarePaginator`, `Paginator`, `CursorPaginator`).

Stub-only change. Fresh-app analysis (`composer test:app`) and existing pagination type tests pass with no regressions.

Closes #1172

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784933178&installation_id=141955579&pr_number=1173&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1173&signature=308e3f9565aaebff947f1d7993938748f703cd85e3ca0175372fec524359e0e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->