### PR TITLE
fix: stop `where()` array form flagging false `TaintedSql`

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -75,3 +75,7 @@ Unparseable = "Unparseable"
 # word here to cover every compound, current and future.
 Encrypter = "Encrypter"
 encrypter = "encrypter"
+# `addArrayOfWheres` is Laravel's real `Illuminate\Database\Query\Builder` method; it
+# appears in WhereColumnTaintHandler's docblock and the where-family taint docs/tests.
+# typos tokenizes the `Wheres` sub-word and flags it as a typo of "Whereas".
+Wheres = "Wheres"

--- a/docs/contributing/taint-analysis.md
+++ b/docs/contributing/taint-analysis.md
@@ -315,6 +315,8 @@ Both `$operator` and `$value` appear in `@psalm-flow` because in the **2-argumen
 
 The same pattern applies to `orWhere()`, `whereNot()`, `orWhereNot()`, `having()`, and `orHaving()`.
 
+The keyed-**map** array form `where(['col' => $value])` is a false positive under the plain sink: `Builder::addArrayOfWheres()` binds each value and uses only the (literal) key as the column, so a tainted value is never interpolated (#734/#733). `Psalm\LaravelPlugin\Handlers\Eloquent\WhereColumnTaintHandler` removes the `sql` taint for exactly that shape (a `TKeyedArray` with all-string keys) — see its docblock. Do **not** "fix" it by dropping the sink (the string form is a real vector) or by adding `@psalm-taint-specialize` to these stubs — the latter silently breaks the non-SQL `@psalm-flow` on the value positions (see the specialize note below).
+
 ### Pattern for find-family methods
 
 ```php

--- a/src/Handlers/Eloquent/WhereColumnTaintHandler.php
+++ b/src/Handlers/Eloquent/WhereColumnTaintHandler.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Eloquent;
+
+use PhpParser\Node\ArrayItem;
+use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\Plugin\EventHandler\Event\AddRemoveTaintsEvent;
+use Psalm\Plugin\EventHandler\RemoveTaintsInterface;
+use Psalm\Type\Atomic\TKeyedArray;
+use Psalm\Type\TaintKind;
+use Psalm\Type\Union;
+
+/**
+ * Removes the `sql` taint from a where-family `$column` argument when it is a keyed-MAP literal —
+ * `where(['status_id' => $userValue])` — killing the false positive #734 / #733 without weakening the
+ * string-form sink.
+ *
+ * The stubs keep the plain `@psalm-taint-sink sql $column` on the where/having family (see
+ * `stubs/common/Database/Query/Builder.phpstub` etc.). That is correct for the string form
+ * `where($column)`, which interpolates `$column` as a raw identifier — a real injection vector. But
+ * the array form routes through `Builder::addArrayOfWheres()`, which for a string key calls
+ * `where($key, '=', $value)`: the literal KEY is the column and each VALUE is PDO-bound. A tainted
+ * value in that map is never interpolated, so the blanket sink over-reported (confirmed in pixelfed /
+ * monica). This handler subtracts exactly that case.
+ *
+ * ## Why a map, not any array
+ *
+ * The gate is a keyed array with ALL STRING keys — the value-binding shape `['col' => $v]`. Two
+ * shapes are deliberately NOT stripped, because for them the array elements ARE column identifiers:
+ *
+ *  - a LIST literal (integer keys) — `whereAll(['a', 'b'])` / `where([[$col, '=', $v]])`. Laravel's
+ *    `whereAll`/`whereAny`/`whereNone` iterate the array's VALUES as columns, and
+ *    `addArrayOfWheres`' numeric-key branch spreads a nested `[[$col, …]]` so element[0] is a raw
+ *    column. Integer keys therefore keep the sink.
+ *  - a generic `array<string, mixed>` — `where($request->all())` — whose keys are unknown and can be
+ *    user-controlled column names. Not a `TKeyedArray`, so it keeps the sink.
+ *
+ * ## Why RemoveTaints and not a per-call sink handler
+ *
+ * A `@psalm-taint-sink` annotation is unconditional — it cannot depend on the argument's type — and a
+ * per-call-site sink handler would need either fragile node-id replication or a stub
+ * `@psalm-taint-specialize`, which silently breaks `@psalm-flow` propagation of non-SQL taint through
+ * the value positions (the documented failure mode in `docs/contributing/taint-analysis.md`). Removing
+ * the taint at the argument, keyed off the argument's own type, needs neither: the keyed-string-map
+ * shape is unique to the where-family value-binding form, so although {@see removeTaints} is
+ * method-agnostic (the event carries no method id), in real code only a where-family map matches —
+ * `whereAll`/`insertUsing` take lists, raw sinks take strings. Same mechanism as
+ * {@see \Psalm\LaravelPlugin\Handlers\Validation\ValidationTaintHandler}.
+ *
+ * Maintenance caveat: this strips `sql` from a sealed keyed-string-map argument to ANY call. That is
+ * safe only while no `@psalm-taint-sink sql` method takes an associative array whose VALUES are
+ * columns (e.g. a future `whereColumn(['a' => $b])` or `select(['alias' => $col])` sink). If such a
+ * sink is ever added, gate this strip on the method/receiver so it does not silently defeat it.
+ *
+ * ## Interim until upstream support
+ *
+ * This exists only because Psalm cannot express a type-scoped sink. It should retire if a feature like
+ * `@psalm-taint-sink sql $column string` ever lands upstream (feature request cross-linked from the
+ * PR). Same auto-retiring pattern as
+ * {@see \Psalm\LaravelPlugin\Handlers\Support\ConditionableWhenHandler}.
+ */
+final class WhereColumnTaintHandler implements RemoveTaintsInterface
+{
+    #[\Override]
+    public static function removeTaints(AddRemoveTaintsEvent $event): int
+    {
+        $statements_source = $event->getStatementsSource();
+
+        // node_data lives on the concrete analyzer. Fires per argument under taint analysis only, so
+        // this and the ArrayItem short-circuit keep the common (non-map) path cheap.
+        if (!$statements_source instanceof StatementsAnalyzer) {
+            return 0;
+        }
+
+        $expr = $event->getExpr();
+
+        // Nested `ArrayItem` dispatches carry the element, not the whole argument — key off the
+        // argument expression only.
+        if ($expr instanceof ArrayItem) {
+            return 0;
+        }
+
+        $type = $statements_source->node_data->getType($expr);
+
+        if (!$type instanceof Union || !self::isBoundValueMap($type)) {
+            return 0;
+        }
+
+        return TaintKind::INPUT_SQL;
+    }
+
+    /**
+     * True only for the pure keyed-MAP form `['col' => $value]` — a single, SEALED `TKeyedArray`
+     * whose keys are all strings. Any integer key (a list or nested-condition literal) means an
+     * element is a column identifier, and an unsealed shape (a `...<string, mixed>` fallback) can
+     * carry dynamic, possibly user-controlled column keys — either way the sink must stand.
+     *
+     * @psalm-mutation-free
+     */
+    private static function isBoundValueMap(Union $type): bool
+    {
+        if (!$type->isSingle()) {
+            return false;
+        }
+
+        $atomic = $type->getSingleAtomic();
+
+        // Sealed only: an unsealed keyed array ($atomic->fallback_params) has additional entries with
+        // unknown, possibly user-controlled keys, which become columns.
+        if (!$atomic instanceof TKeyedArray || $atomic->fallback_params !== null) {
+            return false;
+        }
+
+        foreach (array_keys($atomic->properties) as $key) {
+            if (\is_int($key)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -107,6 +107,11 @@ final class Plugin implements PluginEntryPointInterface
         // taint `.phpstub` would break `app('encrypter')->getKey()`. Keep the taint in a handler.
         require_once __DIR__ . '/Handlers/Encryption/EncrypterTaintHandler.php';
         $registration->registerHooksFromClass(Handlers\Encryption\EncrypterTaintHandler::class);
+        // Removes the `sql` taint from a where-family `$column` when it is a keyed-MAP literal
+        // (`where(['col' => $v])` binds each value), killing the #734/#733 false positive while the
+        // string-form `@psalm-taint-sink sql $column` stub still fires. See the handler docblock.
+        require_once __DIR__ . '/Handlers/Eloquent/WhereColumnTaintHandler.php';
+        $registration->registerHooksFromClass(Handlers\Eloquent\WhereColumnTaintHandler::class);
 
         require_once __DIR__ . '/Handlers/Filesystem/StorageHandler.php';
         $registration->registerHooksFromClass(Handlers\Filesystem\StorageHandler::class);

--- a/tests/Type/tests/TaintAnalysis/SafeSqlEloquentWhereArrayValues.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeSqlEloquentWhereArrayValues.phpt
@@ -1,0 +1,20 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+class ArrayWhereConversation extends \Illuminate\Database\Eloquent\Model {}
+
+/**
+ * The static model form (via `@mixin Builder`) forwards to Eloquent\Builder::where.
+ * The keyed-array form binds its values, so a tainted value must not be flagged. #734
+ *
+ * @psalm-suppress MixedAssignment
+ */
+function safeEloquentArrayWhere(\Illuminate\Http\Request $request): void {
+    $fromId = $request->input('from_id');
+
+    ArrayWhereConversation::where(['status_id' => 1, 'from_id' => $fromId]);
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeSqlFirstWhereArrayValues.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeSqlFirstWhereArrayValues.phpt
@@ -1,0 +1,20 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+class FirstWhereDriver extends \Illuminate\Database\Eloquent\Model {}
+
+/**
+ * firstWhere(['col' => $value]) delegates to where()->first(), so the keyed-array values
+ * are PDO-bound too. Regression guard for #733 (closed as a duplicate of #734).
+ *
+ * @psalm-suppress MixedAssignment
+ */
+function safeFirstWhereArray(\Illuminate\Http\Request $request): void {
+    $driverId = $request->input('driver_id');
+
+    FirstWhereDriver::firstWhere(['driver_id' => $driverId, 'active' => 1]);
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeSqlOrWhereNotArrayValues.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeSqlOrWhereNotArrayValues.phpt
@@ -1,0 +1,19 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Representative or-variant. The keyed-map strip is method-agnostic (one shared path), so this
+ * covers orWhere/whereNot/orWhereNot too — the value-binding map form is safe on all of them. #734
+ *
+ * @psalm-suppress TooFewArguments, MixedAssignment
+ */
+function safeOrWhereNotArray(\Illuminate\Http\Request $request): void {
+    $builder = new \Illuminate\Database\Query\Builder();
+    $status = $request->input('status');
+
+    $builder->orWhereNot(['status_id' => $status]);
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeSqlWhereAllMapKnownLimitation.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeSqlWhereAllMapKnownLimitation.phpt
@@ -1,0 +1,25 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * KNOWN LIMITATION: whereAll(['col' => $tainted]) is NOT flagged.
+ *
+ * The #734 fix strips the `sql` taint from any keyed-MAP-literal argument — the where-family
+ * value-binding shape `['col' => $value]`. whereAll()/whereAny()/whereNone() are normally called with
+ * a LIST of column names (`whereAll(['a', 'b'], '=', $v)`), which has integer keys, is NOT stripped,
+ * and still flags. Passing a keyed map to whereAll (whose values would become columns) is malformed
+ * usage and is the one shape the argument-type strip cannot distinguish from a where() value map.
+ * Documented here rather than fixed — the realistic list form is covered by TaintedSqlWhereAll.phpt.
+ *
+ * @psalm-suppress TooFewArguments
+ */
+function whereAllKeyedMapNotFlagged(\Illuminate\Http\Request $request): void {
+    $builder = new \Illuminate\Database\Query\Builder();
+    $column = (string) $request->input('column');
+
+    $builder->whereAll(['status_id' => $column]);
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeSqlWhereArrayValues.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeSqlWhereArrayValues.phpt
@@ -1,0 +1,20 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * where(['col' => $value]) routes through addArrayOfWheres(), which binds each value as a
+ * PDO parameter (where($key, '=', $value)). A tainted value is never interpolated as a column
+ * identifier, so the keyed-array form must not be flagged. Regression guard for #734.
+ *
+ * @psalm-suppress TooFewArguments, MixedAssignment
+ */
+function safeArrayColumnWhere(\Illuminate\Http\Request $request): void {
+    $builder = new \Illuminate\Database\Query\Builder();
+    $status = $request->input('status');
+
+    $builder->where(['status_id' => $status, 'to_id' => 1]);
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/TaintedShellWhereValueFlowPreserved.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedShellWhereValueFlowPreserved.phpt
@@ -1,0 +1,27 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * The where-family stubs keep `@psalm-flow ($operator, $value) -> return` and deliberately do NOT
+ * carry `@psalm-taint-specialize` — which would silently break propagation of non-SQL taint kinds
+ * through the value positions (see WhereColumnTaintHandler / docs/contributing/taint-analysis.md).
+ * Guard: a non-SQL (shell) taint on a where VALUE must still flow through the returned builder. If a
+ * future change re-adds `@psalm-taint-specialize` to these stubs, this stops reporting.
+ */
+class WhereValueShellRunner {
+    /** @psalm-taint-sink shell $cmd */
+    public function run(mixed $cmd): void {}
+}
+
+/** @psalm-suppress TooFewArguments */
+function shellFlowsThroughWhereValue(\Illuminate\Http\Request $request): void {
+    $value = (string) $request->input('q');
+    $builder = (new \Illuminate\Database\Query\Builder())->where('col', $value);
+
+    (new WhereValueShellRunner())->run($builder);
+}
+?>
+--EXPECTF--
+%ATaintedShell on line %d: Detected tainted shell code

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlFirstWhereColumnSink.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlFirstWhereColumnSink.phpt
@@ -1,0 +1,19 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+class FirstWhereColumnSinkModel extends \Illuminate\Database\Eloquent\Model {}
+
+/**
+ * String-form column injection through firstWhere() must still report (#733). firstWhere resolves via
+ * BuildsQueries, a different path than where(), so it is pinned separately.
+ */
+function unsafeFirstWhereColumn(\Illuminate\Http\Request $request): void {
+    $column = $request->input('column');
+
+    FirstWhereColumnSinkModel::firstWhere($column, 'safe-value');
+}
+?>
+--EXPECTF--
+%ATaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereWholeArrayInput.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereWholeArrayInput.phpt
@@ -1,0 +1,20 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * where($request->all()) is NOT the safe keyed-literal form: the array KEYS become column
+ * identifiers and here they are entirely user-controlled, so this must still be flagged.
+ * This is why the safe gate is a keyed-array literal (TKeyedArray), not is_array().
+ *
+ * @psalm-suppress TooFewArguments
+ */
+function unsafeWholeArrayWhere(\Illuminate\Http\Request $request): void {
+    $builder = new \Illuminate\Database\Query\Builder();
+
+    $builder->where($request->all());
+}
+?>
+--EXPECTF--
+%ATaintedSql on line %d: Detected tainted SQL


### PR DESCRIPTION
## Issue to Solve

`@psalm-taint-sink sql $column` on the `where()` / `having()` family fires on the **keyed-map** form:

```php
$query->where(['status_id' => $request->input('status')]); // false TaintedSql
```

Laravel routes the array form through `Builder::addArrayOfWheres()`, which for a string key calls `where($key, '=', $value)` — the literal **key** is the column identifier and each **value** is PDO-bound. A tainted value there is never interpolated, so the report is a false positive. Confirmed in pixelfed (`DirectMessageController`, `GroupsCommentController`, `GroupsPostController`) and monica. The string form `where($request->input('column'))` is a genuine identifier-injection vector and must keep reporting.

## Related

Closes #734. References #733 (`firstWhere`, closed as a duplicate of #734).

## Solution Description

Psalm cannot express a type-scoped sink (`@psalm-taint-sink` is unconditional), and `AddRemoveTaintsEvent` carries no method id — so a stub-only change cannot tell the where-family (values bound) apart from `whereAll()` (values *are* columns).

The stubs are therefore **unchanged**. A new `WhereColumnTaintHandler` implements `RemoveTaintsInterface` and removes the `sql` taint from an argument **only when its type is a sealed keyed-map literal** — a `TKeyedArray` with all-string keys and no `...<string,mixed>` fallback (`['col' => $v]`). That shape is unique to the where-family value-binding form:

- **map** `['col' => $v]` → stripped → no false positive
- **string** `where($request->input('col'))` → still reports (real injection)
- **whole array** `where($request->all())` (`array<string,mixed>`, user-controlled keys) → still reports
- **list** `whereAll(['a','b'])` (integer keys) → still reports

### Why RemoveTaints and not a per-call-site sink

An earlier draft added a per-call-site sink, which required `@psalm-taint-specialize` on the stubs. That **silently breaks `@psalm-flow` propagation of non-SQL taint** (html/shell/secret) through the `$value` positions — the failure mode documented in `docs/contributing/taint-analysis.md`, reproduced here by an A/B test. Stripping the taint at the argument needs no specialize, so the flow is preserved (guarded by `TaintedShellWhereValueFlowPreserved.phpt`).

### Verification

New taint type-tests under `tests/Type/tests/TaintAnalysis/`:
- map → clean: `SafeSqlWhereArrayValues`, `SafeSqlEloquentWhereArrayValues`, `SafeSqlFirstWhereArrayValues`, `SafeSqlOrWhereNotArrayValues`
- still reports: `TaintedSqlWhereWholeArrayInput` (`$request->all()`), `TaintedSqlFirstWhereColumnSink`
- flow preserved: `TaintedShellWhereValueFlowPreserved` (a non-SQL taint through a where value)
- documented limitation: `SafeSqlWhereAllMapKnownLimitation`

Existing string-form (`TaintedSqlWhereColumnSink`, `…Eloquent…`) and `whereAll`/`whereAny`/`whereNone` tests are unchanged and green. Full `test:type`, `test:unit`, `psalm` (100% coverage), `cs`, `rector` all pass.

### Known limitation

`whereAll(['col' => $tainted])` — a keyed **map** passed to `whereAll` (whose values become columns) — is **not** flagged (the map strip cannot distinguish it from a where value-map). This is malformed usage (`whereAll` takes a list) that also trips a `MixedArgumentTypeCoercion`; the realistic list form is covered. Documented in `SafeSqlWhereAllMapKnownLimitation.phpt`.

### Upstream layer

The truly correct fix is upstream: Psalm should support type-scoped sinks (e.g. `@psalm-taint-sink sql $column string`) or method-id + argument-offset context on `AddRemoveTaintsEvent`. Until then this handler is an interim, auto-retiring workaround (same pattern as `ConditionableWhenHandler`). A vimeo/psalm feature request will be filed and linked here.

### Backporting to 3.x (Psalm 6)

The same false positive exists on `3.x`. The handler is portable — only the `RemoveTaintsInterface` contract differs between Psalm 6 and 7. Copy `WhereColumnTaintHandler` onto `3.x` and change **only** the `removeTaints` method (the `isBoundValueMap` helper and every import/API — `getExpr`/`ArrayItem`, `StatementsAnalyzer::$node_data`, `Union::isSingle()`/`getSingleAtomic()`, `TKeyedArray::$properties`/`$fallback_params` — exist identically in Psalm 6.16):

```php
// Psalm 7 (this PR / master / 4.x): returns an int bitmask
public static function removeTaints(AddRemoveTaintsEvent $event): int
{
    // …guards…
    if (!$type instanceof Union || !self::isBoundValueMap($type)) {
        return 0;
    }
    return TaintKind::INPUT_SQL;
}

// Psalm 6 (3.x): returns list<string>
public static function removeTaints(AddRemoveTaintsEvent $event): array
{
    // …guards… (return [] instead of 0)
    if (!$type instanceof Union || !self::isBoundValueMap($type)) {
        return [];
    }
    return [TaintKind::INPUT_SQL]; // TaintKind::INPUT_SQL is the string 'sql' on Psalm 6
}
```

A single class cannot satisfy both (PHP fatals on the `array` vs `int` return-type mismatch), so the backport is a separate PR on `3.x`, consistent with the plugin's 3.x/4.x split. Register it the same way (paired `require_once` + `registerHooksFromClass`) and port the phpts (`TaintKind` strings match, so the `--EXPECTF--` output is identical). Note: use `$atomic->fallback_params` (not the Psalm-7-only `isSealed()`) so the helper stays byte-identical across versions.

## Checklist
- [x] Tests cover the change (8 type tests in `tests/Type/tests/TaintAnalysis/`)
- [x] Documentation is updated (`docs/contributing/taint-analysis.md`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785681352&installation_id=141955579&pr_number=1218&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1218&signature=51e4d22dfd9fc0db6afc03c90bd8064b85c8f4a60eb6d06a1d7707614b407544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->