### PR TITLE
Cover Laravel real-time facades (`use Facades\App\…`) with a type test

### DIFF
--- a/tests/Type/tests/Facades/RealTimeFacadeTest.phpt
+++ b/tests/Type/tests/Facades/RealTimeFacadeTest.phpt
@@ -1,0 +1,59 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Sandbox;
+
+use Facades\App\Services\DiagnosticService;
+use Facades\App\Services\NoSuchService;
+
+/**
+ * Laravel real-time facades: importing any class under the `Facades\` prefix
+ * (`use Facades\App\Services\DiagnosticService;`) lets it be called statically,
+ * forwarding to a resolved `App\Services\DiagnosticService` instance.
+ *
+ * The plugin needs no real-time-facade-specific code. Booting the app runs
+ * `RegisterFacades`, registering `AliasLoader::load` as an autoloader. The facade
+ * class lives in no project file; Psalm only learns it exists by reflecting
+ * `Facades\App\Services\DiagnosticService`, which triggers the autoloader: the
+ * `Facades\` prefix routes to `ensureFacadeExists()`, writing a real `Facade`
+ * subclass (`@mixin \App\Services\DiagnosticService`) to the app's storage cache
+ * and requiring it. Psalm scans that file; the static call then resolves to the
+ * underlying instance method's return type. The generated `@mixin` and the
+ * plugin's FacadeMethodHandler (which covers concrete Facade subclasses) both
+ * resolve it, so this test guards the autoloader-driven discovery rather than one
+ * resolution layer.
+ */
+function realtime_facade_resolves_to_underlying_return_type(): string
+{
+    /** @psalm-check-type-exact $report = string */
+    $report = DiagnosticService::getReport();
+
+    return $report;
+}
+
+/**
+ * Named-parameter calls resolve through the underlying service signature: the
+ * parameter name (`checkCache`) is recognized for binding.
+ */
+function realtime_facade_resolves_named_parameter_call(): string
+{
+    /** @psalm-check-type-exact $report = string */
+    $report = DiagnosticService::getReport(checkCache: false);
+
+    return $report;
+}
+
+/**
+ * A `Facades\` import whose target class does not exist still generates a facade
+ * (the generator only string-manipulates the name), but its `@mixin` points at an
+ * undefined class and the accessor cannot be auto-wired, so no FacadeMethodHandler
+ * registers either. Both resolution layers no-op and the call falls through to a
+ * clean UndefinedMagicMethod, no fatal.
+ */
+function realtime_facade_missing_target_errors_cleanly(): void
+{
+    NoSuchService::whatever();
+}
+?>
+--EXPECTF--
+UndefinedMagicMethod on line %d: Magic method Facades\App\Services\NoSuchService::whatever does not exist


### PR DESCRIPTION
## Issue to Solve

Laravel real-time facades (`use Facades\App\Services\Publisher; Publisher::publish(...)`) were reported as unsupported (#790): `UndefinedClass` on the import and `UndefinedMagicMethod` on every call. The issue proposed new machinery (boot-time source scanning plus per-target stub generation, ~50-80 LoC) to add support.

## Related

Closes #790

## Solution Description

Investigation found the plugin **already resolves** real-time facades, so no production code is needed. This PR ships only the regression test that locks the behavior.

Why it already works:

- The plugin boots the Laravel app, which runs `RegisterFacades` and registers `AliasLoader::load` as an autoloader in the Psalm process.
- A `Facades\App\Services\X` class exists in no project file. Psalm learns it exists by reflecting it, which triggers the autoloader: the `Facades\` prefix routes to `ensureFacadeExists()`, writing a real `Facade` subclass (`@mixin \App\Services\X`) to the app storage cache and requiring it.
- Psalm scans that generated file. The static call then resolves to the underlying instance method's return type, through the native `@mixin` walk and the existing `FacadeMethodHandler` (both cover it, so the test guards the autoloader-driven discovery rather than one resolution layer).

This corrects the issue's premise that "our Testbench boot doesn't exercise the same path." It does: facades register, storage is writable, and Psalm reflects the generated file. The premise assumed Psalm would not autoload-and-reflect an unknown class, but it does for real-file classes (Laravel writes a real `facade-<sha>.php`, not an `eval`).

The test (`tests/Type/tests/Facades/RealTimeFacadeTest.phpt`) covers:

- positive resolution (`Facades\App\Services\DiagnosticService::getReport()` resolves to `string`),
- a named-parameter call resolving through the underlying signature,
- a missing target (`Facades\App\Services\NoSuchService`) falling through to a clean `UndefinedMagicMethod` (no fatal).

Verified on Psalm 7.0.0-beta19, single and multi threaded, cold and warm storage, and in the full batched `composer test:type` suite.

## Checklist

- [x] Tests cover the change (type test in `tests/Type/`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785054644&installation_id=141955579&pr_number=1180&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1180&signature=15f03fcc5272368e6994c02cfe80d9c5abfe0b612c477644ee2603758ce058a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->