### PR TITLE
Narrow `getCasts()`/`getTouchedRelations()`, fix `Request route()`/`file()` defaults

### DIFF
--- a/stubs/common/Database/Eloquent/Concerns/HasAttributes.phpstub
+++ b/stubs/common/Database/Eloquent/Concerns/HasAttributes.phpstub
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Concerns;
+
+trait HasAttributes
+{
+    /**
+     * @return array<string, string>
+     */
+    public function getCasts() {}
+}

--- a/stubs/common/Database/Eloquent/Concerns/HasRelationships.phpstub
+++ b/stubs/common/Database/Eloquent/Concerns/HasRelationships.phpstub
@@ -6,6 +6,11 @@ trait HasRelationships
 {
 
     /**
+     * @return list<string>
+     */
+    public function getTouchedRelations() {}
+
+    /**
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
      * @psalm-param class-string<TRelatedModel> $related
      *

--- a/stubs/common/Http/Request.phpstub
+++ b/stubs/common/Http/Request.phpstub
@@ -55,20 +55,33 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      * Refs: https://github.com/psalm/psalm-plugin-laravel/issues/925,
      *       https://github.com/psalm/psalm-plugin-laravel/issues/1134
      *
+     * $default's type is threaded through the non-null-$key branch: the real body is
+     * data_get($this->allFiles(), $key, $default), which returns $default verbatim when
+     * the dotted key does not resolve.
+     *
+     * @template TDefault
+     *
      * @param  string|null  $key
-     * @param  mixed  $default
-     * @return ($key is null ? array<string, \Illuminate\Http\UploadedFile|array<\Illuminate\Http\UploadedFile>> : \Illuminate\Http\UploadedFile|array<\Illuminate\Http\UploadedFile>|null)
+     * @param  TDefault  $default
+     * @return ($key is null ? array<string, \Illuminate\Http\UploadedFile|array<\Illuminate\Http\UploadedFile>> : \Illuminate\Http\UploadedFile|array<\Illuminate\Http\UploadedFile>|TDefault)
      */
     public function file($key = null, $default = null) {}
 
     /**
      * Get the route handling the request.
      *
-     * @template TDefault of object
+     * $default is not constrained to object: Laravel accepts any type as the fallback
+     * value (route()->parameter() returns it verbatim when the named parameter is
+     * unbound), so `of object` false-positived on ordinary scalar/null defaults.
+     * The no-arg branch stays non-nullable Route, matching Laravel's own docblock and
+     * the existing RequestTest.phpt lock-in; the with-args branch already carried a
+     * bare `null` (kept, now also covering the object-parameter-binding case below).
+     *
+     * @template TDefault
      *
      * @param string|null $param
      * @param TDefault $default
-     * @psalm-return ($param is null ? \Illuminate\Routing\Route : TDefault|string|null)
+     * @psalm-return ($param is null ? \Illuminate\Routing\Route : TDefault|object|string|null)
      *
      * @psalm-taint-source input
      */

--- a/tests/Type/tests/Http/RequestTest.phpt
+++ b/tests/Type/tests/Http/RequestTest.phpt
@@ -12,5 +12,23 @@ function it_returns_one_header(\Illuminate\Http\Request $request): ?string {
 function it_returns_route(\Illuminate\Http\Request $request): \Illuminate\Routing\Route {
     return $request->route();
 };
+
+/**
+ * route()'s second parameter used to be constrained `@template TDefault of object`,
+ * which false-positived on any ordinary scalar/null default (Argument 2 ... expects
+ * object). Locks in that plain scalar and null defaults are accepted, and that the
+ * with-args return includes the resolved default's own type plus the bare `object`
+ * case for a route-model-bound parameter.
+ */
+function it_accepts_non_object_route_defaults(\Illuminate\Http\Request $request): void {
+    $_stringDefault = $request->route('id', 'fallback-string');
+    /** @psalm-check-type-exact $_stringDefault = object|string|null */
+
+    $_intDefault = $request->route('id', 0);
+    /** @psalm-check-type-exact $_intDefault = 0|null|object|string */
+
+    $_noDefault = $request->route('id');
+    /** @psalm-check-type-exact $_noDefault = null|object|string */
+}
 ?>
 --EXPECTF--

--- a/tests/Type/tests/Request/RequestFileTest.phpt
+++ b/tests/Type/tests/Request/RequestFileTest.phpt
@@ -97,6 +97,18 @@ final class RequestFileTest
             unset($f);
         }
     }
+
+    /**
+     * The real body is data_get($this->allFiles(), $key, $default), which returns
+     * $default verbatim when the dotted key does not resolve. A non-null $default's
+     * own type must appear in the return union, not just a bare `null`.
+     */
+    public function nonNullDefaultTypeIsThreadedThrough(Request $request): void
+    {
+        $r = $request->file('avatar', 'no-file-uploaded');
+        /** @psalm-check-type-exact $r = 'no-file-uploaded'|UploadedFile|array<array-key, UploadedFile> */;
+        unset($r);
+    }
 }
 ?>
 --EXPECTF--


### PR DESCRIPTION
## Issue to Solve

Two independent things surfaced during a Larastan parity comparison, bundled here since both landed in `stubs/`:

1. `HasAttributes::getCasts()` and `HasRelationships::getTouchedRelations()` had no stub at all, so Psalm fell back to Laravel's own loose `@return array` docblock (element types unknown).
2. `Request::route()` had a live false positive: its `@template TDefault of object` rejected any non-object default, e.g. `$request->route('id', 'fallback-string')` raised `InvalidArgument: Argument 2 ... expects object, but 'fallback-string' provided`. Separately, `Request::file()` silently dropped a non-null `$default`'s type from its return, always typing the non-null-key branch as `UploadedFile|array<UploadedFile>|null` regardless of what `$default` actually was.

## Related

Not tied to an open issue. `getCasts()`/`getTouchedRelations()` were borrowed from Larastan's own unreleased (not yet tagged) stub commits past `v3.10.0`, then validated against Laravel source independently of Larastan's typing. The `Request::route()`/`file()` bugs are our own, found incidentally while doing that comparison, unrelated to Larastan.

## Solution Description

- Added `stubs/common/Database/Eloquent/Concerns/HasAttributes.phpstub` (`getCasts(): array<string, string>`). Laravel's real body (`array_merge([$this->getKeyName() => $this->getKeyType()], $this->casts)`) always returns attribute-name keys mapped to cast-type-identifier strings.
- Added `getTouchedRelations(): list<string>` to the existing `stubs/common/Database/Eloquent/Concerns/HasRelationships.phpstub`. The backing `$touches` property follows the same always-a-plain-list convention as `$with`/`$fillable`/`$hidden`.
- `Request::route()`: dropped the `of object` constraint on `TDefault`, and added the missing `object` case to the with-args return branch (a resolved route-model-bound parameter can be a plain object with no default triggered).
- `Request::file()`: threaded `$default`'s actual type through the non-null-key branch via an unconstrained `@template TDefault`, matching the real `data_get($this->allFiles(), $key, $default)` behavior.

Verified with new type tests (`tests/Type/tests/Http/RequestTest.phpt`, `tests/Type/tests/Request/RequestFileTest.phpt`) plus the full unit and type suites, `composer psalm` self-analysis, and `composer cs`, all green.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
- [ ] Documentation is updated (if needed, otherwise remove this item)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785543899&installation_id=141955579&pr_number=1205&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1205&signature=fdb2e9767e39109340cc904bb78218eb0251d5bc8cb8643367c9ec4f3d97fa67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->