### PR TITLE
Add `package`-mode install smoke test (`laravel/socialite`)

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -1,13 +1,16 @@
 name: Install smoke test
 
-# Executes the README quickstart verbatim against a fresh Laravel project on
-# each supported OS: install the plugin from this checkout, then
-# `psalm-laravel init`, `analyze`, and `diagnose`. Complements
-# test-laravel-app.yml (which is Ubuntu-only and covers a PHP x Laravel
-# compatibility matrix on a heavily scaffolded app) by covering OS-specific
-# install/configuration behavior on a minimal one — the class of bug fixed in
-# #1189, where a Windows proc_open() launcher regression could pass every
-# Ubuntu-only check.
+# Executes the README quickstart verbatim on each supported OS: install the
+# plugin from this checkout, then `psalm-laravel init`, `analyze`, and
+# `diagnose`. Runs against two target kinds (matrix `kind`): a fresh Laravel
+# `app`, and a real Laravel `package` (socialite) whose src/-autoload config path
+# and Testbench plugin-boot fallback the app flow never exercises (#1198).
+#
+# Complements test-laravel-app.yml (which is Ubuntu-only and covers a PHP x
+# Laravel compatibility matrix on a heavily scaffolded app) by covering
+# OS-specific install/configuration behavior on minimal targets — the class of
+# bug fixed in #1189, where a Windows proc_open() launcher regression could pass
+# every Ubuntu-only check.
 
 on:
   workflow_dispatch:
@@ -19,6 +22,7 @@ on:
       - bin/ci/install-smoke.php
       - src/Cli/**
       - src/Plugin.php
+      - src/Bootstrap/ApplicationProvider.php
       - .github/workflows/install-smoke.yml
   push:
     branches: [master]
@@ -29,6 +33,7 @@ on:
       - bin/ci/install-smoke.php
       - src/Cli/**
       - src/Plugin.php
+      - src/Bootstrap/ApplicationProvider.php
       - .github/workflows/install-smoke.yml
 
 # Cancel superseded runs on the same branch/PR to save CI minutes on fast pushes.
@@ -41,7 +46,14 @@ permissions:
 
 jobs:
   install-smoke:
-    name: Install smoke (${{ matrix.name }})
+    # The `app` rows keep #1197's exact job names ("Install smoke (Ubuntu)" etc.)
+    # so any branch-protection check keyed on them stays valid; `package` rows
+    # append " / package". Explicit include rows (rather than an os x kind
+    # cross-product) keep `runs-on: ${{ matrix.runner }}` statically resolvable to
+    # a concrete Blacksmith label — lint-workflows.yml's octoscan step ignores the
+    # runner-label warning by label, which a nested `matrix.os.runner` would turn
+    # into an unresolvable expression and trip as a self-hosted-runner alert.
+    name: Install smoke (${{ matrix.name }}${{ matrix.kind == 'package' && ' / package' || '' }})
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -49,10 +61,22 @@ jobs:
         include:
           - name: Ubuntu
             runner: blacksmith-2vcpu-ubuntu-2404
+            kind: app
+          - name: Ubuntu
+            runner: blacksmith-2vcpu-ubuntu-2404
+            kind: package
           - name: Windows
             runner: blacksmith-2vcpu-windows-2025
+            kind: app
+          - name: Windows
+            runner: blacksmith-2vcpu-windows-2025
+            kind: package
           - name: macOS
             runner: blacksmith-6vcpu-macos-15
+            kind: app
+          - name: macOS
+            runner: blacksmith-6vcpu-macos-15
+            kind: package
     runs-on: ${{ matrix.runner }}
     steps:
       # NOTE: step-security/harden-runner is intentionally NOT used here.
@@ -93,13 +117,14 @@ jobs:
         # write concerns.
         env:
           APP_DIR: ${{ runner.temp }}/psalm-install-smoke
+          PROJECT_KIND: ${{ matrix.kind }}
         run: php bin/ci/install-smoke.php
 
       - name: Upload diagnostics
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: install-smoke-${{ matrix.name }}
+          name: install-smoke-${{ matrix.name }}-${{ matrix.kind }}
           path: |
             install-smoke.log
             ${{ runner.temp }}/psalm-install-smoke/composer.json

--- a/bin/ci/install-smoke.php
+++ b/bin/ci/install-smoke.php
@@ -4,8 +4,18 @@ declare(strict_types=1);
 
 /**
  * Cross-OS install/configuration smoke test. Follows the README quickstart
- * verbatim against a fresh Laravel project: create project, install the plugin
- * from the current checkout, then `psalm-laravel init`, `analyze`, `diagnose`.
+ * verbatim, installing the plugin from the current checkout and then running
+ * `psalm-laravel init`, `analyze`, `diagnose` against a target project.
+ *
+ * Two target-project modes, selected by PROJECT_KIND (default `app`):
+ *   - `app`     — a fresh `laravel/laravel` project. Exercises the Laravel-app
+ *                 config path (`InitCommand::detectLaravelAppRoots()` and a
+ *                 `bootstrap/app.php` plugin boot).
+ *   - `package` — a real Laravel *package* checkout (default: laravel/socialite),
+ *                 which autoloads from `src/` and ships no `artisan`. Exercises the
+ *                 package config path (`InitCommand::detectPackageRoots()` and the
+ *                 Orchestra Testbench plugin-boot fallback) that the app flow never
+ *                 touches (#1198).
  *
  * PHP (not Bash) so the exact same script runs on Ubuntu, Windows, and macOS.
  * Subprocesses go through Symfony Process, which already solves the Windows
@@ -20,12 +30,17 @@ declare(strict_types=1);
  *
  * Usage:
  *   php bin/ci/install-smoke.php
+ *   PROJECT_KIND=package php bin/ci/install-smoke.php
  *   KEEP_APP=1 VERBOSE=1 php bin/ci/install-smoke.php
  *
  * Environment variables:
+ *   PROJECT_KIND     `app` (default) or `package` — see the mode descriptions above
  *   PLUGIN_PATH      Checkout to install (default: this repo's root)
- *   LARAVEL_VERSION  `laravel/laravel` installer version (default: latest stable)
- *   APP_DIR          Where to scaffold the throwaway app (default: a fresh temp dir)
+ *   LARAVEL_VERSION  `app` mode only: `laravel/laravel` installer version (default: latest stable)
+ *   PACKAGE_REPO     `package` mode only: git URL to clone (default: laravel/socialite)
+ *   PACKAGE_REF      `package` mode only: tag/branch to clone (default: a pinned socialite tag)
+ *   PACKAGE_EXPECTED_ROOTS  `package` mode only: comma-separated dirs the generated psalm.xml must scan (default: src)
+ *   APP_DIR          Where to scaffold the throwaway project (default: a fresh temp dir)
  *   KEEP_APP         1 to keep the app dir even on success (default: 0; failures always preserve it)
  *   VERBOSE          1 to stream every subprocess's output live (default: 0; failures always show it)
  *
@@ -123,8 +138,12 @@ function logOutput(string $label, string $output, string $errorOutput, bool $ver
  *
  * @param list<string> $command
  * @param array<string, string> $extraEnv
+ * @param list<int> $allowedExitCodes Exit codes treated as success. Defaults to [0];
+ *        `package`-mode `analyze` passes [0, 2] because Psalm exits 2 when it ran to
+ *        completion but found issues — expected for a real third-party package we do
+ *        not own — while 1 (a launcher/config error, the #1189 class) still fails.
  */
-function runStep(string $label, array $command, string $cwd, array $extraEnv, bool $verbose, string $appDir): Process
+function runStep(string $label, array $command, string $cwd, array $extraEnv, bool $verbose, string $appDir, array $allowedExitCodes = [0]): Process
 {
     logLine(\sprintf('==> %s', $label));
     logLine(\sprintf('    $ %s (cwd: %s)', \implode(' ', $command), $cwd));
@@ -151,7 +170,7 @@ function runStep(string $label, array $command, string $cwd, array $extraEnv, bo
 
     logOutput($label, $process->getOutput(), $process->getErrorOutput(), $verbose);
 
-    if (!$process->isSuccessful()) {
+    if (!\in_array($process->getExitCode(), $allowedExitCodes, true)) {
         reportFailure($label, $command, $process->getExitCode(), $cwd, $process->getOutput(), $process->getErrorOutput(), $appDir);
     }
 
@@ -209,6 +228,30 @@ if (!\is_file($pluginPath . \DIRECTORY_SEPARATOR . 'composer.json')) {
     exit(1);
 }
 
+$projectKind = \strtolower(envStr('PROJECT_KIND', 'app'));
+if (!\in_array($projectKind, ['app', 'package'], true)) {
+    \fwrite(\STDERR, \sprintf("PROJECT_KIND must be 'app' or 'package', got '%s'.\n", $projectKind));
+    exit(1);
+}
+
+// `package` mode targets a real Laravel package checkout. Pinned to a released
+// socialite tag (not a floating branch) so the run is reproducible and immune to
+// mid-refactor breakage on socialite's default branch — and so socialite's own
+// require-dev tree, pulled in when the plugin is required into it, stays frozen.
+// Override either to exercise a different package or ref.
+$packageRepo = envStr('PACKAGE_REPO', 'https://github.com/laravel/socialite.git');
+$packageRef = envStr('PACKAGE_REF', 'v5.28.0');
+
+// Directories the generated psalm.xml must scan in package mode, comma-separated.
+// Defaults to socialite's `src`; override it alongside PACKAGE_REPO for a package
+// that autoloads from a different or additional root (e.g. `lib`) so the assertion
+// tracks the target rather than assuming socialite's layout. The app-only-marker
+// negative assertions below are layout-independent and need no override.
+$expectedRoots = \array_values(\array_filter(\array_map(
+    'trim',
+    \explode(',', envStr('PACKAGE_EXPECTED_ROOTS', 'src')),
+)));
+
 $laravelVersion = envStr('LARAVEL_VERSION', '');
 $keepApp = envBool('KEEP_APP', false);
 $verbose = envBool('VERBOSE', false);
@@ -219,11 +262,10 @@ if ($appDir === '') {
         . \DIRECTORY_SEPARATOR . 'psalm-install-smoke-' . \bin2hex(\random_bytes(4));
 }
 
-logLine(\sprintf(
-    'Starting install smoke test: app_dir=%s laravel_version=%s',
-    $appDir,
-    $laravelVersion === '' ? '(latest stable)' : $laravelVersion,
-));
+$targetSummary = $projectKind === 'package'
+    ? \sprintf('package=%s@%s', $packageRepo, $packageRef)
+    : \sprintf('laravel_version=%s', $laravelVersion === '' ? '(latest stable)' : $laravelVersion);
+logLine(\sprintf('Starting install smoke test: kind=%s app_dir=%s %s', $projectKind, $appDir, $targetSummary));
 
 $psalmLaravelBin = static fn(string $dir): string => $dir . \DIRECTORY_SEPARATOR . 'vendor'
     . \DIRECTORY_SEPARATOR . 'bin' . \DIRECTORY_SEPARATOR . 'psalm-laravel';
@@ -234,17 +276,27 @@ if (!\is_dir($launchDir) && !@\mkdir($launchDir, 0755, true) && !\is_dir($launch
     exit(1);
 }
 
-// --- Step 1: fresh Laravel project -----------------------------------------
+// --- Step 1: create the target project -------------------------------------
+//
+// `app` mode scaffolds a fresh Laravel application; `package` mode clones a real
+// Laravel package (socialite by default). Both land at $appDir, and every later
+// step (configure Composer, require the plugin, init/analyze/diagnose) is shared.
 
-// --no-blocking: a security advisory against any of laravel/laravel's transitive
-// deps (historically phpunit's dev range) would otherwise block the install with
-// a Composer policy error unrelated to this script — the same lesson already
-// applied in tests/Application/laravel-test.sh's identical create-project call.
-$createProjectCommand = ['composer', 'create-project', '--prefer-dist', '--no-interaction', '--no-ansi', '--no-blocking', 'laravel/laravel', $appDir];
-if ($laravelVersion !== '') {
-    $createProjectCommand[] = $laravelVersion;
+if ($projectKind === 'package') {
+    // --depth 1 --branch <ref>: fetch only the pinned ref's tree, no history.
+    $cloneCommand = ['git', 'clone', '--depth', '1', '--branch', $packageRef, $packageRepo, $appDir];
+    runStep(\sprintf('git clone %s@%s', $packageRepo, $packageRef), $cloneCommand, $launchDir, [], $verbose, $appDir);
+} else {
+    // --no-blocking: a security advisory against any of laravel/laravel's transitive
+    // deps (historically phpunit's dev range) would otherwise block the install with
+    // a Composer policy error unrelated to this script — the same lesson already
+    // applied in tests/Application/laravel-test.sh's identical create-project call.
+    $createProjectCommand = ['composer', 'create-project', '--prefer-dist', '--no-interaction', '--no-ansi', '--no-blocking', 'laravel/laravel', $appDir];
+    if ($laravelVersion !== '') {
+        $createProjectCommand[] = $laravelVersion;
+    }
+    runStep('composer create-project', $createProjectCommand, $launchDir, [], $verbose, $appDir);
 }
-runStep('composer create-project', $createProjectCommand, $launchDir, [], $verbose, $appDir);
 
 // --- Step 2: configure Composer exactly as the README's Step 1 instructs ---
 //
@@ -287,10 +339,39 @@ if ($psalmXmlContents === false || !\str_contains($psalmXmlContents, 'Psalm\\Lar
     reportFailure('assert psalm.xml registers the plugin', [], null, $appDir, (string) $psalmXmlContents, 'Expected psalm.xml to reference Psalm\\LaravelPlugin\\Plugin.', $appDir);
 }
 
+// Package mode only: prove `init` took the package branch (detectPackageRoots),
+// not the Laravel-app branch. A package autoloads from its own root(s) — `src` for
+// socialite, or whatever PACKAGE_EXPECTED_ROOTS names — and ships no artisan, so a
+// correct package config scans each expected <directory name="..."/> and emits none
+// of the app-only <file name="artisan"/> / <directory name="app"/> entries.
+// Whitespace in the generated markup is fixed by InitCommand's template, so
+// exact-substring matching is safe here.
+if ($projectKind === 'package') {
+    $contents = (string) $psalmXmlContents;
+    foreach ($expectedRoots as $root) {
+        $marker = \sprintf('<directory name="%s"/>', $root);
+        if (!\str_contains($contents, $marker)) {
+            reportFailure('assert psalm.xml scans the package root', [], null, $appDir, $contents, \sprintf('Expected package-mode psalm.xml to scan %s.', $marker), $appDir);
+        }
+    }
+
+    foreach (['<file name="artisan"/>', '<directory name="app"/>'] as $appOnlyMarker) {
+        if (\str_contains($contents, $appOnlyMarker)) {
+            reportFailure('assert psalm.xml used the package (not Laravel-app) layout', [], null, $appDir, $contents, \sprintf('Package-mode psalm.xml unexpectedly contains the app-only marker %s.', $appOnlyMarker), $appDir);
+        }
+    }
+}
+
 // --- Step 5: psalm-laravel analyze ------------------------------------------
 
 $analyzeCommand = [\PHP_BINARY, $psalmLaravelBin($appDir), 'analyze', '--no-cache', '--no-progress', '--output-format=compact'];
-runStep('psalm-laravel analyze', $analyzeCommand, $appDir, [], $verbose, $appDir);
+// app mode analyzes a pristine skeleton and must be issue-free (exit 0). package
+// mode analyzes a real third-party package we do not own: Psalm exiting 2 means it
+// ran to completion but found issues in *that package's* own code, which is not a
+// plugin install failure — accept it, while still failing on 1 (a Psalm/launcher
+// error, the #1189 class this smoke test exists to catch).
+$analyzeAllowedExitCodes = $projectKind === 'package' ? [0, 2] : [0];
+runStep('psalm-laravel analyze', $analyzeCommand, $appDir, [], $verbose, $appDir, $analyzeAllowedExitCodes);
 
 // --- Step 6: psalm-laravel diagnose -----------------------------------------
 //
@@ -298,7 +379,31 @@ runStep('psalm-laravel analyze', $analyzeCommand, $appDir, [], $verbose, $appDir
 // reportFailure() prints it too. No separate artifact is written.
 
 $diagnoseCommand = [\PHP_BINARY, $psalmLaravelBin($appDir), 'diagnose', '--no-tips'];
-runStep('psalm-laravel diagnose', $diagnoseCommand, $appDir, [], $verbose, $appDir);
+$diagnoseProcess = runStep('psalm-laravel diagnose', $diagnoseCommand, $appDir, [], $verbose, $appDir);
+
+// Boot-mode differential. A package has no bootstrap/app.php, so the plugin must
+// boot Laravel through the Orchestra Testbench fallback (branch 3 of
+// ApplicationProvider); a fresh Laravel app must instead boot from its own
+// bootstrap/app.php. `diagnose` reports the resolved mode ("Testbench fallback"
+// is the only label containing "testbench", and only the fallback prints it), so
+// asserting BOTH directions makes the two kinds mutually discriminating: it proves
+// package mode exercises the Testbench path and guards the #766 silent-fallback
+// case on the app side. Matched case-insensitively for robustness to the wording.
+$bootedViaTestbench = \stripos($diagnoseProcess->getOutput(), 'testbench') !== false;
+$expectsTestbench = $projectKind === 'package';
+if ($bootedViaTestbench !== $expectsTestbench) {
+    reportFailure(
+        \sprintf('assert %s-mode boot path', $projectKind),
+        [],
+        null,
+        $appDir,
+        $diagnoseProcess->getOutput(),
+        $expectsTestbench
+            ? 'Expected `diagnose` to report the Testbench fallback boot mode for a package target.'
+            : 'Expected `diagnose` to report a real bootstrap/app.php boot mode (not Testbench) for an app target.',
+        $appDir,
+    );
+}
 
 // --- Done --------------------------------------------------------------
 

--- a/tests/Unit/Cli/InitCommandTest.php
+++ b/tests/Unit/Cli/InitCommandTest.php
@@ -279,6 +279,73 @@ final class InitCommandTest extends TestCase
         }
     }
 
+    #[Test]
+    public function detects_package_autoload_root_from_composer_psr4(): void
+    {
+        // A Composer package (PSR-4 autoload, no artisan) must scan its autoload
+        // root via detectPackageRoots, never the Laravel-app layout — the config
+        // path the package-mode install smoke test exercises end-to-end (#1198).
+        //
+        // Map PSR-4 to a NON-src directory on purpose: detectPackageRoots'
+        // last-resort branch only ever emits `src`, so a distinct name proves the
+        // composer-autoload extraction actually ran. A regressed extractor would
+        // fall through to the app-layout fallback, failing the `lib` assertion,
+        // rather than being silently rescued by the src fallback.
+        \file_put_contents(
+            $this->tempDir . \DIRECTORY_SEPARATOR . 'composer.json',
+            (string) \json_encode(['autoload' => ['psr-4' => ['Acme\\Widget\\' => 'lib/']]]),
+        );
+        \mkdir($this->tempDir . \DIRECTORY_SEPARATOR . 'lib');
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $this->assertStringContainsString('<directory name="lib"/>', $contents);
+        $this->assertStringNotContainsString('<file name="artisan"/>', $contents);
+        $this->assertStringNotContainsString('<directory name="app"/>', $contents);
+    }
+
+    #[Test]
+    public function detects_laravel_app_layout_when_artisan_present(): void
+    {
+        // Presence of artisan selects the Laravel-app branch (detectLaravelAppRoots):
+        // conventional app dirs and entry files are scanned, so the discriminator the
+        // smoke test relies on (artisan/app present => app layout) is exercised here.
+        \file_put_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'artisan', "#!/usr/bin/env php\n");
+        \mkdir($this->tempDir . \DIRECTORY_SEPARATOR . 'app');
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $this->assertStringContainsString('<directory name="app"/>', $contents);
+        $this->assertStringContainsString('<file name="artisan"/>', $contents);
+        // Only on-disk dirs are emitted by detectLaravelAppRoots; bootstrap/ was not
+        // created. If the app branch regressed to empty, detectSourceRoots' ultimate
+        // fallback would emit ALL app dirs (including bootstrap), so this negative
+        // proves the present-only real branch ran rather than the fallback.
+        $this->assertStringNotContainsString('<directory name="bootstrap"/>', $contents);
+    }
+
+    #[Test]
+    public function falls_back_to_src_directory_for_package_without_psr4(): void
+    {
+        // No artisan and no PSR-4 mapping: detectPackageRoots' last-resort branch
+        // scans src/ when present, so even a minimal package gets a valid config.
+        \mkdir($this->tempDir . \DIRECTORY_SEPARATOR . 'src');
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $this->assertStringContainsString('<directory name="src"/>', $contents);
+        $this->assertStringNotContainsString('<file name="artisan"/>', $contents);
+    }
+
     private function makeTester(): CommandTester
     {
         $command = new InitCommand($this->tempDir);


### PR DESCRIPTION
## Issue to Solve

#1195 listed "verify that the plugin can be installed for a Laravel package (e.g. laravel/socialite)" as a goal, but #1197 implemented only the full Laravel-app flow and left package mode out of scope. The package config path (`InitCommand::detectPackageRoots()` and the Orchestra Testbench plugin-boot fallback) had no install-time coverage.

## Related

Closes #1198. Split out of #1195 (the app flow shipped in #1197).

## Solution Description

Adds a second target-project mode to `bin/ci/install-smoke.php`, selected by `PROJECT_KIND=app|package` (default `app`, so existing behavior is byte-identical). `package` mode clones a real Laravel package (laravel/socialite) and reuses the same install, config, `init`, `analyze`, and `diagnose` steps.

What package mode proves, that the app flow never touches:

- **Package config path.** `init` must scan the package `src/` root via `detectPackageRoots()` and must not emit the Laravel-app layout. Asserted on the generated `psalm.xml` (`<directory name="src"/>` present, `<file name="artisan"/>` / `<directory name="app"/>` absent).
- **Testbench plugin boot.** A package has no `bootstrap/app.php`, so the plugin boots Laravel through the Orchestra Testbench fallback. `diagnose` reports the resolved mode; a boot-mode differential asserts package boots via Testbench while app boots from its own `bootstrap/app.php`, making the two kinds mutually discriminating (this also guards the #766 silent-fallback case on the app side).

Design notes:

- **Exit-code tolerance.** `analyze` accepts exit `0` or `2` in package mode. Psalm exits `2` once it completes an analysis and finds issues (socialite is PHPStan-checked, not Psalm-clean, so that is expected), and exits `1` on launcher/config errors (the #1189 class this smoke test exists to catch). App mode stays strict (exit `0` only), so plugin false positives on a pristine skeleton still fail there.
- **Reproducibility.** socialite is pinned to a released tag (`v5.28.0`); `PACKAGE_REPO` / `PACKAGE_REF` override the target and freeze socialite's own require-dev tree.
- **Matrix.** The workflow runs an `os` x `kind` cross-product, (Ubuntu, Windows, macOS) by (app, package). The `app` job names are preserved byte-identically so any branch-protection check keyed on them stays valid.
- **Unit coverage.** `detectPackageRoots()` and the artisan-based branch selector had no unit tests; the second commit adds fast, deterministic fixtures so this pure path logic is not guarded only by a cross-OS, network-cloning CI matrix.

Verified locally against real socialite `v5.28.0` and a fresh `laravel/laravel` app: the package run passes with `analyze` exiting `2`, the app run passes with `analyze` exiting `0`, all 15 `InitCommandTest` cases pass, the full unit suite is green, and `actionlint` is clean. The 6-job matrix itself runs for the first time on this PR.

Possible follow-up (not needed here): a package fixture that also ships `config/` and an Eloquent model (for example laravel/sanctum) would additionally cover the config-retarget (#940) and model paths.

## Checklist

- [x] Tests cover the change (unit tests for `InitCommand` package-root detection; the smoke script is exercised for real across three OSes in CI, consistent with the untested `bin/ci/` precedent)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785526829&installation_id=141955579&pr_number=1200&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1200&signature=e02419b28727abc7b988364b9ec3f642998a89714ff9c55f477e8368e085694d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->