### PR TITLE
Pin vimeo/psalm to a tagged release in psalm-delta app installs

### DIFF
--- a/bin/ci/delta-app.sh
+++ b/bin/ci/delta-app.sh
@@ -160,6 +160,19 @@ configure_plugin_repo() {
             $d["minimum-stability"] = "dev";
             $d["prefer-stable"] = true;
             $d["require-dev"]["psalm/plugin-laravel"] = "*";
+            // minimum-stability=dev above is only needed for the dev-branch
+            // path repo install above; it also makes vimeo/psalm eligible to
+            // resolve to its dev-master branch instead of a tagged beta, which
+            // is a problem because dev-master is a rolling branch that can be
+            // transiently broken (e.g. a bad merge dropping a typed property,
+            // producing a dynamic-property deprecation that the Psalm error
+            // handler escalates into an uncaught crash). Pin vimeo/psalm to at
+            // least beta stability, reusing the floor constraint declared in
+            // the plugin composer.json, so this one package still resolves to
+            // a tagged release regardless of the relaxed root stability.
+            $plugin_composer = json_decode(file_get_contents($argv[2] . "/composer.json"), true, 512, JSON_THROW_ON_ERROR);
+            $psalm_constraint = trim(explode("||", $plugin_composer["require"]["vimeo/psalm"] ?? "^7.0.0-beta19")[0]);
+            $d["require-dev"]["vimeo/psalm"] = $psalm_constraint . "@beta";
             // Relax a pinned PHP constraint (e.g. "8.3.*" -> "^8.3") so install
             // does not fail on the runner PHP; analysis runs under the real binary.
             $php = $d["require"]["php"] ?? "";
@@ -344,14 +357,7 @@ run_side() {
     exit_code=0
     (
         cd "$app_dir"
-        # error_reporting excludes E_DEPRECATED: some Psalm versions crash with an
-        # uncaught RuntimeException when their OWN internals (not the analyzed app)
-        # trigger a PHP deprecation notice on a newer PHP (e.g. dynamic property
-        # creation on Psalm\Internal\Analyzer\StatementsAnalyzer). That is a Psalm
-        # bug, not something this plugin can fix, but a deprecation notice should
-        # never turn "no report for this app" into a false Crashed row. PHP's INI
-        # parser evaluates E_* constant expressions for error_reporting specifically.
-        php -d memory_limit="$MEM" -d error_reporting="E_ALL & ~E_DEPRECATED" \
+        php -d memory_limit="$MEM" \
             vendor/bin/psalm -c psalm.xml \
             --no-cache --no-diff --no-progress --no-suggestions --monochrome \
             ${PSALM_EXTRA[@]+"${PSALM_EXTRA[@]}"} \


### PR DESCRIPTION
## Summary

- The #1206 E_DEPRECATED-suppression fix never worked: Psalm's own `ErrorHandler::install()` calls `error_reporting(E_ALL)` unconditionally, overriding the `-d` ini flag we passed. Removed.
- Real cause of the laravel-excel crash: `configure_plugin_repo()` sets root `minimum-stability: dev` so the plugin's own dev-branch path repo installs. That relaxation also lets `vimeo/psalm` resolve to its `dev-master` branch instead of a tagged beta, because `dev-master` is branch-aliased to `7.x-dev` and Composer picks the newest satisfying version. `dev-master` is currently broken upstream: a bad `6.x` merge on 2026-06-24 dropped a typed `$depth` property from `StatementsAnalyzer` while keeping `$this->depth++` usage, so PHP 8.2+ raises a dynamic-property-creation deprecation that Psalm's error handler escalates into an uncaught crash.
- Fix: pin `vimeo/psalm` explicitly to the plugin's own floor constraint plus `@beta` in `require-dev` during the stability-relaxed install, so it always resolves to a tagged release regardless of the relaxed root stability.

## Verification

Reproduced empirically against a live `laravel-excel` checkout (`SpartnerNL/Laravel-Excel@1854739`):
- Before: Composer resolves `vimeo/psalm (dev-master 290eaec)`, Psalm crashes with `Uncaught RuntimeException: PHP Error: Creation of dynamic property Psalm\Internal\Analyzer\StatementsAnalyzer::$depth is deprecated`.
- After: Composer resolves `vimeo/psalm (7.0.0-beta19)`, full analysis run completes (1162 issues, 94.35% coverage, no crash) via `bin/ci/delta-app.sh` directly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785572859&installation_id=141955579&pr_number=1208&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1208&signature=c62953e96628eaaf9615652066534d220b8fba024ae69c79384d3dfe299232ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->