### PR TITLE
Use conditional return type for `Route::domain()`

### DIFF
--- a/stubs/common/Routing/Route.phpstub
+++ b/stubs/common/Routing/Route.phpstub
@@ -36,6 +36,25 @@ class Route
     public function getAction($key = null) {}
 
     /**
+     * Get or set the domain for the route.
+     *
+     * Null arg is the getter (`getDomain()` → string|null); any other arg is the
+     * setter and returns the route for chaining. Reflected Laravel declares the flat
+     * union `$this|string|null`, which breaks `->domain('x')->name(...)` chains
+     * (Psalm calls the next method on `string|null`). The conditional return keeps
+     * the setter branch chainable.
+     *
+     * Use `static`, not `$this`, on the setter branch: with `$this` Psalm merges the
+     * stub conditional back into the reflected `@return $this|string|null` and the
+     * call collapses to the flat union again. `static` is substituted by the
+     * late-static-bound class and overrides cleanly.
+     *
+     * @param  \BackedEnum|string|null  $domain
+     * @return ($domain is null ? string|null : static)
+     */
+    public function domain($domain = null) {}
+
+    /**
      * Get a given parameter from the route.
      *
      * @template TDefault

--- a/tests/Type/tests/RouteDomainTest.phpt
+++ b/tests/Type/tests/RouteDomainTest.phpt
@@ -1,0 +1,40 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App;
+
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Route as RouteFacade;
+
+// Setter form: a non-null domain returns $this so the route stays chainable.
+function domain_setter_returns_this(Route $route): void
+{
+    $_set = $route->domain('example.com');
+    /** @psalm-check-type-exact $_set = Route&static */
+}
+
+// Getter form: the null arg returns the configured domain (string|null).
+function domain_getter_returns_string_or_null(Route $route): void
+{
+    $_get = $route->domain();
+    /** @psalm-check-type-exact $_get = string|null */
+
+    $_explicit_null = $route->domain(null);
+    /** @psalm-check-type-exact $_explicit_null = string|null */
+}
+
+// Chaining after the setter must type-check — the reflected flat union
+// `$this|string|null` would break this (next call lands on string|null).
+function domain_then_name(Route $route): Route
+{
+    return $route->domain('example.com')->name('home');
+}
+
+// Facade -> verb -> ->domain(...) chain.
+function facade_chain_after_domain(): void
+{
+    $_chain = RouteFacade::get('/test', fn () => 'ok')->domain('example.com');
+    /** @psalm-check-type-exact $_chain = Route&static */
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Problem

`Illuminate\Routing\Route::domain()` is a get-or-set method:

```php
/**
 * @param  \BackedEnum|string|null  $domain
 * @return $this|string|null
 */
public function domain($domain = null)
{
    if (is_null($domain)) {
        return $this->getDomain(); // string|null
    }
    // ...
    return $this; // setter
}
```

The reflected source declares the flat union `$this|string|null`. So chained setter usage like `->domain('example.com')->name(...)` raises `PossiblyNullReference` / `PossiblyInvalidMethodCall`, because Psalm calls the next method on the `string|null` part of the union.

## Fix

Stub a conditional return so the null arg (getter) yields `string|null` and any other arg (setter) yields a chainable route:

```php
/**
 * @param  \BackedEnum|string|null  $domain
 * @return ($domain is null ? string|null : static)
 */
public function domain($domain = null) {}
```

### Why `static`, not `$this`

With `$this` on the setter branch, Psalm merges the stub conditional back into the reflected `@return $this|string|null` and the result collapses to the flat union again (the same stub/source merge behaviour behind #888). `static` is substituted by the late-static-bound class and overrides cleanly. Verified empirically: `$this` reproduces the flat union, `static` resolves to `Route&static`.

## Tests

New `tests/Type/tests/RouteDomainTest.phpt` pins:
- getter (`domain()` / `domain(null)`) → `string|null`
- setter (`domain('example.com')`) → `Route&static`
- chained setter (`->domain(...)->name(...)`)
- facade chain (`RouteFacade::get(...)->domain(...)`)

Stub-only change. All existing route type tests and fresh-app analysis (`composer test:app`) pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784934367&installation_id=141955579&pr_number=1174&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1174&signature=8d9c23575d8a81beb0965608071b825f1e0aed8d458d413405c59e9c32c64657"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->