### PR TITLE
Infer custom builders for model instance query methods like `newQuery`, `newQueryWithoutScopes`, etc

### DIFF
--- a/src/Handlers/Eloquent/ModelMethodHandler.php
+++ b/src/Handlers/Eloquent/ModelMethodHandler.php
@@ -26,24 +26,27 @@ use Psalm\Type;
 use Psalm\Type\Union;
 
 /**
- * Handles static method calls on Eloquent Models that are forwarded to Builder via __callStatic.
+ * Handles Eloquent Model calls whose return types depend on the model's query builder.
  *
  * Responsibilities:
  * 1. Method existence — confirms magic methods exist (suppresses UndefinedMagicMethod)
  * 2. Method visibility — confirms magic methods are public
  * 3. Method params — provides parameter definitions for argument checking
- * 4. Return types — proxies calls to Builder<TModel> for type inference
+ * 4. Return types — proxies forwarded calls to Builder<TModel> for type inference, and
+ *    substitutes custom builders for Model::query() plus the real instance methods that
+ *    construct builders through newEloquentBuilder()
  *
  * Existence, visibility, params, and return type providers for concrete Model subclasses are
  * registered dynamically per-model by {@see ModelRegistrationHandler} because Psalm's
  * provider lookup requires exact class name matching — a handler registered for Model::class
  * is not consulted for concrete subclasses like App\Models\User.
  *
- * The getClassLikeNames() registration for Model::class handles `Model::query()` only when
- * a custom Eloquent builder is registered for the called model. For plain models (base
- * `Builder`), `query()` is intentionally deferred to the stub at
- * `stubs/common/Database/Eloquent/Model.phpstub` whose `@return Builder<static>` is the only
- * way to preserve the `&static` intersection through Psalm's template binding (see #799).
+ * The getClassLikeNames() registration for Model::class handles `Model::query()` and the
+ * real instance builder-construction methods only when a custom Eloquent builder is registered
+ * for the called model. For plain models (base `Builder`), these methods are intentionally
+ * deferred to the stubs at
+ * `stubs/common/Database/Eloquent/Model.phpstub` whose `static`/`$this` annotations preserve
+ * model-specific template binding through Psalm's type expansion (see #799).
  * `__callStatic` is similarly proxied for methods resolvable through the single-hop mixin
  * chain.
  *
@@ -52,6 +55,24 @@ use Psalm\Type\Union;
  */
 final class ModelMethodHandler implements MethodReturnTypeProviderInterface
 {
+    /**
+     * Real Model methods that construct a fresh Eloquent builder directly or indirectly
+     * through newEloquentBuilder(), so custom builder declarations apply to their return type.
+     *
+     * @var array<lowercase-string, true>
+     */
+    private const INSTANCE_QUERY_CONSTRUCTION_METHODS = [
+        'neweloquentbuilder' => true,
+        'newquery' => true,
+        'newmodelquery' => true,
+        'newquerywithoutrelationships' => true,
+        'newquerywithoutscopes' => true,
+        'newquerywithoutscope' => true,
+        'newqueryforrestoration' => true,
+    ];
+
+    private const REGISTER_GLOBAL_SCOPES = 'registerglobalscopes';
+
     /**
      * Cache for isUnresolvedBuilderMethod results.
      *
@@ -152,11 +173,24 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
         string $modelClass,
         Codebase $codebase,
     ): Type\Atomic\TNamedObject {
+        return self::builderTypeWithModelType(
+            $builderClass,
+            new Union([new Type\Atomic\TNamedObject($modelClass)]),
+            $codebase,
+        );
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    private static function builderTypeWithModelType(
+        string $builderClass,
+        Union $modelType,
+        Codebase $codebase,
+    ): Type\Atomic\TNamedObject {
         // Non-custom builders (base Builder) always have the TModel template param.
         if ($builderClass === Builder::class) {
-            return new Type\Atomic\TGenericObject($builderClass, [
-                new Union([new Type\Atomic\TNamedObject($modelClass)]),
-            ]);
+            return new Type\Atomic\TGenericObject($builderClass, [$modelType]);
         }
 
         // Custom builders: check if they declare their own template params.
@@ -167,12 +201,81 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
         }
 
         if ($storage->template_types !== null && $storage->template_types !== []) {
-            return new Type\Atomic\TGenericObject($builderClass, [
-                new Union([new Type\Atomic\TNamedObject($modelClass)]),
-            ]);
+            return new Type\Atomic\TGenericObject($builderClass, [$modelType]);
         }
 
         return new Type\Atomic\TNamedObject($builderClass);
+    }
+
+    /** @psalm-mutation-free */
+    private static function builderTemplateAllowsStaticModel(
+        string $builderClass,
+        Codebase $codebase,
+    ): bool {
+        if ($builderClass === Builder::class) {
+            return true;
+        }
+
+        try {
+            $storage = $codebase->classlike_storage_provider->get(\strtolower($builderClass));
+        } catch (\InvalidArgumentException) {
+            return false;
+        }
+
+        return $storage->template_types !== null
+            && $storage->template_types !== []
+            && ($storage->template_covariants[0] ?? false);
+    }
+
+    /**
+     * Build the builder return type for instance methods whose stubs use `$this`.
+     *
+     * @psalm-mutation-free
+     */
+    private static function instanceBuilderType(
+        string $builderClass,
+        string $modelClass,
+        Codebase $codebase,
+    ): Type\Atomic\TNamedObject {
+        try {
+            $storage = $codebase->classlike_storage_provider->get(\strtolower($modelClass));
+            $isStatic = !$storage->final && self::builderTemplateAllowsStaticModel($builderClass, $codebase);
+        } catch (\InvalidArgumentException) {
+            $isStatic = false;
+        }
+
+        return self::builderTypeWithModelType(
+            $builderClass,
+            new Union([new Type\Atomic\TNamedObject($modelClass, is_static: $isStatic)]),
+            $codebase,
+        );
+    }
+
+    private static function registerGlobalScopesReturnType(
+        MethodReturnTypeProviderEvent $event,
+        string $modelClass,
+        Codebase $codebase,
+    ): ?Union {
+        $source = $event->getSource();
+
+        if (!$source instanceof StatementsAnalyzer) {
+            return null;
+        }
+
+        $builderClass = self::getBuilderClassForModel($modelClass);
+
+        if ($builderClass === Builder::class) {
+            return null;
+        }
+
+        $arg = $event->getCallArgs()[0] ?? null;
+
+        if ($arg === null) {
+            return new Union([self::instanceBuilderType($builderClass, $modelClass, $codebase)]);
+        }
+
+        return $source->node_data->getType($arg->value)
+            ?? new Union([self::instanceBuilderType($builderClass, $modelClass, $codebase)]);
     }
 
     /**
@@ -580,8 +683,27 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
             return null;
         }
 
+        $methodName = $event->getMethodNameLowercase();
+
+        if ($methodName === self::REGISTER_GLOBAL_SCOPES) {
+            return self::registerGlobalScopesReturnType($event, $called_fq_classlike_name, $codebase);
+        }
+
+        if (isset(self::INSTANCE_QUERY_CONSTRUCTION_METHODS[$methodName])) {
+            $builderClass = self::getBuilderClassForModel($called_fq_classlike_name);
+
+            // For models without a custom builder, defer to the stub's
+            // `@return Builder<$this>` annotation so Psalm keeps the existing
+            // instance-specific model template behavior.
+            if ($builderClass === Builder::class) {
+                return null;
+            }
+
+            return new Union([self::instanceBuilderType($builderClass, $called_fq_classlike_name, $codebase)]);
+        }
+
         // Model::query()
-        if ($event->getMethodNameLowercase() === 'query') {
+        if ($methodName === 'query') {
             $builderClass = self::getBuilderClassForModel($called_fq_classlike_name);
 
             // For models without a custom builder, defer to the stub's
@@ -594,11 +716,11 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
                 return null;
             }
 
-            return new Union([self::builderType($builderClass, $called_fq_classlike_name, $codebase)]);
+            return new Union([self::instanceBuilderType($builderClass, $called_fq_classlike_name, $codebase)]);
         }
 
         // proxy to builder object
-        if ($event->getMethodNameLowercase() === '__callstatic') {
+        if ($methodName === '__callstatic') {
             $called_method_name_lowercase = $event->getCalledMethodNameLowercase();
 
             if ($called_method_name_lowercase === null) {

--- a/tests/Application/app/Builders/CovariantNonFinalCustomBuilder.php
+++ b/tests/Application/app/Builders/CovariantNonFinalCustomBuilder.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Builders;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @template-covariant TModel of Model
+ * @extends Builder<TModel>
+ */
+class CovariantNonFinalCustomBuilder extends Builder {}

--- a/tests/Application/app/Builders/NonFinalCustomBuilder.php
+++ b/tests/Application/app/Builders/NonFinalCustomBuilder.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Builders;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @template TModel of Model
+ * @extends Builder<TModel>
+ */
+class NonFinalCustomBuilder extends Builder {}

--- a/tests/Application/app/Models/CovariantNonFinalCustomBuilderModel.php
+++ b/tests/Application/app/Models/CovariantNonFinalCustomBuilderModel.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Builders\CovariantNonFinalCustomBuilder;
+use Illuminate\Database\Eloquent\Model;
+
+class CovariantNonFinalCustomBuilderModel extends Model
+{
+    protected $table = 'covariant_non_final_custom_builder_models';
+
+    /** @var class-string<CovariantNonFinalCustomBuilder<static>> */
+    protected static string $builder = CovariantNonFinalCustomBuilder::class;
+
+    public static function viaQuery(): static
+    {
+        return static::query()->firstOrCreate(['id' => '1']);
+    }
+
+    public function viaNewQuery(): static
+    {
+        return $this->newQuery()->firstOrCreate(['id' => '1']);
+    }
+
+    public function viaNewModelQuery(): static
+    {
+        return $this->newModelQuery()->firstOrNew(['id' => '1']);
+    }
+
+    public function viaNewQueryWithoutRelationships(): static
+    {
+        return $this->newQueryWithoutRelationships()->create(['id' => '1']);
+    }
+
+    public function viaNewQueryWithoutScopes(): static
+    {
+        return $this->newQueryWithoutScopes()->firstOrCreate(['id' => '1']);
+    }
+
+    public function viaNewQueryWithoutScope(): static
+    {
+        return $this->newQueryWithoutScope('tenant')->firstOrNew(['id' => '1']);
+    }
+
+    public function viaNewQueryForRestoration(): static
+    {
+        return $this->newQueryForRestoration(1)->firstOrCreate(['id' => '1']);
+    }
+}

--- a/tests/Application/app/Models/NonFinalCustomBuilderModel.php
+++ b/tests/Application/app/Models/NonFinalCustomBuilderModel.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Builders\NonFinalCustomBuilder;
+use Illuminate\Database\Eloquent\Model;
+
+class NonFinalCustomBuilderModel extends Model
+{
+    protected $table = 'non_final_custom_builder_models';
+
+    /** @var class-string<NonFinalCustomBuilder<static>> */
+    protected static string $builder = NonFinalCustomBuilder::class;
+}

--- a/tests/Type/tests/Builder/CustomQueryBuilderTest.phpt
+++ b/tests/Type/tests/Builder/CustomQueryBuilderTest.phpt
@@ -15,6 +15,7 @@ use App\Models\Mechanic;
 use App\Models\WorkOrder;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 
 /**
  * Tests that models with custom query builders return the correct builder type
@@ -33,6 +34,37 @@ function test_query_returns_custom_builder(): void
 {
     $_result = WorkOrder::query();
     /** @psalm-check-type-exact $_result = WorkOrderBuilder<WorkOrder> */
+}
+
+/** Instance query-construction methods return the custom builder too. */
+function test_instance_query_construction_methods_return_custom_builder(WorkOrder $workOrder, QueryBuilder $query): void
+{
+    $_newEloquentBuilder = $workOrder->newEloquentBuilder($query);
+    /** @psalm-check-type-exact $_newEloquentBuilder = WorkOrderBuilder<WorkOrder> */
+
+    $_newQuery = $workOrder->newQuery();
+    /** @psalm-check-type-exact $_newQuery = WorkOrderBuilder<WorkOrder> */
+
+    $_newModelQuery = $workOrder->newModelQuery();
+    /** @psalm-check-type-exact $_newModelQuery = WorkOrderBuilder<WorkOrder> */
+
+    $_globalScopes = $workOrder->registerGlobalScopes($workOrder->newModelQuery());
+    /** @psalm-check-type-exact $_globalScopes = WorkOrderBuilder<WorkOrder> */
+
+    $_withoutRelationships = $workOrder->newQueryWithoutRelationships();
+    /** @psalm-check-type-exact $_withoutRelationships = WorkOrderBuilder<WorkOrder> */
+
+    $_withoutScopes = $workOrder->newQueryWithoutScopes();
+    /** @psalm-check-type-exact $_withoutScopes = WorkOrderBuilder<WorkOrder> */
+
+    $_withoutScope = $workOrder->newQueryWithoutScope('soft_deleting');
+    /** @psalm-check-type-exact $_withoutScope = WorkOrderBuilder<WorkOrder> */
+
+    $_forRestoration = $workOrder->newQueryForRestoration(1);
+    /** @psalm-check-type-exact $_forRestoration = WorkOrderBuilder<WorkOrder> */
+
+    $_customMethod = $workOrder->newQuery()->whereCompleted();
+    /** @psalm-check-type-exact $_customMethod = WorkOrderBuilder<WorkOrder> */
 }
 
 /** Custom builder methods are accessible via query(). */
@@ -298,6 +330,13 @@ function test_new_eloquent_builder_query(): void
     /** @psalm-check-type-exact $_result = VehicleBuilder<Vehicle> */
 }
 
+/** Vehicle::newQuery() returns the custom builder via newEloquentBuilder() override. */
+function test_new_eloquent_builder_instance_new_query(Vehicle $vehicle): void
+{
+    $_result = $vehicle->newQuery();
+    /** @psalm-check-type-exact $_result = VehicleBuilder<Vehicle> */
+}
+
 /** Custom builder methods work via query() on newEloquentBuilder model. */
 function test_new_eloquent_builder_custom_method(): void
 {
@@ -335,6 +374,20 @@ function test_scope_on_new_eloquent_builder_via_query(): void
 function test_static_builder_property_query(): void
 {
     $_result = Mechanic::query();
+    /** @psalm-check-type-exact $_result = MechanicBuilder<Mechanic> */
+}
+
+/** Mechanic::newQuery() returns the custom builder via static $builder property. */
+function test_static_builder_property_instance_new_query(Mechanic $mechanic): void
+{
+    $_result = $mechanic->newQuery();
+    /** @psalm-check-type-exact $_result = MechanicBuilder<Mechanic> */
+}
+
+/** Mechanic::newEloquentBuilder() returns the custom builder via static $builder property. */
+function test_static_builder_property_instance_new_eloquent_builder(Mechanic $mechanic, QueryBuilder $query): void
+{
+    $_result = $mechanic->newEloquentBuilder($query);
     /** @psalm-check-type-exact $_result = MechanicBuilder<Mechanic> */
 }
 
@@ -376,6 +429,20 @@ function test_nonexistent_method_on_custom_builder_model(): void
 function test_non_template_builder_query(): void
 {
     $_result = Invoice::query();
+    /** @psalm-check-type-exact $_result = InvoiceBuilder */
+}
+
+/** Non-template builder: newQuery() returns plain InvoiceBuilder. */
+function test_non_template_builder_instance_new_query(Invoice $invoice): void
+{
+    $_result = $invoice->newQuery();
+    /** @psalm-check-type-exact $_result = InvoiceBuilder */
+}
+
+/** Non-template builder: newEloquentBuilder() returns plain InvoiceBuilder. */
+function test_non_template_builder_instance_new_eloquent_builder(Invoice $invoice, QueryBuilder $query): void
+{
+    $_result = $invoice->newEloquentBuilder($query);
     /** @psalm-check-type-exact $_result = InvoiceBuilder */
 }
 

--- a/tests/Type/tests/Model/StaticReturnFromCustomBuilderInstanceQueryTest.phpt
+++ b/tests/Type/tests/Model/StaticReturnFromCustomBuilderInstanceQueryTest.phpt
@@ -1,0 +1,57 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Builders\CovariantNonFinalCustomBuilder;
+use App\Builders\NonFinalCustomBuilder;
+use App\Models\CovariantNonFinalCustomBuilderModel;
+use App\Models\NonFinalCustomBuilderModel;
+
+/**
+ * @param NonFinalCustomBuilder<NonFinalCustomBuilderModel> $builder
+ */
+function accepts_invariant_builder_for_exact_model(NonFinalCustomBuilder $builder): void
+{
+    $_model = $builder->getModel();
+    /** @psalm-check-type-exact $_model = NonFinalCustomBuilderModel */
+}
+
+/**
+ * Non-final invariant custom-builder models keep the exact model template so assigning
+ * the result to invariant `CustomBuilder<Model>` consumers does not become a false positive.
+ */
+function invariant_custom_builder_instance_query_methods_use_exact_model(NonFinalCustomBuilderModel $model): void
+{
+    $_newQuery = $model->newQuery();
+    /** @psalm-check-type-exact $_newQuery = NonFinalCustomBuilder<NonFinalCustomBuilderModel> */
+
+    $_scoped = $model->registerGlobalScopes($model->newModelQuery());
+    /** @psalm-check-type-exact $_scoped = NonFinalCustomBuilder<NonFinalCustomBuilderModel> */
+
+    accepts_invariant_builder_for_exact_model($model->newQuery());
+}
+
+/**
+ * Covariant custom-builder templates can safely keep `$this`/`static`, which prevents
+ * terminal model-returning builder calls from flattening `static` to the base model.
+ */
+function covariant_custom_builder_instance_query_methods_preserve_static(CovariantNonFinalCustomBuilderModel $model): void
+{
+    $_newQuery = $model->newQuery();
+    /** @psalm-check-type-exact $_newQuery = CovariantNonFinalCustomBuilder<CovariantNonFinalCustomBuilderModel&static> */
+
+    $_query = CovariantNonFinalCustomBuilderModel::query();
+    /** @psalm-check-type-exact $_query = CovariantNonFinalCustomBuilder<CovariantNonFinalCustomBuilderModel&static> */
+
+    $_scoped = $model->registerGlobalScopes($model->newModelQuery());
+    /** @psalm-check-type-exact $_scoped = CovariantNonFinalCustomBuilder<CovariantNonFinalCustomBuilderModel&static> */
+
+    CovariantNonFinalCustomBuilderModel::viaQuery();
+    $model->viaNewQuery();
+    $model->viaNewModelQuery();
+    $model->viaNewQueryWithoutRelationships();
+    $model->viaNewQueryWithoutScopes();
+    $model->viaNewQueryWithoutScope();
+    $model->viaNewQueryForRestoration();
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve
Custom Eloquent builders were inferred for `Model::query()`, but the instance query-construction methods still returned the base `Builder`, so custom builder methods were unavailable from `$model->newQuery()` and sibling entry points.

## Related
Fixes #1204

## Solution Description
- Substitute the registered custom builder for `newEloquentBuilder()`, `newQuery()`, `newModelQuery()`, `newQueryWithoutRelationships()`, `newQueryWithoutScopes()`, `newQueryWithoutScope()`, and `newQueryForRestoration()`.
- Preserve the instance `$this`/`static` model template for non-final models, while continuing to defer base-builder models to the stubs.
- Add type coverage for attribute, `newEloquentBuilder()` override, static `$builder`, non-template builders, and non-final custom-builder `&static` preservation.
