### PR TITLE
Fix stale documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,23 +15,13 @@ There are 2 main ways how it does it:
 
 - [Configuration](config.md) — plugin XML config options and environment variables
 - [GitHub Actions](github-actions.md) — running Psalm in CI with GitHub Actions
+- [Custom Issues](issues/index.md) — Laravel-aware checks the plugin adds on top of Psalm's built-ins
+- [Security (Taint) Checks](security.md) — what the security analysis detects
 - [Upgrading to v4](upgrade-v4.md) — migration guide from v3
 - Contribution:
     - [Overview](contributing/README.md) — how the plugin works, getting started, adding stubs and handlers
     - [Architecture Decisions](contributing/decisions.md) — key design decisions and rationale
     - [Debugging with Xdebug](contributing/xdebug.md) — stepping through plugin code
-    - [Taint Analysis](contributing/taint-analysis.md)
+    - [Laravel Magic Call Patterns](contributing/laravel-magic-call-patterns.md) — how `__call`/`__callStatic` chains resolve, and how Psalm sees them
+    - [Taint Analysis](contributing/taint-analysis.md) — authoring taint stubs
     - [Types](contributing/types.md) — Psalm types and annotations (incl. internal/hidden)
-
-## Custom Issues
-
-The plugin emits custom issues that Psalm does not have built-in.
-Each one links to detailed documentation with examples and fix guidance.
-
-- [NoEnvOutsideConfig](issues/NoEnvOutsideConfig.md)
-- [InvalidConsoleArgumentName](issues/InvalidConsoleArgumentName.md)
-- [InvalidConsoleOptionName](issues/InvalidConsoleOptionName.md)
-- [MissingTranslation](issues/MissingTranslation.md)
-- [MissingView](issues/MissingView.md)
-- [ModelMakeDiscouraged](issues/ModelMakeDiscouraged.md)
-- [OctaneIncompatibleBinding](issues/OctaneIncompatibleBinding.md)

--- a/docs/config.md
+++ b/docs/config.md
@@ -86,7 +86,7 @@ Closure values stored in config reflect to `\Closure`. Closure defaults resolve 
 
 ### When to disable
 
-When you always use `Config::ineteger()`, `Config::string()` and other typed calls consistently.
+When you always use `Config::integer()`, `Config::string()` and other typed calls consistently.
 
 ### Example
 

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -1,6 +1,6 @@
 ---
 title: Contributing
-nav_order: 3
+nav_order: 7
 has_children: true
 ---
 
@@ -18,41 +18,30 @@ See `ApplicationProvider::doGetApp()` for the resolution logic.
 
 ```mermaid
 flowchart TD
-    A["Plugin::__invoke"] --> B["Boot Laravel app"]
-    B --> C["Build schema\n(if columnFallback=migrations)"]
-    C --> D["Generate alias stubs\n(from AliasLoader)"]
-    D --> E["Register handlers"]
-    E --> F["Register stubs"]
+    A["Plugin::__invoke"] --> B["Parse PluginConfig from psalm.xml"]
+    B --> C["Boot Laravel app\n(ApplicationProvider::bootApp)"]
+    C --> D["Build migration schema\n(only if columnFallback=migrations)"]
+    D --> E["Init facade→service map\n(FacadeMapProvider)"]
+    E --> F["Init translation / view / env handlers\n(from booted app state)"]
+    F --> G["Register handlers\n(Plugin::registerHandlers)"]
+    G --> H["Register stubs\n(Plugin::registerStubs)"]
 
-    E --- handlers["
-        Application — ContainerHandler, OffsetHandler
-        Auth — AuthHandler, GuardHandler, RequestHandler
-        Collections — CollectionPluckHandler, CollectionFilterHandler
-        Console — CommandArgumentHandler
-        Eloquent — ModelRegistrationHandler,
-        ModelMethodHandler, BuilderScopeHandler, CustomCollectionHandler
-        Magic — MethodForwardingHandler
-        Helpers — CacheHandler, PathHandler, TransHandler
-        Translations — TranslationKeyHandler
-        Views — MissingViewHandler
-        Rules — NoEnvOutsideConfigHandler, ModelMakeHandler, OctaneIncompatibleBindingHandler
-        Validation — ValidatedTypeHandler, ValidationTaintHandler
-        SuppressHandler
-    "]
-
-    F --- stubs["
+    H --- stubs["
         stubs/common/ (types + taint annotations)
-        stubs/12/, stubs/13/ (version-specific)
-        aliases.phpstub (generated)
+        versioned dirs, ascending (e.g. stubs/12.42.0/, stubs/13.5.0/, stubs/13.8.0/)
+        stubs/integrations/carbon/ (gated on installed nesbot/carbon version)
+        aliases.phpstub (generated here from AliasLoader)
     "]
 
-    G["Psalm scans all project files"] -.->|afterCodebasePopulated| H["ModelRegistrationHandler"]
-    H --- models["
+    I["Psalm scans all project files"] -.->|afterCodebasePopulated| J["ModelRegistrationHandler"]
+    J --- models["
         Discover Model subclasses
-        Register property handlers:
+        Register per-model property/method closures:
         relationship > factory > accessor > column
     "]
 ```
+
+The whole `__invoke` body is wrapped in a try/catch: on any internal error the plugin reports a warning and disables itself for the run (or rethrows when `failOnInternalError` is set). See `src/Internal/InternalErrorReporter.php`.
 
 ## Getting started
 
@@ -93,7 +82,8 @@ composer rector # run rector refactoring
 Stubs override Laravel's type signatures. Place them in:
 
 - `stubs/common/` — shared across Laravel versions (includes both type stubs and taint annotations)
-- `stubs/12/`, `stubs/13/` — version-specific overrides
+- `stubs/<version>/` — version-specific overrides, loaded when the installed Laravel is `>=` the dir name (`version_compare`). Both major-only (`stubs/13/`) and patch-level (`stubs/13.8.0/`) names work; currently `stubs/12.42.0/`, `stubs/13.5.0/`, and `stubs/13.8.0/` exist
+- `stubs/integrations/<package>/` — optional stubs for third-party packages, gated on the package being installed (currently `carbon/`, with a `pre-3.12/` subdir loaded only for older Carbon; see `src/Stubs/CarbonStubProvider.php`)
 
 Rules:
 - Verify signatures against actual Laravel code (not against Laravel PHPDoc or method signatures)
@@ -127,7 +117,7 @@ Authoring an override:
 
 ### Testing version-specific stubs
 
-A type test that asserts a `stubs/<version>/` override would fail on the lower cells of the CI matrix (`.github/workflows/tests.yml` runs `test:type` over `^13.0` and `^12.4`, including `prefer-lowest`), because the override does not load on the older Laravel. Gate such a test with a `--SKIPIF--` section so it runs only where the stub applies:
+A type test that asserts a `stubs/<version>/` override would fail on the lower cells of the CI matrix (`.github/workflows/tests.yml` runs `test:type` over Laravel `^13.0` and `^12.4`), because the override does not load on the older Laravel. Gate such a test with a `--SKIPIF--` section so it runs only where the stub applies:
 
 ```
 --SKIPIF--
@@ -150,101 +140,35 @@ Create the handler class in the appropriate `src/Handlers/` subdirectory, then r
 Psalm processes code in phases. Each hook fires at a specific phase and has different data available.
 Analysis hooks are hot paths — they fire on every matching expression. Scanning hooks fire once per class or once total.
 
-```mermaid
-flowchart LR
-    subgraph scanning ["Phase 1: Scanning"]
-        direction TB
-        S1["AfterClassLikeVisitInterface
-        fires after each class/trait/interface
-        ----
-        data: ClassLikeStorage
-        (direct parent only), AST statements
-        ----
-        ContainerHandler
-        ModelMethodHandler
-        SuppressHandler"]
-    end
+The table below maps each hook to the handlers using it. Source of truth: `Plugin::registerHandlers()` plus each handler's `implements` clause. Handlers marked `*` are registered conditionally (config flag or package detection).
 
-    subgraph populated ["Phase 2: Codebase populated"]
-        direction TB
-        P1["AfterCodebasePopulatedInterface
-        fires once, after all classes are known
-        ----
-        data: full Codebase, complete
-        ClassLikeStorage (full parent chain)
-        ----
-        ModelRegistrationHandler
-        SuppressHandler"]
-    end
+**Phase 1 — Scanning** (per class/trait/interface; `ClassLikeStorage` has direct parent only):
 
-    subgraph analysis ["Phase 3: Analysis (hot path)"]
-        direction TB
-        A1["FunctionReturnTypeProvider
-        on each global function call
-        ----
-        args, call location, file path
-        ----
-        CacheHandler, PathHandler
-        TranslationKeyHandler, TransHandler
-        MissingViewHandler
-        NoEnvOutsideConfigHandler"]
+| Hook | Handlers |
+|---|---|
+| `AfterClassLikeVisitInterface` | ContainerHandler, SuppressHandler, GuardTaintHandler, EncrypterTaintHandler, AppFacadeRegistrationHandler |
 
-        A2["MethodReturnTypeProvider
-        on each method call
-        ----
-        args, class FQCN, method name
-        ----
-        AuthHandler, GuardHandler
-        RequestHandler, ContainerHandler
-        CommandArgumentHandler
-        MethodForwardingHandler
-        ModelMethodHandler
-        BuilderScopeHandler, PathHandler
-        CollectionPluckHandler
-        CollectionFilterHandler
-        MissingViewHandler
-        ValidatedTypeHandler"]
+**Phase 2 — Codebase populated** (fires once; full parent chains resolved):
 
-        A3["MethodParamsProvider
-        before type-checking args
-        ----
-        overrides parameter types
-        ----
-        AuthHandler"]
+| Hook | Handlers |
+|---|---|
+| `AfterCodebasePopulatedInterface` | ModelRegistrationHandler, SuppressHandler, ContractMethodBridgeHandler, CastContractUserDefinedHandler, BuilderSubclassQueryMixinHandler, MacroHandler, FormRequestPropertyHandler, AppFacadeRegistrationHandler, PublicScopeAccessorVisibilityHandler |
 
-        A4["Property providers
-        Existence / Type / Visibility
-        ----
-        property name, class FQCN
-        read/write context
-        ----
-        Model property handlers
-        (registered via closures)"]
+**Phase 3 — Analysis** (hot path):
 
-        A5["AddTaints / RemoveTaints
-        on each expression with data flow
-        ----
-        expression, node type info
-        ----
-        ValidationTaintHandler"]
-
-        A6["AfterExpressionAnalysis
-        on each expression
-        ----
-        expression AST, codebase
-        ----
-        ModelMakeHandler"]
-
-        A7["AfterMethodCallAnalysis
-        on each resolved method call
-        ----
-        expression, declaring method id
-        ----
-        OctaneIncompatibleBindingHandler"]
-    end
-
-    scanning --> populated --> analysis
-```
+| Hook | Handlers |
+|---|---|
+| `FunctionReturnTypeProviderInterface` | ContainerHandler, AuthFunctionHandler, CacheHandler, NowTodayHandler, PathHandler, LiteralHandler, EnvHandler, TranslationKeyHandler, NoEnvOutsideConfigHandler, ConfigHelperHandler\*, MissingViewHandler\* |
+| `MethodReturnTypeProviderInterface` | OffsetHandler, ContainerHandler, AuthMethodHandler, GuardHandler, RequestHandler, StorageHandler, ModelFactoryMethodTypeProvider, FactoryCountTypeProvider, ModelBuilderMixinHandler, MethodForwardingHandler, ModelMethodHandler, BuilderScopeHandler, BuilderPluckHandler, BuilderAggregateHandler, CustomCollectionHandler, CollectionFilterHandler, CollectionFlattenHandler, CollectionPluckHandler, CollectionValuesAllHandler, HigherOrderCollectionProxyHandler, ConditionableWhenHandler, TappableTapHandler, CommandArgumentHandler, ValidatedTypeHandler, PathHandler, AppFacadeMakeHandler, DateFacadeHandler, ConfigRepositoryMethodHandler\*, MissingViewHandler\* |
+| `MethodParamsProviderInterface` | OffsetHandler, AuthMethodHandler, StorageHandler, MethodForwardingHandler, BuilderScopeHandler, HigherOrderCollectionProxyHandler, AppFacadeMakeHandler, DateFacadeHandler, ConfigRepositoryMethodHandler\* |
+| `MethodExistenceProviderInterface`, `MethodVisibilityProviderInterface` | OffsetHandler |
+| Property providers (existence / type / visibility) | per-model closures registered by ModelRegistrationHandler |
+| `AddTaintsInterface`, `RemoveTaintsInterface` | ValidationTaintHandler |
+| `AfterExpressionAnalysisInterface` | ModelMakeHandler, DispatchableHandler, TimingUnsafeComparisonHandler, UndefinedBuilderMethodHandler, ConsoleClosureScopeHandler, InlineValidateRulesCollector, ImplicitQueryBuilderCallHandler\* |
+| `AfterMethodCallAnalysisInterface` | HigherOrderCollectionProxyHandler, OctaneIncompatibleBindingHandler\* |
+| `Before{File,Statement,Expression}AnalysisInterface` | ConsoleClosureScopeHandler, InlineValidateRulesCollector (statement + expression) |
+| `AfterFunctionLikeAnalysisInterface`, `AfterFileAnalysisInterface` | ValidationTaintHandler, InlineValidateRulesCollector (function-like only) |
+| `AfterAnalysisInterface` | StatsHandler |
 
 ### Registering handlers
 

--- a/docs/contributing/decisions.md
+++ b/docs/contributing/decisions.md
@@ -22,7 +22,7 @@ Decisions made during development of the plugin. Contributors should follow thes
 
 **Decision:** Prefer deriving types from Psalm's `ClassLikeStorage` and source code analysis. Use runtime reflection (booting the Laravel app via Testbench) only when the needed information is unavailable statically.
 
-**Currently runtime:** Model table names (`getTable()`), model casts (`getCasts()`), container bindings, facade alias resolution.
+**Currently runtime:** Model table names (`getTable()`), model casts (`getCasts()`), container bindings, facade alias resolution, macro discovery (`Macroable::$macros` reflection).
 
 **Currently static:** Relationships, accessors, migration schema parsing, stub overrides.
 
@@ -51,7 +51,7 @@ The plugin should respect that consistently across all handlers rather than over
 
 **Decision:** `registerWriteTypesForMethods` (which registers `pseudo_property_set_types` for relationship properties, legacy mutators, and new-style `Attribute` accessors) runs for all models regardless of the `modelProperties` config. Only `registerWriteTypesForColumns` (migration-inferred columns) is gated behind `useMigrations`.
 
-**Why:** Accessor and relationship properties are discovered from the model's own method signatures — they don't depend on migration files. A user with `columnFallback="none"` still expects `$user->roles = $collection` to work when `sealAllProperties` is enabled. This is consistent with the read-side handlers, which are also unconditional (see below).
+**Why:** Accessor and relationship properties are discovered from the model's own method signatures — they don't depend on migration files. A user with `columnFallback="none"` still expects `$user->roles = $collection` to work when Psalm's own `sealAllProperties` option is enabled. This is consistent with the read-side handlers, which are also unconditional (see below).
 
 **See:** [#446](https://github.com/psalm/psalm-plugin-laravel/issues/446)
 
@@ -224,7 +224,7 @@ Bug fixes (where the previous type was demonstrably wrong) are exempt.
 
 **Decision:** When a new feature has a strictness spectrum (e.g. sealed properties, migration inference), the default should be the least disruptive option. Stricter modes are opt-in via config.
 
-**Example:** `sealAllProperties="false"` by default. `columnFallback="migrations"` (migration inference) by default.
+**Example:** `columnFallback="migrations"` (migration inference) is the default because it only adds property types; stricter behavior (such as Psalm's `sealAllProperties`) stays opt-in on the Psalm side.
 
 **Why:** Users who install or upgrade the plugin should not be greeted with a wall of new errors. The plugin should improve analysis incrementally. Users who want stricter checking can enable it when they're ready.
 

--- a/docs/contributing/laravel-magic-call-patterns.md
+++ b/docs/contributing/laravel-magic-call-patterns.md
@@ -421,20 +421,24 @@ Builder::macro('active', function () {
 User::query()->active();  // works via __call → macro lookup
 ```
 
-**Psalm challenge:** Macros are registered at runtime, so Psalm cannot see them during static analysis. Users must either:
-- Add `@mixin` annotations pointing to a class with the macro methods declared
-- Use `@method` annotations on the class
-- Accept that macro calls will be flagged as undefined methods
+**Psalm challenge:** Macros are registered at runtime, so Psalm cannot see them from source alone.
 
-**Plugin handler:** None currently. Larastan solves this via **runtime introspection**: it reads the
-actual `static::$macros` property via PHP reflection at analysis time (the app is already booted, so
-macros registered in ServiceProviders are populated). It then uses `ClosureTypeFactory` to extract
-parameter/return types from the Closure objects. Handles `Macroable` classes, Eloquent Builder (its
-own macro system), Facades (via `getFacadeRoot()`), and Carbon (`Carbon\Traits\Macro`).
+**Plugin handler:** `MacroHandler` (with `MacroRegistry`), registered unconditionally. During
+`AfterCodebasePopulated` it reads the booted app's `Macroable::$macros` registries via PHP reflection
+(macros registered in ServiceProviders are populated by then) and injects each macro as a synthesized
+pseudo-method into `ClassLikeStorage::$pseudo_methods` **and** `$pseudo_static_methods` — the same
+storage shape Psalm uses for `@method` annotations, so both `$instance->macroName()` and
+`Class::macroName()` resolve. It propagates macros to subclasses (walking `parent_classes`) and to
+facades that proxy to the Macroable owner (via `FacadeMapProvider`, including manager-forwarding
+facades like `Auth`/`Cache`/`Session`/`Storage`/`Mail`). Closure param/return types are recovered from
+Psalm's own scanned `FunctionLikeStorage` when the closure's file is analysed (docblock-aware); a
+`: static` native return type narrows to the calling instance.
 
-This plugin already boots the app for container bindings, auth config, translations, and views —
-the same pattern could discover macros. Limitation: only finds macros registered at boot time;
-conditional macros or those in unbooted providers are invisible.
+Known limitations (see `MacroHandler`'s docblock for the full list): only macros registered at boot
+time are visible (conditional macros and unbooted providers are not); Eloquent Builder's per-instance
+`$localMacros` are unreachable by reflection; macros on a package's own provider are invisible under
+the Testbench fallback (no `bootstrap/app.php`); vendor closures outside `<projectFiles>` fall back
+to `mixed` signatures.
 
 
 ### 7. Container `make()` / `app()` resolution
@@ -779,5 +783,5 @@ but the handler ensures template params propagate correctly.
 | Model scopes               | `BuilderScopeHandler`                                        | Resolves scope calls on Builder to model scope methods               |
 | Custom collections         | `CustomCollectionHandler`                                    | Narrows `Builder::get()`, `findMany()`, `Model::all()` return types  |
 | Model attributes           | Virtual properties from `@property` / migrations             | Requires schema analysis or annotations                              |
-| Macros                     | Not handled by plugin                                        | Runtime-registered; users need `@mixin` or `@method` annotations     |
+| Macros                     | `MacroHandler` (runtime reflection → pseudo-methods)         | Boot-time registrations only; Builder `$localMacros` not covered     |
 | Container resolution       | `ContainerHandler`                                           | Only known bindings are narrowed                                     |

--- a/docs/contributing/taint-analysis.md
+++ b/docs/contributing/taint-analysis.md
@@ -128,6 +128,7 @@ Most taint kind names are defined in [`Psalm\Type\TaintKind::TAINT_NAMES`](https
 | `extract`            | `INPUT_EXTRACT`            | Values passed to `extract()`                               |
 | `user_secret`        | `USER_SECRET`              | User-supplied secrets (passwords, tokens)                  |
 | `system_secret`      | `SYSTEM_SECRET`            | System secrets (API keys, encryption keys)                 |
+| `llm_prompt`         | `INPUT_LLM_PROMPT`         | Strings interpolated into LLM prompts (prompt injection)   |
 | `input`              | `ALL_INPUT`                | Alias: all input-related kinds combined (excludes secrets) |
 | `tainted`            | `ALL_INPUT`                | Alias: same as `input`                                     |
 | `input_except_sleep` | `ALL_INPUT & ~INPUT_SLEEP` | All input kinds except `sleep` (used by `filter_var()`)    |

--- a/docs/contributing/types.md
+++ b/docs/contributing/types.md
@@ -28,6 +28,7 @@ Psalm docs (deep links):
 | `numeric`                              | `TNumeric`          | `int\|float\|numeric-string`                                       |
 | `array-key`                            | `TArrayKey`         | `int\|string`                                                      |
 | `mixed`                                | `TMixed`            | Top type                                                           |
+| `iterable`                             |                     | `array\|Traversable`; accepts generics: `iterable<TKey, TValue>`   |
 | `never`                                | `TNever`            | Bottom type. Aliases: `no-return`, `never-return`, `never-returns` |
 | `object`                               | `TObject`           | Any object                                                         |
 | `resource`                             | `TResource`         |                                                                    |
@@ -222,7 +223,7 @@ Foo&Bar                 // intersection (must satisfy both)
 
 `@var`, `@param`, `@return`, `@property`, `@property-read`, `@property-write`, `@method`, `@throws`, `@deprecated`, `@internal`, `@mixin`
 
-All of the above also accept a `@psalm-` prefix (e.g. `@psalm-param`) for advanced type syntax that phpDocumentor can't parse. PHPStan prefix (`@phpstan-param`, etc.) is also recognized.
+The type-carrying tags (`@var`, `@param`, `@return`, `@property*`, `@method`) also accept a `@psalm-` prefix (e.g. `@psalm-param`) for advanced type syntax that phpDocumentor can't parse. PHPStan prefix (`@phpstan-param`, etc.) is also recognized. `@psalm-throws`, `@psalm-deprecated`, and `@psalm-mixin` do NOT exist — Psalm rejects unknown `@psalm-*` tags with `Unrecognised annotation` (see `DocComment::PSALM_ANNOTATIONS`).
 
 ### Assertions
 
@@ -234,6 +235,7 @@ All of the above also accept a `@psalm-` prefix (e.g. `@psalm-param`) for advanc
 | `@psalm-assert-if-true !Type $param`  | Function returns `true`   |
 | `@psalm-assert-if-false Type $param`  | Function returns `false`  |
 | `@psalm-assert-if-false !Type $param` | Function returns `false`  |
+| `@psalm-assert-untainted $param`      | Function returns normally (taint analysis: marks param untainted) |
 
 Negated assertions (`!Type`) assert the param is **not** of the given type. Common examples: `!null`, `!false`, `!string`.
 
@@ -340,4 +342,4 @@ Negated assertions (`!Type`) assert the param is **not** of the given type. Comm
 | `@psalm-taint-specialize`            | Track taint per-instance or per-call                      |
 | `@psalm-flow ($param) -> return`     | Define explicit taint flow path                           |
 
-Taint types: `html`, `sql`, `shell`, `file`, `cookie`, `header`, `redirect`, `ldap`, `ssrf`, `user_secret`, `system_secret`, `callable`, `eval`, `unserialize`, `include`, `text`, `crypto` (and custom ones).
+Taint kinds: `html`, `has_quotes`, `sql`, `shell`, `file`, `cookie`, `header`, `ldap`, `ssrf`, `xpath`, `sleep`, `extract`, `user_secret`, `system_secret`, `callable`, `eval`, `unserialize`, `include`, `llm_prompt`, plus the aliases `input` / `tainted` / `input_except_sleep` — see `Psalm\Type\TaintKind::TAINT_NAMES`. Arbitrary custom kind names are also accepted (they report as `TaintedCustom`). Full table with attack vectors: [Taint Analysis](taint-analysis.md#taint-kinds).

--- a/docs/issues/InvalidConsoleArgumentName.md
+++ b/docs/issues/InvalidConsoleArgumentName.md
@@ -10,7 +10,7 @@ Emitted when `$this->argument('name')` references an argument that is not define
 
 ## Why this is a problem
 
-If you request an argument that doesn't exist in your command's `$signature`, Laravel will throw a `RuntimeException` at runtime.
+If you request an argument that doesn't exist in your command's `$signature`, Symfony Console throws an `InvalidArgumentException` at runtime.
 This check catches the mismatch during static analysis.
 
 ## Examples

--- a/docs/issues/InvalidConsoleOptionName.md
+++ b/docs/issues/InvalidConsoleOptionName.md
@@ -10,7 +10,7 @@ Emitted when `$this->option('name')` references an option that is not defined in
 
 ## Why this is a problem
 
-If you request an option that doesn't exist in your command's `$signature`, Laravel will throw a `RuntimeException` at runtime.
+If you request an option that doesn't exist in your command's `$signature`, Symfony Console throws an `InvalidArgumentException` at runtime.
 This check catches the mismatch during static analysis.
 
 ## Examples

--- a/docs/issues/MissingView.md
+++ b/docs/issues/MissingView.md
@@ -6,8 +6,7 @@ nav_order: 4
 
 # MissingView
 
-Emitted when `view()` or `Factory::make()` (e.g., `view()->make()`) references a Blade template that does not exist on disk.
-Facade calls like `View::make()` are not currently detected (see [#591](https://github.com/psalm/psalm-plugin-laravel/issues/591)).
+Emitted when `view()`, `Factory::make()` (e.g., `view()->make()`), or the `View::make()` facade call references a Blade template that does not exist on disk.
 
 ## Why this is a problem
 

--- a/docs/issues/NoEnvOutsideConfig.md
+++ b/docs/issues/NoEnvOutsideConfig.md
@@ -6,7 +6,7 @@ nav_order: 1
 
 # NoEnvOutsideConfig
 
-Emitted when `env()` is called outside the application's config directory (by default the booted app's [`config_path()`](../config.md#configdirectory); configurable via `<configDirectory>` for non-standard layouts).
+Emitted when `env()` is called outside the application's config directory (by default the booted app's [`config_path()`](../config.md#configdirectory); configurable via `<configDirectory>` for non-standard layouts). Files under a `tests/` directory are always exempt.
 
 ## Why this is a problem
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,3 +1,8 @@
+---
+title: Security (Taint) Checks
+nav_order: 6
+---
+
 # Security (Taint) Checks
 
 ### What it detects

--- a/docs/upgrade-v4.md
+++ b/docs/upgrade-v4.md
@@ -19,10 +19,10 @@ Laravel 11 and Psalm 6 are no longer supported. If you need them, stay on v3.
 
 ### Psalm 7 is required
 
-v4 requires `vimeo/psalm ^7.0.0-beta17` or later. If your project still uses Psalm 6, upgrade Psalm first:
+v4 requires `vimeo/psalm ^7.0.0-beta19` or later. If your project still uses Psalm 6, upgrade Psalm first:
 
 ```bash
-composer require --dev vimeo/psalm:^7.0.0-beta17
+composer require --dev vimeo/psalm:^7.0.0-beta19
 ```
 
 Psalm 7 is still in beta. You may need to add this to your project's `composer.json`:
@@ -120,7 +120,7 @@ No flags needed — just run `./vendor/bin/psalm`.
 # 1. Update PHP to 8.2+ and Laravel to 12+ if needed
 
 # 2. Upgrade Psalm to v7
-composer require --dev vimeo/psalm:^7.0.0-beta17
+composer require --dev vimeo/psalm:^7.0.0-beta19
 
 # 3. Upgrade the plugin
 composer require --dev psalm/plugin-laravel:^4.0


### PR DESCRIPTION
## Issue to Solve

`docs/` had drifted from the code: handler diagrams listed classes that no longer exist (`AuthHandler`, `TransHandler`) while missing ~30 registered handlers, the macro pattern doc predated `MacroHandler`, and several reference tables contained claims that are false against current Psalm 7 / Laravel 13 sources. Agents and contributors using these docs would be misled.

## Related

None.

## Solution Description

Every doc file was cross-checked against `src/`, `stubs/`, `vendor/laravel/framework` 13.18, and `vendor/vimeo/psalm` 7.0.0-beta19. Only statements contradicted by source were changed; verified-correct content was left as is.

Wrong and fixed:

- `contributing/README.md`: boot-flow diagram placed alias-stub generation before handler registration (it happens inside `Plugin::registerStubs()`, which runs last, after `FacadeMapProvider::init()`); the Psalm-hooks diagram was replaced with hook-to-handler tables built from each handler's actual `implements` clause; stub dirs corrected to the real `stubs/12.42.0/`, `stubs/13.5.0/`, `stubs/13.8.0/`, `stubs/integrations/carbon/`; dropped the `prefer-lowest` CI claim (coded in the workflow but never present in the matrix).
- `contributing/laravel-magic-call-patterns.md`: stated macros are "not handled by plugin". `MacroHandler` implements runtime reflection of `Macroable::$macros` into pseudo-methods, with subclass and facade propagation. Section and summary table rewritten; the other 15 verified claims in this doc checked out against Laravel and Psalm source.
- `contributing/types.md`: taint list contained `redirect`, `text`, `crypto`, which do not exist in `TaintKind::TAINT_NAMES`; added missing `@psalm-assert-untainted`, `iterable`, `llm_prompt`; narrowed the false "every tag accepts a `@psalm-` prefix" claim (`@psalm-throws` / `@psalm-deprecated` / `@psalm-mixin` are rejected by `DocComment::PSALM_ANNOTATIONS`).
- `issues/MissingView.md`: claimed `View::make()` facade calls are not detected (#591); they are, as asserted by `tests/Type/tests/MissingViewTest.phpt`.
- `issues/InvalidConsoleArgumentName.md` / `InvalidConsoleOptionName.md`: the runtime exception is Symfony Console's `InvalidArgumentException`, not `RuntimeException`.
- `issues/NoEnvOutsideConfig.md`: documented the always-on `tests/` path exemption.
- `upgrade-v4.md`: `beta17` references bumped to the actual `beta19` composer floor.
- `docs/README.md`: the inline issue list duplicated `issues/index.md` and missed 3 of the 10 issues; replaced with a link. Added missing links to the security and magic-call-patterns pages.
- `security.md`: added front matter; fixed `nav_order` collision between GitHub Actions and Contributing pages.
- `contributing/decisions.md`: clarified `sealAllProperties` is Psalm's own option, added macro discovery to the runtime-reflection list.
- `contributing/taint-analysis.md`: added the `llm_prompt` kind to the taint-kinds table.
- `config.md`: `Config::ineteger()` typo.

Verified correct and untouched: `config.md` option list (matches `PluginConfig::fromXml` one-to-one), `github-actions.md` workflow claims, the psalter `--plugin=/vendor/...` leading slash (required: Psalm concatenates `getcwd() . $path`), "taint analysis runs by default in Psalm 7" (`Config::$run_taint_analysis = true`), all relation-generic signatures in `upgrade-v4.md`, every detection row in `security.md` (each backed by an existing stub or handler), and the remaining seven issue pages.

## Checklist
- [x] Documentation is updated

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785536372&installation_id=141955579&pr_number=1202&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1202&signature=ae7582968b770ef8938a69c68d42b371d7dd12f02f6706632a33c1a4a576d844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->