### PR TITLE
Port master features to 3.x (v4.14.9)

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -1,13 +1,16 @@
 name: Install smoke test
 
-# Executes the README quickstart verbatim against a fresh Laravel project on
-# each supported OS: install the plugin from this checkout, then
-# `psalm-laravel init`, `analyze`, and `diagnose`. Complements
-# test-laravel-app.yml (which is Ubuntu-only and covers a PHP x Laravel
-# compatibility matrix on a heavily scaffolded app) by covering OS-specific
-# install/configuration behavior on a minimal one — the class of bug fixed in
-# #1189, where a Windows proc_open() launcher regression could pass every
-# Ubuntu-only check.
+# Executes the README quickstart verbatim on each supported OS: install the
+# plugin from this checkout, then `psalm-laravel init`, `analyze`, and
+# `diagnose`. Runs against two target kinds (matrix `kind`): a fresh Laravel
+# `app`, and a real Laravel `package` (socialite) whose src/-autoload config path
+# and Testbench plugin-boot fallback the app flow never exercises (#1198).
+#
+# Complements test-laravel-app.yml (which is Ubuntu-only and covers a PHP x
+# Laravel compatibility matrix on a heavily scaffolded app) by covering
+# OS-specific install/configuration behavior on minimal targets — the class of
+# bug fixed in #1189, where a Windows proc_open() launcher regression could pass
+# every Ubuntu-only check.
 
 on:
   workflow_dispatch:
@@ -19,6 +22,7 @@ on:
       - bin/ci/install-smoke.php
       - src/Cli/**
       - src/Plugin.php
+      - src/Bootstrap/ApplicationProvider.php
       - .github/workflows/install-smoke.yml
   push:
     branches: [master]
@@ -29,6 +33,7 @@ on:
       - bin/ci/install-smoke.php
       - src/Cli/**
       - src/Plugin.php
+      - src/Bootstrap/ApplicationProvider.php
       - .github/workflows/install-smoke.yml
 
 # Cancel superseded runs on the same branch/PR to save CI minutes on fast pushes.
@@ -41,7 +46,14 @@ permissions:
 
 jobs:
   install-smoke:
-    name: Install smoke (${{ matrix.name }})
+    # The `app` rows keep #1197's exact job names ("Install smoke (Ubuntu)" etc.)
+    # so any branch-protection check keyed on them stays valid; `package` rows
+    # append " / package". Explicit include rows (rather than an os x kind
+    # cross-product) keep `runs-on: ${{ matrix.runner }}` statically resolvable to
+    # a concrete Blacksmith label — lint-workflows.yml's octoscan step ignores the
+    # runner-label warning by label, which a nested `matrix.os.runner` would turn
+    # into an unresolvable expression and trip as a self-hosted-runner alert.
+    name: Install smoke (${{ matrix.name }}${{ matrix.kind == 'package' && ' / package' || '' }})
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -49,10 +61,22 @@ jobs:
         include:
           - name: Ubuntu
             runner: blacksmith-2vcpu-ubuntu-2404
+            kind: app
+          - name: Ubuntu
+            runner: blacksmith-2vcpu-ubuntu-2404
+            kind: package
           - name: Windows
             runner: blacksmith-2vcpu-windows-2025
+            kind: app
+          - name: Windows
+            runner: blacksmith-2vcpu-windows-2025
+            kind: package
           - name: macOS
             runner: blacksmith-6vcpu-macos-15
+            kind: app
+          - name: macOS
+            runner: blacksmith-6vcpu-macos-15
+            kind: package
     runs-on: ${{ matrix.runner }}
     steps:
       # NOTE: step-security/harden-runner is intentionally NOT used here.
@@ -93,13 +117,14 @@ jobs:
         # write concerns.
         env:
           APP_DIR: ${{ runner.temp }}/psalm-install-smoke
+          PROJECT_KIND: ${{ matrix.kind }}
         run: php bin/ci/install-smoke.php
 
       - name: Upload diagnostics
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: install-smoke-${{ matrix.name }}
+          name: install-smoke-${{ matrix.name }}-${{ matrix.kind }}
           path: |
             install-smoke.log
             ${{ runner.temp }}/psalm-install-smoke/composer.json

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ CLAUDE.local.md
 ## Codex agents
 .agents/
 AGENTS.md
+
+# local benchmark app registry (private app names)
+/bin/ci/test-apps.override.yml

--- a/README.md
+++ b/README.md
@@ -111,11 +111,11 @@ See [docs/issues/index.md](docs/issues/index.md) for the full catalog.
 
 Maintained versions:
 
-| Laravel Psalm Plugin                         | PHP  | Laravel    | Psalm  | Plugin Status |
-|----------------------------------------------|------|------------|--------|---------------|
-| 4.x                                          | ^8.2 | 12, 13     | 7-beta | Stable        |
-| 3.x ([upgrade to v4](UPGRADING.md))          | ^8.2 | 11, 12, 13 | 6      | Stable        |
-| 2.12+ ([upgrade to v3](UPGRADING.md#2x--3x)) | ^8.0 | 9, 10, 11  | 5, 6   | Legacy        |
+| Laravel Psalm Plugin                         | Laravel    | Psalm  | Plugin Status |
+|----------------------------------------------|------------|--------|---------------|
+| 4.x                                          | 12, 13     | 7-beta | Stable        |
+| 3.x ([upgrade to v4](UPGRADING.md))          | 11, 12, 13 | 6      | Stable        |
+| 2.12+ ([upgrade to v3](UPGRADING.md#2x--3x)) | 9, 10, 11  | 5, 6   | Legacy        |
 
 _(Older versions of Laravel, PHP, and Psalm were supported by version 1.x of the plugin, but they are no longer maintained)_
 

--- a/README.md
+++ b/README.md
@@ -111,11 +111,11 @@ See [docs/issues/index.md](docs/issues/index.md) for the full catalog.
 
 Maintained versions:
 
-| Laravel Psalm Plugin                         | Laravel    | Psalm  | Plugin Status |
-|----------------------------------------------|------------|--------|---------------|
-| 4.x                                          | 12, 13     | 7-beta | Stable        |
-| 3.x ([upgrade to v4](UPGRADING.md))          | 11, 12, 13 | 6      | Stable        |
-| 2.12+ ([upgrade to v3](UPGRADING.md#2x--3x)) | 9, 10, 11  | 5, 6   | Legacy        |
+| Laravel Psalm Plugin                       | Laravel    | Psalm  | Plugin Status |
+|--------------------------------------------|------------|--------|---------------|
+| 4.x                                        | 12, 13     | 7-beta | Stable        |
+| 3.x ([upgrade to v4](UPGRADING.md))        | 11, 12, 13 | 6      | Stable        |
+| 2.x ([upgrade to v3](UPGRADING.md#2x--3x)) | 9, 10, 11  | 5, 6   | Legacy        |
 
 _(Older versions of Laravel, PHP, and Psalm were supported by version 1.x of the plugin, but they are no longer maintained)_
 

--- a/bin/ci/delta-app.sh
+++ b/bin/ci/delta-app.sh
@@ -344,7 +344,15 @@ run_side() {
     exit_code=0
     (
         cd "$app_dir"
-        php -d memory_limit="$MEM" vendor/bin/psalm -c psalm.xml \
+        # error_reporting excludes E_DEPRECATED: some Psalm versions crash with an
+        # uncaught RuntimeException when their OWN internals (not the analyzed app)
+        # trigger a PHP deprecation notice on a newer PHP (e.g. dynamic property
+        # creation on Psalm\Internal\Analyzer\StatementsAnalyzer). That is a Psalm
+        # bug, not something this plugin can fix, but a deprecation notice should
+        # never turn "no report for this app" into a false Crashed row. PHP's INI
+        # parser evaluates E_* constant expressions for error_reporting specifically.
+        php -d memory_limit="$MEM" -d error_reporting="E_ALL & ~E_DEPRECATED" \
+            vendor/bin/psalm -c psalm.xml \
             --no-cache --no-diff --no-progress --no-suggestions --monochrome \
             ${PSALM_EXTRA[@]+"${PSALM_EXTRA[@]}"} \
             --report="${issues_file}" >"$out_txt" 2>"$err_txt"

--- a/bin/ci/delta-app.sh
+++ b/bin/ci/delta-app.sh
@@ -160,6 +160,19 @@ configure_plugin_repo() {
             $d["minimum-stability"] = "dev";
             $d["prefer-stable"] = true;
             $d["require-dev"]["psalm/plugin-laravel"] = "*";
+            // minimum-stability=dev above is only needed for the dev-branch
+            // path repo install above; it also makes vimeo/psalm eligible to
+            // resolve to its dev-master branch instead of a tagged beta, which
+            // is a problem because dev-master is a rolling branch that can be
+            // transiently broken (e.g. a bad merge dropping a typed property,
+            // producing a dynamic-property deprecation that the Psalm error
+            // handler escalates into an uncaught crash). Pin vimeo/psalm to at
+            // least beta stability, reusing the floor constraint declared in
+            // the plugin composer.json, so this one package still resolves to
+            // a tagged release regardless of the relaxed root stability.
+            $plugin_composer = json_decode(file_get_contents($argv[2] . "/composer.json"), true, 512, JSON_THROW_ON_ERROR);
+            $psalm_constraint = trim(explode("||", $plugin_composer["require"]["vimeo/psalm"] ?? "^7.0.0-beta19")[0]);
+            $d["require-dev"]["vimeo/psalm"] = $psalm_constraint . "@beta";
             // Relax a pinned PHP constraint (e.g. "8.3.*" -> "^8.3") so install
             // does not fail on the runner PHP; analysis runs under the real binary.
             $php = $d["require"]["php"] ?? "";
@@ -344,14 +357,7 @@ run_side() {
     exit_code=0
     (
         cd "$app_dir"
-        # error_reporting excludes E_DEPRECATED: some Psalm versions crash with an
-        # uncaught RuntimeException when their OWN internals (not the analyzed app)
-        # trigger a PHP deprecation notice on a newer PHP (e.g. dynamic property
-        # creation on Psalm\Internal\Analyzer\StatementsAnalyzer). That is a Psalm
-        # bug, not something this plugin can fix, but a deprecation notice should
-        # never turn "no report for this app" into a false Crashed row. PHP's INI
-        # parser evaluates E_* constant expressions for error_reporting specifically.
-        php -d memory_limit="$MEM" -d error_reporting="E_ALL & ~E_DEPRECATED" \
+        php -d memory_limit="$MEM" \
             vendor/bin/psalm -c psalm.xml \
             --no-cache --no-diff --no-progress --no-suggestions --monochrome \
             ${PSALM_EXTRA[@]+"${PSALM_EXTRA[@]}"} \

--- a/bin/ci/install-smoke.php
+++ b/bin/ci/install-smoke.php
@@ -4,8 +4,18 @@ declare(strict_types=1);
 
 /**
  * Cross-OS install/configuration smoke test. Follows the README quickstart
- * verbatim against a fresh Laravel project: create project, install the plugin
- * from the current checkout, then `psalm-laravel init`, `analyze`, `diagnose`.
+ * verbatim, installing the plugin from the current checkout and then running
+ * `psalm-laravel init`, `analyze`, `diagnose` against a target project.
+ *
+ * Two target-project modes, selected by PROJECT_KIND (default `app`):
+ *   - `app`     — a fresh `laravel/laravel` project. Exercises the Laravel-app
+ *                 config path (`InitCommand::detectLaravelAppRoots()` and a
+ *                 `bootstrap/app.php` plugin boot).
+ *   - `package` — a real Laravel *package* checkout (default: laravel/socialite),
+ *                 which autoloads from `src/` and ships no `artisan`. Exercises the
+ *                 package config path (`InitCommand::detectPackageRoots()` and the
+ *                 Orchestra Testbench plugin-boot fallback) that the app flow never
+ *                 touches (#1198).
  *
  * PHP (not Bash) so the exact same script runs on Ubuntu, Windows, and macOS.
  * Subprocesses go through Symfony Process, which already solves the Windows
@@ -20,12 +30,17 @@ declare(strict_types=1);
  *
  * Usage:
  *   php bin/ci/install-smoke.php
+ *   PROJECT_KIND=package php bin/ci/install-smoke.php
  *   KEEP_APP=1 VERBOSE=1 php bin/ci/install-smoke.php
  *
  * Environment variables:
+ *   PROJECT_KIND     `app` (default) or `package` — see the mode descriptions above
  *   PLUGIN_PATH      Checkout to install (default: this repo's root)
- *   LARAVEL_VERSION  `laravel/laravel` installer version (default: latest stable)
- *   APP_DIR          Where to scaffold the throwaway app (default: a fresh temp dir)
+ *   LARAVEL_VERSION  `app` mode only: `laravel/laravel` installer version (default: latest stable)
+ *   PACKAGE_REPO     `package` mode only: git URL to clone (default: laravel/socialite)
+ *   PACKAGE_REF      `package` mode only: tag/branch to clone (default: a pinned socialite tag)
+ *   PACKAGE_EXPECTED_ROOTS  `package` mode only: comma-separated dirs the generated psalm.xml must scan (default: src)
+ *   APP_DIR          Where to scaffold the throwaway project (default: a fresh temp dir)
  *   KEEP_APP         1 to keep the app dir even on success (default: 0; failures always preserve it)
  *   VERBOSE          1 to stream every subprocess's output live (default: 0; failures always show it)
  *
@@ -123,8 +138,12 @@ function logOutput(string $label, string $output, string $errorOutput, bool $ver
  *
  * @param list<string> $command
  * @param array<string, string> $extraEnv
+ * @param list<int> $allowedExitCodes Exit codes treated as success. Defaults to [0];
+ *        `package`-mode `analyze` passes [0, 2] because Psalm exits 2 when it ran to
+ *        completion but found issues — expected for a real third-party package we do
+ *        not own — while 1 (a launcher/config error, the #1189 class) still fails.
  */
-function runStep(string $label, array $command, string $cwd, array $extraEnv, bool $verbose, string $appDir): Process
+function runStep(string $label, array $command, string $cwd, array $extraEnv, bool $verbose, string $appDir, array $allowedExitCodes = [0]): Process
 {
     logLine(\sprintf('==> %s', $label));
     logLine(\sprintf('    $ %s (cwd: %s)', \implode(' ', $command), $cwd));
@@ -151,7 +170,7 @@ function runStep(string $label, array $command, string $cwd, array $extraEnv, bo
 
     logOutput($label, $process->getOutput(), $process->getErrorOutput(), $verbose);
 
-    if (!$process->isSuccessful()) {
+    if (!\in_array($process->getExitCode(), $allowedExitCodes, true)) {
         reportFailure($label, $command, $process->getExitCode(), $cwd, $process->getOutput(), $process->getErrorOutput(), $appDir);
     }
 
@@ -209,6 +228,30 @@ if (!\is_file($pluginPath . \DIRECTORY_SEPARATOR . 'composer.json')) {
     exit(1);
 }
 
+$projectKind = \strtolower(envStr('PROJECT_KIND', 'app'));
+if (!\in_array($projectKind, ['app', 'package'], true)) {
+    \fwrite(\STDERR, \sprintf("PROJECT_KIND must be 'app' or 'package', got '%s'.\n", $projectKind));
+    exit(1);
+}
+
+// `package` mode targets a real Laravel package checkout. Pinned to a released
+// socialite tag (not a floating branch) so the run is reproducible and immune to
+// mid-refactor breakage on socialite's default branch — and so socialite's own
+// require-dev tree, pulled in when the plugin is required into it, stays frozen.
+// Override either to exercise a different package or ref.
+$packageRepo = envStr('PACKAGE_REPO', 'https://github.com/laravel/socialite.git');
+$packageRef = envStr('PACKAGE_REF', 'v5.28.0');
+
+// Directories the generated psalm.xml must scan in package mode, comma-separated.
+// Defaults to socialite's `src`; override it alongside PACKAGE_REPO for a package
+// that autoloads from a different or additional root (e.g. `lib`) so the assertion
+// tracks the target rather than assuming socialite's layout. The app-only-marker
+// negative assertions below are layout-independent and need no override.
+$expectedRoots = \array_values(\array_filter(\array_map(
+    'trim',
+    \explode(',', envStr('PACKAGE_EXPECTED_ROOTS', 'src')),
+)));
+
 $laravelVersion = envStr('LARAVEL_VERSION', '');
 $keepApp = envBool('KEEP_APP', false);
 $verbose = envBool('VERBOSE', false);
@@ -219,11 +262,10 @@ if ($appDir === '') {
         . \DIRECTORY_SEPARATOR . 'psalm-install-smoke-' . \bin2hex(\random_bytes(4));
 }
 
-logLine(\sprintf(
-    'Starting install smoke test: app_dir=%s laravel_version=%s',
-    $appDir,
-    $laravelVersion === '' ? '(latest stable)' : $laravelVersion,
-));
+$targetSummary = $projectKind === 'package'
+    ? \sprintf('package=%s@%s', $packageRepo, $packageRef)
+    : \sprintf('laravel_version=%s', $laravelVersion === '' ? '(latest stable)' : $laravelVersion);
+logLine(\sprintf('Starting install smoke test: kind=%s app_dir=%s %s', $projectKind, $appDir, $targetSummary));
 
 $psalmLaravelBin = static fn(string $dir): string => $dir . \DIRECTORY_SEPARATOR . 'vendor'
     . \DIRECTORY_SEPARATOR . 'bin' . \DIRECTORY_SEPARATOR . 'psalm-laravel';
@@ -234,17 +276,27 @@ if (!\is_dir($launchDir) && !@\mkdir($launchDir, 0755, true) && !\is_dir($launch
     exit(1);
 }
 
-// --- Step 1: fresh Laravel project -----------------------------------------
+// --- Step 1: create the target project -------------------------------------
+//
+// `app` mode scaffolds a fresh Laravel application; `package` mode clones a real
+// Laravel package (socialite by default). Both land at $appDir, and every later
+// step (configure Composer, require the plugin, init/analyze/diagnose) is shared.
 
-// --no-blocking: a security advisory against any of laravel/laravel's transitive
-// deps (historically phpunit's dev range) would otherwise block the install with
-// a Composer policy error unrelated to this script — the same lesson already
-// applied in tests/Application/laravel-test.sh's identical create-project call.
-$createProjectCommand = ['composer', 'create-project', '--prefer-dist', '--no-interaction', '--no-ansi', '--no-blocking', 'laravel/laravel', $appDir];
-if ($laravelVersion !== '') {
-    $createProjectCommand[] = $laravelVersion;
+if ($projectKind === 'package') {
+    // --depth 1 --branch <ref>: fetch only the pinned ref's tree, no history.
+    $cloneCommand = ['git', 'clone', '--depth', '1', '--branch', $packageRef, $packageRepo, $appDir];
+    runStep(\sprintf('git clone %s@%s', $packageRepo, $packageRef), $cloneCommand, $launchDir, [], $verbose, $appDir);
+} else {
+    // --no-blocking: a security advisory against any of laravel/laravel's transitive
+    // deps (historically phpunit's dev range) would otherwise block the install with
+    // a Composer policy error unrelated to this script — the same lesson already
+    // applied in tests/Application/laravel-test.sh's identical create-project call.
+    $createProjectCommand = ['composer', 'create-project', '--prefer-dist', '--no-interaction', '--no-ansi', '--no-blocking', 'laravel/laravel', $appDir];
+    if ($laravelVersion !== '') {
+        $createProjectCommand[] = $laravelVersion;
+    }
+    runStep('composer create-project', $createProjectCommand, $launchDir, [], $verbose, $appDir);
 }
-runStep('composer create-project', $createProjectCommand, $launchDir, [], $verbose, $appDir);
 
 // --- Step 2: configure Composer exactly as the README's Step 1 instructs ---
 //
@@ -287,10 +339,39 @@ if ($psalmXmlContents === false || !\str_contains($psalmXmlContents, 'Psalm\\Lar
     reportFailure('assert psalm.xml registers the plugin', [], null, $appDir, (string) $psalmXmlContents, 'Expected psalm.xml to reference Psalm\\LaravelPlugin\\Plugin.', $appDir);
 }
 
+// Package mode only: prove `init` took the package branch (detectPackageRoots),
+// not the Laravel-app branch. A package autoloads from its own root(s) — `src` for
+// socialite, or whatever PACKAGE_EXPECTED_ROOTS names — and ships no artisan, so a
+// correct package config scans each expected <directory name="..."/> and emits none
+// of the app-only <file name="artisan"/> / <directory name="app"/> entries.
+// Whitespace in the generated markup is fixed by InitCommand's template, so
+// exact-substring matching is safe here.
+if ($projectKind === 'package') {
+    $contents = (string) $psalmXmlContents;
+    foreach ($expectedRoots as $root) {
+        $marker = \sprintf('<directory name="%s"/>', $root);
+        if (!\str_contains($contents, $marker)) {
+            reportFailure('assert psalm.xml scans the package root', [], null, $appDir, $contents, \sprintf('Expected package-mode psalm.xml to scan %s.', $marker), $appDir);
+        }
+    }
+
+    foreach (['<file name="artisan"/>', '<directory name="app"/>'] as $appOnlyMarker) {
+        if (\str_contains($contents, $appOnlyMarker)) {
+            reportFailure('assert psalm.xml used the package (not Laravel-app) layout', [], null, $appDir, $contents, \sprintf('Package-mode psalm.xml unexpectedly contains the app-only marker %s.', $appOnlyMarker), $appDir);
+        }
+    }
+}
+
 // --- Step 5: psalm-laravel analyze ------------------------------------------
 
 $analyzeCommand = [\PHP_BINARY, $psalmLaravelBin($appDir), 'analyze', '--no-cache', '--no-progress', '--output-format=compact'];
-runStep('psalm-laravel analyze', $analyzeCommand, $appDir, [], $verbose, $appDir);
+// app mode analyzes a pristine skeleton and must be issue-free (exit 0). package
+// mode analyzes a real third-party package we do not own: Psalm exiting 2 means it
+// ran to completion but found issues in *that package's* own code, which is not a
+// plugin install failure — accept it, while still failing on 1 (a Psalm/launcher
+// error, the #1189 class this smoke test exists to catch).
+$analyzeAllowedExitCodes = $projectKind === 'package' ? [0, 2] : [0];
+runStep('psalm-laravel analyze', $analyzeCommand, $appDir, [], $verbose, $appDir, $analyzeAllowedExitCodes);
 
 // --- Step 6: psalm-laravel diagnose -----------------------------------------
 //
@@ -298,7 +379,31 @@ runStep('psalm-laravel analyze', $analyzeCommand, $appDir, [], $verbose, $appDir
 // reportFailure() prints it too. No separate artifact is written.
 
 $diagnoseCommand = [\PHP_BINARY, $psalmLaravelBin($appDir), 'diagnose', '--no-tips'];
-runStep('psalm-laravel diagnose', $diagnoseCommand, $appDir, [], $verbose, $appDir);
+$diagnoseProcess = runStep('psalm-laravel diagnose', $diagnoseCommand, $appDir, [], $verbose, $appDir);
+
+// Boot-mode differential. A package has no bootstrap/app.php, so the plugin must
+// boot Laravel through the Orchestra Testbench fallback (branch 3 of
+// ApplicationProvider); a fresh Laravel app must instead boot from its own
+// bootstrap/app.php. `diagnose` reports the resolved mode ("Testbench fallback"
+// is the only label containing "testbench", and only the fallback prints it), so
+// asserting BOTH directions makes the two kinds mutually discriminating: it proves
+// package mode exercises the Testbench path and guards the #766 silent-fallback
+// case on the app side. Matched case-insensitively for robustness to the wording.
+$bootedViaTestbench = \stripos($diagnoseProcess->getOutput(), 'testbench') !== false;
+$expectsTestbench = $projectKind === 'package';
+if ($bootedViaTestbench !== $expectsTestbench) {
+    reportFailure(
+        \sprintf('assert %s-mode boot path', $projectKind),
+        [],
+        null,
+        $appDir,
+        $diagnoseProcess->getOutput(),
+        $expectsTestbench
+            ? 'Expected `diagnose` to report the Testbench fallback boot mode for a package target.'
+            : 'Expected `diagnose` to report a real bootstrap/app.php boot mode (not Testbench) for an app target.',
+        $appDir,
+    );
+}
 
 // --- Done --------------------------------------------------------------
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,23 +15,13 @@ There are 2 main ways how it does it:
 
 - [Configuration](config.md) — plugin XML config options and environment variables
 - [GitHub Actions](github-actions.md) — running Psalm in CI with GitHub Actions
+- [Custom Issues](issues/index.md) — Laravel-aware checks the plugin adds on top of Psalm's built-ins
+- [Security (Taint) Checks](security.md) — what the security analysis detects
 - [Upgrading to v4](upgrade-v4.md) — migration guide from v3
 - Contribution:
     - [Overview](contributing/README.md) — how the plugin works, getting started, adding stubs and handlers
     - [Architecture Decisions](contributing/decisions.md) — key design decisions and rationale
     - [Debugging with Xdebug](contributing/xdebug.md) — stepping through plugin code
-    - [Taint Analysis](contributing/taint-analysis.md)
+    - [Laravel Magic Call Patterns](contributing/laravel-magic-call-patterns.md) — how `__call`/`__callStatic` chains resolve, and how Psalm sees them
+    - [Taint Analysis](contributing/taint-analysis.md) — authoring taint stubs
     - [Types](contributing/types.md) — Psalm types and annotations (incl. internal/hidden)
-
-## Custom Issues
-
-The plugin emits custom issues that Psalm does not have built-in.
-Each one links to detailed documentation with examples and fix guidance.
-
-- [NoEnvOutsideConfig](issues/NoEnvOutsideConfig.md)
-- [InvalidConsoleArgumentName](issues/InvalidConsoleArgumentName.md)
-- [InvalidConsoleOptionName](issues/InvalidConsoleOptionName.md)
-- [MissingTranslation](issues/MissingTranslation.md)
-- [MissingView](issues/MissingView.md)
-- [ModelMakeDiscouraged](issues/ModelMakeDiscouraged.md)
-- [OctaneIncompatibleBinding](issues/OctaneIncompatibleBinding.md)

--- a/docs/config.md
+++ b/docs/config.md
@@ -86,7 +86,7 @@ Closure values stored in config reflect to `\Closure`. Closure defaults resolve 
 
 ### When to disable
 
-When you always use `Config::ineteger()`, `Config::string()` and other typed calls consistently.
+When you always use `Config::integer()`, `Config::string()` and other typed calls consistently.
 
 ### Example
 

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -1,6 +1,6 @@
 ---
 title: Contributing
-nav_order: 3
+nav_order: 7
 has_children: true
 ---
 
@@ -18,41 +18,30 @@ See `ApplicationProvider::doGetApp()` for the resolution logic.
 
 ```mermaid
 flowchart TD
-    A["Plugin::__invoke"] --> B["Boot Laravel app"]
-    B --> C["Build schema\n(if columnFallback=migrations)"]
-    C --> D["Generate alias stubs\n(from AliasLoader)"]
-    D --> E["Register handlers"]
-    E --> F["Register stubs"]
+    A["Plugin::__invoke"] --> B["Parse PluginConfig from psalm.xml"]
+    B --> C["Boot Laravel app\n(ApplicationProvider::bootApp)"]
+    C --> D["Build migration schema\n(only if columnFallback=migrations)"]
+    D --> E["Init facade→service map\n(FacadeMapProvider)"]
+    E --> F["Init translation / view / env handlers\n(from booted app state)"]
+    F --> G["Register handlers\n(Plugin::registerHandlers)"]
+    G --> H["Register stubs\n(Plugin::registerStubs)"]
 
-    E --- handlers["
-        Application — ContainerHandler, OffsetHandler
-        Auth — AuthHandler, GuardHandler, RequestHandler
-        Collections — CollectionPluckHandler, CollectionFilterHandler
-        Console — CommandArgumentHandler
-        Eloquent — ModelRegistrationHandler,
-        ModelMethodHandler, BuilderScopeHandler, CustomCollectionHandler
-        Magic — MethodForwardingHandler
-        Helpers — CacheHandler, PathHandler, TransHandler
-        Translations — TranslationKeyHandler
-        Views — MissingViewHandler
-        Rules — NoEnvOutsideConfigHandler, ModelMakeHandler, OctaneIncompatibleBindingHandler
-        Validation — ValidatedTypeHandler, ValidationTaintHandler
-        SuppressHandler
-    "]
-
-    F --- stubs["
+    H --- stubs["
         stubs/common/ (types + taint annotations)
-        stubs/12/, stubs/13/ (version-specific)
-        aliases.phpstub (generated)
+        versioned dirs, ascending (e.g. stubs/12.42.0/, stubs/13.5.0/, stubs/13.8.0/)
+        stubs/integrations/carbon/ (gated on installed nesbot/carbon version)
+        aliases.phpstub (generated here from AliasLoader)
     "]
 
-    G["Psalm scans all project files"] -.->|afterCodebasePopulated| H["ModelRegistrationHandler"]
-    H --- models["
+    I["Psalm scans all project files"] -.->|afterCodebasePopulated| J["ModelRegistrationHandler"]
+    J --- models["
         Discover Model subclasses
-        Register property handlers:
+        Register per-model property/method closures:
         relationship > factory > accessor > column
     "]
 ```
+
+The whole `__invoke` body is wrapped in a try/catch: on any internal error the plugin reports a warning and disables itself for the run (or rethrows when `failOnInternalError` is set). See `src/Internal/InternalErrorReporter.php`.
 
 ## Getting started
 
@@ -93,7 +82,8 @@ composer rector # run rector refactoring
 Stubs override Laravel's type signatures. Place them in:
 
 - `stubs/common/` — shared across Laravel versions (includes both type stubs and taint annotations)
-- `stubs/12/`, `stubs/13/` — version-specific overrides
+- `stubs/<version>/` — version-specific overrides, loaded when the installed Laravel is `>=` the dir name (`version_compare`). Both major-only (`stubs/13/`) and patch-level (`stubs/13.8.0/`) names work; currently `stubs/12.42.0/`, `stubs/13.5.0/`, and `stubs/13.8.0/` exist
+- `stubs/integrations/<package>/` — optional stubs for third-party packages, gated on the package being installed (currently `carbon/`, with a `pre-3.12/` subdir loaded only for older Carbon; see `src/Stubs/CarbonStubProvider.php`)
 
 Rules:
 - Verify signatures against actual Laravel code (not against Laravel PHPDoc or method signatures)
@@ -127,7 +117,7 @@ Authoring an override:
 
 ### Testing version-specific stubs
 
-A type test that asserts a `stubs/<version>/` override would fail on the lower cells of the CI matrix (`.github/workflows/tests.yml` runs `test:type` over `^13.0` and `^12.4`, including `prefer-lowest`), because the override does not load on the older Laravel. Gate such a test with a `--SKIPIF--` section so it runs only where the stub applies:
+A type test that asserts a `stubs/<version>/` override would fail on the lower cells of the CI matrix (`.github/workflows/tests.yml` runs `test:type` over Laravel `^13.0` and `^12.4`), because the override does not load on the older Laravel. Gate such a test with a `--SKIPIF--` section so it runs only where the stub applies:
 
 ```
 --SKIPIF--
@@ -150,101 +140,35 @@ Create the handler class in the appropriate `src/Handlers/` subdirectory, then r
 Psalm processes code in phases. Each hook fires at a specific phase and has different data available.
 Analysis hooks are hot paths — they fire on every matching expression. Scanning hooks fire once per class or once total.
 
-```mermaid
-flowchart LR
-    subgraph scanning ["Phase 1: Scanning"]
-        direction TB
-        S1["AfterClassLikeVisitInterface
-        fires after each class/trait/interface
-        ----
-        data: ClassLikeStorage
-        (direct parent only), AST statements
-        ----
-        ContainerHandler
-        ModelMethodHandler
-        SuppressHandler"]
-    end
+The table below maps each hook to the handlers using it. Source of truth: `Plugin::registerHandlers()` plus each handler's `implements` clause. Handlers marked `*` are registered conditionally (config flag or package detection).
 
-    subgraph populated ["Phase 2: Codebase populated"]
-        direction TB
-        P1["AfterCodebasePopulatedInterface
-        fires once, after all classes are known
-        ----
-        data: full Codebase, complete
-        ClassLikeStorage (full parent chain)
-        ----
-        ModelRegistrationHandler
-        SuppressHandler"]
-    end
+**Phase 1 — Scanning** (per class/trait/interface; `ClassLikeStorage` has direct parent only):
 
-    subgraph analysis ["Phase 3: Analysis (hot path)"]
-        direction TB
-        A1["FunctionReturnTypeProvider
-        on each global function call
-        ----
-        args, call location, file path
-        ----
-        CacheHandler, PathHandler
-        TranslationKeyHandler, TransHandler
-        MissingViewHandler
-        NoEnvOutsideConfigHandler"]
+| Hook | Handlers |
+|---|---|
+| `AfterClassLikeVisitInterface` | ContainerHandler, SuppressHandler, GuardTaintHandler, EncrypterTaintHandler, AppFacadeRegistrationHandler |
 
-        A2["MethodReturnTypeProvider
-        on each method call
-        ----
-        args, class FQCN, method name
-        ----
-        AuthHandler, GuardHandler
-        RequestHandler, ContainerHandler
-        CommandArgumentHandler
-        MethodForwardingHandler
-        ModelMethodHandler
-        BuilderScopeHandler, PathHandler
-        CollectionPluckHandler
-        CollectionFilterHandler
-        MissingViewHandler
-        ValidatedTypeHandler"]
+**Phase 2 — Codebase populated** (fires once; full parent chains resolved):
 
-        A3["MethodParamsProvider
-        before type-checking args
-        ----
-        overrides parameter types
-        ----
-        AuthHandler"]
+| Hook | Handlers |
+|---|---|
+| `AfterCodebasePopulatedInterface` | ModelRegistrationHandler, SuppressHandler, ContractMethodBridgeHandler, CastContractUserDefinedHandler, BuilderSubclassQueryMixinHandler, MacroHandler, FormRequestPropertyHandler, AppFacadeRegistrationHandler, PublicScopeAccessorVisibilityHandler |
 
-        A4["Property providers
-        Existence / Type / Visibility
-        ----
-        property name, class FQCN
-        read/write context
-        ----
-        Model property handlers
-        (registered via closures)"]
+**Phase 3 — Analysis** (hot path):
 
-        A5["AddTaints / RemoveTaints
-        on each expression with data flow
-        ----
-        expression, node type info
-        ----
-        ValidationTaintHandler"]
-
-        A6["AfterExpressionAnalysis
-        on each expression
-        ----
-        expression AST, codebase
-        ----
-        ModelMakeHandler"]
-
-        A7["AfterMethodCallAnalysis
-        on each resolved method call
-        ----
-        expression, declaring method id
-        ----
-        OctaneIncompatibleBindingHandler"]
-    end
-
-    scanning --> populated --> analysis
-```
+| Hook | Handlers |
+|---|---|
+| `FunctionReturnTypeProviderInterface` | ContainerHandler, AuthFunctionHandler, CacheHandler, NowTodayHandler, PathHandler, LiteralHandler, EnvHandler, TranslationKeyHandler, NoEnvOutsideConfigHandler, ConfigHelperHandler\*, MissingViewHandler\* |
+| `MethodReturnTypeProviderInterface` | OffsetHandler, ContainerHandler, AuthMethodHandler, GuardHandler, RequestHandler, StorageHandler, ModelFactoryMethodTypeProvider, FactoryCountTypeProvider, ModelBuilderMixinHandler, MethodForwardingHandler, ModelMethodHandler, BuilderScopeHandler, BuilderPluckHandler, BuilderAggregateHandler, CustomCollectionHandler, CollectionFilterHandler, CollectionFlattenHandler, CollectionPluckHandler, CollectionValuesAllHandler, HigherOrderCollectionProxyHandler, ConditionableWhenHandler, TappableTapHandler, CommandArgumentHandler, ValidatedTypeHandler, PathHandler, AppFacadeMakeHandler, DateFacadeHandler, ConfigRepositoryMethodHandler\*, MissingViewHandler\* |
+| `MethodParamsProviderInterface` | OffsetHandler, AuthMethodHandler, StorageHandler, MethodForwardingHandler, BuilderScopeHandler, HigherOrderCollectionProxyHandler, AppFacadeMakeHandler, DateFacadeHandler, ConfigRepositoryMethodHandler\* |
+| `MethodExistenceProviderInterface`, `MethodVisibilityProviderInterface` | OffsetHandler |
+| Property providers (existence / type / visibility) | per-model closures registered by ModelRegistrationHandler |
+| `AddTaintsInterface`, `RemoveTaintsInterface` | ValidationTaintHandler |
+| `AfterExpressionAnalysisInterface` | ModelMakeHandler, DispatchableHandler, TimingUnsafeComparisonHandler, UndefinedBuilderMethodHandler, ConsoleClosureScopeHandler, InlineValidateRulesCollector, ImplicitQueryBuilderCallHandler\* |
+| `AfterMethodCallAnalysisInterface` | HigherOrderCollectionProxyHandler, OctaneIncompatibleBindingHandler\* |
+| `Before{File,Statement,Expression}AnalysisInterface` | ConsoleClosureScopeHandler, InlineValidateRulesCollector (statement + expression) |
+| `AfterFunctionLikeAnalysisInterface`, `AfterFileAnalysisInterface` | ValidationTaintHandler, InlineValidateRulesCollector (function-like only) |
+| `AfterAnalysisInterface` | StatsHandler |
 
 ### Registering handlers
 

--- a/docs/contributing/decisions.md
+++ b/docs/contributing/decisions.md
@@ -22,7 +22,7 @@ Decisions made during development of the plugin. Contributors should follow thes
 
 **Decision:** Prefer deriving types from Psalm's `ClassLikeStorage` and source code analysis. Use runtime reflection (booting the Laravel app via Testbench) only when the needed information is unavailable statically.
 
-**Currently runtime:** Model table names (`getTable()`), model casts (`getCasts()`), container bindings, facade alias resolution.
+**Currently runtime:** Model table names (`getTable()`), model casts (`getCasts()`), container bindings, facade alias resolution, macro discovery (`Macroable::$macros` reflection).
 
 **Currently static:** Relationships, accessors, migration schema parsing, stub overrides.
 
@@ -51,7 +51,7 @@ The plugin should respect that consistently across all handlers rather than over
 
 **Decision:** `registerWriteTypesForMethods` (which registers `pseudo_property_set_types` for relationship properties, legacy mutators, and new-style `Attribute` accessors) runs for all models regardless of the `modelProperties` config. Only `registerWriteTypesForColumns` (migration-inferred columns) is gated behind `useMigrations`.
 
-**Why:** Accessor and relationship properties are discovered from the model's own method signatures — they don't depend on migration files. A user with `columnFallback="none"` still expects `$user->roles = $collection` to work when `sealAllProperties` is enabled. This is consistent with the read-side handlers, which are also unconditional (see below).
+**Why:** Accessor and relationship properties are discovered from the model's own method signatures — they don't depend on migration files. A user with `columnFallback="none"` still expects `$user->roles = $collection` to work when Psalm's own `sealAllProperties` option is enabled. This is consistent with the read-side handlers, which are also unconditional (see below).
 
 **See:** [#446](https://github.com/psalm/psalm-plugin-laravel/issues/446)
 
@@ -224,7 +224,7 @@ Bug fixes (where the previous type was demonstrably wrong) are exempt.
 
 **Decision:** When a new feature has a strictness spectrum (e.g. sealed properties, migration inference), the default should be the least disruptive option. Stricter modes are opt-in via config.
 
-**Example:** `sealAllProperties="false"` by default. `columnFallback="migrations"` (migration inference) by default.
+**Example:** `columnFallback="migrations"` (migration inference) is the default because it only adds property types; stricter behavior (such as Psalm's `sealAllProperties`) stays opt-in on the Psalm side.
 
 **Why:** Users who install or upgrade the plugin should not be greeted with a wall of new errors. The plugin should improve analysis incrementally. Users who want stricter checking can enable it when they're ready.
 

--- a/docs/contributing/laravel-magic-call-patterns.md
+++ b/docs/contributing/laravel-magic-call-patterns.md
@@ -421,20 +421,24 @@ Builder::macro('active', function () {
 User::query()->active();  // works via __call → macro lookup
 ```
 
-**Psalm challenge:** Macros are registered at runtime, so Psalm cannot see them during static analysis. Users must either:
-- Add `@mixin` annotations pointing to a class with the macro methods declared
-- Use `@method` annotations on the class
-- Accept that macro calls will be flagged as undefined methods
+**Psalm challenge:** Macros are registered at runtime, so Psalm cannot see them from source alone.
 
-**Plugin handler:** None currently. Larastan solves this via **runtime introspection**: it reads the
-actual `static::$macros` property via PHP reflection at analysis time (the app is already booted, so
-macros registered in ServiceProviders are populated). It then uses `ClosureTypeFactory` to extract
-parameter/return types from the Closure objects. Handles `Macroable` classes, Eloquent Builder (its
-own macro system), Facades (via `getFacadeRoot()`), and Carbon (`Carbon\Traits\Macro`).
+**Plugin handler:** `MacroHandler` (with `MacroRegistry`), registered unconditionally. During
+`AfterCodebasePopulated` it reads the booted app's `Macroable::$macros` registries via PHP reflection
+(macros registered in ServiceProviders are populated by then) and injects each macro as a synthesized
+pseudo-method into `ClassLikeStorage::$pseudo_methods` **and** `$pseudo_static_methods` — the same
+storage shape Psalm uses for `@method` annotations, so both `$instance->macroName()` and
+`Class::macroName()` resolve. It propagates macros to subclasses (walking `parent_classes`) and to
+facades that proxy to the Macroable owner (via `FacadeMapProvider`, including manager-forwarding
+facades like `Auth`/`Cache`/`Session`/`Storage`/`Mail`). Closure param/return types are recovered from
+Psalm's own scanned `FunctionLikeStorage` when the closure's file is analysed (docblock-aware); a
+`: static` native return type narrows to the calling instance.
 
-This plugin already boots the app for container bindings, auth config, translations, and views —
-the same pattern could discover macros. Limitation: only finds macros registered at boot time;
-conditional macros or those in unbooted providers are invisible.
+Known limitations (see `MacroHandler`'s docblock for the full list): only macros registered at boot
+time are visible (conditional macros and unbooted providers are not); Eloquent Builder's per-instance
+`$localMacros` are unreachable by reflection; macros on a package's own provider are invisible under
+the Testbench fallback (no `bootstrap/app.php`); vendor closures outside `<projectFiles>` fall back
+to `mixed` signatures.
 
 
 ### 7. Container `make()` / `app()` resolution
@@ -779,5 +783,5 @@ but the handler ensures template params propagate correctly.
 | Model scopes               | `BuilderScopeHandler`                                        | Resolves scope calls on Builder to model scope methods               |
 | Custom collections         | `CustomCollectionHandler`                                    | Narrows `Builder::get()`, `findMany()`, `Model::all()` return types  |
 | Model attributes           | Virtual properties from `@property` / migrations             | Requires schema analysis or annotations                              |
-| Macros                     | Not handled by plugin                                        | Runtime-registered; users need `@mixin` or `@method` annotations     |
+| Macros                     | `MacroHandler` (runtime reflection → pseudo-methods)         | Boot-time registrations only; Builder `$localMacros` not covered     |
 | Container resolution       | `ContainerHandler`                                           | Only known bindings are narrowed                                     |

--- a/docs/contributing/taint-analysis.md
+++ b/docs/contributing/taint-analysis.md
@@ -128,6 +128,7 @@ Most taint kind names are defined in [`Psalm\Type\TaintKind::TAINT_NAMES`](https
 | `extract`            | `INPUT_EXTRACT`            | Values passed to `extract()`                               |
 | `user_secret`        | `USER_SECRET`              | User-supplied secrets (passwords, tokens)                  |
 | `system_secret`      | `SYSTEM_SECRET`            | System secrets (API keys, encryption keys)                 |
+| `llm_prompt`         | `INPUT_LLM_PROMPT`         | Strings interpolated into LLM prompts (prompt injection)   |
 | `input`              | `ALL_INPUT`                | Alias: all input-related kinds combined (excludes secrets) |
 | `tainted`            | `ALL_INPUT`                | Alias: same as `input`                                     |
 | `input_except_sleep` | `ALL_INPUT & ~INPUT_SLEEP` | All input kinds except `sleep` (used by `filter_var()`)    |

--- a/docs/contributing/types.md
+++ b/docs/contributing/types.md
@@ -28,6 +28,7 @@ Psalm docs (deep links):
 | `numeric`                              | `TNumeric`          | `int\|float\|numeric-string`                                       |
 | `array-key`                            | `TArrayKey`         | `int\|string`                                                      |
 | `mixed`                                | `TMixed`            | Top type                                                           |
+| `iterable`                             |                     | `array\|Traversable`; accepts generics: `iterable<TKey, TValue>`   |
 | `never`                                | `TNever`            | Bottom type. Aliases: `no-return`, `never-return`, `never-returns` |
 | `object`                               | `TObject`           | Any object                                                         |
 | `resource`                             | `TResource`         |                                                                    |
@@ -222,7 +223,7 @@ Foo&Bar                 // intersection (must satisfy both)
 
 `@var`, `@param`, `@return`, `@property`, `@property-read`, `@property-write`, `@method`, `@throws`, `@deprecated`, `@internal`, `@mixin`
 
-All of the above also accept a `@psalm-` prefix (e.g. `@psalm-param`) for advanced type syntax that phpDocumentor can't parse. PHPStan prefix (`@phpstan-param`, etc.) is also recognized.
+The type-carrying tags (`@var`, `@param`, `@return`, `@property*`, `@method`) also accept a `@psalm-` prefix (e.g. `@psalm-param`) for advanced type syntax that phpDocumentor can't parse. PHPStan prefix (`@phpstan-param`, etc.) is also recognized. `@psalm-throws`, `@psalm-deprecated`, and `@psalm-mixin` do NOT exist — Psalm rejects unknown `@psalm-*` tags with `Unrecognised annotation` (see `DocComment::PSALM_ANNOTATIONS`).
 
 ### Assertions
 
@@ -234,6 +235,7 @@ All of the above also accept a `@psalm-` prefix (e.g. `@psalm-param`) for advanc
 | `@psalm-assert-if-true !Type $param`  | Function returns `true`   |
 | `@psalm-assert-if-false Type $param`  | Function returns `false`  |
 | `@psalm-assert-if-false !Type $param` | Function returns `false`  |
+| `@psalm-assert-untainted $param`      | Function returns normally (taint analysis: marks param untainted) |
 
 Negated assertions (`!Type`) assert the param is **not** of the given type. Common examples: `!null`, `!false`, `!string`.
 
@@ -340,4 +342,4 @@ Negated assertions (`!Type`) assert the param is **not** of the given type. Comm
 | `@psalm-taint-specialize`            | Track taint per-instance or per-call                      |
 | `@psalm-flow ($param) -> return`     | Define explicit taint flow path                           |
 
-Taint types: `html`, `sql`, `shell`, `file`, `cookie`, `header`, `redirect`, `ldap`, `ssrf`, `user_secret`, `system_secret`, `callable`, `eval`, `unserialize`, `include`, `text`, `crypto` (and custom ones).
+Taint kinds: `html`, `has_quotes`, `sql`, `shell`, `file`, `cookie`, `header`, `ldap`, `ssrf`, `xpath`, `sleep`, `extract`, `user_secret`, `system_secret`, `callable`, `eval`, `unserialize`, `include`, `llm_prompt`, plus the aliases `input` / `tainted` / `input_except_sleep` — see `Psalm\Type\TaintKind::TAINT_NAMES`. Arbitrary custom kind names are also accepted (they report as `TaintedCustom`). Full table with attack vectors: [Taint Analysis](taint-analysis.md#taint-kinds).

--- a/docs/issues/InvalidConsoleArgumentName.md
+++ b/docs/issues/InvalidConsoleArgumentName.md
@@ -10,7 +10,7 @@ Emitted when `$this->argument('name')` references an argument that is not define
 
 ## Why this is a problem
 
-If you request an argument that doesn't exist in your command's `$signature`, Laravel will throw a `RuntimeException` at runtime.
+If you request an argument that doesn't exist in your command's `$signature`, Symfony Console throws an `InvalidArgumentException` at runtime.
 This check catches the mismatch during static analysis.
 
 ## Examples

--- a/docs/issues/InvalidConsoleOptionName.md
+++ b/docs/issues/InvalidConsoleOptionName.md
@@ -10,7 +10,7 @@ Emitted when `$this->option('name')` references an option that is not defined in
 
 ## Why this is a problem
 
-If you request an option that doesn't exist in your command's `$signature`, Laravel will throw a `RuntimeException` at runtime.
+If you request an option that doesn't exist in your command's `$signature`, Symfony Console throws an `InvalidArgumentException` at runtime.
 This check catches the mismatch during static analysis.
 
 ## Examples

--- a/docs/issues/MissingView.md
+++ b/docs/issues/MissingView.md
@@ -6,8 +6,7 @@ nav_order: 4
 
 # MissingView
 
-Emitted when `view()` or `Factory::make()` (e.g., `view()->make()`) references a Blade template that does not exist on disk.
-Facade calls like `View::make()` are not currently detected (see [#591](https://github.com/psalm/psalm-plugin-laravel/issues/591)).
+Emitted when `view()`, `Factory::make()` (e.g., `view()->make()`), or the `View::make()` facade call references a Blade template that does not exist on disk.
 
 ## Why this is a problem
 

--- a/docs/issues/NoEnvOutsideConfig.md
+++ b/docs/issues/NoEnvOutsideConfig.md
@@ -6,7 +6,7 @@ nav_order: 1
 
 # NoEnvOutsideConfig
 
-Emitted when `env()` is called outside the application's config directory (by default the booted app's [`config_path()`](../config.md#configdirectory); configurable via `<configDirectory>` for non-standard layouts).
+Emitted when `env()` is called outside the application's config directory (by default the booted app's [`config_path()`](../config.md#configdirectory); configurable via `<configDirectory>` for non-standard layouts). Files under a `tests/` directory are always exempt.
 
 ## Why this is a problem
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,3 +1,8 @@
+---
+title: Security (Taint) Checks
+nav_order: 6
+---
+
 # Security (Taint) Checks
 
 ### What it detects

--- a/docs/upgrade-v4.md
+++ b/docs/upgrade-v4.md
@@ -19,10 +19,10 @@ Laravel 11 and Psalm 6 are no longer supported. If you need them, stay on v3.
 
 ### Psalm 7 is required
 
-v4 requires `vimeo/psalm ^7.0.0-beta17` or later. If your project still uses Psalm 6, upgrade Psalm first:
+v4 requires `vimeo/psalm ^7.0.0-beta19` or later. If your project still uses Psalm 6, upgrade Psalm first:
 
 ```bash
-composer require --dev vimeo/psalm:^7.0.0-beta17
+composer require --dev vimeo/psalm:^7.0.0-beta19
 ```
 
 Psalm 7 is still in beta. You may need to add this to your project's `composer.json`:
@@ -120,7 +120,7 @@ No flags needed — just run `./vendor/bin/psalm`.
 # 1. Update PHP to 8.2+ and Laravel to 12+ if needed
 
 # 2. Upgrade Psalm to v7
-composer require --dev vimeo/psalm:^7.0.0-beta17
+composer require --dev vimeo/psalm:^7.0.0-beta19
 
 # 3. Upgrade the plugin
 composer require --dev psalm/plugin-laravel:^4.0

--- a/src/Handlers/Config/ConfigRepositoryMethodHandler.php
+++ b/src/Handlers/Config/ConfigRepositoryMethodHandler.php
@@ -55,9 +55,24 @@ final class ConfigRepositoryMethodHandler implements MethodReturnTypeProviderInt
 
         return match ($event->getMethodNameLowercase()) {
             'get' => ConfigKeyResolver::resolveFromCallArgs($event->getCallArgs(), $nodeTypeProvider),
-            'collection' => ConfigKeyResolver::resolveCollectionFromCallArgs($event->getCallArgs(), $nodeTypeProvider),
+            'collection' => self::collectionMethodExists()
+                ? ConfigKeyResolver::resolveCollectionFromCallArgs($event->getCallArgs(), $nodeTypeProvider)
+                : null,
             default => null,
         };
+    }
+
+    /**
+     * `Repository::collection()` was added in Laravel 12; on Laravel 11 the
+     * real method doesn't exist. Without this guard, registering a return
+     * type for 'collection' regardless of version makes Psalm try to fetch
+     * params for a nonexistent method and crash with `Cannot get method
+     * params for ...Repository::collection` (same crash class documented
+     * below for the params provider).
+     */
+    private static function collectionMethodExists(): bool
+    {
+        return method_exists(\Illuminate\Config\Repository::class, 'collection');
     }
 
     /**

--- a/src/Handlers/Eloquent/ModelMethodHandler.php
+++ b/src/Handlers/Eloquent/ModelMethodHandler.php
@@ -26,24 +26,27 @@ use Psalm\Type;
 use Psalm\Type\Union;
 
 /**
- * Handles static method calls on Eloquent Models that are forwarded to Builder via __callStatic.
+ * Handles Eloquent Model calls whose return types depend on the model's query builder.
  *
  * Responsibilities:
  * 1. Method existence — confirms magic methods exist (suppresses UndefinedMagicMethod)
  * 2. Method visibility — confirms magic methods are public
  * 3. Method params — provides parameter definitions for argument checking
- * 4. Return types — proxies calls to Builder<TModel> for type inference
+ * 4. Return types — proxies forwarded calls to Builder<TModel> for type inference, and
+ *    substitutes custom builders for Model::query() plus the real instance methods that
+ *    construct builders through newEloquentBuilder()
  *
  * Existence, visibility, params, and return type providers for concrete Model subclasses are
  * registered dynamically per-model by {@see ModelRegistrationHandler} because Psalm's
  * provider lookup requires exact class name matching — a handler registered for Model::class
  * is not consulted for concrete subclasses like App\Models\User.
  *
- * The getClassLikeNames() registration for Model::class handles `Model::query()` only when
- * a custom Eloquent builder is registered for the called model. For plain models (base
- * `Builder`), `query()` is intentionally deferred to the stub at
- * `stubs/common/Database/Eloquent/Model.phpstub` whose `@return Builder<static>` is the only
- * way to preserve the `&static` intersection through Psalm's template binding (see #799).
+ * The getClassLikeNames() registration for Model::class handles `Model::query()` and the
+ * real instance builder-construction methods only when a custom Eloquent builder is registered
+ * for the called model. For plain models (base `Builder`), these methods are intentionally
+ * deferred to the stubs at
+ * `stubs/common/Database/Eloquent/Model.phpstub` whose `static`/`$this` annotations preserve
+ * model-specific template binding through Psalm's type expansion (see #799).
  * `__callStatic` is similarly proxied for methods resolvable through the single-hop mixin
  * chain.
  *
@@ -52,6 +55,24 @@ use Psalm\Type\Union;
  */
 final class ModelMethodHandler implements MethodReturnTypeProviderInterface
 {
+    /**
+     * Real Model methods that construct a fresh Eloquent builder directly or indirectly
+     * through newEloquentBuilder(), so custom builder declarations apply to their return type.
+     *
+     * @var array<lowercase-string, true>
+     */
+    private const INSTANCE_QUERY_CONSTRUCTION_METHODS = [
+        'neweloquentbuilder' => true,
+        'newquery' => true,
+        'newmodelquery' => true,
+        'newquerywithoutrelationships' => true,
+        'newquerywithoutscopes' => true,
+        'newquerywithoutscope' => true,
+        'newqueryforrestoration' => true,
+    ];
+
+    private const REGISTER_GLOBAL_SCOPES = 'registerglobalscopes';
+
     /**
      * Cache for isUnresolvedBuilderMethod results.
      *
@@ -152,11 +173,24 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
         string $modelClass,
         Codebase $codebase,
     ): Type\Atomic\TNamedObject {
+        return self::builderTypeWithModelType(
+            $builderClass,
+            new Union([new Type\Atomic\TNamedObject($modelClass)]),
+            $codebase,
+        );
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    private static function builderTypeWithModelType(
+        string $builderClass,
+        Union $modelType,
+        Codebase $codebase,
+    ): Type\Atomic\TNamedObject {
         // Non-custom builders (base Builder) always have the TModel template param.
         if ($builderClass === Builder::class) {
-            return new Type\Atomic\TGenericObject($builderClass, [
-                new Union([new Type\Atomic\TNamedObject($modelClass)]),
-            ]);
+            return new Type\Atomic\TGenericObject($builderClass, [$modelType]);
         }
 
         // Custom builders: check if they declare their own template params.
@@ -167,12 +201,81 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
         }
 
         if ($storage->template_types !== null && $storage->template_types !== []) {
-            return new Type\Atomic\TGenericObject($builderClass, [
-                new Union([new Type\Atomic\TNamedObject($modelClass)]),
-            ]);
+            return new Type\Atomic\TGenericObject($builderClass, [$modelType]);
         }
 
         return new Type\Atomic\TNamedObject($builderClass);
+    }
+
+    /** @psalm-mutation-free */
+    private static function builderTemplateAllowsStaticModel(
+        string $builderClass,
+        Codebase $codebase,
+    ): bool {
+        if ($builderClass === Builder::class) {
+            return true;
+        }
+
+        try {
+            $storage = $codebase->classlike_storage_provider->get(\strtolower($builderClass));
+        } catch (\InvalidArgumentException) {
+            return false;
+        }
+
+        return $storage->template_types !== null
+            && $storage->template_types !== []
+            && ($storage->template_covariants[0] ?? false);
+    }
+
+    /**
+     * Build the builder return type for instance methods whose stubs use `$this`.
+     *
+     * @psalm-mutation-free
+     */
+    private static function instanceBuilderType(
+        string $builderClass,
+        string $modelClass,
+        Codebase $codebase,
+    ): Type\Atomic\TNamedObject {
+        try {
+            $storage = $codebase->classlike_storage_provider->get(\strtolower($modelClass));
+            $isStatic = !$storage->final && self::builderTemplateAllowsStaticModel($builderClass, $codebase);
+        } catch (\InvalidArgumentException) {
+            $isStatic = false;
+        }
+
+        return self::builderTypeWithModelType(
+            $builderClass,
+            new Union([new Type\Atomic\TNamedObject($modelClass, is_static: $isStatic)]),
+            $codebase,
+        );
+    }
+
+    private static function registerGlobalScopesReturnType(
+        MethodReturnTypeProviderEvent $event,
+        string $modelClass,
+        Codebase $codebase,
+    ): ?Union {
+        $source = $event->getSource();
+
+        if (!$source instanceof StatementsAnalyzer) {
+            return null;
+        }
+
+        $builderClass = self::getBuilderClassForModel($modelClass);
+
+        if ($builderClass === Builder::class) {
+            return null;
+        }
+
+        $arg = $event->getCallArgs()[0] ?? null;
+
+        if ($arg === null) {
+            return new Union([self::instanceBuilderType($builderClass, $modelClass, $codebase)]);
+        }
+
+        return $source->node_data->getType($arg->value)
+            ?? new Union([self::instanceBuilderType($builderClass, $modelClass, $codebase)]);
     }
 
     /**
@@ -580,8 +683,27 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
             return null;
         }
 
+        $methodName = $event->getMethodNameLowercase();
+
+        if ($methodName === self::REGISTER_GLOBAL_SCOPES) {
+            return self::registerGlobalScopesReturnType($event, $called_fq_classlike_name, $codebase);
+        }
+
+        if (isset(self::INSTANCE_QUERY_CONSTRUCTION_METHODS[$methodName])) {
+            $builderClass = self::getBuilderClassForModel($called_fq_classlike_name);
+
+            // For models without a custom builder, defer to the stub's
+            // `@return Builder<$this>` annotation so Psalm keeps the existing
+            // instance-specific model template behavior.
+            if ($builderClass === Builder::class) {
+                return null;
+            }
+
+            return new Union([self::instanceBuilderType($builderClass, $called_fq_classlike_name, $codebase)]);
+        }
+
         // Model::query()
-        if ($event->getMethodNameLowercase() === 'query') {
+        if ($methodName === 'query') {
             $builderClass = self::getBuilderClassForModel($called_fq_classlike_name);
 
             // For models without a custom builder, defer to the stub's
@@ -594,11 +716,11 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
                 return null;
             }
 
-            return new Union([self::builderType($builderClass, $called_fq_classlike_name, $codebase)]);
+            return new Union([self::instanceBuilderType($builderClass, $called_fq_classlike_name, $codebase)]);
         }
 
         // proxy to builder object
-        if ($event->getMethodNameLowercase() === '__callstatic') {
+        if ($methodName === '__callstatic') {
             $called_method_name_lowercase = $event->getCalledMethodNameLowercase();
 
             if ($called_method_name_lowercase === null) {

--- a/stubs/common/Database/Eloquent/Concerns/HasAttributes.phpstub
+++ b/stubs/common/Database/Eloquent/Concerns/HasAttributes.phpstub
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Concerns;
+
+trait HasAttributes
+{
+    /**
+     * @return array<string, string>
+     */
+    public function getCasts() {}
+}

--- a/stubs/common/Database/Eloquent/Concerns/HasRelationships.phpstub
+++ b/stubs/common/Database/Eloquent/Concerns/HasRelationships.phpstub
@@ -6,6 +6,11 @@ trait HasRelationships
 {
 
     /**
+     * @return list<string>
+     */
+    public function getTouchedRelations() {}
+
+    /**
      * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
      * @psalm-param class-string<TRelatedModel> $related
      *

--- a/stubs/common/Http/Request.phpstub
+++ b/stubs/common/Http/Request.phpstub
@@ -55,20 +55,33 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      * Refs: https://github.com/psalm/psalm-plugin-laravel/issues/925,
      *       https://github.com/psalm/psalm-plugin-laravel/issues/1134
      *
+     * $default's type is threaded through the non-null-$key branch: the real body is
+     * data_get($this->allFiles(), $key, $default), which returns $default verbatim when
+     * the dotted key does not resolve.
+     *
+     * @template TDefault
+     *
      * @param  string|null  $key
-     * @param  mixed  $default
-     * @return ($key is null ? array<string, \Illuminate\Http\UploadedFile|array<\Illuminate\Http\UploadedFile>> : \Illuminate\Http\UploadedFile|array<\Illuminate\Http\UploadedFile>|null)
+     * @param  TDefault  $default
+     * @return ($key is null ? array<string, \Illuminate\Http\UploadedFile|array<\Illuminate\Http\UploadedFile>> : \Illuminate\Http\UploadedFile|array<\Illuminate\Http\UploadedFile>|TDefault)
      */
     public function file($key = null, $default = null) {}
 
     /**
      * Get the route handling the request.
      *
-     * @template TDefault of object
+     * $default is not constrained to object: Laravel accepts any type as the fallback
+     * value (route()->parameter() returns it verbatim when the named parameter is
+     * unbound), so `of object` false-positived on ordinary scalar/null defaults.
+     * The no-arg branch stays non-nullable Route, matching Laravel's own docblock and
+     * the existing RequestTest.phpt lock-in; the with-args branch already carried a
+     * bare `null` (kept, now also covering the object-parameter-binding case below).
+     *
+     * @template TDefault
      *
      * @param string|null $param
      * @param TDefault $default
-     * @psalm-return ($param is null ? \Illuminate\Routing\Route : TDefault|string|null)
+     * @psalm-return ($param is null ? \Illuminate\Routing\Route : TDefault|object|string|null)
      *
      * @psalm-taint-source input
      */

--- a/tests/Application/app/Builders/CovariantNonFinalCustomBuilder.php
+++ b/tests/Application/app/Builders/CovariantNonFinalCustomBuilder.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Builders;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @template-covariant TModel of Model
+ * @extends Builder<TModel>
+ */
+class CovariantNonFinalCustomBuilder extends Builder {}

--- a/tests/Application/app/Builders/NonFinalCustomBuilder.php
+++ b/tests/Application/app/Builders/NonFinalCustomBuilder.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Builders;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @template TModel of Model
+ * @extends Builder<TModel>
+ */
+class NonFinalCustomBuilder extends Builder {}

--- a/tests/Application/app/Models/CovariantNonFinalCustomBuilderModel.php
+++ b/tests/Application/app/Models/CovariantNonFinalCustomBuilderModel.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Builders\CovariantNonFinalCustomBuilder;
+use Illuminate\Database\Eloquent\Model;
+
+class CovariantNonFinalCustomBuilderModel extends Model
+{
+    protected $table = 'covariant_non_final_custom_builder_models';
+
+    /** @var class-string<CovariantNonFinalCustomBuilder<static>> */
+    protected static string $builder = CovariantNonFinalCustomBuilder::class;
+
+    public static function viaQuery(): static
+    {
+        return static::query()->firstOrCreate(['id' => '1']);
+    }
+
+    public function viaNewQuery(): static
+    {
+        return $this->newQuery()->firstOrCreate(['id' => '1']);
+    }
+
+    public function viaNewModelQuery(): static
+    {
+        return $this->newModelQuery()->firstOrNew(['id' => '1']);
+    }
+
+    public function viaNewQueryWithoutRelationships(): static
+    {
+        return $this->newQueryWithoutRelationships()->create(['id' => '1']);
+    }
+
+    public function viaNewQueryWithoutScopes(): static
+    {
+        return $this->newQueryWithoutScopes()->firstOrCreate(['id' => '1']);
+    }
+
+    public function viaNewQueryWithoutScope(): static
+    {
+        return $this->newQueryWithoutScope('tenant')->firstOrNew(['id' => '1']);
+    }
+
+    public function viaNewQueryForRestoration(): static
+    {
+        return $this->newQueryForRestoration(1)->firstOrCreate(['id' => '1']);
+    }
+}

--- a/tests/Application/app/Models/NonFinalCustomBuilderModel.php
+++ b/tests/Application/app/Models/NonFinalCustomBuilderModel.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Builders\NonFinalCustomBuilder;
+use Illuminate\Database\Eloquent\Model;
+
+class NonFinalCustomBuilderModel extends Model
+{
+    protected $table = 'non_final_custom_builder_models';
+
+    /** @var class-string<NonFinalCustomBuilder<static>> */
+    protected static string $builder = NonFinalCustomBuilder::class;
+}

--- a/tests/Type/README.md
+++ b/tests/Type/README.md
@@ -17,10 +17,57 @@ To go deeper with PHPT syntax, please check [PHPT](https://qa.php.net/phpt_detai
 |---------|--------------------------------------------------------------|
 | `%d`    | One or more digits (`[0-9]+`)                                |
 | `%s`    | One or more characters (`.+`)                                |
-| `%S`    | Zero or more characters (`.*`) — optional match              |
+| `%S`    | Zero or more characters (`.*`), an optional match            |
 | `%i`    | Signed integer (`[+-]?\d+`)                                  |
 | `%f`    | Floating point number (`[+-]?\.?\d+\.?\d*(?:[Ee][+-]?\d+)?`) |
 | `%c`    | Single character (`.`)                                       |
 | `%x`    | Hex digits (`[0-9a-fA-F]+`)                                  |
 | `%e`    | Directory separator (`\\` or `/`)                            |
 | `%%`    | Literal `%`                                                  |
+
+## Gotchas
+
+Hard-won rules. Each of these has silently produced a test that passes while asserting nothing, or a red CI cell.
+
+1. **`@psalm-check-type-exact` works only as an inline, statement-attached docblock.**
+   Placed in a method or class docblock it is silently dead: the test passes without asserting anything.
+   Attach it to a statement, right above the line that uses the variable:
+
+   ```php
+   $user = User::query()->first();
+   /** @psalm-check-type-exact $user = App\Models\User|null */
+   ```
+
+2. **`%A` in `--EXPECTF--` is a lower bound, not an exact match.** It expands to a lazy `.*` (with `/s`),
+   so it absorbs any extra findings. A test using `%A` cannot pin an exact error count and cannot assert
+   that something is NOT reported. To assert the absence of errors, write a separate test with an empty
+   `--EXPECTF--` block (empty means "no Psalm output at all").
+
+3. **Version-gated stubs need `--SKIPIF--`.** A test asserting a `stubs/<version>/` override fails on
+   the lower cells of the CI matrix, where the override does not load. Gate it:
+
+   ```
+   --SKIPIF--
+   <?php
+   require getcwd() . '/vendor/autoload.php';
+   \Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipBelow('12.42.0');
+   --FILE--
+   ```
+
+   `LaravelVersion::skipFrom()` covers the reverse (behavior only on older lines); `CarbonVersion`
+   does the same for Carbon-gated stubs. The `--SKIPIF--` script runs in a bare process from the
+   project root, hence the `getcwd()` autoload require.
+
+4. **Reuse the shared app models, do not declare models inline.** Under the strict type-test config
+   (`errorLevel=1`), scope calls on a model declared inside the `.phpt` misbehave (repeated scope
+   calls degrade to `MixedAssignment`/`MixedMethodCall`/`UndefinedMagicMethod`), and inline public
+   scopes or accessors trip the `PublicModelScope`/`PublicModelAccessor` rules. Models under
+   `tests/Application/app/Models/` are fully registered archetypes; reuse them
+   (`User` for a standard int PK, `UuidModel`, `UlidModel`, `CustomPkUuidModel`, and friends)
+   before creating a new one. New models represent PK/trait archetypes, not individual test cases.
+
+5. **`findUnusedCode` assertions cannot be tested here.** The psalm-tester runner passes the file as
+   a CLI argument, which makes Psalm skip whole-program analysis, so dead-code issues never fire in a
+   `.phpt`. Use a subprocess test running Psalm over a fixture project with `<projectFiles>` instead
+   (see `tests/Unit/` fixtures for the pattern). The same limit applies to any rule that emits only
+   during a full-project scan; cover those with unit tests plus `composer test:app`.

--- a/tests/Type/tests/Builder/CustomQueryBuilderTest.phpt
+++ b/tests/Type/tests/Builder/CustomQueryBuilderTest.phpt
@@ -15,6 +15,7 @@ use App\Models\Mechanic;
 use App\Models\WorkOrder;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 
 /**
  * Tests that models with custom query builders return the correct builder type
@@ -33,6 +34,37 @@ function test_query_returns_custom_builder(): void
 {
     $_result = WorkOrder::query();
     /** @psalm-check-type-exact $_result = WorkOrderBuilder<WorkOrder> */
+}
+
+/** Instance query-construction methods return the custom builder too. */
+function test_instance_query_construction_methods_return_custom_builder(WorkOrder $workOrder, QueryBuilder $query): void
+{
+    $_newEloquentBuilder = $workOrder->newEloquentBuilder($query);
+    /** @psalm-check-type-exact $_newEloquentBuilder = WorkOrderBuilder<WorkOrder> */
+
+    $_newQuery = $workOrder->newQuery();
+    /** @psalm-check-type-exact $_newQuery = WorkOrderBuilder<WorkOrder> */
+
+    $_newModelQuery = $workOrder->newModelQuery();
+    /** @psalm-check-type-exact $_newModelQuery = WorkOrderBuilder<WorkOrder> */
+
+    $_globalScopes = $workOrder->registerGlobalScopes($workOrder->newModelQuery());
+    /** @psalm-check-type-exact $_globalScopes = WorkOrderBuilder<WorkOrder> */
+
+    $_withoutRelationships = $workOrder->newQueryWithoutRelationships();
+    /** @psalm-check-type-exact $_withoutRelationships = WorkOrderBuilder<WorkOrder> */
+
+    $_withoutScopes = $workOrder->newQueryWithoutScopes();
+    /** @psalm-check-type-exact $_withoutScopes = WorkOrderBuilder<WorkOrder> */
+
+    $_withoutScope = $workOrder->newQueryWithoutScope('soft_deleting');
+    /** @psalm-check-type-exact $_withoutScope = WorkOrderBuilder<WorkOrder> */
+
+    $_forRestoration = $workOrder->newQueryForRestoration(1);
+    /** @psalm-check-type-exact $_forRestoration = WorkOrderBuilder<WorkOrder> */
+
+    $_customMethod = $workOrder->newQuery()->whereCompleted();
+    /** @psalm-check-type-exact $_customMethod = WorkOrderBuilder<WorkOrder> */
 }
 
 /** Custom builder methods are accessible via query(). */
@@ -298,6 +330,13 @@ function test_new_eloquent_builder_query(): void
     /** @psalm-check-type-exact $_result = VehicleBuilder<Vehicle> */
 }
 
+/** Vehicle::newQuery() returns the custom builder via newEloquentBuilder() override. */
+function test_new_eloquent_builder_instance_new_query(Vehicle $vehicle): void
+{
+    $_result = $vehicle->newQuery();
+    /** @psalm-check-type-exact $_result = VehicleBuilder<Vehicle> */
+}
+
 /** Custom builder methods work via query() on newEloquentBuilder model. */
 function test_new_eloquent_builder_custom_method(): void
 {
@@ -335,6 +374,20 @@ function test_scope_on_new_eloquent_builder_via_query(): void
 function test_static_builder_property_query(): void
 {
     $_result = Mechanic::query();
+    /** @psalm-check-type-exact $_result = MechanicBuilder<Mechanic> */
+}
+
+/** Mechanic::newQuery() returns the custom builder via static $builder property. */
+function test_static_builder_property_instance_new_query(Mechanic $mechanic): void
+{
+    $_result = $mechanic->newQuery();
+    /** @psalm-check-type-exact $_result = MechanicBuilder<Mechanic> */
+}
+
+/** Mechanic::newEloquentBuilder() returns the custom builder via static $builder property. */
+function test_static_builder_property_instance_new_eloquent_builder(Mechanic $mechanic, QueryBuilder $query): void
+{
+    $_result = $mechanic->newEloquentBuilder($query);
     /** @psalm-check-type-exact $_result = MechanicBuilder<Mechanic> */
 }
 
@@ -376,6 +429,20 @@ function test_nonexistent_method_on_custom_builder_model(): void
 function test_non_template_builder_query(): void
 {
     $_result = Invoice::query();
+    /** @psalm-check-type-exact $_result = InvoiceBuilder */
+}
+
+/** Non-template builder: newQuery() returns plain InvoiceBuilder. */
+function test_non_template_builder_instance_new_query(Invoice $invoice): void
+{
+    $_result = $invoice->newQuery();
+    /** @psalm-check-type-exact $_result = InvoiceBuilder */
+}
+
+/** Non-template builder: newEloquentBuilder() returns plain InvoiceBuilder. */
+function test_non_template_builder_instance_new_eloquent_builder(Invoice $invoice, QueryBuilder $query): void
+{
+    $_result = $invoice->newEloquentBuilder($query);
     /** @psalm-check-type-exact $_result = InvoiceBuilder */
 }
 

--- a/tests/Type/tests/ConfigCollectionTest.phpt
+++ b/tests/Type/tests/ConfigCollectionTest.phpt
@@ -1,3 +1,11 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// Skip on Laravel < 12: Repository::collection() was added in Laravel 12 and
+// doesn't exist on the real class on Laravel 11, so ConfigRepositoryMethodHandler
+// declines to register a return type there (see collectionMethodExists()) and
+// the asserted narrowing never fires.
+\Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipBelow('12.0.0');
 --FILE--
 <?php declare(strict_types=1);
 

--- a/tests/Type/tests/Facades/DateFacadeCreateL11Test.phpt
+++ b/tests/Type/tests/Facades/DateFacadeCreateL11Test.phpt
@@ -1,0 +1,18 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// Laravel 11's Date facade declares `create()` as non-null (`@method static Carbon
+// create(...)`), unlike Carbon's own `?static` and unlike Laravel 12+'s facade tag
+// (`Carbon|null`). DateFacadeHandler swaps the Carbon atomic but preserves whatever
+// nullability the facade itself declares, so the asserted type differs by version.
+\Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipFrom('12.0.0');
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Facades\Date;
+
+// Call with scalar args — exercises checkMethodArgs against the synthesised params.
+$_create = Date::create(2024, 1, 1);
+/** @psalm-check-type-exact $_create = \Illuminate\Support\Carbon */
+?>
+--EXPECTF--

--- a/tests/Type/tests/Facades/DateFacadeCreateL12Test.phpt
+++ b/tests/Type/tests/Facades/DateFacadeCreateL12Test.phpt
@@ -1,0 +1,17 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// Laravel 12+'s Date facade declares `create()` as nullable (`@method static
+// Carbon|null create(...)`), matching Carbon's own `?static`. Laravel 11's facade
+// tag omits the `|null`, so this is asserted separately from DateFacadeCreateL11Test.phpt.
+\Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipBelow('12.0.0');
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Facades\Date;
+
+// Call with scalar args — exercises checkMethodArgs against the synthesised params.
+$_create = Date::create(2024, 1, 1);
+/** @psalm-check-type-exact $_create = \Illuminate\Support\Carbon|null */
+?>
+--EXPECTF--

--- a/tests/Type/tests/Facades/DateFacadeStaticCallTest.phpt
+++ b/tests/Type/tests/Facades/DateFacadeStaticCallTest.phpt
@@ -20,9 +20,10 @@ $_today = Date::today();
 $_parse = Date::parse('2024-01-01');
 /** @psalm-check-type-exact $_parse = \Illuminate\Support\Carbon */
 
-// Call with scalar args — exercises checkMethodArgs against the synthesised params.
-$_create = Date::create(2024, 1, 1);
-/** @psalm-check-type-exact $_create = \Illuminate\Support\Carbon|null */
+// create()'s nullability flips between Laravel 11 (non-null) and 12+ (Carbon|null) in
+// the facade's own `@method` tag, so it's asserted separately in DateFacadeCreateL11Test.phpt
+// / DateFacadeCreateL12Test.phpt instead of here. It still exercises checkMethodArgs
+// against the synthesised params there.
 
 // Call with an object arg.
 $_instance = Date::instance(new \DateTime());

--- a/tests/Type/tests/Helpers/LiteralHandlerTest.phpt
+++ b/tests/Type/tests/Helpers/LiteralHandlerTest.phpt
@@ -82,14 +82,10 @@ function literal_result_is_assignable_to_stdclass(): stdClass
     return consume_stdclass(literal(a: 1, b: 'x'));
 }
 
-/**
- * Unpacking depends on runtime array contents, which the handler cannot resolve,
- * so it bails to the reflected (mixed) type rather than guessing a shape.
- */
-function literal_unpack_falls_back_to_reflected_type(array $arr): void
-{
-    $_r = literal(...$arr);
-    /** @psalm-check-type-exact $_r = mixed */
-}
+// Unpacking depends on runtime array contents, which the handler cannot resolve, so
+// it bails to the reflected type instead of guessing a shape. That reflected type is
+// Laravel's own `@return` tag on literal()'s real declaration, which differs by
+// version (`\stdClass` on Laravel 11, `mixed` on 12+) — asserted separately in
+// LiteralUnpackFallbackL11Test.phpt / LiteralUnpackFallbackL12Test.phpt.
 ?>
 --EXPECTF--

--- a/tests/Type/tests/Helpers/LiteralUnpackFallbackL11Test.phpt
+++ b/tests/Type/tests/Helpers/LiteralUnpackFallbackL11Test.phpt
@@ -1,0 +1,17 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// Laravel 11's literal() declares `@return \stdClass`, unlike 12+'s `@return mixed`.
+// LiteralHandler defers to the reflected type for literal(...$arr) (property names
+// depend on runtime array contents), so the asserted type differs by version.
+\Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipFrom('12.0.0');
+--FILE--
+<?php declare(strict_types=1);
+
+function literal_unpack_falls_back_to_reflected_type(array $arr): void
+{
+    $_r = literal(...$arr);
+    /** @psalm-check-type-exact $_r = stdClass */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Helpers/LiteralUnpackFallbackL12Test.phpt
+++ b/tests/Type/tests/Helpers/LiteralUnpackFallbackL12Test.phpt
@@ -1,0 +1,17 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// Laravel 12+'s literal() declares `@return mixed`, unlike 11's `@return \stdClass`.
+// LiteralHandler defers to the reflected type for literal(...$arr) (property names
+// depend on runtime array contents), so the asserted type differs by version.
+\Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipBelow('12.0.0');
+--FILE--
+<?php declare(strict_types=1);
+
+function literal_unpack_falls_back_to_reflected_type(array $arr): void
+{
+    $_r = literal(...$arr);
+    /** @psalm-check-type-exact $_r = mixed */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Http/RequestTest.phpt
+++ b/tests/Type/tests/Http/RequestTest.phpt
@@ -12,5 +12,23 @@ function it_returns_one_header(\Illuminate\Http\Request $request): ?string {
 function it_returns_route(\Illuminate\Http\Request $request): \Illuminate\Routing\Route {
     return $request->route();
 };
+
+/**
+ * route()'s second parameter used to be constrained `@template TDefault of object`,
+ * which false-positived on any ordinary scalar/null default (Argument 2 ... expects
+ * object). Locks in that plain scalar and null defaults are accepted, and that the
+ * with-args return includes the resolved default's own type plus the bare `object`
+ * case for a route-model-bound parameter.
+ */
+function it_accepts_non_object_route_defaults(\Illuminate\Http\Request $request): void {
+    $_stringDefault = $request->route('id', 'fallback-string');
+    /** @psalm-check-type-exact $_stringDefault = object|string|null */
+
+    $_intDefault = $request->route('id', 0);
+    /** @psalm-check-type-exact $_intDefault = 0|null|object|string */
+
+    $_noDefault = $request->route('id');
+    /** @psalm-check-type-exact $_noDefault = null|object|string */
+}
 ?>
 --EXPECTF--

--- a/tests/Type/tests/Model/StaticReturnFromCustomBuilderInstanceQueryTest.phpt
+++ b/tests/Type/tests/Model/StaticReturnFromCustomBuilderInstanceQueryTest.phpt
@@ -1,0 +1,57 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Builders\CovariantNonFinalCustomBuilder;
+use App\Builders\NonFinalCustomBuilder;
+use App\Models\CovariantNonFinalCustomBuilderModel;
+use App\Models\NonFinalCustomBuilderModel;
+
+/**
+ * @param NonFinalCustomBuilder<NonFinalCustomBuilderModel> $builder
+ */
+function accepts_invariant_builder_for_exact_model(NonFinalCustomBuilder $builder): void
+{
+    $_model = $builder->getModel();
+    /** @psalm-check-type-exact $_model = NonFinalCustomBuilderModel */
+}
+
+/**
+ * Non-final invariant custom-builder models keep the exact model template so assigning
+ * the result to invariant `CustomBuilder<Model>` consumers does not become a false positive.
+ */
+function invariant_custom_builder_instance_query_methods_use_exact_model(NonFinalCustomBuilderModel $model): void
+{
+    $_newQuery = $model->newQuery();
+    /** @psalm-check-type-exact $_newQuery = NonFinalCustomBuilder<NonFinalCustomBuilderModel> */
+
+    $_scoped = $model->registerGlobalScopes($model->newModelQuery());
+    /** @psalm-check-type-exact $_scoped = NonFinalCustomBuilder<NonFinalCustomBuilderModel> */
+
+    accepts_invariant_builder_for_exact_model($model->newQuery());
+}
+
+/**
+ * Covariant custom-builder templates can safely keep `$this`/`static`, which prevents
+ * terminal model-returning builder calls from flattening `static` to the base model.
+ */
+function covariant_custom_builder_instance_query_methods_preserve_static(CovariantNonFinalCustomBuilderModel $model): void
+{
+    $_newQuery = $model->newQuery();
+    /** @psalm-check-type-exact $_newQuery = CovariantNonFinalCustomBuilder<CovariantNonFinalCustomBuilderModel&static> */
+
+    $_query = CovariantNonFinalCustomBuilderModel::query();
+    /** @psalm-check-type-exact $_query = CovariantNonFinalCustomBuilder<CovariantNonFinalCustomBuilderModel&static> */
+
+    $_scoped = $model->registerGlobalScopes($model->newModelQuery());
+    /** @psalm-check-type-exact $_scoped = CovariantNonFinalCustomBuilder<CovariantNonFinalCustomBuilderModel&static> */
+
+    CovariantNonFinalCustomBuilderModel::viaQuery();
+    $model->viaNewQuery();
+    $model->viaNewModelQuery();
+    $model->viaNewQueryWithoutRelationships();
+    $model->viaNewQueryWithoutScopes();
+    $model->viaNewQueryWithoutScope();
+    $model->viaNewQueryForRestoration();
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Request/RequestFileTest.phpt
+++ b/tests/Type/tests/Request/RequestFileTest.phpt
@@ -97,6 +97,18 @@ final class RequestFileTest
             unset($f);
         }
     }
+
+    /**
+     * The real body is data_get($this->allFiles(), $key, $default), which returns
+     * $default verbatim when the dotted key does not resolve. A non-null $default's
+     * own type must appear in the return union, not just a bare `null`.
+     */
+    public function nonNullDefaultTypeIsThreadedThrough(Request $request): void
+    {
+        $r = $request->file('avatar', 'no-file-uploaded');
+        /** @psalm-check-type-exact $r = 'no-file-uploaded'|UploadedFile|array<array-key, UploadedFile> */;
+        unset($r);
+    }
 }
 ?>
 --EXPECTF--

--- a/tests/Unit/Cli/InitCommandTest.php
+++ b/tests/Unit/Cli/InitCommandTest.php
@@ -279,6 +279,73 @@ final class InitCommandTest extends TestCase
         }
     }
 
+    #[Test]
+    public function detects_package_autoload_root_from_composer_psr4(): void
+    {
+        // A Composer package (PSR-4 autoload, no artisan) must scan its autoload
+        // root via detectPackageRoots, never the Laravel-app layout — the config
+        // path the package-mode install smoke test exercises end-to-end (#1198).
+        //
+        // Map PSR-4 to a NON-src directory on purpose: detectPackageRoots'
+        // last-resort branch only ever emits `src`, so a distinct name proves the
+        // composer-autoload extraction actually ran. A regressed extractor would
+        // fall through to the app-layout fallback, failing the `lib` assertion,
+        // rather than being silently rescued by the src fallback.
+        \file_put_contents(
+            $this->tempDir . \DIRECTORY_SEPARATOR . 'composer.json',
+            (string) \json_encode(['autoload' => ['psr-4' => ['Acme\\Widget\\' => 'lib/']]]),
+        );
+        \mkdir($this->tempDir . \DIRECTORY_SEPARATOR . 'lib');
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $this->assertStringContainsString('<directory name="lib"/>', $contents);
+        $this->assertStringNotContainsString('<file name="artisan"/>', $contents);
+        $this->assertStringNotContainsString('<directory name="app"/>', $contents);
+    }
+
+    #[Test]
+    public function detects_laravel_app_layout_when_artisan_present(): void
+    {
+        // Presence of artisan selects the Laravel-app branch (detectLaravelAppRoots):
+        // conventional app dirs and entry files are scanned, so the discriminator the
+        // smoke test relies on (artisan/app present => app layout) is exercised here.
+        \file_put_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'artisan', "#!/usr/bin/env php\n");
+        \mkdir($this->tempDir . \DIRECTORY_SEPARATOR . 'app');
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $this->assertStringContainsString('<directory name="app"/>', $contents);
+        $this->assertStringContainsString('<file name="artisan"/>', $contents);
+        // Only on-disk dirs are emitted by detectLaravelAppRoots; bootstrap/ was not
+        // created. If the app branch regressed to empty, detectSourceRoots' ultimate
+        // fallback would emit ALL app dirs (including bootstrap), so this negative
+        // proves the present-only real branch ran rather than the fallback.
+        $this->assertStringNotContainsString('<directory name="bootstrap"/>', $contents);
+    }
+
+    #[Test]
+    public function falls_back_to_src_directory_for_package_without_psr4(): void
+    {
+        // No artisan and no PSR-4 mapping: detectPackageRoots' last-resort branch
+        // scans src/ when present, so even a minimal package gets a valid config.
+        \mkdir($this->tempDir . \DIRECTORY_SEPARATOR . 'src');
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $this->assertStringContainsString('<directory name="src"/>', $contents);
+        $this->assertStringNotContainsString('<file name="artisan"/>', $contents);
+    }
+
     private function makeTester(): CommandTester
     {
         $command = new InitCommand($this->tempDir);


### PR DESCRIPTION
## Summary

Ports `master`@v4.14.9 onto `3.x` (Psalm 6 line).

- Infer custom query builders for model instance query methods like `newQuery()`, `newQueryWithoutScopes()`, etc. (#1207)
- Narrow `getCasts()`/`getTouchedRelations()` return types, fix `Request::route()`/`Request::file()` defaults (#1205)
- Doc accuracy fixes (#1202)

No Psalm 6 adaptation was required: the merge carries no taint bitmask, purity-annotation, DataFlow API, or `::make()` factory usage that diverges between Psalm 6 and 7.

## Verification

`composer test:all` on this branch: cs 0 fixable, psalm 0 errors / 100% type coverage, unit 828 tests, type 534 tests, fresh Laravel app test completed. All green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785575470&installation_id=141955579&pr_number=1210&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1210&signature=1dbb71b376ee9f222774dc7c9edaafb3b03aa5e3587457a0b0b7a8fecfe916aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->