### PR TITLE
Improve Laravel app boot diagnostics

### DIFF
--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -14,7 +14,17 @@ The app is needed at boot time to read config values (e.g. `auth.php` guards), r
 When run inside a Laravel project, the plugin loads the project's own `bootstrap/app.php` — so it sees the real config, routes, and providers.
 When no `bootstrap/app.php` is found (e.g. analyzing a Laravel package, or running the plugin's own tests), it falls back to [Orchestra Testbench](https://github.com/orchestral/testbench) which provides a minimal Laravel app skeleton.
 
-See `ApplicationProvider::doGetApp()` for the resolution logic.
+See `ApplicationProvider::getApp()` for the resolution logic and the recorded boot context.
+
+### Laravel app boot strategy
+
+Application boot has three outcomes:
+
+1. **Full boot** — `bootstrap/app.php` or Testbench returns an app and the console kernel bootstrap completes. All container-backed features may run.
+2. **Partial boot** — an app object exists, but Laravel's analysis prep or kernel bootstrap throws, usually because `config/*.php`, `.env`-dependent code, the container, or a service provider is broken. The plugin records that throwable on `ApplicationProvider`, warns once through `ApplicationBootReporter`, keeps the partial app, and feature code must degrade locally when a binding is missing or unresolvable.
+3. **Hard failure** — no usable app can be returned. The plugin reports the failure through `InternalErrorReporter`, points the user at `vendor/bin/psalm-laravel diagnose --tips --providers`, and disables itself for that run unless `failOnInternalError` asks Psalm to throw.
+
+Feature code should not try to repair a broken application by force-registering framework providers. Prefer `bound()` plus a guarded `make()` and a narrow fallback for that feature. For example, migration schema discovery may scan only the default `database/migrations` directory when `migrator` is unavailable, while the global boot warning carries the root cause.
 
 ```mermaid
 flowchart TD

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -64,6 +64,12 @@ flowchart TD
     "]
 ```
 
+### Initialisation diagnostics
+
+Warnings raised while the plugin initialises (partial boot, an unavailable `migrator`, a missing translator or view binding, stub discovery) are not printed the moment they happen, because inline they would interleave with Psalm's progress bars. A small in-memory buffer (`Diagnostics\DiagnosticsBuffer`) collects them instead, each tagged with a severity (info, warning, error) and a lifecycle stage (boot, schema, facades, translations, views, handlers, stubs, internal). A `Diagnostics\BufferedProgress` decorator captures every `Progress::warning()` call during init, so existing call sites stay unchanged.
+
+The buffer is flushed once, at a stable point. On a successful init that happens after handlers and stubs are registered, grouped by severity. On a failed init `InternalErrorReporter` replays the collected diagnostics ahead of the final error report, so the warnings that explain the failure travel with it. Each diagnostic surfaces exactly once.
+
 ## Getting started
 
 ```bash

--- a/src/Cli/Diagnose/Diagnostics.php
+++ b/src/Cli/Diagnose/Diagnostics.php
@@ -23,27 +23,37 @@ class Diagnostics
     public function collect(): Report
     {
         $bootstrapErrors = [];
+        $bootFailure = null;
 
         try {
             ApplicationProvider::bootApp();
         } catch (\Throwable $throwable) {
-            $bootstrapErrors[] = $throwable->getMessage();
+            $bootFailure = $throwable;
         }
 
-        // Throws swallowed inside `doGetApp()` (e.g. `$consoleApp->bootstrap()`
-        // failing on a bad `config/*.php`) never propagate to the catch above —
-        // ApplicationProvider stashes them so diagnose can surface partial-boot state.
-        $swallowed = ApplicationProvider::getBootstrapError();
-        if ($swallowed instanceof \Throwable) {
-            $bootstrapErrors[] = $swallowed->getMessage();
+        $recordedBootFailure = ApplicationProvider::getBootFailure();
+        if ($recordedBootFailure instanceof \Throwable) {
+            $bootFailure = $recordedBootFailure;
         }
 
-        // A null bootMode means the boot pipeline never reached a resolution branch
-        // (the try/catch above swallowed a hard throw). Treat that as a hard failure
-        // so the CLI exits non-zero; partial-bootstrap warnings alone are informational.
+        if ($bootFailure instanceof \Throwable) {
+            $bootstrapErrors[] = $bootFailure->getMessage();
+        }
+
+        // Partial boot errors (e.g. analysis prep or `$consoleApp->bootstrap()`
+        // failing on a bad `config/*.php`) are recorded by ApplicationProvider so
+        // diagnose can surface degraded app state without re-running boot.
+        $partialBootError = ApplicationProvider::getBootstrapError();
+        if ($partialBootError instanceof \Throwable) {
+            $bootstrapErrors[] = $partialBootError->getMessage();
+        }
+
+        // Hard failures prevent the plugin from returning a usable Application and
+        // make diagnose exit non-zero. Partial-boot warnings alone are
+        // informational because the plugin can continue in degraded mode.
         $hardFailures = [];
-        if (ApplicationProvider::getBootMode() === null && $bootstrapErrors !== []) {
-            $hardFailures[] = 'Application boot failed: ' . $bootstrapErrors[0];
+        if ($bootFailure instanceof \Throwable) {
+            $hardFailures[] = 'Application boot failed: ' . $bootFailure->getMessage();
         }
 
         $cwd = \getcwd();

--- a/src/Cli/DiagnoseCommand.php
+++ b/src/Cli/DiagnoseCommand.php
@@ -98,13 +98,24 @@ final class DiagnoseCommand extends Command
             'Analysis' => $report->phpAnalysisVersion . ' (from ' . $report->phpAnalysisSource . ')',
         ]);
 
-        if ($report->bootMode === null) {
-            $this->renderSection($io, 'Boot mode', ['Status' => '<error>FAILED</error>']);
+        if ($report->hardFailures !== []) {
+            $boot = ['Status' => '<error>FAILED</error>'];
+            if ($report->bootMode !== null) {
+                $boot['Mode'] = self::BOOT_MODE_LABELS[$report->bootMode] ?? '(unknown)';
+            }
+
+            if ($report->bootPath !== null) {
+                $boot['Path'] = $report->bootPath;
+            }
+
+            $this->renderSection($io, 'Boot mode', $boot);
             foreach ($report->bootstrapErrors as $error) {
                 $io->writeln('  <fg=red>!</> ' . $error);
             }
 
             $io->newLine();
+        } elseif ($report->bootMode === null) {
+            $this->renderSection($io, 'Boot mode', ['Status' => '(not attempted)']);
         } else {
             $this->renderSection($io, 'Boot mode', [
                 'Mode' => self::BOOT_MODE_LABELS[$report->bootMode] ?? '(unknown)',

--- a/src/Diagnostics/BufferedProgress.php
+++ b/src/Diagnostics/BufferedProgress.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Diagnostics;
+
+use Psalm\Progress\Phase;
+use Psalm\Progress\Progress;
+
+/**
+ * A {@see Progress} decorator that captures `warning()` into a {@see DiagnosticsBuffer}
+ * instead of printing it immediately, while forwarding every other output call
+ * (`debug`, `write`, and the scanning-phase calls) straight to the wrapped instance.
+ *
+ * The plugin hands this to its initialisation steps so their warnings buffer (tagged with
+ * the {@see setStage() current stage}) and surface together at a stable point, rather than
+ * interleaving with Psalm's progress bars. {@see stopBuffering()} restores direct output
+ * once that point is reached, so a warning raised later still prints.
+ *
+ * @psalm-import-type DiagnosticStage from Diagnostic
+ *
+ * @internal
+ */
+final class BufferedProgress extends Progress
+{
+    /** @var DiagnosticStage */
+    private string $stage = 'internal';
+
+    private bool $buffering = true;
+
+    /** @psalm-mutation-free */
+    public function __construct(
+        private readonly Progress $inner,
+        private readonly DiagnosticsBuffer $diagnostics,
+    ) {}
+
+    /**
+     * Tag subsequently buffered warnings with the initialisation stage they came from.
+     *
+     * @param DiagnosticStage $stage
+     *
+     * @psalm-external-mutation-free
+     */
+    public function setStage(string $stage): void
+    {
+        $this->stage = $stage;
+    }
+
+    /**
+     * Stop capturing warnings and route them straight to the wrapped progress again.
+     * Called once the buffer has been flushed at the end of init, so a warning raised
+     * later (e.g. by a handler that retained this instance) is printed, not dropped.
+     *
+     * @psalm-external-mutation-free
+     */
+    public function stopBuffering(): void
+    {
+        $this->buffering = false;
+    }
+
+    #[\Override]
+    public function warning(string $message): void
+    {
+        if ($this->buffering) {
+            $this->diagnostics->warning($this->stage, $message);
+
+            return;
+        }
+
+        $this->inner->warning($message);
+    }
+
+    #[\Override]
+    public function debug(string $message): void
+    {
+        $this->inner->debug($message);
+    }
+
+    // `write()` is concrete on Progress (not abstract), so override it explicitly:
+    // a bare `Progress::write()` would go straight to STDERR and bypass the wrapped
+    // instance (e.g. a VoidProgress's output suppression).
+    #[\Override]
+    public function write(string $message): void
+    {
+        $this->inner->write($message);
+    }
+
+    #[\Override]
+    public function startPhase(Phase $phase, int $threads = 1): void
+    {
+        $this->inner->startPhase($phase, $threads);
+    }
+
+    #[\Override]
+    public function expand(int $number_of_tasks): void
+    {
+        $this->inner->expand($number_of_tasks);
+    }
+
+    #[\Override]
+    public function taskDone(int $level): void
+    {
+        $this->inner->taskDone($level);
+    }
+
+    #[\Override]
+    public function finish(): void
+    {
+        $this->inner->finish();
+    }
+
+    #[\Override]
+    public function alterFileDone(string $file_name): void
+    {
+        $this->inner->alterFileDone($file_name);
+    }
+}

--- a/src/Diagnostics/Diagnostic.php
+++ b/src/Diagnostics/Diagnostic.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Diagnostics;
+
+/**
+ * One buffered plugin-initialisation diagnostic: a single severity/stage/message
+ * record collected during {@see \Psalm\LaravelPlugin\Plugin::__invoke()} and replayed
+ * at a stable output point instead of mid-progress.
+ *
+ * Severity and stage are plain strings, not enums — matching the existing
+ * boot-diagnostics convention on {@see \Psalm\LaravelPlugin\Providers\ApplicationProvider}'s
+ * `$bootMode`. The literal-union types below keep them typo-safe without enum ceremony.
+ *
+ * @psalm-type DiagnosticSeverity = 'info'|'warning'|'error'
+ * @psalm-type DiagnosticStage = 'boot'|'schema'|'facades'|'translations'|'views'|'handlers'|'stubs'|'internal'
+ *
+ * @psalm-immutable
+ *
+ * @internal
+ */
+final readonly class Diagnostic
+{
+    /**
+     * @param DiagnosticSeverity $severity
+     * @param DiagnosticStage    $stage
+     */
+    public function __construct(
+        public string $severity,
+        public string $stage,
+        public string $message,
+    ) {}
+}

--- a/src/Diagnostics/DiagnosticsBuffer.php
+++ b/src/Diagnostics/DiagnosticsBuffer.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Diagnostics;
+
+use Psalm\Progress\Progress;
+
+/**
+ * In-memory log buffer for plugin-initialisation diagnostics.
+ *
+ * Warnings raised while the plugin boots Laravel, builds schema, and registers
+ * handlers/stubs are collected here instead of being printed immediately, so they
+ * never interleave with Psalm's progress output. {@see flushTo()} replays them at a
+ * stable point: after a successful init, or as the lead-in for
+ * {@see \Psalm\LaravelPlugin\Util\InternalErrorReporter} on a failed one.
+ *
+ * Deliberately a flat append-and-drain buffer, not an event system.
+ *
+ * @psalm-import-type DiagnosticSeverity from Diagnostic
+ * @psalm-import-type DiagnosticStage from Diagnostic
+ *
+ * @internal
+ */
+final class DiagnosticsBuffer
+{
+    /**
+     * Flush order, most severe first. Psalm's {@see Progress} exposes only a warning
+     * channel, so severity drives the replay ordering rather than a per-level stream.
+     */
+    private const SEVERITY_ORDER = ['error', 'warning', 'info'];
+
+    /** @var list<Diagnostic> */
+    private array $entries = [];
+
+    /**
+     * @param DiagnosticSeverity $severity
+     * @param DiagnosticStage    $stage
+     *
+     * @psalm-external-mutation-free
+     */
+    public function add(string $severity, string $stage, string $message): void
+    {
+        $this->entries[] = new Diagnostic($severity, $stage, $message);
+    }
+
+    /**
+     * @param DiagnosticStage $stage
+     *
+     * @psalm-external-mutation-free
+     */
+    public function warning(string $stage, string $message): void
+    {
+        $this->add('warning', $stage, $message);
+    }
+
+    /**
+     * Drain buffered diagnostics to $output, grouped by severity (most severe first)
+     * and tagged with the lifecycle stage they came from. Entries are cleared after
+     * replay, so a second flush is a no-op and no warning can ever surface twice.
+     * A no-op when nothing was collected, so callers can flush unconditionally.
+     */
+    public function flushTo(Progress $output): void
+    {
+        foreach (self::SEVERITY_ORDER as $severity) {
+            foreach ($this->entries as $entry) {
+                if ($entry->severity === $severity) {
+                    $output->warning("[{$entry->stage}] {$entry->message}");
+                }
+            }
+        }
+
+        $this->entries = [];
+    }
+}

--- a/src/Handlers/Eloquent/Schema/MigrationSchemaBuilder.php
+++ b/src/Handlers/Eloquent/Schema/MigrationSchemaBuilder.php
@@ -28,10 +28,12 @@ final class MigrationSchemaBuilder
         private readonly MigrationCache $cache,
     ) {}
 
-    public function build(): SchemaAggregator
+    /**
+     * @param Progress $progress Injected by the caller (rather than read from `$this->codebase->progress`)
+     *                           so init-time warnings route through the plugin's buffered progress (#1170).
+     */
+    public function build(Progress $progress): SchemaAggregator
     {
-        $progress = $this->codebase->progress;
-
         // Discover all files first — needed for cache fingerprinting
         $sqlDumpFiles = $this->discoverSqlDumpFiles($progress);
         $migrationFiles = $this->discoverMigrationFiles($progress);

--- a/src/Handlers/Eloquent/Schema/MigrationSchemaBuilder.php
+++ b/src/Handlers/Eloquent/Schema/MigrationSchemaBuilder.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Handlers\Eloquent\Schema;
 
+use Illuminate\Database\Migrations\Migrator;
 use Illuminate\Foundation\Application;
 use Psalm\Codebase;
-use Psalm\LaravelPlugin\Providers\ApplicationProvider;
 use Psalm\Progress\Progress;
 
 /**
@@ -222,32 +222,33 @@ final class MigrationSchemaBuilder
             return [$defaultDirectory];
         }
 
-        /** @var \Illuminate\Database\Migrations\Migrator $migrator */
-        $migrator = $this->app->make('migrator');
+        try {
+            $migrator = $this->app->make('migrator');
+        } catch (\Throwable $throwable) {
+            $progress->warning($this->migratorUnavailableWarning($throwable));
+
+            return [$defaultDirectory];
+        }
+
+        if (!$migrator instanceof Migrator) {
+            $progress->warning($this->migratorUnavailableWarning());
+
+            return [$defaultDirectory];
+        }
 
         return \array_values(\array_merge($migrator->paths(), [$defaultDirectory]));
     }
 
-    /**
-     * Graceful degradation skips {@see InternalErrorReporter}, so surface the swallowed
-     * bootstrap error here — it's the root cause of the missing migrator, not just the symptom.
-     *
-     * @psalm-external-mutation-free
-     */
-    private function migratorUnavailableWarning(): string
+    /** @psalm-mutation-free */
+    private function migratorUnavailableWarning(?\Throwable $throwable = null): string
     {
-        $bootMode = ApplicationProvider::getBootMode();
-        $mode = $bootMode !== null ? " (boot mode: {$bootMode})" : '';
-
-        $bootstrapError = ApplicationProvider::getBootstrapError();
-        $cause = $bootstrapError instanceof \Throwable
-            ? " The Laravel bootstrap did not complete: {$bootstrapError->getMessage()}."
+        $cause = $throwable instanceof \Throwable
+            ? ' Resolving the service threw ' . $throwable::class . ": {$throwable->getMessage()}."
             : '';
 
-        return "Laravel plugin: the 'migrator' service is not bound{$mode}, so migration paths "
+        return "Laravel plugin: the 'migrator' service is unavailable, so migration paths "
             . 'registered via loadMigrationsFrom() cannot be auto-discovered.' . $cause
-            . ' Only the default database/migrations directory will be scanned — fix the bootstrap '
-            . 'error above or declare the extra paths another way.';
+            . ' Only the default database/migrations directory will be scanned.';
     }
 
     /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -7,6 +7,8 @@ namespace Psalm\LaravelPlugin;
 use Illuminate\Foundation\Application;
 use Psalm\Internal\Analyzer\ProjectAnalyzer;
 use Psalm\LaravelPlugin\Config\PluginConfig;
+use Psalm\LaravelPlugin\Diagnostics\BufferedProgress;
+use Psalm\LaravelPlugin\Diagnostics\DiagnosticsBuffer;
 use Psalm\LaravelPlugin\Providers\AliasStubProvider;
 use Psalm\LaravelPlugin\Providers\ApplicationProvider;
 use Psalm\LaravelPlugin\Providers\CarbonStubProvider;
@@ -29,35 +31,58 @@ final class Plugin implements PluginEntryPointInterface
     public function __invoke(RegistrationInterface $registration, ?\SimpleXMLElement $config = null): void
     {
         $pluginConfig = PluginConfig::fromXml($config);
-        $output = $this->getProgress($registration);
+        $realOutput = $this->getProgress($registration);
+
+        // Buffer init-time warnings instead of printing them mid-progress: the wrapper
+        // tags every captured warning with the current lifecycle stage. The collected
+        // diagnostics are flushed once at a stable point below on success, or replayed by
+        // InternalErrorReporter ahead of the failure report in the catch.
+        $diagnostics = new DiagnosticsBuffer();
+        $output = new BufferedProgress($realOutput, $diagnostics);
 
         try {
+            $output->setStage('boot');
             ApplicationProvider::bootApp();
             ApplicationBootReporter::reportPartialBoot($output);
 
             if ($pluginConfig->shouldUseMigrations()) {
-                $this->buildSchema($pluginConfig);
+                $output->setStage('schema');
+                $this->buildSchema($pluginConfig, $output);
             }
 
             // Build facade → service class map before registering handlers.
             // Handlers use FacadeMapProvider::getFacadeClasses() in getClassLikeNames()
             // to also register for facade/alias classes that proxy to their service.
+            $output->setStage('facades');
             FacadeMapProvider::init($output);
 
             // Always called — provides type narrowing (string vs array) regardless
             // of whether findMissingTranslations is enabled
+            $output->setStage('translations');
             $this->initTranslationKeyHandler($output, $pluginConfig->findMissingTranslations);
 
             if ($pluginConfig->findMissingViews) {
+                $output->setStage('views');
                 $this->initMissingViewHandler($output);
             }
 
+            $output->setStage('handlers');
             $this->initNoEnvOutsideConfigHandler($pluginConfig, $output);
-
             $this->registerHandlers($registration, $pluginConfig);
+
+            $output->setStage('stubs');
             $this->registerStubs($registration, $pluginConfig, $output);
+
+            // Stable output point: replay the buffered diagnostics once, grouped by severity.
+            $diagnostics->flushTo($realOutput);
         } catch (\Throwable $throwable) {
-            InternalErrorReporter::report($throwable, $output, $pluginConfig);
+            // Failure: InternalErrorReporter replays the diagnostics collected so far ahead
+            // of the error report, so the warnings that explain the failure travel with it.
+            InternalErrorReporter::report($throwable, $realOutput, $pluginConfig, $diagnostics);
+        } finally {
+            // Restore direct output on every exit path, so a warning raised later (e.g. by a
+            // handler that retained the wrapper) prints instead of vanishing into the buffer.
+            $output->stopBuffering();
         }
     }
 
@@ -484,7 +509,7 @@ final class Plugin implements PluginEntryPointInterface
         Handlers\Views\MissingViewHandler::init($paths, $extensions);
     }
 
-    private function buildSchema(PluginConfig $pluginConfig): void
+    private function buildSchema(PluginConfig $pluginConfig, \Psalm\Progress\Progress $output): void
     {
         $app = ApplicationProvider::getApp();
 
@@ -499,7 +524,7 @@ final class Plugin implements PluginEntryPointInterface
         $codebase = ProjectAnalyzer::getInstance()->getCodebase();
         $cache = new Handlers\Eloquent\Schema\MigrationCache(self::getCacheLocation($pluginConfig));
 
-        $aggregator = (new Handlers\Eloquent\Schema\MigrationSchemaBuilder($app, $codebase, $cache))->build();
+        $aggregator = (new Handlers\Eloquent\Schema\MigrationSchemaBuilder($app, $codebase, $cache))->build($output);
 
         SchemaStateProvider::setSchema($aggregator);
     }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -12,6 +12,7 @@ use Psalm\LaravelPlugin\Providers\ApplicationProvider;
 use Psalm\LaravelPlugin\Providers\CarbonStubProvider;
 use Psalm\LaravelPlugin\Providers\FacadeMapProvider;
 use Psalm\LaravelPlugin\Providers\SchemaStateProvider;
+use Psalm\LaravelPlugin\Util\ApplicationBootReporter;
 use Psalm\LaravelPlugin\Util\InternalErrorReporter;
 use Psalm\LaravelPlugin\Util\StubFileFinder;
 use Psalm\Plugin\PluginEntryPointInterface;
@@ -32,6 +33,7 @@ final class Plugin implements PluginEntryPointInterface
 
         try {
             ApplicationProvider::bootApp();
+            ApplicationBootReporter::reportPartialBoot($output);
 
             if ($pluginConfig->shouldUseMigrations()) {
                 $this->buildSchema($pluginConfig);

--- a/src/Providers/ApplicationProvider.php
+++ b/src/Providers/ApplicationProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Providers;
 
-use Illuminate\Container\Container;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Application as LaravelApplication;
@@ -19,7 +18,7 @@ final class ApplicationProvider
 {
     use CreatesApplication;
 
-    private static ?\Illuminate\Foundation\Application $app = null;
+    private static ?LaravelApplication $app = null;
 
     /**
      * Records which {@see doGetApp()} branch resolved the Laravel app.
@@ -37,18 +36,22 @@ final class ApplicationProvider
     private static ?string $bootPath = null;
 
     /**
-     * Set when {@see doGetApp()} successfully `require`d a `bootstrap/app.php`
-     * but the subsequent `$consoleApp->bootstrap()` threw — typically because
-     * one of the user project's `config/*.php` files fatals during evaluation
-     * (e.g. `parse_url(env('UNSET_VAR'))` returning null on PHP 8.1+).
+     * Set when the provider could not return a usable Laravel app at all. Unlike
+     * {@see $bootstrapError}, this disables the plugin for the current run.
+     */
+    private static ?\Throwable $bootFailure = null;
+
+    /**
+     * Set when an Application instance exists, but analysis prep or Laravel's
+     * console bootstrap throws — typically because a user project's `config/*.php`,
+     * `.env`-dependent code, container binding, or service provider is broken.
      *
-     * Plugin continues with a partially-loaded app: `config` binding still
-     * exists (created before LoadConfiguration iterates files) but later
-     * bootstrappers (RegisterFacades, RegisterProviders, BootProviders) never
-     * ran. Handlers tolerate partial state — same swallow semantics as
-     * {@see Plugin::__invoke}.
+     * Plugin continues with a partially-loaded app. Handlers must tolerate
+     * missing bindings locally and let the global warning carry the root cause.
      */
     private static ?\Throwable $bootstrapError = null;
+
+    private static bool $booted = false;
 
     public static function bootApp(): void
     {
@@ -56,8 +59,9 @@ final class ApplicationProvider
     }
 
     /**
-     * Throwable raised during eager Laravel bootstrap (LoadConfiguration etc.).
-     * Null when no bootstrap was attempted yet, or when bootstrap succeeded.
+     * Throwable raised after an Application instance was resolved, while preparing
+     * Laravel for static-analysis reads. Null when no boot was attempted yet, or
+     * when boot/prep succeeded.
      *
      * @psalm-external-mutation-free
      */
@@ -66,7 +70,18 @@ final class ApplicationProvider
         return self::$bootstrapError;
     }
 
-    private static bool $booted = false;
+    /**
+     * Throwable that prevented returning a usable Application instance.
+     * Null when boot has not been attempted yet, when boot succeeded, or when
+     * the app is only partially booted and {@see getBootstrapError()} carries
+     * the recoverable failure.
+     *
+     * @psalm-external-mutation-free
+     */
+    public static function getBootFailure(): ?\Throwable
+    {
+        return self::$bootFailure;
+    }
 
     /**
      * Which {@see doGetApp()} branch resolved the Laravel app.
@@ -98,7 +113,7 @@ final class ApplicationProvider
 
     public static function getApp(): LaravelApplication
     {
-        if (self::$app instanceof Container) {
+        if (self::$app instanceof LaravelApplication) {
             return self::$app;
         }
 
@@ -106,9 +121,13 @@ final class ApplicationProvider
         // Laravel's bootstrap process may emit warnings during service provider loading
         // (e.g., deprecated features, missing extensions). We suppress exception-throwing
         // during boot to prevent these from crashing the plugin.
-        return self::withErrorExceptionsSuppressed(static function (): LaravelApplication {
-            return (new self())->doGetApp();
-        });
+        try {
+            return self::withErrorExceptionsSuppressed(static fn(): LaravelApplication => (new self())->doGetApp());
+        } catch (\Throwable $throwable) {
+            self::$bootFailure = $throwable;
+
+            throw $throwable;
+        }
     }
 
     /**
@@ -117,6 +136,11 @@ final class ApplicationProvider
      */
     private function doGetApp(): LaravelApplication
     {
+        self::$bootFailure = null;
+        self::$bootstrapError = null;
+        self::$bootMode = null;
+        self::$bootPath = null;
+
         if (!\defined('LARAVEL_START')) {
             \define('LARAVEL_START', \microtime(true));
         }
@@ -125,64 +149,22 @@ final class ApplicationProvider
         //   1. cwd-relative bootstrap/app.php — Applications and local dev (Psalm run from project root).
         //   2. vendor-parent-relative bootstrap/app.php — plugin installed into a project's vendor/.
         //   3. Orchestra Testbench skeleton — Laravel packages with no host app (e.g. test:type).
-        $app
-            = $this->bootFromBootstrapFile((\getcwd() ?: '.') . '/bootstrap/app.php') ?? $this->bootFromBootstrapFile(
-                \dirname(__DIR__, 5) . '/bootstrap/app.php',
-            ) ?? $this->bootFromTestbench();
+        $app = $this->bootFromBootstrapFile((\getcwd() ?: '.') . '/bootstrap/app.php');
+        if (!$app instanceof LaravelApplication) {
+            $app = $this->bootFromBootstrapFile(\dirname(__DIR__, 5) . '/bootstrap/app.php');
+        }
+
+        if (!$app instanceof LaravelApplication) {
+            $app = $this->bootFromTestbench();
+        }
 
         self::$app = $app;
 
-        // Initialize view system first. Must precede vendor-provider registration: the
-        // app is already booted by createApplication() / bootstrap/app.php, so each
-        // $app->register() in registerDiscoveredVendorProviders() triggers the
-        // provider's boot() inline. Many vendor packages (Filament, Livewire, Telescope,
-        // etc.) touch View::composer() or Blade::component() in boot(); without a 'view'
-        // binding those throw BindingResolutionException and the per-provider try/catch
-        // silently swallows the failure.
-        if (!$app->bound('view')) {
-            $filesystem = new \Illuminate\Filesystem\Filesystem();
-            $viewFinder = new FileViewFinder($filesystem, []);
-            $engineResolver = new EngineResolver();
-            $engineResolver->register('php', fn(): PhpEngine => new PhpEngine($filesystem));
-            /** @var \Illuminate\Contracts\Events\Dispatcher $events */
-            $events = $app['events'];
-            $app->singleton(
-                'view',
-                fn(): \Illuminate\View\Factory => new Factory($engineResolver, $viewFinder, $events),
-            );
-        }
-
-        // Branch 3 only: register Composer-discovered vendor providers that Testbench's
-        // swapped PackageManifest filters out via `ignorePackageDiscoveriesFrom() === ['*']`.
-        // The `bootMode` sentinel is set by `bootFromTestbench()`. View must be bound first
-        // (handled above) — many vendor `boot()` methods touch `View::composer()`.
-        if (self::$bootMode === 'testbench_fallback') {
-            $this->registerDiscoveredVendorProviders($app);
-        }
-
         if (!self::$booted) {
-            // Bootstrap console app — runs Laravel's standard bootstrappers
-            // (LoadEnvironmentVariables, LoadConfiguration, RegisterFacades,
-            // RegisterProviders, BootProviders). Required because handlers
-            // read app('config'), facades, and provider-registered bindings.
-            $consoleApp = $app->make(Kernel::class);
-            $app->bind('Illuminate\Foundation\Bootstrap\HandleExceptions', function (): object {
-                return new class {
-                    /** @psalm-mutation-free */
-                    public function bootstrap(): void {}
-                };
-            });
-
-            // Tolerate partial bootstrap. One bad config file (`parse_url(env('UNSET'))`
-            // throwing TypeError on PHP 8.1+ is a common pattern) would otherwise
-            // abort the entire bootstrap chain and disable the plugin for the run.
-            // The 'config' binding is created BEFORE LoadConfiguration iterates files,
-            // so handlers reading config still see whatever loaded prior to the throw.
             try {
-                $consoleApp->bootstrap();
-                $this->ensureAppKey($app);
-            } catch (\Throwable $bootstrapError) {
-                self::$bootstrapError = $bootstrapError;
+                $this->prepareApplicationForAnalysis($app);
+            } catch (\Throwable $throwable) {
+                self::$bootstrapError = $throwable;
             }
 
             self::$booted = true;
@@ -233,7 +215,7 @@ final class ApplicationProvider
     /**
      * Require a `bootstrap/app.php` from $path and return its Application, or
      * null if the file does not exist. Records `bootMode = 'bootstrap'` and the
-     * resolved path as a side effect on success.
+     * resolved path before requiring the file so hard failures can still report it.
      */
     private function bootFromBootstrapFile(string $path): ?LaravelApplication
     {
@@ -241,15 +223,15 @@ final class ApplicationProvider
             return null;
         }
 
+        self::$bootMode = 'bootstrap';
+        self::$bootPath = $path;
+
         /** @psalm-suppress MixedAssignment */
         $app = require $path;
         assert(
             $app instanceof LaravelApplication,
             'bootstrap/app.php did not return an Application instance: ' . $path,
         );
-
-        self::$bootMode = 'bootstrap';
-        self::$bootPath = $path;
 
         return $app;
     }
@@ -261,7 +243,7 @@ final class ApplicationProvider
     private function bootFromTestbench(): LaravelApplication
     {
         /** @psalm-suppress InternalMethod */
-        $app = (new self())->createApplication();
+        $app = $this->createApplication();
 
         $this->retargetConfigPathAtProjectRoot($app);
 
@@ -288,9 +270,9 @@ final class ApplicationProvider
      * may not handle a real-but-empty project tree well — leaving them at the
      * Testbench skeleton keeps that behaviour unchanged.
      *
-     * Only branch 3 of {@see self::doGetApp()} calls this — for projects with a
-     * real `bootstrap/app.php`, that file's Application instance is used verbatim
-     * and Testbench is never consulted.
+     * Only the Testbench-fallback branch calls this — for projects with a real
+     * `bootstrap/app.php`, that file's Application instance is used verbatim and
+     * Testbench is never consulted.
      *
      * @see https://github.com/psalm/psalm-plugin-laravel/issues/940
      */
@@ -303,6 +285,55 @@ final class ApplicationProvider
         }
 
         $app->useConfigPath($projectRoot . \DIRECTORY_SEPARATOR . 'config');
+    }
+
+    /**
+     * Prepare a resolved Laravel app for static-analysis reads.
+     *
+     * The caller catches any throwable here as a partial boot: an Application
+     * object exists, but container-backed inference may be degraded.
+     */
+    private function prepareApplicationForAnalysis(LaravelApplication $app): void
+    {
+        // Initialize view system first. Must precede vendor-provider registration:
+        // the app is already booted by createApplication() / bootstrap/app.php, so
+        // each $app->register() in registerDiscoveredVendorProviders() triggers the
+        // provider's boot() inline. Many vendor packages touch View::composer() or
+        // Blade::component() in boot(); without a 'view' binding those throw.
+        if (!$app->bound('view')) {
+            $filesystem = new \Illuminate\Filesystem\Filesystem();
+            $viewFinder = new FileViewFinder($filesystem, []);
+            $engineResolver = new EngineResolver();
+            $engineResolver->register('php', fn(): PhpEngine => new PhpEngine($filesystem));
+            /** @var \Illuminate\Contracts\Events\Dispatcher $events */
+            $events = $app['events'];
+            $app->singleton(
+                'view',
+                fn(): \Illuminate\View\Factory => new Factory($engineResolver, $viewFinder, $events),
+            );
+        }
+
+        // Branch 3 only: register Composer-discovered vendor providers that Testbench's
+        // swapped PackageManifest filters out via `ignorePackageDiscoveriesFrom() === ['*']`.
+        // View must be bound first (handled above).
+        if (self::$bootMode === 'testbench_fallback') {
+            $this->registerDiscoveredVendorProviders($app);
+        }
+
+        // Bootstrap console app — runs Laravel's standard bootstrappers
+        // (LoadEnvironmentVariables, LoadConfiguration, RegisterFacades,
+        // RegisterProviders, BootProviders). Required because handlers read
+        // app('config'), facades, and provider-registered bindings.
+        $consoleApp = $app->make(Kernel::class);
+        $app->bind('Illuminate\Foundation\Bootstrap\HandleExceptions', function (): object {
+            return new class {
+                /** @psalm-mutation-free */
+                public function bootstrap(): void {}
+            };
+        });
+
+        $consoleApp->bootstrap();
+        $this->ensureAppKey($app);
     }
 
     /**
@@ -555,9 +586,9 @@ final class ApplicationProvider
     {
         // Backfill app.key BEFORE testbench's BootProviders runs (called next in
         // resolveApplicationBootstrappers) so any provider that reads config('app.key')
-        // during boot sees the dummy. doGetApp() also calls ensureAppKey() after the
-        // console bootstrap completes — that covers the bootstrap-file branch, which
-        // never enters this method. Single constant lives in ensureAppKey().
+        // during boot sees the dummy. doGetApp() also calls ensureAppKey()
+        // after the console bootstrap completes — that covers the bootstrap-file
+        // branch, which never enters this method. Single constant lives in ensureAppKey().
         $this->ensureAppKey($app);
 
         /** @var \Illuminate\Config\Repository $config */

--- a/src/Util/ApplicationBootReporter.php
+++ b/src/Util/ApplicationBootReporter.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Util;
+
+use Psalm\LaravelPlugin\Providers\ApplicationProvider;
+use Psalm\Progress\Progress;
+
+/** @internal */
+final class ApplicationBootReporter
+{
+    public static function reportPartialBoot(Progress $output): void
+    {
+        $bootstrapError = ApplicationProvider::getBootstrapError();
+
+        if (!$bootstrapError instanceof \Throwable) {
+            return;
+        }
+
+        $output->warning(self::partialBootMessage($bootstrapError));
+    }
+
+    /** @psalm-pure */
+    public static function hardFailureNextSteps(): string
+    {
+        return 'Run `vendor/bin/psalm-laravel diagnose --tips --providers` for a Laravel boot report. '
+            . 'If `php artisan` fails with the same error, fix the application bootstrap first '
+            . '(usually config, .env, or a service provider).';
+    }
+
+    /** @psalm-external-mutation-free */
+    public static function partialBootMessage(\Throwable $bootstrapError): string
+    {
+        return 'Laravel plugin: Laravel boot completed only partially'
+            . self::bootContext()
+            . '. Laravel initialization threw ' . $bootstrapError::class . ': ' . $bootstrapError->getMessage()
+            . '. Psalm will continue with degraded Laravel inference; container-dependent features '
+            . 'may be incomplete until the application bootstrap is fixed. '
+            . self::hardFailureNextSteps();
+    }
+
+    /** @psalm-external-mutation-free */
+    private static function bootContext(): string
+    {
+        $context = [];
+
+        $bootMode = ApplicationProvider::getBootMode();
+        if ($bootMode !== null) {
+            $context[] = "mode: {$bootMode}";
+        }
+
+        $bootPath = ApplicationProvider::getBootPath();
+        if ($bootPath !== null) {
+            $context[] = "path: {$bootPath}";
+        }
+
+        if ($context === []) {
+            return '';
+        }
+
+        return ' (' . \implode(', ', $context) . ')';
+    }
+}

--- a/src/Util/InternalErrorReporter.php
+++ b/src/Util/InternalErrorReporter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Psalm\LaravelPlugin\Util;
 
 use Psalm\LaravelPlugin\Config\PluginConfig;
+use Psalm\LaravelPlugin\Diagnostics\DiagnosticsBuffer;
 use Psalm\Progress\Progress;
 
 /**
@@ -20,8 +21,16 @@ use Psalm\Progress\Progress;
 final class InternalErrorReporter
 {
     /** @throws \Throwable when {@see PluginConfig::$failOnInternalError} is on */
-    public static function report(\Throwable $throwable, Progress $output, PluginConfig $pluginConfig): void
-    {
+    public static function report(
+        \Throwable $throwable,
+        Progress $output,
+        PluginConfig $pluginConfig,
+        DiagnosticsBuffer $diagnostics,
+    ): void {
+        // Replay diagnostics collected before the failure first, so the partial-boot /
+        // schema warnings that may explain the error appear ahead of the report itself.
+        $diagnostics->flushTo($output);
+
         $output->warning("Laravel plugin error on initialisation: {$throwable->getMessage()}");
 
         // Best-effort classification: tells the user whether the failure

--- a/src/Util/InternalErrorReporter.php
+++ b/src/Util/InternalErrorReporter.php
@@ -32,6 +32,8 @@ final class InternalErrorReporter
             $output->warning("Laravel plugin: {$hint}");
         }
 
+        $output->warning('Laravel plugin: ' . ApplicationBootReporter::hardFailureNextSteps());
+
         // URL generation is best-effort — a secondary failure here (e.g. a
         // throwable with a broken __toString(), a corrupt composer installed.php)
         // must never shadow the original init error that the user actually cares

--- a/tests/Unit/Cli/DiagnoseCommandTest.php
+++ b/tests/Unit/Cli/DiagnoseCommandTest.php
@@ -11,6 +11,7 @@ use Psalm\LaravelPlugin\Cli\Diagnose\Diagnostics;
 use Psalm\LaravelPlugin\Cli\Diagnose\Report;
 use Psalm\LaravelPlugin\Cli\Diagnose\TipsProvider;
 use Psalm\LaravelPlugin\Cli\DiagnoseCommand;
+use Psalm\LaravelPlugin\Providers\ApplicationProvider;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -62,6 +63,35 @@ final class DiagnoseCommandTest extends TestCase
         $this->assertSame(Command::FAILURE, $exit);
         $this->assertStringContainsString('Hard failures', $display);
         $this->assertStringContainsString('Application boot failed: synthetic', $display);
+    }
+
+    #[Test]
+    public function hard_failure_can_still_render_the_attempted_bootstrap_path(): void
+    {
+        $base = $this->okReport();
+        $failing = new Report(
+            pluginVersion: $base->pluginVersion,
+            psalmVersion: $base->psalmVersion,
+            laravelVersion: $base->laravelVersion,
+            phpRuntimeVersion: $base->phpRuntimeVersion,
+            phpRequiredVersion: $base->phpRequiredVersion,
+            phpAnalysisVersion: $base->phpAnalysisVersion,
+            phpAnalysisSource: $base->phpAnalysisSource,
+            bootMode: 'bootstrap',
+            bootPath: '/broken/bootstrap/app.php',
+            bootstrapErrors: ['syntax error in bootstrap/app.php'],
+            hardFailures: ['Application boot failed: syntax error in bootstrap/app.php'],
+            loadedProviders: [],
+        );
+
+        $tester = $this->testerFor($this->fixtureProvider($failing));
+
+        $exit = $tester->execute([]);
+        $display = $tester->getDisplay();
+
+        $this->assertSame(Command::FAILURE, $exit);
+        $this->assertStringContainsString('FAILED', $display);
+        $this->assertStringContainsString('/broken/bootstrap/app.php', $display);
     }
 
     #[Test]
@@ -182,6 +212,58 @@ final class DiagnoseCommandTest extends TestCase
         $this->assertSame($sorted, $report->loadedProviders);
     }
 
+    #[Test]
+    public function real_diagnostics_collect_reports_recorded_hard_boot_failure_without_rethrowing(): void
+    {
+        $originalState = $this->snapshotApplicationProviderState();
+
+        $app = $this->createStub(\Illuminate\Foundation\Application::class);
+        $app->method('getLoadedProviders')->willReturn([]);
+
+        $this->reflectApplicationProviderProperty('app')->setValue(null, $app);
+        $this->reflectApplicationProviderProperty('bootMode')->setValue(null, 'bootstrap');
+        $this->reflectApplicationProviderProperty('bootPath')->setValue(null, '/broken/bootstrap/app.php');
+        $this->reflectApplicationProviderProperty('bootFailure')->setValue(
+            null,
+            new \RuntimeException('syntax error in bootstrap/app.php'),
+        );
+        $this->reflectApplicationProviderProperty('bootstrapError')->setValue(null, null);
+        $this->reflectApplicationProviderProperty('booted')->setValue(null, true);
+
+        try {
+            $report = (new Diagnostics())->collect();
+        } finally {
+            foreach ($originalState as $property => $value) {
+                $this->reflectApplicationProviderProperty($property)->setValue(null, $value);
+            }
+        }
+
+        $this->assertSame('bootstrap', $report->bootMode);
+        $this->assertSame('/broken/bootstrap/app.php', $report->bootPath);
+        $this->assertSame(['syntax error in bootstrap/app.php'], $report->bootstrapErrors);
+        $this->assertSame(['Application boot failed: syntax error in bootstrap/app.php'], $report->hardFailures);
+        $this->assertSame([], $report->loadedProviders);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function snapshotApplicationProviderState(): array
+    {
+        return [
+            'app' => $this->reflectApplicationProviderProperty('app')->getValue(),
+            'bootMode' => $this->reflectApplicationProviderProperty('bootMode')->getValue(),
+            'bootPath' => $this->reflectApplicationProviderProperty('bootPath')->getValue(),
+            'bootFailure' => $this->reflectApplicationProviderProperty('bootFailure')->getValue(),
+            'bootstrapError' => $this->reflectApplicationProviderProperty('bootstrapError')->getValue(),
+            'booted' => $this->reflectApplicationProviderProperty('booted')->getValue(),
+        ];
+    }
+
+    private function reflectApplicationProviderProperty(string $name): \ReflectionProperty
+    {
+        return new \ReflectionProperty(ApplicationProvider::class, $name);
+    }
 
     private function testerFor(Diagnostics $diagnostics, ?TipsProvider $tipsProvider = null): CommandTester
     {

--- a/tests/Unit/Diagnostics/BufferedProgressTest.php
+++ b/tests/Unit/Diagnostics/BufferedProgressTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Diagnostics;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Diagnostics\BufferedProgress;
+use Psalm\LaravelPlugin\Diagnostics\Diagnostic;
+use Psalm\LaravelPlugin\Diagnostics\DiagnosticsBuffer;
+use Psalm\Progress\Progress;
+
+#[CoversClass(BufferedProgress::class)]
+#[CoversClass(DiagnosticsBuffer::class)]
+#[CoversClass(Diagnostic::class)]
+final class BufferedProgressTest extends TestCase
+{
+    /** @var list<string> */
+    private array $innerWarnings = [];
+
+    /** @var list<string> */
+    private array $innerDebug = [];
+
+    /** @var list<string> */
+    private array $flushed = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->innerWarnings = [];
+        $this->innerDebug = [];
+        $this->flushed = [];
+    }
+
+    #[Test]
+    public function a_warning_is_captured_into_the_buffer_not_the_inner_progress(): void
+    {
+        $buffer = new DiagnosticsBuffer();
+        $progress = new BufferedProgress($this->recordingInner(), $buffer);
+
+        $progress->setStage('schema');
+        $progress->warning("the 'migrator' service is unavailable");
+
+        $this->assertSame([], $this->innerWarnings, 'Buffered warnings must not reach the inner progress.');
+
+        $buffer->flushTo($this->recordingSink());
+        $this->assertSame(["[schema] the 'migrator' service is unavailable"], $this->flushed);
+    }
+
+    #[Test]
+    public function each_warning_is_tagged_with_the_stage_active_when_it_was_raised(): void
+    {
+        $buffer = new DiagnosticsBuffer();
+        $progress = new BufferedProgress($this->recordingInner(), $buffer);
+
+        $progress->setStage('boot');
+        $progress->warning('partial boot');
+        $progress->setStage('schema');
+        $progress->warning('migrator unavailable');
+
+        $buffer->flushTo($this->recordingSink());
+
+        $this->assertSame(['[boot] partial boot', '[schema] migrator unavailable'], $this->flushed);
+    }
+
+    #[Test]
+    public function non_warning_calls_pass_through_to_the_inner_progress_immediately(): void
+    {
+        $buffer = new DiagnosticsBuffer();
+        $progress = new BufferedProgress($this->recordingInner(), $buffer);
+
+        $progress->debug('scanning migrations');
+
+        $this->assertSame(['scanning migrations'], $this->innerDebug);
+
+        // The debug call must not have been captured as a diagnostic.
+        $buffer->flushTo($this->recordingSink());
+        $this->assertSame([], $this->flushed);
+    }
+
+    #[Test]
+    public function stop_buffering_routes_later_warnings_straight_to_the_inner_progress(): void
+    {
+        $buffer = new DiagnosticsBuffer();
+        $progress = new BufferedProgress($this->recordingInner(), $buffer);
+
+        $progress->stopBuffering();
+        $progress->warning('raised after the flush point');
+
+        $this->assertSame(['raised after the flush point'], $this->innerWarnings);
+
+        $buffer->flushTo($this->recordingSink());
+        $this->assertSame([], $this->flushed, 'Nothing should have been buffered after stopBuffering().');
+    }
+
+    /** Inner Progress double that records warning() and debug() passthrough. */
+    private function recordingInner(): Progress
+    {
+        $progress = $this->createStub(Progress::class);
+        $progress->method('warning')->willReturnCallback(
+            function (string $message): void {
+                $this->innerWarnings[] = $message;
+            },
+        );
+        $progress->method('debug')->willReturnCallback(
+            function (string $message): void {
+                $this->innerDebug[] = $message;
+            },
+        );
+
+        return $progress;
+    }
+
+    /** Separate sink that records what a flush replays. */
+    private function recordingSink(): Progress
+    {
+        $progress = $this->createStub(Progress::class);
+        $progress->method('warning')->willReturnCallback(
+            function (string $message): void {
+                $this->flushed[] = $message;
+            },
+        );
+
+        return $progress;
+    }
+}

--- a/tests/Unit/Diagnostics/DiagnosticsBufferTest.php
+++ b/tests/Unit/Diagnostics/DiagnosticsBufferTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Diagnostics;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Diagnostics\Diagnostic;
+use Psalm\LaravelPlugin\Diagnostics\DiagnosticsBuffer;
+use Psalm\Progress\Progress;
+
+#[CoversClass(DiagnosticsBuffer::class)]
+#[CoversClass(Diagnostic::class)]
+final class DiagnosticsBufferTest extends TestCase
+{
+    /** @var list<string> */
+    private array $flushed = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->flushed = [];
+    }
+
+    #[Test]
+    public function flush_emits_nothing_when_empty(): void
+    {
+        (new DiagnosticsBuffer())->flushTo($this->recordingProgress());
+
+        $this->assertSame([], $this->flushed);
+    }
+
+    #[Test]
+    public function a_warning_is_collected_and_flushed_with_its_stage_tag(): void
+    {
+        $buffer = new DiagnosticsBuffer();
+        $buffer->warning('schema', "the 'migrator' service is unavailable");
+
+        $buffer->flushTo($this->recordingProgress());
+
+        $this->assertSame(["[schema] the 'migrator' service is unavailable"], $this->flushed);
+    }
+
+    #[Test]
+    public function entries_are_grouped_by_severity_most_severe_first(): void
+    {
+        $buffer = new DiagnosticsBuffer();
+        // Add out of severity order on purpose: flush must reorder to error > warning > info.
+        $buffer->warning('boot', 'partial boot');
+        $buffer->add('info', 'facades', 'facade map ready');
+        $buffer->add('error', 'internal', 'init failed');
+
+        $buffer->flushTo($this->recordingProgress());
+
+        $this->assertSame(
+            ['[internal] init failed', '[boot] partial boot', '[facades] facade map ready'],
+            $this->flushed,
+        );
+    }
+
+    #[Test]
+    public function insertion_order_is_preserved_within_a_severity(): void
+    {
+        $buffer = new DiagnosticsBuffer();
+        $buffer->warning('schema', 'first');
+        $buffer->warning('views', 'second');
+
+        $buffer->flushTo($this->recordingProgress());
+
+        $this->assertSame(['[schema] first', '[views] second'], $this->flushed);
+    }
+
+    /** Stubbed Progress that records flushed warnings into {@see self::$flushed}. */
+    private function recordingProgress(): Progress
+    {
+        $progress = $this->createStub(Progress::class);
+        $progress->method('warning')->willReturnCallback(
+            function (string $message): void {
+                $this->flushed[] = $message;
+            },
+        );
+
+        return $progress;
+    }
+}

--- a/tests/Unit/Handlers/Eloquent/Schema/MigrationDirectoryResolutionTest.php
+++ b/tests/Unit/Handlers/Eloquent/Schema/MigrationDirectoryResolutionTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Eloquent\Schema;
 
+use Illuminate\Database\Migrations\Migrator;
 use Illuminate\Foundation\Application;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\MigrationSchemaBuilder;
-use Psalm\LaravelPlugin\Providers\ApplicationProvider;
 use Psalm\Progress\Progress;
 
 /**
@@ -49,31 +49,19 @@ final class MigrationDirectoryResolutionTest extends TestCase
     }
 
     #[Test]
-    public function warning_surfaces_boot_mode_and_swallowed_bootstrap_error(): void
+    public function falls_back_to_default_directory_when_migrator_resolution_throws(): void
     {
-        // The plugin swallows a partial-bootstrap throwable to stay alive; that throwable is
-        // the real reason the migrator is missing, so the warning must surface it (#1170).
-        $this->setBootState('testbench_fallback', new \RuntimeException('parse error in config/app.php'));
+        $app = $this->fakeApp(
+            migratorBound: true,
+            migratorPaths: [],
+            makeFailure: new \RuntimeException('database manager is unavailable'),
+        );
 
-        $app = $this->fakeApp(migratorBound: false, migratorPaths: []);
+        $directories = $this->resolveDirectories($app);
 
-        $this->resolveDirectories($app);
-
-        $this->assertStringContainsString('boot mode: testbench_fallback', $this->warnings[0]);
-        $this->assertStringContainsString('parse error in config/app.php', $this->warnings[0]);
-    }
-
-    protected function tearDown(): void
-    {
-        // Boot state is global static — reset so it can't leak into other tests.
-        $this->setBootState(null, null);
-        parent::tearDown();
-    }
-
-    private function setBootState(?string $bootMode, ?\Throwable $bootstrapError): void
-    {
-        (new \ReflectionProperty(ApplicationProvider::class, 'bootMode'))->setValue(null, $bootMode);
-        (new \ReflectionProperty(ApplicationProvider::class, 'bootstrapError'))->setValue(null, $bootstrapError);
+        $this->assertSame(['/fake-app/database/migrations'], $directories);
+        $this->assertStringContainsString('Resolving the service threw RuntimeException', $this->warnings[0]);
+        $this->assertStringContainsString('database manager is unavailable', $this->warnings[0]);
     }
 
     /**
@@ -97,18 +85,10 @@ final class MigrationDirectoryResolutionTest extends TestCase
      *
      * @param list<string> $migratorPaths loadMigrationsFrom() paths the migrator would expose
      */
-    private function fakeApp(bool $migratorBound, array $migratorPaths): Application
+    private function fakeApp(bool $migratorBound, array $migratorPaths, ?\Throwable $makeFailure = null): Application
     {
-        $migrator = new class ($migratorPaths) {
-            /** @param list<string> $paths */
-            public function __construct(private readonly array $paths) {}
-
-            /** @return list<string> */
-            public function paths(): array
-            {
-                return $this->paths;
-            }
-        };
+        $migrator = $this->createStub(Migrator::class);
+        $migrator->method('paths')->willReturn($migratorPaths);
 
         $app = $this->createStub(Application::class);
         $app->method('databasePath')->willReturn('/fake-app/database/migrations');
@@ -116,7 +96,13 @@ final class MigrationDirectoryResolutionTest extends TestCase
             static fn(string $abstract): bool => $abstract === 'migrator' && $migratorBound,
         );
         $app->method('make')->willReturnCallback(
-            static fn(string $abstract): ?object => $abstract === 'migrator' ? $migrator : null,
+            static function (string $abstract) use ($makeFailure, $migrator): ?object {
+                if ($makeFailure instanceof \Throwable) {
+                    throw $makeFailure;
+                }
+
+                return $abstract === 'migrator' ? $migrator : null;
+            },
         );
 
         return $app;

--- a/tests/Unit/Handlers/Eloquent/Schema/MigrationDirectoryResolutionTest.php
+++ b/tests/Unit/Handlers/Eloquent/Schema/MigrationDirectoryResolutionTest.php
@@ -9,6 +9,8 @@ use Illuminate\Foundation\Application;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Diagnostics\BufferedProgress;
+use Psalm\LaravelPlugin\Diagnostics\DiagnosticsBuffer;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\MigrationSchemaBuilder;
 use Psalm\Progress\Progress;
 
@@ -64,12 +66,47 @@ final class MigrationDirectoryResolutionTest extends TestCase
         $this->assertStringContainsString('database manager is unavailable', $this->warnings[0]);
     }
 
+    #[Test]
+    public function the_migrator_unavailable_warning_is_buffered_not_printed_mid_progress(): void
+    {
+        $app = $this->fakeApp(migratorBound: false, migratorPaths: []);
+
+        $buffer = new DiagnosticsBuffer();
+        $output = new BufferedProgress($this->recordingProgress(), $buffer);
+        $output->setStage('schema');
+
+        $directories = $this->invokeGetMigrationDirectories($app, $output);
+
+        // Fallback is unchanged: still scan only the default directory.
+        $this->assertSame(['/fake-app/database/migrations'], $directories);
+        // Captured into the buffer, so nothing reached the (inner) progress mid-scan.
+        $this->assertSame([], $this->warnings);
+
+        // Draining the buffer surfaces the warning under the schema stage.
+        $buffer->flushTo($this->recordingProgress());
+        $this->assertCount(1, $this->warnings);
+        $this->assertStringContainsString('[schema]', $this->warnings[0]);
+        $this->assertStringContainsString('migrator', $this->warnings[0]);
+    }
+
     /**
-     * Call the private resolver directly, skipping the Codebase/MigrationCache collaborators.
+     * Call the private resolver directly with the test's recording progress, skipping
+     * the Codebase/MigrationCache collaborators.
      *
      * @return list<string>
      */
     private function resolveDirectories(Application $app): array
+    {
+        return $this->invokeGetMigrationDirectories($app, $this->recordingProgress());
+    }
+
+    /**
+     * Invoke the private resolver with a caller-supplied progress, so tests can pass a
+     * {@see BufferedProgress} to assert buffering as well as a plain recording stub.
+     *
+     * @return list<string>
+     */
+    private function invokeGetMigrationDirectories(Application $app, Progress $progress): array
     {
         $builder = (new \ReflectionClass(MigrationSchemaBuilder::class))->newInstanceWithoutConstructor();
         (new \ReflectionProperty(MigrationSchemaBuilder::class, 'app'))->setValue($builder, $app);
@@ -77,7 +114,7 @@ final class MigrationDirectoryResolutionTest extends TestCase
         $method = new \ReflectionMethod(MigrationSchemaBuilder::class, 'getMigrationDirectories');
 
         /** @var list<string> */
-        return $method->invoke($builder, $this->recordingProgress());
+        return $method->invoke($builder, $progress);
     }
 
     /**

--- a/tests/Unit/Handlers/Eloquent/Schema/MigrationDirectoryResolutionTest.php
+++ b/tests/Unit/Handlers/Eloquent/Schema/MigrationDirectoryResolutionTest.php
@@ -85,8 +85,8 @@ final class MigrationDirectoryResolutionTest extends TestCase
         // Draining the buffer surfaces the warning under the schema stage.
         $buffer->flushTo($this->recordingProgress());
         $this->assertCount(1, $this->warnings);
-        $this->assertStringContainsString('[schema]', $this->warnings[0]);
-        $this->assertStringContainsString('migrator', $this->warnings[0]);
+        $this->assertStringContainsString('[schema]', (string) $this->warnings[0]);
+        $this->assertStringContainsString('migrator', (string) $this->warnings[0]);
     }
 
     /**

--- a/tests/Unit/Providers/ApplicationProviderConfigPathTest.php
+++ b/tests/Unit/Providers/ApplicationProviderConfigPathTest.php
@@ -30,7 +30,7 @@ final class ApplicationProviderConfigPathTest extends TestCase
     private string $originalCwd;
 
     /** @var array<string, mixed> */
-    private array $originalState;
+    private array $originalState = [];
 
     protected function setUp(): void
     {
@@ -40,23 +40,23 @@ final class ApplicationProviderConfigPathTest extends TestCase
         \assert(\is_string($cwd), 'getcwd() must succeed before the test');
         $this->originalCwd = $cwd;
 
-        // Snapshot ApplicationProvider's memoised state so a previous test that booted
-        // the app from a different cwd cannot leak its `configPath()` into this one.
-        $this->originalState = [
-            'app' => $this->reflectProperty('app')->getValue(),
-            'booted' => $this->reflectProperty('booted')->getValue(),
-        ];
-
+        // Snapshot ApplicationProvider's memoised state so a previous test that
+        // booted the app from a different cwd cannot leak its `configPath()` into
+        // this one.
+        $this->originalState = $this->snapshotApplicationProviderState();
         $this->reflectProperty('app')->setValue(null, null);
         $this->reflectProperty('booted')->setValue(null, false);
+        $this->reflectProperty('bootFailure')->setValue(null, null);
+        $this->reflectProperty('bootstrapError')->setValue(null, null);
     }
 
     protected function tearDown(): void
     {
         \chdir($this->originalCwd);
 
-        $this->reflectProperty('app')->setValue(null, $this->originalState['app']);
-        $this->reflectProperty('booted')->setValue(null, $this->originalState['booted']);
+        foreach ($this->originalState as $property => $value) {
+            $this->reflectProperty($property)->setValue(null, $value);
+        }
 
         parent::tearDown();
     }
@@ -74,8 +74,8 @@ final class ApplicationProviderConfigPathTest extends TestCase
             'pre-condition: the auto-detection requires composer.json at the anchor',
         );
 
-        // Boots via Testbench because the plugin repo has no `bootstrap/app.php`.
-        // Branch 3 of doGetApp() fires and retargetConfigPathAtProjectRoot() runs.
+        // Boots via Testbench because the plugin repo has no `bootstrap/app.php`;
+        // that fallback branch retargets config_path() at the package root.
         $app = ApplicationProvider::getApp();
 
         $this->assertSame(
@@ -84,6 +84,21 @@ final class ApplicationProviderConfigPathTest extends TestCase
             'config_path() must resolve to <project>/config so NoEnvOutsideConfig '
                 . 'sees the package config files instead of Testbench skeleton.',
         );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function snapshotApplicationProviderState(): array
+    {
+        return [
+            'app' => $this->reflectProperty('app')->getValue(),
+            'bootMode' => $this->reflectProperty('bootMode')->getValue(),
+            'bootPath' => $this->reflectProperty('bootPath')->getValue(),
+            'bootFailure' => $this->reflectProperty('bootFailure')->getValue(),
+            'bootstrapError' => $this->reflectProperty('bootstrapError')->getValue(),
+            'booted' => $this->reflectProperty('booted')->getValue(),
+        ];
     }
 
     private function reflectProperty(string $name): \ReflectionProperty

--- a/tests/Unit/Providers/ApplicationProviderVendorRegistrationTest.php
+++ b/tests/Unit/Providers/ApplicationProviderVendorRegistrationTest.php
@@ -12,9 +12,9 @@ use Tests\Psalm\LaravelPlugin\Unit\Providers\Fixtures\BindingServiceProvider;
 use Tests\Psalm\LaravelPlugin\Unit\Providers\Fixtures\ThrowingServiceProvider;
 
 /**
- * Regression coverage for issue #942 — branch 3 of `ApplicationProvider::doGetApp()`
- * must discover and register vendor service providers (which Testbench would
- * otherwise filter out via `ignorePackageDiscoveriesFrom() === ['*']`), and a single
+ * Regression coverage for issue #942 — the Testbench-fallback branch must
+ * discover and register vendor service providers (which Testbench would otherwise
+ * filter out via `ignorePackageDiscoveriesFrom() === ['*']`), and a single
  * throwing provider must NOT prevent the rest from registering.
  *
  * We pin a fake project root via `APP_BASE_PATH` (Testbench's documented escape
@@ -33,20 +33,14 @@ final class ApplicationProviderVendorRegistrationTest extends TestCase
     private ?string $originalAppBasePath;
 
     /** @var array<string, mixed> */
-    private array $originalState;
+    private array $originalState = [];
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->originalAppBasePath = $_ENV['APP_BASE_PATH'] ?? null;
-        $this->originalState = [
-            'app' => $this->reflectProperty('app')->getValue(),
-            'booted' => $this->reflectProperty('booted')->getValue(),
-            'bootMode' => $this->reflectProperty('bootMode')->getValue(),
-            'bootPath' => $this->reflectProperty('bootPath')->getValue(),
-            'bootstrapError' => $this->reflectProperty('bootstrapError')->getValue(),
-        ];
+        $this->originalState = $this->snapshotApplicationProviderState();
 
         $this->fakeProjectRoot = \sys_get_temp_dir() . \DIRECTORY_SEPARATOR
             . 'psalm-plugin-laravel-test-' . \bin2hex(\random_bytes(6));
@@ -55,6 +49,8 @@ final class ApplicationProviderVendorRegistrationTest extends TestCase
         $_ENV['APP_BASE_PATH'] = $this->fakeProjectRoot;
         $this->reflectProperty('app')->setValue(null, null);
         $this->reflectProperty('booted')->setValue(null, false);
+        $this->reflectProperty('bootFailure')->setValue(null, null);
+        $this->reflectProperty('bootstrapError')->setValue(null, null);
     }
 
     protected function tearDown(): void
@@ -65,11 +61,9 @@ final class ApplicationProviderVendorRegistrationTest extends TestCase
             $_ENV['APP_BASE_PATH'] = $this->originalAppBasePath;
         }
 
-        $this->reflectProperty('app')->setValue(null, $this->originalState['app']);
-        $this->reflectProperty('booted')->setValue(null, $this->originalState['booted']);
-        $this->reflectProperty('bootMode')->setValue(null, $this->originalState['bootMode']);
-        $this->reflectProperty('bootPath')->setValue(null, $this->originalState['bootPath']);
-        $this->reflectProperty('bootstrapError')->setValue(null, $this->originalState['bootstrapError']);
+        foreach ($this->originalState as $property => $value) {
+            $this->reflectProperty($property)->setValue(null, $value);
+        }
 
         $this->removeDirectory($this->fakeProjectRoot);
 
@@ -79,9 +73,9 @@ final class ApplicationProviderVendorRegistrationTest extends TestCase
     #[Test]
     public function discovered_vendor_provider_binding_survives_an_earlier_throwing_provider(): void
     {
-        // ApplicationProvider::getApp() goes through doGetApp(). The plugin repo has no
-        // bootstrap/app.php at the test's cwd nor at dirname(__DIR__, 5), so branch 3
-        // fires and registerDiscoveredVendorProviders() runs against APP_BASE_PATH.
+        // The plugin repo has no bootstrap/app.php at the test's cwd nor at
+        // dirname(__DIR__, 5), so the Testbench fallback runs vendor discovery
+        // against APP_BASE_PATH.
         $app = ApplicationProvider::getApp();
 
         $this->assertTrue(
@@ -149,6 +143,21 @@ final class ApplicationProviderVendorRegistrationTest extends TestCase
         }
 
         \rmdir($path);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function snapshotApplicationProviderState(): array
+    {
+        return [
+            'app' => $this->reflectProperty('app')->getValue(),
+            'bootMode' => $this->reflectProperty('bootMode')->getValue(),
+            'bootPath' => $this->reflectProperty('bootPath')->getValue(),
+            'bootFailure' => $this->reflectProperty('bootFailure')->getValue(),
+            'bootstrapError' => $this->reflectProperty('bootstrapError')->getValue(),
+            'booted' => $this->reflectProperty('booted')->getValue(),
+        ];
     }
 
     private function reflectProperty(string $name): \ReflectionProperty

--- a/tests/Unit/Util/ApplicationBootReporterTest.php
+++ b/tests/Unit/Util/ApplicationBootReporterTest.php
@@ -88,9 +88,9 @@ final class ApplicationBootReporterTest extends TestCase
         // Draining the buffer surfaces the warning under the boot stage.
         $buffer->flushTo($this->recordingProgress());
         $this->assertCount(1, $this->warnings);
-        $this->assertStringContainsString('[boot]', $this->warnings[0]);
-        $this->assertStringContainsString('Laravel boot completed only partially', $this->warnings[0]);
-        $this->assertStringContainsString('boom in config/app.php', $this->warnings[0]);
+        $this->assertStringContainsString('[boot]', (string) $this->warnings[0]);
+        $this->assertStringContainsString('Laravel boot completed only partially', (string) $this->warnings[0]);
+        $this->assertStringContainsString('boom in config/app.php', (string) $this->warnings[0]);
     }
 
     /** Stubbed Progress that records emitted warnings into the test buffer. */

--- a/tests/Unit/Util/ApplicationBootReporterTest.php
+++ b/tests/Unit/Util/ApplicationBootReporterTest.php
@@ -7,6 +7,8 @@ namespace Tests\Psalm\LaravelPlugin\Unit\Util;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Diagnostics\BufferedProgress;
+use Psalm\LaravelPlugin\Diagnostics\DiagnosticsBuffer;
 use Psalm\LaravelPlugin\Providers\ApplicationProvider;
 use Psalm\LaravelPlugin\Util\ApplicationBootReporter;
 use Psalm\Progress\Progress;
@@ -65,6 +67,30 @@ final class ApplicationBootReporterTest extends TestCase
         $this->assertStringContainsString('/app/bootstrap/app.php', $this->warnings[0]);
         $this->assertStringContainsString('parse_url(): Argument #1 must be string', $this->warnings[0]);
         $this->assertStringContainsString('vendor/bin/psalm-laravel diagnose --tips --providers', $this->warnings[0]);
+    }
+
+    #[Test]
+    public function the_partial_boot_warning_is_buffered_not_printed_mid_progress(): void
+    {
+        $this->reflectProperty('bootMode')->setValue(null, 'bootstrap');
+        $this->reflectProperty('bootPath')->setValue(null, '/app/bootstrap/app.php');
+        $this->reflectProperty('bootstrapError')->setValue(null, new \RuntimeException('boom in config/app.php'));
+
+        $buffer = new DiagnosticsBuffer();
+        $output = new BufferedProgress($this->recordingProgress(), $buffer);
+        $output->setStage('boot');
+
+        ApplicationBootReporter::reportPartialBoot($output);
+
+        // Captured into the buffer, so nothing reached the (inner) progress yet.
+        $this->assertSame([], $this->warnings);
+
+        // Draining the buffer surfaces the warning under the boot stage.
+        $buffer->flushTo($this->recordingProgress());
+        $this->assertCount(1, $this->warnings);
+        $this->assertStringContainsString('[boot]', $this->warnings[0]);
+        $this->assertStringContainsString('Laravel boot completed only partially', $this->warnings[0]);
+        $this->assertStringContainsString('boom in config/app.php', $this->warnings[0]);
     }
 
     /** Stubbed Progress that records emitted warnings into the test buffer. */

--- a/tests/Unit/Util/ApplicationBootReporterTest.php
+++ b/tests/Unit/Util/ApplicationBootReporterTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Util;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Providers\ApplicationProvider;
+use Psalm\LaravelPlugin\Util\ApplicationBootReporter;
+use Psalm\Progress\Progress;
+
+#[CoversClass(ApplicationBootReporter::class)]
+final class ApplicationBootReporterTest extends TestCase
+{
+    /** @var array<string, mixed> */
+    private array $originalState = [];
+
+    /** @var list<string> */
+    private array $warnings = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalState = $this->snapshotApplicationProviderState();
+        $this->warnings = [];
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->originalState as $property => $value) {
+            $this->reflectProperty($property)->setValue(null, $value);
+        }
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function it_does_not_warn_when_bootstrap_succeeded(): void
+    {
+        $this->reflectProperty('bootstrapError')->setValue(null, null);
+
+        ApplicationBootReporter::reportPartialBoot($this->recordingProgress());
+
+        $this->assertSame([], $this->warnings);
+    }
+
+    #[Test]
+    public function it_reports_partial_boot_with_context_and_next_steps(): void
+    {
+        $this->reflectProperty('bootMode')->setValue(null, 'bootstrap');
+        $this->reflectProperty('bootPath')->setValue(null, '/app/bootstrap/app.php');
+        $this->reflectProperty('bootstrapError')->setValue(
+            null,
+            new \RuntimeException('parse_url(): Argument #1 must be string'),
+        );
+
+        ApplicationBootReporter::reportPartialBoot($this->recordingProgress());
+
+        $this->assertCount(1, $this->warnings);
+        $this->assertStringContainsString('Laravel boot completed only partially', $this->warnings[0]);
+        $this->assertStringContainsString('mode: bootstrap', $this->warnings[0]);
+        $this->assertStringContainsString('/app/bootstrap/app.php', $this->warnings[0]);
+        $this->assertStringContainsString('parse_url(): Argument #1 must be string', $this->warnings[0]);
+        $this->assertStringContainsString('vendor/bin/psalm-laravel diagnose --tips --providers', $this->warnings[0]);
+    }
+
+    /** Stubbed Progress that records emitted warnings into the test buffer. */
+    private function recordingProgress(): Progress
+    {
+        $progress = $this->createStub(Progress::class);
+        $progress->method('warning')->willReturnCallback(
+            function (string $message): void {
+                $this->warnings[] = $message;
+            },
+        );
+
+        return $progress;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function snapshotApplicationProviderState(): array
+    {
+        return [
+            'app' => $this->reflectProperty('app')->getValue(),
+            'bootMode' => $this->reflectProperty('bootMode')->getValue(),
+            'bootPath' => $this->reflectProperty('bootPath')->getValue(),
+            'bootFailure' => $this->reflectProperty('bootFailure')->getValue(),
+            'bootstrapError' => $this->reflectProperty('bootstrapError')->getValue(),
+            'booted' => $this->reflectProperty('booted')->getValue(),
+        ];
+    }
+
+    private function reflectProperty(string $name): \ReflectionProperty
+    {
+        return new \ReflectionProperty(ApplicationProvider::class, $name);
+    }
+}

--- a/tests/Unit/Util/InternalErrorReporterTest.php
+++ b/tests/Unit/Util/InternalErrorReporterTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Util;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Config\PluginConfig;
+use Psalm\LaravelPlugin\Diagnostics\DiagnosticsBuffer;
+use Psalm\LaravelPlugin\Util\InternalErrorReporter;
+use Psalm\Progress\Progress;
+
+#[CoversClass(InternalErrorReporter::class)]
+final class InternalErrorReporterTest extends TestCase
+{
+    /** @var list<string> */
+    private array $warnings = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->warnings = [];
+    }
+
+    #[Test]
+    public function it_replays_collected_diagnostics_ahead_of_the_error_report(): void
+    {
+        $diagnostics = new DiagnosticsBuffer();
+        $diagnostics->warning('boot', 'Laravel boot completed only partially');
+
+        InternalErrorReporter::report(
+            new \RuntimeException('something broke during init'),
+            $this->recordingProgress(),
+            PluginConfig::fromXml(null),
+            $diagnostics,
+        );
+
+        // The buffered diagnostic must precede the "error on initialisation" line, so the
+        // warning that explains the failure travels with the report rather than being lost.
+        $diagnosticIndex = $this->indexOfWarningContaining('[boot] Laravel boot completed only partially');
+        $reportIndex = $this->indexOfWarningContaining('Laravel plugin error on initialisation');
+
+        $this->assertGreaterThanOrEqual(0, $diagnosticIndex, 'the buffered diagnostic was not replayed');
+        $this->assertGreaterThanOrEqual(0, $reportIndex, 'the error report line is missing');
+        $this->assertLessThan($reportIndex, $diagnosticIndex, 'diagnostics must precede the error report');
+    }
+
+    #[Test]
+    public function it_does_not_rethrow_when_fail_on_internal_error_is_off(): void
+    {
+        // fromXml(null) leaves failOnInternalError at its default (false), so report() must
+        // surface the warnings and return rather than rethrow.
+        $this->expectNotToPerformAssertions();
+
+        InternalErrorReporter::report(
+            new \RuntimeException('boom'),
+            $this->recordingProgress(),
+            PluginConfig::fromXml(null),
+            new DiagnosticsBuffer(),
+        );
+    }
+
+    #[Test]
+    public function it_still_replays_diagnostics_when_it_rethrows_on_fail_on_internal_error(): void
+    {
+        $diagnostics = new DiagnosticsBuffer();
+        $diagnostics->warning('boot', 'Laravel boot completed only partially');
+
+        $config = PluginConfig::fromXml(
+            new \SimpleXMLElement('<pluginClass><failOnInternalError value="true" /></pluginClass>'),
+        );
+
+        $thrown = null;
+
+        try {
+            InternalErrorReporter::report(
+                new \RuntimeException('something broke during init'),
+                $this->recordingProgress(),
+                $config,
+                $diagnostics,
+            );
+        } catch (\Throwable $caught) {
+            $thrown = $caught;
+        }
+
+        // The rethrow must not skip the flush: failOnInternalError is the CI path, exactly
+        // where the buffered warning explaining the failure matters most.
+        $this->assertInstanceOf(\RuntimeException::class, $thrown, 'report() must rethrow when the flag is on');
+        $this->assertSame('something broke during init', $thrown->getMessage());
+        $this->assertGreaterThanOrEqual(
+            0,
+            $this->indexOfWarningContaining('[boot] Laravel boot completed only partially'),
+            'diagnostics must still be flushed before the rethrow',
+        );
+    }
+
+    private function indexOfWarningContaining(string $needle): int
+    {
+        foreach ($this->warnings as $index => $message) {
+            if (\str_contains($message, $needle)) {
+                return $index;
+            }
+        }
+
+        return -1;
+    }
+
+    /** Stubbed Progress that records emitted warnings, in order, into {@see self::$warnings}. */
+    private function recordingProgress(): Progress
+    {
+        $progress = $this->createStub(Progress::class);
+        $progress->method('warning')->willReturnCallback(
+            function (string $message): void {
+                $this->warnings[] = $message;
+            },
+        );
+
+        return $progress;
+    }
+}

--- a/tests/Unit/Util/InternalErrorReporterTest.php
+++ b/tests/Unit/Util/InternalErrorReporterTest.php
@@ -82,8 +82,8 @@ final class InternalErrorReporterTest extends TestCase
                 $config,
                 $diagnostics,
             );
-        } catch (\Throwable $caught) {
-            $thrown = $caught;
+        } catch (\Throwable $throwable) {
+            $thrown = $throwable;
         }
 
         // The rethrow must not skip the flush: failOnInternalError is the CI path, exactly


### PR DESCRIPTION
## Issue to Solve
Laravel app boot failures are currently reported through a mix of hard plugin errors, partial-bootstrap state stored for `diagnose`, and feature-level missing-binding warnings. When config, `.env`, the container, or a provider breaks boot, users need one clear explanation of what happened and what inference may be degraded. The warnings also surfaced the moment they occurred, interleaving with Psalm's progress output.

## Related
Builds on #1175.

## Solution Description
- Keep the boot model simple inside `ApplicationProvider`: cached app, boot mode/path, partial boot throwable, and hard boot throwable.
- Treat failures after an `Application` object is resolved, including analysis-prep/container failures and kernel bootstrap failures, as partial boot so the plugin can continue with degraded inference.
- Add `ApplicationBootReporter` so partial boots produce one user-facing warning with boot context and `psalm-laravel diagnose` guidance.
- Buffer the initialisation warnings (partial boot, unavailable `migrator`, missing translator/view bindings, stub discovery) in a small in-memory `Diagnostics\DiagnosticsBuffer`, tagged with a severity and lifecycle stage, and flush them once at a stable point: grouped after a successful init, or replayed by `InternalErrorReporter` ahead of the failure report. A `Diagnostics\BufferedProgress` decorator captures `Progress::warning()` during init, so the warnings no longer interleave with Psalm's progress output and existing call sites stay unchanged.
- Make `diagnose` surface both hard boot failures and partial boot warnings without hiding the attempted bootstrap path.
- Keep migration-schema degradation local when `migrator` is unbound or throws during resolution (scan only the default `database/migrations` directory).
- Document the full/partial/hard boot strategy and the init-diagnostics buffering for future feature code.

Verified:

```sh
composer cs -- --show-progress=none --no-ansi -n
composer psalm -- --no-progress --no-suggestions --output-format=compact
composer test:unit -- --no-progress --colors=never --display-errors --display-warnings
composer test:type -- --no-progress
composer test:app
```

Focused unit coverage also passes:

```sh
./vendor/bin/phpunit tests/Unit/Util/ApplicationBootReporterTest.php tests/Unit/Util/InternalErrorReporterTest.php tests/Unit/Diagnostics/DiagnosticsBufferTest.php tests/Unit/Diagnostics/BufferedProgressTest.php tests/Unit/Handlers/Eloquent/Schema/MigrationDirectoryResolutionTest.php tests/Unit/Cli/DiagnoseCommandTest.php tests/Unit/Providers/ApplicationProviderConfigPathTest.php tests/Unit/Providers/ApplicationProviderVendorRegistrationTest.php --no-progress --colors=never --display-errors --display-warnings
```

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)
- [x] Documentation is updated

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784974452&installation_id=141955579&pr_number=1177&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1177&signature=d73f12bfa603c88b141ac29299e0c782dbbfaba3a46a26d1d4e37a7f4447b523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
