### PR TITLE
Prevent crash when a container binding resolves to an over-long string

### DIFF
--- a/src/Util/ContainerResolver.php
+++ b/src/Util/ContainerResolver.php
@@ -7,8 +7,8 @@ namespace Psalm\LaravelPlugin\Util;
 use PhpParser\Node\Arg;
 use Psalm\LaravelPlugin\Providers\ApplicationProvider;
 use Psalm\NodeTypeProvider;
+use Psalm\Type;
 use Psalm\Type\Atomic\TClassString;
-use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Atomic\TTemplateParamClass;
 use Psalm\Type\Union;
@@ -135,9 +135,14 @@ final class ContainerResolver
             ]);
         }
 
-        // the likes of publicPath, which returns a literal string
+        // The likes of publicPath, which returns a literal string. Use
+        // Type::getAtomicStringFromLiteral() rather than TLiteralString::make(): a binding can
+        // resolve to a string at least Config::$max_string_length chars long (e.g. a minified
+        // asset blob), and make() throws InvalidArgumentException on those — uncaught, that
+        // crashes the whole run under amphp workers. The helper degrades such values to a
+        // non-falsy-string supertype instead, keeping the inferred type sound. See #1178.
         return new Union([
-            TLiteralString::make($concrete),
+            Type::getAtomicStringFromLiteral($concrete),
         ]);
     }
 

--- a/tests/Type/tests/ContainerLiteralStringBindingTest.phpt
+++ b/tests/Type/tests/ContainerLiteralStringBindingTest.phpt
@@ -1,0 +1,23 @@
+--FILE--
+<?php declare(strict_types=1);
+
+// Covers the literal-string branch of ContainerResolver::resolveFromLiteralString() (#1178).
+// When a container abstract resolves to a non-class string — Laravel's path bindings, e.g.
+// `path.public` → the public directory — the resolver returns a string-typed Union. The #1178 fix
+// swapped TLiteralString::make() (which throws on >1000-char concretes, crashing the run) for
+// Type::getAtomicStringFromLiteral(); this locks in that the common short-string path still
+// narrows to a usable string after that swap.
+//
+// The over-long crash itself can only fire when the booted app holds a >1000-char binding, which a
+// phpt cannot inject without polluting the plugin's production Testbench boot. That path is
+// verified by a real Psalm subprocess repro (see PR #1178): red (uncaught Throwable, run crashes)
+// before the fix, green after.
+
+function publicPathBindingResolvesToString(): string
+{
+    // app('path.public') resolves through the container to the public-directory string; the literal
+    // value is environment-dependent, so we assert only that it satisfies the string return type.
+    return app('path.public');
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

`ContainerResolver::resolveFromLiteralString()` built the inferred type for a string abstract (`app('x')`, `resolve('x')`, `make('x')`) by calling `TLiteralString::make($concrete)` on the container concrete. That constructor throws `InvalidArgumentException` once the string reaches `Config::$max_string_length` (default 1000). When a binding resolves to a large string value (the report hit `app('mcp.sdk')` resolving to a minified JS blob), the uncaught throwable propagates out of the amphp workers as a `TaskFailureException` and crashes the whole Psalm run.

The literal-string branch is reached only when the concrete is a non-class string (Laravel's path bindings, e.g. `path.public`). Those values are short, so the bug stayed latent until a binding held arbitrary large string data.

## Related

Fixes #1178

## Solution Description

Swap `TLiteralString::make()` for `Psalm\Type::getAtomicStringFromLiteral()`, the public helper Psalm itself uses for every source literal. It applies the same length cap, but degrades over-long values to a `non-falsy-string` (a sound supertype of the literal) instead of throwing. The common short-string path stays byte for byte identical (still a `TLiteralString`); only the over-limit path changes, from a crash to a valid string type.

`getAtomicStringFromLiteral()` is reached only inside return-type providers (analysis phase), where `ProjectAnalyzer` and `Config` are always initialized, so the helper's extra dependency on them is safe here.

### Verification

New type test `tests/Type/tests/ContainerLiteralStringBindingTest.phpt` locks in that the literal-string branch still narrows `app('path.public')` to a string after the swap.

The over-long crash itself cannot be reproduced in a phpt (it needs a binding over 1000 chars in the plugin's booted app, which a phpt cannot inject without polluting the production Testbench boot). It was reproduced and fixed with a throwaway subprocess harness (not committed, kept basic per scope):

1. A fixture app binds an over-long string via a provider listed in the fixture's `composer.json` `extra.laravel.providers`: `$app->instance('long.blob', str_repeat('a', 2000))`.
2. Analyzed code calls `app('long.blob')`.
3. Run Psalm over the fixture.

Before the fix the run aborts with "crashed due to an uncaught Throwable" and emits no JSON (red), even at `--threads=1`. After the fix the run completes cleanly (green).

### Scope (follow-up)

The same `TLiteralString::make()` on a runtime-derived string survives in two sibling sites: `PathHandler` (a path-helper return) and `ModelRelationReturnTypeHandler` (a relation accessor identifier). Both share the bug class but are realistically unreachable (a filesystem path or an accessor name exceeding 1000 chars), so they are left for a separate "harden the bug class" change rather than bundled here. Three other sites already guard the same throw with try/catch.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784986891&installation_id=141955579&pr_number=1179&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1179&signature=216f12f0408f3a675c8ee8fe907e990b3fd2e95971589e22eb229b74cb371dcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->