### PR TITLE
Stop `init` ignoring `packages/` and disabling analysis on monorepos

### DIFF
--- a/src/Cli/InitCommand.php
+++ b/src/Cli/InitCommand.php
@@ -42,8 +42,16 @@ final class InitCommand extends Command
     /** Conventional Laravel entry-point files. Only emitted if present. */
     private const LARAVEL_APP_FILES = ['public/index.php', 'artisan'];
 
-    /** Ignore-target candidates. Only emitted if present on disk. */
-    private const IGNORE_DIRS = ['bootstrap/cache', 'storage', 'vendor', 'packages', 'nova-components'];
+    /**
+     * Ignore-target candidates. Only emitted if present on disk.
+     *
+     * Deliberately excludes `packages/` and `nova-components/`: `<ignoreFiles>`
+     * only subtracts from `<projectFiles>`, and init never emits a projectFiles
+     * root that contains them — so ignoring them is inert for app layouts and
+     * actively disables analysis on monorepos whose PSR-4 source lives under
+     * `packages/*\/src` (scanned for reflection, never analysed). See #1213.
+     */
+    private const IGNORE_DIRS = ['bootstrap/cache', 'storage', 'vendor'];
 
     /** One indent level. Matches the template heredoc's per-nesting whitespace. */
     private const TAB = '    ';

--- a/tests/Unit/Cli/InitCommandTest.php
+++ b/tests/Unit/Cli/InitCommandTest.php
@@ -308,6 +308,32 @@ final class InitCommandTest extends TestCase
     }
 
     #[Test]
+    public function monorepo_package_source_is_not_swallowed_by_the_packages_ignore(): void
+    {
+        // Monorepo layout: PSR-4 source lives under packages/*/src. 'packages' is
+        // no longer an ignore candidate, so it must not appear in <ignoreFiles>;
+        // otherwise it would remove the whole source tree from ANALYSIS (Psalm
+        // still scans it for reflection) — a silent zero-issue run. Genuine
+        // ignores like vendor/ are still emitted. See #1213.
+        \file_put_contents(
+            $this->tempDir . \DIRECTORY_SEPARATOR . 'composer.json',
+            (string) \json_encode(['autoload' => ['psr-4' => ['Acme\\Core\\' => 'packages/core/src']]]),
+        );
+        \mkdir($this->tempDir . \DIRECTORY_SEPARATOR . 'packages' . \DIRECTORY_SEPARATOR . 'core' . \DIRECTORY_SEPARATOR . 'src', 0o777, true);
+        \mkdir($this->tempDir . \DIRECTORY_SEPARATOR . 'vendor');
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $this->assertStringContainsString('<directory name="packages/core/src"/>', $contents);
+        // The overlapping ignore is dropped; the non-overlapping one survives.
+        $this->assertStringNotContainsString('<directory name="packages"/>', $contents);
+        $this->assertStringContainsString('<directory name="vendor"/>', $contents);
+    }
+
+    #[Test]
     public function detects_laravel_app_layout_when_artisan_present(): void
     {
         // Presence of artisan selects the Laravel-app branch (detectLaravelAppRoots):


### PR DESCRIPTION
## Issue to Solve
On a Composer monorepo whose PSR-4 source lives under `packages/*/src` (e.g. `lunarphp/lunar`), `psalm-laravel init` writes a `psalm.xml` where the same `packages/` tree appears in **both** `<projectFiles>` and `<ignoreFiles>`.

`<ignoreFiles>` wins for the analysis step (Psalm still shallow-scans those dirs for reflection), so every source file is scanned but never analysed. The run reports **0 issues**, which reads as "the plugin found nothing" rather than a misconfiguration.

## Root cause
`InitCommand::IGNORE_DIRS` hardcoded `packages` and `nova-components`. But `<ignoreFiles>` only subtracts from `<projectFiles>`, and `init` never emits a projectFiles root that contains those dirs:
- **App layout** → `LARAVEL_APP_DIRS` (`app`, `bootstrap`, `config`, `database`, `lang`, `routes`) — none contain `packages/`.
- **Package/monorepo** → PSR-4 roots like `packages/core/src`.

So ignoring `packages`/`nova-components` is **inert for app layouts** (never a projectFiles child) and **actively disables analysis on monorepos** where the PSR-4 source lives beneath them. There is no generated case where the ignore helps.

## Related
Closes #1213

## Solution Description
Drop `packages` and `nova-components` from the ignore candidates; keep the genuinely useful ones (`bootstrap/cache` is a child of the analysed `bootstrap/` root; `storage`/`vendor` are conventional).

Verified with a new unit test (`monorepo_package_source_is_not_swallowed_by_the_packages_ignore`): the generated config keeps `<directory name="packages/core/src"/>` in project files, does **not** emit `<directory name="packages"/>`, and still emits `<directory name="vendor"/>`. Full `InitCommandTest` suite green (16 tests).

## Checklist
- [x] Tests cover the change (unit test in `tests/Unit/Cli/InitCommandTest.php`)
