### PR TITLE
Guard `migrator` resolution when the app bootstraps partially

### DIFF
--- a/src/Handlers/Eloquent/Schema/MigrationSchemaBuilder.php
+++ b/src/Handlers/Eloquent/Schema/MigrationSchemaBuilder.php
@@ -244,6 +244,8 @@ final class MigrationSchemaBuilder
      * the bootstrap throwable the plugin swallowed to tolerate a partial boot — is pulled
      * in here from {@see ApplicationProvider}. Without it the user sees only the symptom
      * (migrator missing) and not the root cause (the bad config/provider that aborted boot).
+     *
+     * @psalm-external-mutation-free
      */
     private function migratorUnavailableWarning(): string
     {

--- a/src/Handlers/Eloquent/Schema/MigrationSchemaBuilder.php
+++ b/src/Handlers/Eloquent/Schema/MigrationSchemaBuilder.php
@@ -116,7 +116,7 @@ final class MigrationSchemaBuilder
     {
         $files = [];
 
-        foreach ($this->getMigrationDirectories() as $directory) {
+        foreach ($this->getMigrationDirectories($progress) as $directory) {
             \array_push($files, ...$this->findPhpFilesRecursive($directory, $progress));
         }
 
@@ -206,14 +206,36 @@ final class MigrationSchemaBuilder
      * Resolve migration directories the same way Laravel does:
      * extra paths registered via loadMigrationsFrom() + the default database/migrations directory.
      *
+     * `migrator` is a *deferred* service (MigrationServiceProvider implements DeferrableProvider),
+     * so it only becomes resolvable once the RegisterProviders bootstrapper builds the app's
+     * deferred-services map. The plugin deliberately tolerates a partial bootstrap
+     * (see ApplicationProvider), which can leave that map incomplete — `make('migrator')` would
+     * then throw BindingResolutionException and abort the whole migration-schema feature (#1170).
+     *
+     * Guard with `bound()` exactly like the sibling init methods (translator/view in Plugin.php):
+     * `Application::bound()` already accounts for deferred services and partial bootstrap, so an
+     * unresolvable migrator degrades to the default migrations directory instead of crashing.
+     *
      * @return non-empty-list<string>
      */
-    private function getMigrationDirectories(): array
+    private function getMigrationDirectories(Progress $progress): array
     {
+        $defaultDirectory = $this->app->databasePath('migrations');
+
+        if (!$this->app->bound('migrator')) {
+            $progress->warning(
+                "Laravel plugin: the 'migrator' service is not bound (the app bootstrapped only partially); "
+                . 'falling back to the default migrations directory. Paths registered via '
+                . 'loadMigrationsFrom() will be ignored.',
+            );
+
+            return [$defaultDirectory];
+        }
+
         /** @var \Illuminate\Database\Migrations\Migrator $migrator */
         $migrator = $this->app->make('migrator');
 
-        return \array_values(\array_merge($migrator->paths(), [$this->app->databasePath('migrations')]));
+        return \array_values(\array_merge($migrator->paths(), [$defaultDirectory]));
     }
 
     /**

--- a/src/Handlers/Eloquent/Schema/MigrationSchemaBuilder.php
+++ b/src/Handlers/Eloquent/Schema/MigrationSchemaBuilder.php
@@ -204,18 +204,11 @@ final class MigrationSchemaBuilder
     }
 
     /**
-     * Resolve migration directories the same way Laravel does:
-     * extra paths registered via loadMigrationsFrom() + the default database/migrations directory.
+     * loadMigrationsFrom() paths + the default database/migrations directory.
      *
-     * `migrator` is a *deferred* service (MigrationServiceProvider implements DeferrableProvider),
-     * so it only becomes resolvable once the RegisterProviders bootstrapper builds the app's
-     * deferred-services map. The plugin deliberately tolerates a partial bootstrap
-     * (see ApplicationProvider), which can leave that map incomplete — `make('migrator')` would
-     * then throw BindingResolutionException and abort the whole migration-schema feature (#1170).
-     *
-     * Guard with `bound()` exactly like the sibling init methods (translator/view in Plugin.php):
-     * `Application::bound()` already accounts for deferred services and partial bootstrap, so an
-     * unresolvable migrator degrades to the default migrations directory instead of crashing.
+     * `migrator` is deferred, so it's only resolvable after a full bootstrap. The plugin
+     * tolerates a partial boot, so guard with `bound()` (like translator/view in Plugin.php)
+     * and fall back to the default directory instead of crashing on `make()` (#1170).
      *
      * @return non-empty-list<string>
      */
@@ -236,14 +229,8 @@ final class MigrationSchemaBuilder
     }
 
     /**
-     * Compose the migrator-unavailable warning, enriched with the boot diagnostics
-     * the plugin already captured.
-     *
-     * This degrades gracefully instead of reaching {@see InternalErrorReporter}, so the
-     * one datum that actually explains *why* the deferred-services map is incomplete —
-     * the bootstrap throwable the plugin swallowed to tolerate a partial boot — is pulled
-     * in here from {@see ApplicationProvider}. Without it the user sees only the symptom
-     * (migrator missing) and not the root cause (the bad config/provider that aborted boot).
+     * Graceful degradation skips {@see InternalErrorReporter}, so surface the swallowed
+     * bootstrap error here — it's the root cause of the missing migrator, not just the symptom.
      *
      * @psalm-external-mutation-free
      */

--- a/src/Handlers/Eloquent/Schema/MigrationSchemaBuilder.php
+++ b/src/Handlers/Eloquent/Schema/MigrationSchemaBuilder.php
@@ -6,6 +6,7 @@ namespace Psalm\LaravelPlugin\Handlers\Eloquent\Schema;
 
 use Illuminate\Foundation\Application;
 use Psalm\Codebase;
+use Psalm\LaravelPlugin\Providers\ApplicationProvider;
 use Psalm\Progress\Progress;
 
 /**
@@ -223,11 +224,7 @@ final class MigrationSchemaBuilder
         $defaultDirectory = $this->app->databasePath('migrations');
 
         if (!$this->app->bound('migrator')) {
-            $progress->warning(
-                "Laravel plugin: the 'migrator' service is not bound (the app bootstrapped only partially); "
-                . 'falling back to the default migrations directory. Paths registered via '
-                . 'loadMigrationsFrom() will be ignored.',
-            );
+            $progress->warning($this->migratorUnavailableWarning());
 
             return [$defaultDirectory];
         }
@@ -236,6 +233,32 @@ final class MigrationSchemaBuilder
         $migrator = $this->app->make('migrator');
 
         return \array_values(\array_merge($migrator->paths(), [$defaultDirectory]));
+    }
+
+    /**
+     * Compose the migrator-unavailable warning, enriched with the boot diagnostics
+     * the plugin already captured.
+     *
+     * This degrades gracefully instead of reaching {@see InternalErrorReporter}, so the
+     * one datum that actually explains *why* the deferred-services map is incomplete —
+     * the bootstrap throwable the plugin swallowed to tolerate a partial boot — is pulled
+     * in here from {@see ApplicationProvider}. Without it the user sees only the symptom
+     * (migrator missing) and not the root cause (the bad config/provider that aborted boot).
+     */
+    private function migratorUnavailableWarning(): string
+    {
+        $bootMode = ApplicationProvider::getBootMode();
+        $mode = $bootMode !== null ? " (boot mode: {$bootMode})" : '';
+
+        $bootstrapError = ApplicationProvider::getBootstrapError();
+        $cause = $bootstrapError instanceof \Throwable
+            ? " The Laravel bootstrap did not complete: {$bootstrapError->getMessage()}."
+            : '';
+
+        return "Laravel plugin: the 'migrator' service is not bound{$mode}, so migration paths "
+            . 'registered via loadMigrationsFrom() cannot be auto-discovered.' . $cause
+            . ' Only the default database/migrations directory will be scanned — fix the bootstrap '
+            . 'error above or declare the extra paths another way.';
     }
 
     /**

--- a/tests/Unit/Handlers/Eloquent/Schema/MigrationDirectoryResolutionTest.php
+++ b/tests/Unit/Handlers/Eloquent/Schema/MigrationDirectoryResolutionTest.php
@@ -24,35 +24,30 @@ final class MigrationDirectoryResolutionTest extends TestCase
     #[Test]
     public function falls_back_to_default_directory_when_migrator_is_unbound(): void
     {
-        // A bare Application registers base providers only — `migrator` stays unbound,
-        // so make('migrator') throws BindingResolutionException, reproducing #1170.
-        $app = new Application('/tmp/app-without-migrator');
+        // migrator unbound reproduces #1170: make('migrator') would throw, the guard must not.
+        $app = $this->fakeApp(migratorBound: false, migratorPaths: []);
         $progress = $this->capturingProgress();
 
         $directories = $this->resolveDirectories($app, $progress);
 
-        $this->assertSame(['/tmp/app-without-migrator/database/migrations'], $directories);
-        $this->assertNotEmpty($progress->warnings, 'A warning must surface the missing migrator service.');
-        $this->assertStringContainsString('migrator', (string) $progress->warnings[0]);
+        self::assertSame(['/fake-app/database/migrations'], $directories);
+        self::assertNotEmpty($progress->warnings, 'A warning must surface the missing migrator service.');
+        self::assertStringContainsString('migrator', $progress->warnings[0]);
     }
 
     #[Test]
     public function merges_registered_paths_when_migrator_is_available(): void
     {
-        $app = new Application('/tmp/app-with-migrator');
-        $app->instance('migrator', new class {
-            /** @return list<string> */
-            public function paths(): array
-            {
-                return ['/extra/package/migrations'];
-            }
-        });
+        $app = $this->fakeApp(migratorBound: true, migratorPaths: ['/extra/package/migrations']);
         $progress = $this->capturingProgress();
 
         $directories = $this->resolveDirectories($app, $progress);
 
-        $this->assertSame(['/extra/package/migrations', '/tmp/app-with-migrator/database/migrations'], $directories);
-        $this->assertSame([], $progress->warnings, 'No warning when the migrator resolves cleanly.');
+        self::assertSame(
+            ['/extra/package/migrations', '/fake-app/database/migrations'],
+            $directories,
+        );
+        self::assertSame([], $progress->warnings, 'No warning when the migrator resolves cleanly.');
     }
 
     /**
@@ -70,6 +65,36 @@ final class MigrationDirectoryResolutionTest extends TestCase
 
         /** @var list<string> */
         return $method->invoke($builder, $progress);
+    }
+
+    /**
+     * A real {@see Application} built *without* its constructor, so the framework
+     * boot (provider registration, global container/facade binding) never runs —
+     * a full `new Application()` inside a unit test crashes the process. The
+     * untyped legacy `$basePath` / `$databasePath` properties tolerate the missing
+     * constructor, so `databasePath('migrations')` resolves to `<base>/database/migrations`.
+     *
+     * @param list<string> $migratorPaths the migrator's registered extra paths (loadMigrationsFrom)
+     */
+    private function fakeApp(bool $migratorBound, array $migratorPaths): Application
+    {
+        $app = (new \ReflectionClass(Application::class))->newInstanceWithoutConstructor();
+        (new \ReflectionProperty(Application::class, 'basePath'))->setValue($app, '/fake-app');
+
+        if ($migratorBound) {
+            $app->instance('migrator', new class ($migratorPaths) {
+                /** @param list<string> $paths */
+                public function __construct(private readonly array $paths) {}
+
+                /** @return list<string> */
+                public function paths(): array
+                {
+                    return $this->paths;
+                }
+            });
+        }
+
+        return $app;
     }
 
     private function capturingProgress(): Progress

--- a/tests/Unit/Handlers/Eloquent/Schema/MigrationDirectoryResolutionTest.php
+++ b/tests/Unit/Handlers/Eloquent/Schema/MigrationDirectoryResolutionTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\MigrationSchemaBuilder;
+use Psalm\LaravelPlugin\Providers\ApplicationProvider;
 use Psalm\Progress\Progress;
 
 /**
@@ -45,6 +46,35 @@ final class MigrationDirectoryResolutionTest extends TestCase
 
         $this->assertSame(['/extra/package/migrations', '/fake-app/database/migrations'], $directories);
         $this->assertSame([], $progress->warnings, 'No warning when the migrator resolves cleanly.');
+    }
+
+    #[Test]
+    public function warning_surfaces_boot_mode_and_swallowed_bootstrap_error(): void
+    {
+        // The plugin swallows a partial-bootstrap throwable to stay alive; that throwable is
+        // the real reason the migrator is missing, so the warning must surface it (#1170).
+        $this->setBootState('testbench_fallback', new \RuntimeException('parse error in config/app.php'));
+
+        $app = $this->fakeApp(migratorBound: false, migratorPaths: []);
+        $progress = $this->capturingProgress();
+
+        $this->resolveDirectories($app, $progress);
+
+        $this->assertStringContainsString('boot mode: testbench_fallback', (string) $progress->warnings[0]);
+        $this->assertStringContainsString('parse error in config/app.php', (string) $progress->warnings[0]);
+    }
+
+    protected function tearDown(): void
+    {
+        // Boot state is global static — reset so it can't leak into other tests.
+        $this->setBootState(null, null);
+        parent::tearDown();
+    }
+
+    private function setBootState(?string $bootMode, ?\Throwable $bootstrapError): void
+    {
+        (new \ReflectionProperty(ApplicationProvider::class, 'bootMode'))->setValue(null, $bootMode);
+        (new \ReflectionProperty(ApplicationProvider::class, 'bootstrapError'))->setValue(null, $bootstrapError);
     }
 
     /**

--- a/tests/Unit/Handlers/Eloquent/Schema/MigrationDirectoryResolutionTest.php
+++ b/tests/Unit/Handlers/Eloquent/Schema/MigrationDirectoryResolutionTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Eloquent\Schema;
+
+use Illuminate\Foundation\Application;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\MigrationSchemaBuilder;
+use Psalm\Progress\Progress;
+
+/**
+ * Guards the {@see MigrationSchemaBuilder::getMigrationDirectories()} fallback.
+ *
+ * A booted app whose container can't resolve the `migrator` service (trimmed or
+ * partially-registered providers) must not abort the whole migration-schema
+ * feature with an uncaught BindingResolutionException — see issue #1170.
+ */
+#[CoversClass(MigrationSchemaBuilder::class)]
+final class MigrationDirectoryResolutionTest extends TestCase
+{
+    #[Test]
+    public function falls_back_to_default_directory_when_migrator_is_unbound(): void
+    {
+        // A bare Application registers base providers only — `migrator` stays unbound,
+        // so make('migrator') throws BindingResolutionException, reproducing #1170.
+        $app = new Application('/tmp/app-without-migrator');
+        $progress = $this->capturingProgress();
+
+        $directories = $this->resolveDirectories($app, $progress);
+
+        self::assertSame(['/tmp/app-without-migrator/database/migrations'], $directories);
+        self::assertNotEmpty($progress->warnings, 'A warning must surface the missing migrator service.');
+        self::assertStringContainsString('migrator', $progress->warnings[0]);
+    }
+
+    #[Test]
+    public function merges_registered_paths_when_migrator_is_available(): void
+    {
+        $app = new Application('/tmp/app-with-migrator');
+        $app->instance('migrator', new class {
+            /** @return list<string> */
+            public function paths(): array
+            {
+                return ['/extra/package/migrations'];
+            }
+        });
+        $progress = $this->capturingProgress();
+
+        $directories = $this->resolveDirectories($app, $progress);
+
+        self::assertSame(
+            ['/extra/package/migrations', '/tmp/app-with-migrator/database/migrations'],
+            $directories,
+        );
+        self::assertSame([], $progress->warnings, 'No warning when the migrator resolves cleanly.');
+    }
+
+    /**
+     * Invokes the private resolver without booting the heavy Codebase/MigrationCache
+     * collaborators the constructor wants — only the app is exercised here.
+     *
+     * @return list<string>
+     */
+    private function resolveDirectories(Application $app, Progress $progress): array
+    {
+        $builder = (new \ReflectionClass(MigrationSchemaBuilder::class))->newInstanceWithoutConstructor();
+        (new \ReflectionProperty(MigrationSchemaBuilder::class, 'app'))->setValue($builder, $app);
+
+        $method = new \ReflectionMethod(MigrationSchemaBuilder::class, 'getMigrationDirectories');
+
+        /** @var list<string> */
+        return $method->invoke($builder, $progress);
+    }
+
+    private function capturingProgress(): Progress
+    {
+        // Progress is abstract but ships concrete no-op methods; only warning() needs capturing.
+        return new class extends Progress {
+            /** @var list<string> */
+            public array $warnings = [];
+
+            #[\Override]
+            public function warning(string $message): void
+            {
+                $this->warnings[] = $message;
+            }
+        };
+    }
+}

--- a/tests/Unit/Handlers/Eloquent/Schema/MigrationDirectoryResolutionTest.php
+++ b/tests/Unit/Handlers/Eloquent/Schema/MigrationDirectoryResolutionTest.php
@@ -31,9 +31,9 @@ final class MigrationDirectoryResolutionTest extends TestCase
 
         $directories = $this->resolveDirectories($app, $progress);
 
-        self::assertSame(['/tmp/app-without-migrator/database/migrations'], $directories);
-        self::assertNotEmpty($progress->warnings, 'A warning must surface the missing migrator service.');
-        self::assertStringContainsString('migrator', $progress->warnings[0]);
+        $this->assertSame(['/tmp/app-without-migrator/database/migrations'], $directories);
+        $this->assertNotEmpty($progress->warnings, 'A warning must surface the missing migrator service.');
+        $this->assertStringContainsString('migrator', (string) $progress->warnings[0]);
     }
 
     #[Test]
@@ -51,11 +51,8 @@ final class MigrationDirectoryResolutionTest extends TestCase
 
         $directories = $this->resolveDirectories($app, $progress);
 
-        self::assertSame(
-            ['/extra/package/migrations', '/tmp/app-with-migrator/database/migrations'],
-            $directories,
-        );
-        self::assertSame([], $progress->warnings, 'No warning when the migrator resolves cleanly.');
+        $this->assertSame(['/extra/package/migrations', '/tmp/app-with-migrator/database/migrations'], $directories);
+        $this->assertSame([], $progress->warnings, 'No warning when the migrator resolves cleanly.');
     }
 
     /**

--- a/tests/Unit/Handlers/Eloquent/Schema/MigrationDirectoryResolutionTest.php
+++ b/tests/Unit/Handlers/Eloquent/Schema/MigrationDirectoryResolutionTest.php
@@ -13,16 +13,10 @@ use Psalm\LaravelPlugin\Providers\ApplicationProvider;
 use Psalm\Progress\Progress;
 
 /**
- * Guards the {@see MigrationSchemaBuilder::getMigrationDirectories()} fallback.
- *
- * A booted app whose container can't resolve the `migrator` service (trimmed or
- * partially-registered providers) must not abort the whole migration-schema
- * feature with an uncaught BindingResolutionException — see issue #1170.
- *
- * Both Application and Progress are mocked rather than instantiated: a real
- * Application boots framework code, and a hand-rolled Progress subclass risks
- * leaving an abstract Progress method unimplemented — either crashes the PHP
- * process when this runs inside the full unit suite.
+ * An unresolvable `migrator` service (partial bootstrap) must degrade to the default
+ * directory, not crash the whole migration-schema feature (#1170). Application and Progress
+ * are stubbed, not instantiated — real instances boot framework/Psalm code that crashes the
+ * process inside the full unit suite.
  */
 #[CoversClass(MigrationSchemaBuilder::class)]
 final class MigrationDirectoryResolutionTest extends TestCase
@@ -83,8 +77,7 @@ final class MigrationDirectoryResolutionTest extends TestCase
     }
 
     /**
-     * Invoke the private resolver without booting the heavy Codebase/MigrationCache
-     * collaborators the constructor wants — only the app is exercised here.
+     * Call the private resolver directly, skipping the Codebase/MigrationCache collaborators.
      *
      * @return list<string>
      */
@@ -100,10 +93,9 @@ final class MigrationDirectoryResolutionTest extends TestCase
     }
 
     /**
-     * A mocked {@see Application} — only the three container methods the resolver
-     * touches are stubbed; every other method is a mock no-op, so nothing boots.
+     * Stubbed Application — only the methods the resolver calls; nothing boots.
      *
-     * @param list<string> $migratorPaths the migrator's registered extra paths (loadMigrationsFrom)
+     * @param list<string> $migratorPaths loadMigrationsFrom() paths the migrator would expose
      */
     private function fakeApp(bool $migratorBound, array $migratorPaths): Application
     {
@@ -130,10 +122,7 @@ final class MigrationDirectoryResolutionTest extends TestCase
         return $app;
     }
 
-    /**
-     * A mocked Progress that records the warnings the resolver emits. Mocking sidesteps
-     * the abstract-method surface of Progress, which differs across Psalm versions.
-     */
+    /** Stubbed Progress that records emitted warnings into {@see self::$warnings}. */
     private function recordingProgress(): Progress
     {
         $progress = $this->createStub(Progress::class);

--- a/tests/Unit/Handlers/Eloquent/Schema/MigrationDirectoryResolutionTest.php
+++ b/tests/Unit/Handlers/Eloquent/Schema/MigrationDirectoryResolutionTest.php
@@ -18,34 +18,40 @@ use Psalm\Progress\Progress;
  * A booted app whose container can't resolve the `migrator` service (trimmed or
  * partially-registered providers) must not abort the whole migration-schema
  * feature with an uncaught BindingResolutionException — see issue #1170.
+ *
+ * Both Application and Progress are mocked rather than instantiated: a real
+ * Application boots framework code, and a hand-rolled Progress subclass risks
+ * leaving an abstract Progress method unimplemented — either crashes the PHP
+ * process when this runs inside the full unit suite.
  */
 #[CoversClass(MigrationSchemaBuilder::class)]
 final class MigrationDirectoryResolutionTest extends TestCase
 {
+    /** @var list<string> */
+    private array $warnings = [];
+
     #[Test]
     public function falls_back_to_default_directory_when_migrator_is_unbound(): void
     {
         // migrator unbound reproduces #1170: make('migrator') would throw, the guard must not.
         $app = $this->fakeApp(migratorBound: false, migratorPaths: []);
-        $progress = $this->capturingProgress();
 
-        $directories = $this->resolveDirectories($app, $progress);
+        $directories = $this->resolveDirectories($app);
 
         $this->assertSame(['/fake-app/database/migrations'], $directories);
-        $this->assertNotEmpty($progress->warnings, 'A warning must surface the missing migrator service.');
-        $this->assertStringContainsString('migrator', (string) $progress->warnings[0]);
+        $this->assertNotEmpty($this->warnings, 'A warning must surface the missing migrator service.');
+        $this->assertStringContainsString('migrator', $this->warnings[0]);
     }
 
     #[Test]
     public function merges_registered_paths_when_migrator_is_available(): void
     {
         $app = $this->fakeApp(migratorBound: true, migratorPaths: ['/extra/package/migrations']);
-        $progress = $this->capturingProgress();
 
-        $directories = $this->resolveDirectories($app, $progress);
+        $directories = $this->resolveDirectories($app);
 
         $this->assertSame(['/extra/package/migrations', '/fake-app/database/migrations'], $directories);
-        $this->assertSame([], $progress->warnings, 'No warning when the migrator resolves cleanly.');
+        $this->assertSame([], $this->warnings, 'No warning when the migrator resolves cleanly.');
     }
 
     #[Test]
@@ -56,12 +62,11 @@ final class MigrationDirectoryResolutionTest extends TestCase
         $this->setBootState('testbench_fallback', new \RuntimeException('parse error in config/app.php'));
 
         $app = $this->fakeApp(migratorBound: false, migratorPaths: []);
-        $progress = $this->capturingProgress();
 
-        $this->resolveDirectories($app, $progress);
+        $this->resolveDirectories($app);
 
-        $this->assertStringContainsString('boot mode: testbench_fallback', (string) $progress->warnings[0]);
-        $this->assertStringContainsString('parse error in config/app.php', (string) $progress->warnings[0]);
+        $this->assertStringContainsString('boot mode: testbench_fallback', $this->warnings[0]);
+        $this->assertStringContainsString('parse error in config/app.php', $this->warnings[0]);
     }
 
     protected function tearDown(): void
@@ -78,12 +83,12 @@ final class MigrationDirectoryResolutionTest extends TestCase
     }
 
     /**
-     * Invokes the private resolver without booting the heavy Codebase/MigrationCache
+     * Invoke the private resolver without booting the heavy Codebase/MigrationCache
      * collaborators the constructor wants — only the app is exercised here.
      *
      * @return list<string>
      */
-    private function resolveDirectories(Application $app, Progress $progress): array
+    private function resolveDirectories(Application $app): array
     {
         $builder = (new \ReflectionClass(MigrationSchemaBuilder::class))->newInstanceWithoutConstructor();
         (new \ReflectionProperty(MigrationSchemaBuilder::class, 'app'))->setValue($builder, $app);
@@ -91,51 +96,53 @@ final class MigrationDirectoryResolutionTest extends TestCase
         $method = new \ReflectionMethod(MigrationSchemaBuilder::class, 'getMigrationDirectories');
 
         /** @var list<string> */
-        return $method->invoke($builder, $progress);
+        return $method->invoke($builder, $this->recordingProgress());
     }
 
     /**
-     * A real {@see Application} built *without* its constructor, so the framework
-     * boot (provider registration, global container/facade binding) never runs —
-     * a full `new Application()` inside a unit test crashes the process. The
-     * untyped legacy `$basePath` / `$databasePath` properties tolerate the missing
-     * constructor, so `databasePath('migrations')` resolves to `<base>/database/migrations`.
+     * A mocked {@see Application} — only the three container methods the resolver
+     * touches are stubbed; every other method is a mock no-op, so nothing boots.
      *
      * @param list<string> $migratorPaths the migrator's registered extra paths (loadMigrationsFrom)
      */
     private function fakeApp(bool $migratorBound, array $migratorPaths): Application
     {
-        $app = (new \ReflectionClass(Application::class))->newInstanceWithoutConstructor();
-        (new \ReflectionProperty(Application::class, 'basePath'))->setValue($app, '/fake-app');
+        $migrator = new class ($migratorPaths) {
+            /** @param list<string> $paths */
+            public function __construct(private readonly array $paths) {}
 
-        if ($migratorBound) {
-            $app->instance('migrator', new class ($migratorPaths) {
-                /** @param list<string> $paths */
-                public function __construct(private readonly array $paths) {}
+            /** @return list<string> */
+            public function paths(): array
+            {
+                return $this->paths;
+            }
+        };
 
-                /** @return list<string> */
-                public function paths(): array
-                {
-                    return $this->paths;
-                }
-            });
-        }
+        $app = $this->createStub(Application::class);
+        $app->method('databasePath')->willReturn('/fake-app/database/migrations');
+        $app->method('bound')->willReturnCallback(
+            static fn(string $abstract): bool => $abstract === 'migrator' && $migratorBound,
+        );
+        $app->method('make')->willReturnCallback(
+            static fn(string $abstract): ?object => $abstract === 'migrator' ? $migrator : null,
+        );
 
         return $app;
     }
 
-    private function capturingProgress(): Progress
+    /**
+     * A mocked Progress that records the warnings the resolver emits. Mocking sidesteps
+     * the abstract-method surface of Progress, which differs across Psalm versions.
+     */
+    private function recordingProgress(): Progress
     {
-        // Progress is abstract but ships concrete no-op methods; only warning() needs capturing.
-        return new class extends Progress {
-            /** @var list<string> */
-            public array $warnings = [];
-
-            #[\Override]
-            public function warning(string $message): void
-            {
+        $progress = $this->createStub(Progress::class);
+        $progress->method('warning')->willReturnCallback(
+            function (string $message): void {
                 $this->warnings[] = $message;
-            }
-        };
+            },
+        );
+
+        return $progress;
     }
 }

--- a/tests/Unit/Handlers/Eloquent/Schema/MigrationDirectoryResolutionTest.php
+++ b/tests/Unit/Handlers/Eloquent/Schema/MigrationDirectoryResolutionTest.php
@@ -30,9 +30,9 @@ final class MigrationDirectoryResolutionTest extends TestCase
 
         $directories = $this->resolveDirectories($app, $progress);
 
-        self::assertSame(['/fake-app/database/migrations'], $directories);
-        self::assertNotEmpty($progress->warnings, 'A warning must surface the missing migrator service.');
-        self::assertStringContainsString('migrator', $progress->warnings[0]);
+        $this->assertSame(['/fake-app/database/migrations'], $directories);
+        $this->assertNotEmpty($progress->warnings, 'A warning must surface the missing migrator service.');
+        $this->assertStringContainsString('migrator', (string) $progress->warnings[0]);
     }
 
     #[Test]
@@ -43,11 +43,8 @@ final class MigrationDirectoryResolutionTest extends TestCase
 
         $directories = $this->resolveDirectories($app, $progress);
 
-        self::assertSame(
-            ['/extra/package/migrations', '/fake-app/database/migrations'],
-            $directories,
-        );
-        self::assertSame([], $progress->warnings, 'No warning when the migrator resolves cleanly.');
+        $this->assertSame(['/extra/package/migrations', '/fake-app/database/migrations'], $directories);
+        $this->assertSame([], $progress->warnings, 'No warning when the migrator resolves cleanly.');
     }
 
     /**


### PR DESCRIPTION
## Issue to Solve
On a partially-bootstrapped Laravel app, the migration-schema feature aborts the entire plugin with an uncaught `BindingResolutionException: Target class [migrator] does not exist`.

`migrator` is a **deferred** service (`MigrationServiceProvider implements DeferrableProvider`), so it only becomes resolvable once the `RegisterProviders` bootstrapper builds the app's deferred-services map. The plugin deliberately tolerates a partial bootstrap (`ApplicationProvider` swallows bootstrap throwables to survive a single bad config file), which can leave that map incomplete. `MigrationSchemaBuilder::getMigrationDirectories()` then called `make('migrator')` unconditionally and crashed.

This is the unguarded sibling of the existing `databasePath()` guard in `buildSchema()`: the same method already skips when `databasePath()` is absent, but the `migrator` resolution had no equivalent check.

## Related
Fixes #1170

## Solution Description
Guard the resolution with `Application::bound('migrator')`, matching the convention the sibling init methods (`initTranslationKeyHandler` / `initMissingViewHandler` in `Plugin.php`) already use. `Application::bound()` is `isDeferredService() || parent::bound()`, so it already accounts for deferred services and partial bootstrap. When `migrator` is unresolvable, fall back to the default `database/migrations` directory and emit a warning, instead of crashing.

Degradation is now tiered and never fatal:
- **not bound** (the #1170 case) - feature-level: schema discovery keeps working against the default migrations directory.
- **bound but construction throws** (rare) - plugin-level: handled by the outer `__invoke` `catch`, disabling the plugin with a warning rather than a hard fatal.

Note: the reporter's crash was escalated to a hard fatal by an unrelated dependency-version mismatch (Psalm 6 installed against 4.x plugin code) that broke the graceful-degradation path. This change fixes the underlying robustness gap so the migration-schema feature degrades cleanly regardless.

Verified with a new unit test (`MigrationDirectoryResolutionTest`):
- bare `Application` (unbound `migrator`, reproduces #1170) - returns the default directory and warns, no throw.
- `migrator` bound with extra `loadMigrationsFrom()` paths - merges paths, no warning.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)

## Boot diagnostics in the warning

After the guard, the migrator-unbound path degrades gracefully and no longer reaches `InternalErrorReporter`. The one datum that explains *why* the deferred-services map is incomplete — the bootstrap throwable the plugin swallowed to tolerate a partial boot (`ApplicationProvider::getBootstrapError()`) — is therefore pulled directly into the warning, alongside `getBootMode()`. Without it the user sees only the symptom (migrator missing), not the root cause (the bad config/provider that aborted boot). Those values were previously surfaced only by the separate `bin/psalm-laravel diagnose` command, never in the auto-report.

Note on the initial #1170 report: it does not state which boot fork was used. The pasted config block is `IssueUrlGenerator` output, which omits `bootMode`/`bootstrapError`. A real app is present (framework v12.60.2), so the `bootstrap` fork is the likely one, but it is an inference.
