### PR TITLE
Narrow `sum`/`avg`/`min`/`max` on relations and collections

### DIFF
--- a/src/Handlers/Eloquent/BuilderAggregateHandler.php
+++ b/src/Handlers/Eloquent/BuilderAggregateHandler.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Psalm\LaravelPlugin\Handlers\Eloquent;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Collection;
 use Psalm\LaravelPlugin\Util\ModelPropertyResolver;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
@@ -17,26 +20,28 @@ use Psalm\Type\Atomic\TNull;
 use Psalm\Type\Union;
 
 /**
- * Narrows Builder::sum/avg/average/min/max returns using the column's resolved
+ * Narrows sum/avg/average/min/max returns using the aggregated column's resolved
  * Psalm type (user `@property` → cast → schema).
  *
- * Targets Eloquent Builder only (Query\Builder has no model template). Calls
- * arriving via Eloquent's `@mixin Query\Builder` chain still surface the
- * Eloquent template parameters on the event.
+ * Covers the three call shapes that surface the same aggregate: the query builder
+ * (`Model::query()->sum('col')`), the relation (`$model->rel()->sum('col')`), and the
+ * in-memory collection (`$model->rel->sum('col')`). See {@see self::getClassLikeNames()}
+ * for how each shape carries the model and why all three register here.
  *
  * Cast-aware min/max diverges from Laravel runtime: the query-level aggregate
  * does NOT apply casts, but reporting the cast type matches the rest of the
  * plugin's column-read view and the issue's stated request.
  *
  * @see https://github.com/psalm/psalm-plugin-laravel/issues/1004
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1182
  * @internal
  */
 final class BuilderAggregateHandler implements MethodReturnTypeProviderInterface
 {
     /**
      * Hash-lookup table for the method-name quick reject. Hoisted as a const so
-     * the array isn't reallocated on every Builder method call (this provider
-     * fires on the hot path).
+     * the array isn't reallocated on every method call of a registered receiver —
+     * Collection is among them, so this provider fires on a very hot path.
      */
     private const AGGREGATE_METHODS = [
         'sum' => true,
@@ -47,12 +52,35 @@ final class BuilderAggregateHandler implements MethodReturnTypeProviderInterface
     ];
 
     /**
-     * Registers both Builder classes because sum/avg/min/max are declared on
-     * Query\Builder and reached from Eloquent\Builder via `@mixin`. Psalm's
+     * Three call shapes (across five registered classes) reach the same
+     * column-narrowing logic; each surfaces the aggregated model differently.
      * {@see \Psalm\Internal\Analyzer\Statements\Expression\Call\Method\MethodCallReturnTypeFetcher}
-     * fires the provider for the premixin class first and the declaring class
-     * second — registering both ensures the call is resolved regardless of
-     * which leg picks up the model template.
+     * dispatches return-type providers on two legs: the premixin (receiver) class and the
+     * declaring class.
+     *
+     * - {@see Builder} / {@see QueryBuilder} — the direct query path. sum/avg/min/max are
+     *   declared on Query\Builder and reached from Eloquent\Builder via `@mixin`; registering
+     *   both classes resolves the call regardless of which leg carries the model template.
+     * - {@see Relation} — `$model->rel()->sum('col')`. Relations forward aggregates to the
+     *   builder via `__call`, a path on which Psalm exposes neither argument types nor the
+     *   substituted model, so the aggregates are declared as real methods in Relation.phpstub
+     *   for this provider to read the column. Registering the abstract base suffices: the
+     *   methods are inherited, so every subclass call's declaring method id is `Relation::{m}`
+     *   and the declaring-class leg fires.
+     * - {@see Collection} / {@see EloquentCollection} — the in-memory path
+     *   (`$model->rel->sum('col')`). Both are registered so the receiver-class leg fires for
+     *   each; the aggregated model is the collection's value parameter, picked up by
+     *   {@see self::resolveModelClass()} scanning all template params.
+     *
+     * Custom collection subclasses (newCollection() / #[CollectedBy]) are not narrowed on the
+     * in-memory read — they resolve to `mixed`; LazyCollection is likewise out of scope. The
+     * relation-level path still narrows those models via `rel()->sum('col')`.
+     *
+     * Unlike the pluck handlers (a Builder/Collection split sharing a Util resolver), all
+     * shapes live in one handler because the column resolver this uses,
+     * {@see ModelPropertyHandler::resolveColumnType()} (schema + casts, not just `@property`),
+     * is an Eloquent handler; a Util-level split would either lose schema columns or make a
+     * util reach back into a handler.
      *
      * @return list<string>
      * @psalm-pure
@@ -60,7 +88,13 @@ final class BuilderAggregateHandler implements MethodReturnTypeProviderInterface
     #[\Override]
     public static function getClassLikeNames(): array
     {
-        return [Builder::class, QueryBuilder::class];
+        return [
+            Builder::class,
+            QueryBuilder::class,
+            Relation::class,
+            Collection::class,
+            EloquentCollection::class,
+        ];
     }
 
     #[\Override]
@@ -102,6 +136,11 @@ final class BuilderAggregateHandler implements MethodReturnTypeProviderInterface
     }
 
     /**
+     * Resolves the model whose column is being aggregated from the receiver's template
+     * parameters: `Builder<TModel>` and `Relation<TRelated, ...>` carry it first, while
+     * `Collection<TKey, TValue>` carries it second (the key is never a model). Scanning all
+     * params and taking the first that resolves to a Model handles every shape uniformly.
+     *
      * LHS fallback handles @mixin chains where event template params arrive
      * unsubstituted (mirrors {@see ModelPropertyResolver::resolvePluckReturnType}).
      *
@@ -110,9 +149,11 @@ final class BuilderAggregateHandler implements MethodReturnTypeProviderInterface
     private static function resolveModelClass(MethodReturnTypeProviderEvent $event): ?string
     {
         $templateParams = $event->getTemplateTypeParameters();
-        $modelClass = ModelPropertyResolver::extractModelFromUnion($templateParams[0] ?? null);
-        if ($modelClass !== null) {
-            return $modelClass;
+        foreach ($templateParams ?? [] as $param) {
+            $modelClass = ModelPropertyResolver::extractModelFromUnion($param);
+            if ($modelClass !== null) {
+                return $modelClass;
+            }
         }
 
         $stmt = $event->getStmt();

--- a/stubs/common/Database/Eloquent/Relations/Relation.phpstub
+++ b/stubs/common/Database/Eloquent/Relations/Relation.phpstub
@@ -242,4 +242,45 @@ abstract class Relation implements BuilderContract
      * @throws \Illuminate\Database\MultipleRecordsFoundException
      */
     public function sole($columns = ['*']) {}
+
+    /**
+     * Aggregates forwarded to the related model's Builder (Relation::__call ->
+     * forwardCallTo($this->query)). Declared here for the same reason as get()/
+     * first(): on the __call path Psalm exposes neither the argument types nor the
+     * substituted TRelatedModel, so BuilderAggregateHandler cannot read the column.
+     * As real methods they regain both, and the handler narrows the return to the
+     * column's resolved type. These base returns mirror Query\Builder (the forwarding
+     * target) and act as the fallback for non-literal / unknown columns.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @return numeric-string|int|float
+     */
+    public function sum($column) {}
+
+    /**
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @return numeric-string|int|float|null
+     */
+    public function avg($column) {}
+
+    /**
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @return numeric-string|int|float|null
+     */
+    public function average($column) {}
+
+    /**
+     * min()/max() mirror Query\Builder, which leaves them unstubbed (reflected
+     * `mixed`); BuilderAggregateHandler narrows known columns to `columnType|null`.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @return mixed
+     */
+    public function min($column) {}
+
+    /**
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
+     * @return mixed
+     */
+    public function max($column) {}
 }

--- a/tests/Type/tests/Builder/AggregateRelationCollectionTest.phpt
+++ b/tests/Type/tests/Builder/AggregateRelationCollectionTest.phpt
@@ -1,0 +1,121 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use App\Models\Shop;
+use App\Models\Supplier;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Collection as SupportCollection;
+
+/**
+ * Aggregates (sum/avg/average/min/max) must narrow to the aggregated column's
+ * resolved type for the relation-level and in-memory-collection call shapes, not
+ * only the direct query builder. Before #1182 both returned `mixed` (relations
+ * forward via __call; Collection::sum(string) was unnarrowed), producing
+ * MixedOperand the moment the result was used arithmetically.
+ *
+ * Supplier::parts() is HasMany<Part>; Part has `@property float $unit_price`.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1182
+ */
+
+// --- Relation-level aggregate (issue case 1) ---
+
+/** HasMany sum → float. */
+function rel_sum(Supplier $s): void
+{
+    $_r = $s->parts()->sum('unit_price');
+    /** @psalm-check-type-exact $_r = float */
+}
+
+/** HasMany avg → float|int|null (null on empty). */
+function rel_avg(Supplier $s): void
+{
+    $_r = $s->parts()->avg('unit_price');
+    /** @psalm-check-type-exact $_r = float|int|null */
+}
+
+/** average() is an alias for avg(). */
+function rel_average(Supplier $s): void
+{
+    $_r = $s->parts()->average('unit_price');
+    /** @psalm-check-type-exact $_r = float|int|null */
+}
+
+/** HasMany min → column type | null. */
+function rel_min(Supplier $s): void
+{
+    $_r = $s->parts()->min('unit_price');
+    /** @psalm-check-type-exact $_r = float|null */
+}
+
+/** HasMany max → column type | null. */
+function rel_max(Supplier $s): void
+{
+    $_r = $s->parts()->max('unit_price');
+    /** @psalm-check-type-exact $_r = float|null */
+}
+
+/**
+ * BelongsToMany<Part, Shop, Pivot, 'pivot'> — four template params, three of them
+ * models (related, declaring, pivot). The aggregated model must be the *related*
+ * model (param 0), never the declaring model or the pivot.
+ */
+function rel_belongs_to_many_picks_related(Shop $shop): void
+{
+    $_r = $shop->suggestedParts()->sum('unit_price');
+    /** @psalm-check-type-exact $_r = float */
+}
+
+/** Aggregate after a chained where() (forwarding self-return path) still narrows. */
+function rel_chained(Supplier $s): void
+{
+    $_r = $s->parts()->where('unit_price', '>', 1)->sum('unit_price');
+    /** @psalm-check-type-exact $_r = float */
+}
+
+/** Unknown column falls back to the Relation stub's declared return (not mixed). */
+function rel_unknown_column(Supplier $s): void
+{
+    $_r = $s->parts()->sum('does_not_exist');
+    /** @psalm-check-type-exact $_r = float|int|numeric-string */
+}
+
+/** Issue's actual symptom: arithmetic on the narrowed result is no longer MixedOperand. */
+function rel_arithmetic_no_mixed_operand(Supplier $s): float
+{
+    return $s->parts()->sum('unit_price') / 100.0;
+}
+
+// --- In-memory collection aggregate (issue case 2) ---
+//
+// Covers Illuminate\Support\Collection and Illuminate\Database\Eloquent\Collection.
+// Custom collection subclasses (newCollection() / #[CollectedBy]) are not narrowed on
+// the in-memory read — they resolve to `mixed`, so the original MixedOperand persists
+// for `$model->customCollectionRelation->sum('col')`. The relation-level path above
+// ($model->rel()->sum('col')) still narrows those models.
+
+/** Eloquent\Collection<int, Part> sum → float. */
+function mem_eloquent_collection_sum(EloquentCollection $parts): void
+{
+    /** @var EloquentCollection<int, \App\Models\Part> $parts */
+    $_r = $parts->sum('unit_price');
+    /** @psalm-check-type-exact $_r = float */
+}
+
+/** $model->relation read backed by the default Eloquent\Collection narrows on min (string column). */
+function mem_relation_read_min(Customer $c): void
+{
+    $_r = $c->vehicles->min('make');
+    /** @psalm-check-type-exact $_r = string|null */
+}
+
+/** Support\Collection<int, Part> avg → float|int|null. */
+function mem_support_collection_avg(SupportCollection $parts): void
+{
+    /** @var SupportCollection<int, \App\Models\Part> $parts */
+    $_r = $parts->avg('unit_price');
+    /** @psalm-check-type-exact $_r = float|int|null */
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

`sum()`/`avg()`/`average()`/`min()`/`max()` were narrowed only when called directly on the query builder (`Model::query()->sum('col')`). The two equally common shapes returned `mixed`:

1. **Relation-level** — `$model->rel()->sum('col')`. A relation (`HasMany`, `BelongsToMany`, `HasManyThrough`, …) forwards aggregates to the underlying builder at runtime, but only via `Relation::__call`, so the call on the relation type was never narrowed.
2. **In-memory collection** — `$model->rel->sum('col')` (any `Illuminate\Support\Collection::sum(string $key)`).

Both surfaced as `MixedOperand` the moment the result was used arithmetically, even though the column type is known. The direct query-builder path narrows correctly, so the behavior was asymmetric.

## Related

Closes #1182

## Solution Description

Both shapes reach the existing column-narrowing logic in `BuilderAggregateHandler` once the receiver is intercepted:

- **Relations** — declared `sum`/`avg`/`average`/`min`/`max` as real methods on `Relation.phpstub`. On the `__call` forwarding path Psalm exposes neither the argument types nor the substituted related model, so the handler could not read the column; declaring them as real methods restores both (same precedent as the existing `get()`/`first()`/`paginate()` stubs on `Relation`). Registering the abstract `Relation` base suffices because the methods are inherited, so every subclass call's declaring method is `Relation::{m}`. Base returns mirror `Query\Builder` (the forwarding target) as the unknown-column fallback.
- **Collections** — registered `Support\Collection` + `Eloquent\Collection` in the handler. The aggregated model is resolved from whichever template parameter holds it (the value parameter for collections, the first for builder/relation).

Why one handler instead of a `Builder` + `Collection` split like `pluck`: the column resolver this uses, `ModelPropertyHandler::resolveColumnType()` (schema + casts, not just `@property`), is an Eloquent handler. A `Util`-level split like `pluck`'s would either lose schema/cast-typed columns or force a `Collections → Eloquent` / `Util → Handler` edge the codebase avoids. The rationale is captured in the handler docblock.

Verified with a new type test (`tests/Type/tests/Builder/AggregateRelationCollectionTest.phpt`): relation `sum`/`avg`/`average`/`min`/`max`, a four-parameter `BelongsToMany` (extraction picks the related model, never the declaring model or pivot), chained `where()->sum()`, unknown-column fallback, the issue's arithmetic symptom (no more `MixedOperand`), and `Support`/`Eloquent` collection reads.

**Scope / known limitations**
- Custom collection subclasses (`newCollection()` / `#[CollectedBy]`) and `LazyCollection` are not narrowed on the in-memory read, because Psalm dispatches return-type providers on the exact receiver class. The relation-level path still narrows those models via `$model->rel()->sum('col')`.
- `count()` is intentionally excluded (it always returns `int`, no column narrowing needed).
- Separate, pre-existing: the aggregate `$column` argument is an unflagged SQL-identifier sink (column-name injection) on both `Query\Builder` and the new `Relation` stubs. Out of scope here; a follow-up could add `@psalm-taint-sink sql $column` to the Builder + Relation aggregates (not the collection ones, where `$column` is an in-memory array key).

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785347869&installation_id=141955579&pr_number=1183&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1183&signature=e4bb720f029c3572ff3fface0703af422cdcf24e6e11c35118f41f3d2513271e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->