### PR TITLE
Docs: flowchart the Psalm hook sequence in contributing guide

### DIFF
--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -139,36 +139,47 @@ Create the handler class in the appropriate `src/Handlers/` subdirectory, then r
 
 Psalm processes code in phases. Each hook fires at a specific phase and has different data available.
 Analysis hooks are hot paths — they fire on every matching expression. Scanning hooks fire once per class or once total.
+Source of truth for which handler implements which hook: `Plugin::registerHandlers()` plus each handler's `implements` clause.
 
-The table below maps each hook to the handlers using it. Source of truth: `Plugin::registerHandlers()` plus each handler's `implements` clause. Handlers marked `*` are registered conditionally (config flag or package detection).
+```mermaid
+flowchart TD
+    subgraph P1["Phase 1 — Scanning (per class/trait/interface)"]
+        A1["AfterClassLikeVisitInterface"]
+    end
 
-**Phase 1 — Scanning** (per class/trait/interface; `ClassLikeStorage` has direct parent only):
+    subgraph P2["Phase 2 — Codebase populated (fires once)"]
+        B1["AfterCodebasePopulatedInterface"]
+    end
 
-| Hook | Handlers |
-|---|---|
-| `AfterClassLikeVisitInterface` | ContainerHandler, SuppressHandler, GuardTaintHandler, EncrypterTaintHandler, AppFacadeRegistrationHandler |
+    subgraph P3["Phase 3 — Analysis (hot path, per file)"]
+        direction TB
+        C1["BeforeFileAnalysisInterface"] --> C2
 
-**Phase 2 — Codebase populated** (fires once; full parent chains resolved):
+        subgraph LOOP["repeats per statement / expression"]
+            direction TB
+            C2["BeforeStatementAnalysisInterface"] --> C3["BeforeExpressionAnalysisInterface"]
+            C3 --> C4["Type/taint providers on the matched expression:
+            FunctionReturnTypeProviderInterface
+            MethodReturnTypeProviderInterface
+            MethodParamsProviderInterface
+            MethodExistenceProviderInterface
+            MethodVisibilityProviderInterface
+            property existence/type/visibility providers
+            AddTaintsInterface / RemoveTaintsInterface"]
+            C4 --> C5["AfterExpressionAnalysisInterface"]
+            C5 --> C6["AfterMethodCallAnalysisInterface"]
+        end
 
-| Hook | Handlers |
-|---|---|
-| `AfterCodebasePopulatedInterface` | ModelRegistrationHandler, SuppressHandler, ContractMethodBridgeHandler, CastContractUserDefinedHandler, BuilderSubclassQueryMixinHandler, MacroHandler, FormRequestPropertyHandler, AppFacadeRegistrationHandler, PublicScopeAccessorVisibilityHandler |
+        C6 --> C7["AfterFunctionLikeAnalysisInterface"]
+        C7 --> C8["AfterFileAnalysisInterface"]
+    end
 
-**Phase 3 — Analysis** (hot path):
+    subgraph P4["Phase 4 — Run complete (fires once)"]
+        D1["AfterAnalysisInterface"]
+    end
 
-| Hook | Handlers |
-|---|---|
-| `FunctionReturnTypeProviderInterface` | ContainerHandler, AuthFunctionHandler, CacheHandler, NowTodayHandler, PathHandler, LiteralHandler, EnvHandler, TranslationKeyHandler, NoEnvOutsideConfigHandler, ConfigHelperHandler\*, MissingViewHandler\* |
-| `MethodReturnTypeProviderInterface` | OffsetHandler, ContainerHandler, AuthMethodHandler, GuardHandler, RequestHandler, StorageHandler, ModelFactoryMethodTypeProvider, FactoryCountTypeProvider, ModelBuilderMixinHandler, MethodForwardingHandler, ModelMethodHandler, BuilderScopeHandler, BuilderPluckHandler, BuilderAggregateHandler, CustomCollectionHandler, CollectionFilterHandler, CollectionFlattenHandler, CollectionPluckHandler, CollectionValuesAllHandler, HigherOrderCollectionProxyHandler, ConditionableWhenHandler, TappableTapHandler, CommandArgumentHandler, ValidatedTypeHandler, PathHandler, AppFacadeMakeHandler, DateFacadeHandler, ConfigRepositoryMethodHandler\*, MissingViewHandler\* |
-| `MethodParamsProviderInterface` | OffsetHandler, AuthMethodHandler, StorageHandler, MethodForwardingHandler, BuilderScopeHandler, HigherOrderCollectionProxyHandler, AppFacadeMakeHandler, DateFacadeHandler, ConfigRepositoryMethodHandler\* |
-| `MethodExistenceProviderInterface`, `MethodVisibilityProviderInterface` | OffsetHandler |
-| Property providers (existence / type / visibility) | per-model closures registered by ModelRegistrationHandler |
-| `AddTaintsInterface`, `RemoveTaintsInterface` | ValidationTaintHandler |
-| `AfterExpressionAnalysisInterface` | ModelMakeHandler, DispatchableHandler, TimingUnsafeComparisonHandler, UndefinedBuilderMethodHandler, ConsoleClosureScopeHandler, InlineValidateRulesCollector, ImplicitQueryBuilderCallHandler\* |
-| `AfterMethodCallAnalysisInterface` | HigherOrderCollectionProxyHandler, OctaneIncompatibleBindingHandler\* |
-| `Before{File,Statement,Expression}AnalysisInterface` | ConsoleClosureScopeHandler, InlineValidateRulesCollector (statement + expression) |
-| `AfterFunctionLikeAnalysisInterface`, `AfterFileAnalysisInterface` | ValidationTaintHandler, InlineValidateRulesCollector (function-like only) |
-| `AfterAnalysisInterface` | StatsHandler |
+    P1 --> P2 --> P3 --> P4
+```
 
 ### Registering handlers
 


### PR DESCRIPTION
## Issue to Solve
`docs/contributing/README.md` mapped each Psalm hook to the handlers that implement it, in a table grouped by phase. That table drifts every time a handler is added, removed, or reassigned to a different hook, and it didn't communicate the actual firing order within Phase 3 (statement vs. expression vs. method-call hooks interleave per file).

## Related
#0

## Solution Description
Replaced the three phase tables with a single mermaid flowchart covering all four phases (scanning, codebase-populated, per-file analysis loop, run-complete), showing only hook interface names in their real fire sequence. Handler names are dropped entirely — `Plugin::registerHandlers()` remains the source of truth for the hook-to-handler mapping, referenced by a line above the diagram.

Verified the diagram renders by extracting it and running `@mermaid-js/mermaid-cli` locally (produces a valid SVG, no syntax errors).

## Checklist
- [x] Tests cover the change (docs-only change, no test surface)
- [x] Documentation is updated

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785576699&installation_id=141955579&pr_number=1211&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1211&signature=7cdde7859b8a364ff2d0367a6ddbbc3e7bf6287e3f601bdec9cc742823a02bcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->