### PR TITLE
Resolve false `UndefinedMagicMethod` on `IndexDefinition` modifiers (DB migrations)

### DIFF
--- a/stubs/common/Database/Schema/IndexDefinition.phpstub
+++ b/stubs/common/Database/Schema/IndexDefinition.phpstub
@@ -1,0 +1,46 @@
+<?php
+
+namespace Illuminate\Database\Schema;
+
+/**
+ * IndexDefinition fluent modifiers (algorithm, language, lock, ...).
+ *
+ * Laravel declares these only as class-level @method tags on IndexDefinition, dispatched
+ * at runtime through Fluent::__call(). Because the class carries @method tags, Psalm seals
+ * its magic methods (ClassLikeStorage::$sealed_methods = true) regardless of the
+ * sealAllMethods setting, so a modifier absent from the *installed* Laravel version's
+ * @method block resolves to no pseudo-method and raises UndefinedMagicMethod. Laravel's
+ * block has grown over time (nullsNotDistinct/online/lock are recent additions), so older
+ * installs legitimately lack some tags. Declaring each modifier as a real method resolves
+ * it before the sealed magic-method path on every supported Laravel version.
+ *
+ * Parameter types mirror Laravel's @method annotations verbatim, including lock()'s
+ * literal-string union ('none'|'shared'|'default'|'exclusive').
+ */
+class IndexDefinition extends \Illuminate\Support\Fluent
+{
+    /** Specify an algorithm for the index (MySQL/PostgreSQL). */
+    public function algorithm(string $algorithm): static {}
+
+    /** Specify that the unique index is deferrable (PostgreSQL). */
+    public function deferrable(bool $value = true): static {}
+
+    /** Specify the default time to check the unique index constraint (PostgreSQL). */
+    public function initiallyImmediate(bool $value = true): static {}
+
+    /** Specify a language for the full text index (PostgreSQL). */
+    public function language(string $language): static {}
+
+    /**
+     * Specify the DDL lock mode for the index operation (MySQL).
+     *
+     * @param 'none'|'shared'|'default'|'exclusive' $value
+     */
+    public function lock(string $value): static {}
+
+    /** Specify that the null values should not be treated as distinct (PostgreSQL). */
+    public function nullsNotDistinct(bool $value = true): static {}
+
+    /** Specify that index creation should not lock the table (PostgreSQL/SqlServer). */
+    public function online(bool $value = true): static {}
+}

--- a/tests/Type/tests/Schema/IndexDefinitionTest.phpt
+++ b/tests/Type/tests/Schema/IndexDefinitionTest.phpt
@@ -1,0 +1,45 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\IndexDefinition;
+use Illuminate\Support\Facades\Schema;
+
+// IndexDefinition fluent modifiers: verifies no UndefinedMagicMethod errors.
+// Blueprint::index()/fullText()/spatialIndex()/primary()/unique()/rawIndex() all
+// return IndexDefinition, whose fluent modifiers (algorithm(), language(), ...) are
+// declared only as class-level @method tags and dispatched via Fluent::__call(). Those
+// tags auto-seal the class's magic methods, so a modifier absent from the installed
+// Laravel version's @method block raises UndefinedMagicMethod; the stub declares each
+// modifier as a real method so it resolves before Psalm's sealed magic-method path.
+//
+// Guard scope: every Laravel version currently exercised (CI runs ^12.4 and ^13.0 at
+// highest, both resolving to blocks that already list all 7 modifiers) resolves these
+// via reflection even without the stub, so this test pins Blueprint's index-family
+// return type to IndexDefinition and documents the full modifier contract. The stub is
+// the load-bearing fix for installs on older Laravel whose @method block predates some
+// modifiers (lock()/online()/nullsNotDistinct()).
+// https://github.com/psalm/psalm-plugin-laravel/issues/1217
+Schema::table('songs', function (Blueprint $table) {
+    $_index = $table->fullText(['title', 'artist_name', 'album_name']);
+    /** @psalm-check-type-exact $_index = IndexDefinition */
+
+    // Exact reproduction from koel/koel migration
+    $table->fullText(['title', 'artist_name', 'album_name'])->language('simple');
+
+    // Every @method fluent modifier documented on IndexDefinition (Laravel 13)
+    $table->index(['a', 'b'])->algorithm('btree');
+    $table->fullText(['body'])->language('english');
+    $table->unique(['email'])->deferrable();
+    $table->unique(['slug'])->deferrable()->initiallyImmediate();
+    $table->index(['status'])->lock('none');
+    $table->unique(['token'])->nullsNotDistinct();
+    $table->index(['created_at'])->online();
+
+    // Every Blueprint index-family method returns IndexDefinition
+    $table->primary(['id'])->algorithm('btree');
+    $table->spatialIndex('location')->algorithm('gist');
+    $table->rawIndex('lower(email)', 'idx_lower_email')->algorithm('btree');
+});
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

`Illuminate\Database\Schema\IndexDefinition` fluent modifiers (`language()`, `algorithm()`, `lock()`, `deferrable()`, `initiallyImmediate()`, `nullsNotDistinct()`, `online()`) were reported as false `UndefinedMagicMethod`, so `$table->fullText(...)->language('simple')` failed analysis. Found auditing [koel/koel](https://github.com/koel/koel) (7 occurrences in one full-text migration).

## Related

Fixes #1217

## Solution Description

**Root cause.** `Blueprint::index()`/`fullText()`/`spatialIndex()`/`primary()`/`unique()`/`rawIndex()` return `IndexDefinition`, whose fluent modifiers live only as class-level `@method` tags (dispatched at runtime via `Fluent::__call()`). Once a class carries any `@method` tag, Psalm sets `sealed_methods = true` (auto-seal, independent of the `sealAllMethods` setting), so a modifier absent from the *installed* Laravel version's `@method` block resolves to no pseudo-method and raises `UndefinedMagicMethod`, even in a default config. Laravel's block has grown over time (`nullsNotDistinct` in 12.4, `online` in 12.23, `lock` in 12.46), so installs pinned below those versions legitimately lack some tags.

**Fix.** A new `stubs/common/Database/Schema/IndexDefinition.phpstub` declares all seven modifiers as real methods, carrying the full `extends \Illuminate\Support\Fluent` clause (mirroring the sibling `ColumnDefinition.phpstub`). Real methods resolve before Psalm's sealed magic-method path on every supported Laravel version; the stub also unseals the class, so any modifier not yet listed still routes through `Fluent::__call` rather than erroring. Parameter types mirror Laravel's `@method` verbatim, including `lock()`'s `'none'|'shared'|'default'|'exclusive'` literal union.

**Coverage.** `tests/Type/tests/Schema/IndexDefinitionTest.phpt` exercises all seven modifiers, all six `Blueprint` index-family return sites, and the exact koel/koel reproduction. On the Laravel versions CI runs (`^12.4`/`^13.0` at highest, both listing all seven tags), these resolve via reflection, so the test pins `Blueprint`'s index-family return type and documents the modifier contract; the stub is the load-bearing fix for installs on older Laravel.

Out of scope (follow-ups): the sibling `ColumnDefinition.phpstub` carries an older, less precise docblock describing the same mechanism; and `algorithm()`/`language()` values interpolate into raw DDL SQL but are not modeled as taint sinks (consistent with the sibling Definition stubs). Both could be revisited separately.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785690966&installation_id=141955579&pr_number=1220&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1220&signature=8e18a3d8df6d0d1648397c44cfba81d52174a2beb7b6f771ea4b520eb84964a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->