### PR TITLE
Add conditional return types for `Pagination::fragment()`, `Arr::random()`, `Lottery::choose()`

### DIFF
--- a/stubs/common/Contracts/Pagination.phpstub
+++ b/stubs/common/Contracts/Pagination.phpstub
@@ -12,6 +12,18 @@ interface Paginator
      * @return array<TItem>
      */
     public function items(): array;
+
+    /**
+     * Get / set the URL fragment to be appended to URLs.
+     *
+     * Conditional return mirrors the concrete `AbstractPaginator::fragment()`:
+     * null arg is the getter (string|null), any other arg returns the implementor
+     * for chaining. `static`, not `$this`, on the setter branch (stub/source merge).
+     *
+     * @param  string|null  $fragment
+     * @return ($fragment is null ? string|null : static)
+     */
+    public function fragment($fragment = null);
 }
 
 /**
@@ -33,4 +45,13 @@ interface CursorPaginator
      * @return array<TItem>
      */
     public function items(): array;
+
+    /**
+     * Get / set the URL fragment to be appended to URLs. See `Paginator::fragment()`
+     * for the conditional-return / `static`-setter-branch rationale.
+     *
+     * @param  string|null  $fragment
+     * @return ($fragment is null ? string|null : static)
+     */
+    public function fragment($fragment = null);
 }

--- a/stubs/common/Pagination/Pagination.phpstub
+++ b/stubs/common/Pagination/Pagination.phpstub
@@ -52,6 +52,25 @@ abstract class AbstractPaginator implements CanBeEscapedWhenCastToString, \Illum
     public function through(callable $callback) {}
 
     /**
+     * Get / set the URL fragment to be appended to URLs.
+     *
+     * Null arg is the getter (string|null); any other arg is the setter and
+     * returns the paginator for chaining. Reflected Laravel declares the flat
+     * union `$this|string|null`, which breaks `->fragment('x')->links()` chains
+     * (Psalm would call the next method on `string|null`). The conditional return
+     * keeps the setter branch chainable.
+     *
+     * `static`, not `$this`, on the setter branch: with `$this` Psalm merges the
+     * stub conditional back into the reflected union and the call collapses to the
+     * flat union again. `static` is substituted by the late-static-bound class
+     * (carrying `<TKey, TValue>`) and overrides cleanly. Mirrors `domain()` (#1174).
+     *
+     * @param  string|null  $fragment
+     * @return ($fragment is null ? string|null : static)
+     */
+    public function fragment($fragment = null) {}
+
+    /**
      * @return \ArrayIterator<TKey, TValue>
      */
     public function getIterator(): \Traversable {}
@@ -141,6 +160,15 @@ abstract class AbstractCursorPaginator implements \Illuminate\Contracts\Support\
      * @return static<TKey, TMapValue>
      */
     public function through(callable $callback) {}
+
+    /**
+     * Get / set the URL fragment to be appended to URLs. See `AbstractPaginator::fragment()`
+     * for the `static`-not-`$this` setter-branch rationale (stub/source merge bug).
+     *
+     * @param  string|null  $fragment
+     * @return ($fragment is null ? string|null : static)
+     */
+    public function fragment($fragment = null) {}
 
     /**
      * @return \ArrayIterator<TKey, TValue>

--- a/stubs/common/Support/Arr.phpstub
+++ b/stubs/common/Support/Arr.phpstub
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Support;
+
+/**
+ * Arr declares no interfaces, so re-declaring it to narrow `random()` resets no reflected
+ * metadata (the stub re-scan resets only class_implements / parent_interfaces, never
+ * methods or used_traits). The `Macroable` trait is copied verbatim per stub convention
+ * and survives via reflection regardless; every other static helper merges from reflection.
+ */
+class Arr
+{
+    use Traits\Macroable;
+
+    /**
+     * Get one or a specified number of random values from an array.
+     *
+     * Null/absent `$number` returns a single random element (mixed); any int returns
+     * that many elements as an array. Reflected Laravel declares the flat `mixed`, so
+     * `Arr::random($a, 2)` would otherwise stay `mixed`.
+     *
+     * @param  array  $array
+     * @param  int|null  $number
+     * @param  bool  $preserveKeys
+     * @return ($number is null ? mixed : array)
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function random($array, $number = null, $preserveKeys = false) {}
+}

--- a/stubs/common/Support/Lottery.phpstub
+++ b/stubs/common/Support/Lottery.phpstub
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\Support;
+
+/**
+ * Lottery has no interfaces or traits, so re-declaring it to narrow `choose()` resets
+ * no metadata; every other method merges from reflection.
+ */
+class Lottery
+{
+    /**
+     * Run the lottery.
+     *
+     * Null/absent `$times` runs the lottery once and returns the callback result
+     * (mixed); an int runs it that many times and collects the results into a list.
+     * Reflected Laravel declares the flat `mixed`.
+     *
+     * @param  int|null  $times
+     * @return ($times is null ? mixed : list<mixed>)
+     */
+    public function choose($times = null) {}
+}

--- a/tests/Type/tests/ArrRandomTest.phpt
+++ b/tests/Type/tests/ArrRandomTest.phpt
@@ -1,0 +1,38 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Arr;
+
+/**
+ * @param array<string, int> $array
+ */
+function arr_random(array $array): void
+{
+    // No count: a single random element (mixed).
+    $_one = Arr::random($array);
+    /** @psalm-check-type-exact $_one = mixed */
+
+    // Explicit null is the same getter form.
+    $_explicit_null = Arr::random($array, null);
+    /** @psalm-check-type-exact $_explicit_null = mixed */
+
+    // A count returns that many elements as an array.
+    $_many = Arr::random($array, 2);
+    /** @psalm-check-type-exact $_many = array<array-key, mixed> */
+}
+
+/**
+ * Re-declaring Arr to narrow random() must not drop its other static helpers —
+ * they merge from reflection.
+ *
+ * @param array<string, int> $array
+ */
+function arr_other_helpers_still_resolve(array $array): void
+{
+    $_get = Arr::get($array, 'key');
+    $_first = Arr::first($array);
+    $_exists = Arr::exists($array, 'key');
+    /** @psalm-check-type-exact $_exists = bool */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/LotteryChooseTest.phpt
+++ b/tests/Type/tests/LotteryChooseTest.phpt
@@ -1,0 +1,17 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Lottery;
+
+function lottery_choose(Lottery $lottery): void
+{
+    // No count: a single run returns the callback result (mixed).
+    $_one = $lottery->choose();
+    /** @psalm-check-type-exact $_one = mixed */
+
+    // A count returns the runs collected into a list.
+    $_many = $lottery->choose(3);
+    /** @psalm-check-type-exact $_many = list<mixed> */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/PaginationTest.phpt
+++ b/tests/Type/tests/PaginationTest.phpt
@@ -51,4 +51,31 @@ function cursor_paginator_items(CursorPaginator $paginator): void
     $_collection = $paginator->getCollection();
     /** @psalm-check-type-exact $_collection = Collection<int, string> */
 }
+
+// fragment() is get-or-set: null arg reads the fragment (string|null), any other
+// arg sets it and returns the paginator (carrying its templates) for chaining.
+
+/** @param Paginator<int, string> $paginator */
+function paginator_fragment(Paginator $paginator): void
+{
+    $_get = $paginator->fragment();
+    /** @psalm-check-type-exact $_get = string|null */
+
+    $_set = $paginator->fragment('foo');
+    /** @psalm-check-type-exact $_set = Paginator<int, string>&static */
+
+    // Setter stays a paginator, so the next chained call resolves.
+    $_chained = $paginator->fragment('foo')->items();
+    /** @psalm-check-type-exact $_chained = array<string> */
+}
+
+/** @param CursorPaginator<int, string> $paginator */
+function cursor_paginator_fragment(CursorPaginator $paginator): void
+{
+    $_get = $paginator->fragment();
+    /** @psalm-check-type-exact $_get = string|null */
+
+    $_set = $paginator->fragment('foo');
+    /** @psalm-check-type-exact $_set = CursorPaginator<int, string>&static */
+}
 --EXPECTF--


### PR DESCRIPTION
## Issue to Solve

Several Laravel methods return a different type depending on their argument (get-or-set, count-or-single). The plugin stubs declared flat unions, so analysis could not pick the right branch at each call site. Upstream Laravel PR laravel/framework#60586 adds conditional `@return` types for these; this ports the still-missing, low-risk ones into the plugin stubs.

## Related

Ports laravel/framework#60586. (`random()`, `__()`, and `Route::domain()` from that PR already landed in the plugin.)

## Solution Description

Per-method conditional `@return` added to the stubs, each with a type test:

- `fragment()` on `AbstractPaginator` / `AbstractCursorPaginator` and the `Paginator` / `CursorPaginator` contracts: `($fragment is null ? string|null : static)` (getter reads, setter chains).
- `Arr::random()`: `($number is null ? mixed : array)`.
- `Lottery::choose()`: `($times is null ? mixed : list<mixed>)`.

`static`, not `$this`, on every chainable/getter branch — a `$this` branch collapses back into the reflected flat union through Psalm's stub/source merge (the #888 family; cf. `Route::domain()` #1174).

Deliberately not ported:

- `Password` / `File` / `Email::defaults()` — narrowing one rarely-called get-or-set method requires re-declaring the whole (Macroable, multi-interface) rule class, and on packages that do not fully autoload `Illuminate\Validation\Rules\*` the re-declaration *defines* those classes and unblocks downstream analysis, surfacing latent `Mixed*` noise. Not worth the maintenance / churn.
- `Route::getMetadata()` — 13.17.0-only (released days ago); upstream provides it natively once #60586 lands.
- `ComponentAttributeBag::data()` — `protected` (no external callers), header unstable on the 12.4 floor.

Verified green on Laravel 13.17.0: full type suite, unit tests, self-Psalm (100% coverage), `php-cs-fixer`, and the fresh-app integration test.

## Checklist
- [x] Tests cover the change (type tests in `tests/Type/`)
