### PR TITLE
Don't let a Psalm-internal PHP deprecation crash psalm-delta

### DIFF
--- a/bin/ci/delta-app.sh
+++ b/bin/ci/delta-app.sh
@@ -344,7 +344,15 @@ run_side() {
     exit_code=0
     (
         cd "$app_dir"
-        php -d memory_limit="$MEM" vendor/bin/psalm -c psalm.xml \
+        # error_reporting excludes E_DEPRECATED: some Psalm versions crash with an
+        # uncaught RuntimeException when their OWN internals (not the analyzed app)
+        # trigger a PHP deprecation notice on a newer PHP (e.g. dynamic property
+        # creation on Psalm\Internal\Analyzer\StatementsAnalyzer). That is a Psalm
+        # bug, not something this plugin can fix, but a deprecation notice should
+        # never turn "no report for this app" into a false Crashed row. PHP's INI
+        # parser evaluates E_* constant expressions for error_reporting specifically.
+        php -d memory_limit="$MEM" -d error_reporting="E_ALL & ~E_DEPRECATED" \
+            vendor/bin/psalm -c psalm.xml \
             --no-cache --no-diff --no-progress --no-suggestions --monochrome \
             ${PSALM_EXTRA[@]+"${PSALM_EXTRA[@]}"} \
             --report="${issues_file}" >"$out_txt" 2>"$err_txt"


### PR DESCRIPTION
## Issue to Solve

`psalm-delta` reports a "Crashed" row for `laravel-excel` with:

```
Uncaught RuntimeException: PHP Error: Creation of dynamic property Psalm\Internal\Analyzer\StatementsAnalyzer::$depth is deprecated
```

This is Psalm's own internal code triggering a PHP deprecation notice (dynamic property creation) that gets escalated to an uncaught exception, on a PHP version where that deprecation is enforced more strictly than whatever PHP version that Psalm release was written against. It crashes on both base and PR checkouts, so it isn't caused by any plugin change, but it does turn a real, potentially useful app comparison into a useless "no report" row every time it happens.

## Related

Surfaced while reviewing the `psalm-delta` comment on #1205.

## Solution Description

`bin/ci/delta-app.sh` now passes `-d error_reporting="E_ALL & ~E_DEPRECATED"` to the per-app `vendor/bin/psalm` invocation, alongside the existing `-d memory_limit`. PHP's INI parser evaluates `E_*` constant expressions for the `error_reporting` directive specifically, so this is a plain CLI flag, no wrapper script or error handler needed. Verified locally that `error_reporting()` no longer includes `E_DEPRECATED` under this flag.

This only affects the delta comparison's own psalm process, not the plugin's main test suite or self-analysis. The root cause is in `vimeo/psalm` itself; this is a workaround so a Psalm-internal deprecation notice doesn't masquerade as a plugin regression or hide a real comparison.

## Checklist
- [x] Manually verified: `php -d error_reporting="E_ALL & ~E_DEPRECATED" -r '...'` confirms E_DEPRECATED is excluded (no automated test for a bash CI script)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785545470&installation_id=141955579&pr_number=1206&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1206&signature=a8d525ea1ca46b1608694b3ff08387a278c2c62f031f264546eb1914189e638d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
