### PR TITLE
Fix false `TaintedSql` on the `where()` keyed-map form

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -75,3 +75,7 @@ Unparseable = "Unparseable"
 # word here to cover every compound, current and future.
 Encrypter = "Encrypter"
 encrypter = "encrypter"
+# `addArrayOfWheres` is Laravel's real `Illuminate\Database\Query\Builder` method; it
+# appears in WhereColumnTaintHandler's docblock and the where-family taint docs/tests.
+# typos tokenizes the `Wheres` sub-word and flags it as a typo of "Whereas".
+Wheres = "Wheres"

--- a/docs/contributing/taint-analysis.md
+++ b/docs/contributing/taint-analysis.md
@@ -315,6 +315,8 @@ Both `$operator` and `$value` appear in `@psalm-flow` because in the **2-argumen
 
 The same pattern applies to `orWhere()`, `whereNot()`, `orWhereNot()`, `having()`, and `orHaving()`.
 
+The keyed-**map** array form `where(['col' => $value])` is a false positive under the plain sink: `Builder::addArrayOfWheres()` binds each value and uses only the (literal) key as the column, so a tainted value is never interpolated (#734/#733). `Psalm\LaravelPlugin\Handlers\Eloquent\WhereColumnTaintHandler` removes the `sql` taint for exactly that shape (a sealed `TKeyedArray` with all-string keys), CALL-SITE-SCOPED: a `BeforeExpressionAnalysis` hook records the first-argument nodes of where-family calls, and only those exact nodes are stripped (so a map that merely happens to have that shape elsewhere, in an assignment, a return, or an element read, keeps its taint). The strip covers `where`, `orWhere`, `whereNot`, `orWhereNot`, and `firstWhere` (exactly the methods whose array form routes through `addArrayOfWheres()`). It does **not** cover `having`/`orHaving`: despite sharing the flow pattern above, their array form never reaches `addArrayOfWheres()` (there is no `is_array($column)` branch), so an array column compiles raw and the sink must stand (issue #734 wrongly proposed including them). See the handler docblock. Do **not** "fix" it by dropping the sink (the string form is a real vector) or by adding `@psalm-taint-specialize` to these stubs, which silently breaks the non-SQL `@psalm-flow` on the value positions (see the specialize note below).
+
 ### Pattern for find-family methods
 
 ```php

--- a/src/Handlers/Eloquent/WhereColumnTaintHandler.php
+++ b/src/Handlers/Eloquent/WhereColumnTaintHandler.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Eloquent;
+
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\NullsafeMethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\Plugin\EventHandler\BeforeExpressionAnalysisInterface;
+use Psalm\Plugin\EventHandler\BeforeFileAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AddRemoveTaintsEvent;
+use Psalm\Plugin\EventHandler\Event\BeforeExpressionAnalysisEvent;
+use Psalm\Plugin\EventHandler\Event\BeforeFileAnalysisEvent;
+use Psalm\Plugin\EventHandler\RemoveTaintsInterface;
+use Psalm\Type\Atomic\TKeyedArray;
+use Psalm\Type\TaintKind;
+use Psalm\Type\Union;
+
+/**
+ * Removes the `sql` taint from a where-family `$column` argument that is a keyed-MAP —
+ * `where(['status_id' => $userValue])` — the false positive #734 / #733.
+ *
+ * The stubs keep `@psalm-taint-sink sql $column` on the where family: correct for the string form
+ * `where($column)` (interpolated as a raw identifier), wrong for the map form, which routes through
+ * `Illuminate\Database\Query\Builder::addArrayOfWheres()` → `where($key, '=', $value)` — the KEY is
+ * the column, each VALUE is PDO-bound and never interpolated. Only the map form is stripped; the
+ * shapes {@see isBoundValueMap} rejects (list literals, `array<string, mixed>`) keep the sink.
+ *
+ * ## Why call-site scoped
+ *
+ * The strip happens at the argument node rather than via a stub `@psalm-taint-specialize` (which would
+ * silently break `@psalm-flow` of non-SQL taint through the value positions — guarded by
+ * TaintedShellWhereValueFlowPreserved.phpt), because {@see AddRemoveTaintsEvent} carries no method id
+ * or argument offset, and Psalm dispatches {@see removeTaints} from ~17 analyzers (assignment, return,
+ * fetches, …). An UNSCOPED strip of every sealed string-key map (superseded PR #1218) therefore caused
+ * false NEGATIVES — a map whose value flowed out via `$map['k']` or a return lost its taint.
+ *
+ * So {@see beforeExpressionAnalysis} records the first-argument node of each where-family call, and
+ * {@see removeTaints} strips only those exact nodes — covering the literal `where(['a' => $v])` and
+ * the variable `$conds = [...]; where($conds)` forms, while the same value used elsewhere keeps taint.
+ *
+ * ## Why the flush is per-FILE, not per-function-like
+ *
+ * The record→read gap spans a whole call's analysis — receiver first (MethodCallAnalyzer descends
+ * `$stmt->var`), then every argument expression, then `processTaintedness`. A closure or arrow-fn in
+ * the receiver chain or among the map values completes a FunctionLikeAnalyzer inside that gap, so a
+ * per-function-like flush would wipe the record before the argument is read and the #734 FP would
+ * return. (Contrast {@see \Psalm\LaravelPlugin\Handlers\Validation\ValidationTaintHandler}, whose dedup
+ * set has a record→read gap within a single expression and so flushes per function-like safely.)
+ * Flushing at file START ({@see beforeAnalyzeFile}) instead survives a mid-file analysis throw (an
+ * end-of-file flush would leave stale ids) and prevents cross-file `spl_object_id` reuse; within one
+ * file the AST stays alive, so an id cannot be reused mid-file.
+ *
+ * Retirement: the method id and argument offset already exist at `ArgumentAnalyzer::processTaintedness()`
+ * where the event is built; if an upstream PR adds them to {@see AddRemoveTaintsEvent}, the
+ * Before-hook shim retires and {@see removeTaints} gates on the event field. Same auto-retiring
+ * pattern as {@see \Psalm\LaravelPlugin\Handlers\Support\ConditionableWhenHandler}. Refs #734, #733,
+ * PR #1218.
+ */
+final class WhereColumnTaintHandler implements
+    BeforeExpressionAnalysisInterface,
+    RemoveTaintsInterface,
+    BeforeFileAnalysisInterface
+{
+    /**
+     * Where-family methods that carry `@psalm-taint-sink sql $column` AND whose array form Laravel
+     * routes through `Builder::addArrayOfWheres()` (verified vs Laravel 13.19: `where` Builder.php:944
+     * `is_array` → `addArrayOfWheres`; `orWhere`/`orWhereNot` delegate; `whereNot` wraps a nested
+     * `where`; `firstWhere` → `where(...)->first()`).
+     *
+     * EXCLUDED (their array element is a column, so the sink must stand): `having`/`orHaving` (no
+     * `is_array` branch — array column compiles raw); `whereAll`/`whereAny`/`whereNone` and their
+     * or-variants `orWhereAll`/`orWhereAny`/`orWhereNone` (all carry `sql $columns` over arrays that
+     * are lists of column NAMES, so `whereAll(['col' => $tainted])` correctly keeps flagging);
+     * `orderBy` (no keyed-map form).
+     *
+     * A numeric-string key (e.g. `'1.5'`, which PHP keeps as a string while `is_numeric` is true) is
+     * rejected by `isBoundValueMap` like an int key, mirroring `addArrayOfWheres`' own `is_numeric($key)`
+     * dispatch, so such maps are never treated as bound-value maps.
+     */
+    private const WHERE_MAP_METHODS = [
+        'where' => true,
+        'orwhere' => true,
+        'wherenot' => true,
+        'orwherenot' => true,
+        'firstwhere' => true,
+    ];
+
+    /**
+     * `spl_object_id` of each recorded where-family first-argument node, consumed by
+     * {@see removeTaints}. Flushed per file at {@see beforeAnalyzeFile} (NOT per function-like — the
+     * record→read gap spans a closure-bearing call's whole analysis; see the class docblock). A stale
+     * cross-file id would wrongly STRIP taint, so the file flush is load-bearing.
+     *
+     * @var array<int, true>
+     */
+    private static array $whereColumnArgumentIds = [];
+
+    /**
+     * Record the first-argument node id of a where-family call before its arguments are descended
+     * into. Never short-circuits.
+     */
+    #[\Override]
+    public static function beforeExpressionAnalysis(BeforeExpressionAnalysisEvent $event): ?bool
+    {
+        $expr = $event->getExpr();
+
+        if (!$expr instanceof MethodCall && !$expr instanceof NullsafeMethodCall && !$expr instanceof StaticCall) {
+            return null;
+        }
+
+        // Gate on the taint run via the Codebase property (declared `?TaintFlowGraph`, so this is its
+        // null-check). Do NOT gate on the statements-analyzer's `data_flow_graph`: taint + unused-var
+        // runs wrap THAT in a CombinedFlowGraph, so an instanceof gate there silently disables the fix.
+        if (!$event->getCodebase()->taint_flow_graph instanceof \Psalm\Internal\Codebase\TaintFlowGraph) {
+            return null;
+        }
+
+        if (!$expr->name instanceof Identifier) {
+            return null;
+        }
+
+        if (!isset(self::WHERE_MAP_METHODS[\strtolower($expr->name->name)])) {
+            return null;
+        }
+
+        // getArgs() throws on a first-class callable (`where(...)`).
+        if ($expr->isFirstClassCallable()) {
+            return null;
+        }
+
+        $args = $expr->getArgs();
+
+        if (!isset($args[0]) || $args[0]->unpack) {
+            return null;
+        }
+
+        // `getArgs()[0]` is written-order first, so a named first arg need not be the `$column` slot.
+        // All five allowlisted methods name their first parameter `$column` (verified against the three
+        // sink stubs and vendor Laravel), so only record when the first arg is positional or `column:`.
+        // A map passed as `value:` (written first) would otherwise be stripped on that VALUE edge — an
+        // exotic false negative via `@psalm-flow ($operator, $value) -> return`; missing the FP fix on
+        // `where(boolean: 'and', column: $map)` is the safe direction. (Not phpt-covered: the corridor
+        // flows through the shared, non-specialized `where` value->return node, so a keep-taint test
+        // contaminates the batch, while a specialized `firstWhere` variant has its sql escaped and is
+        // vacuous. The guard is by-construction and teeth-checked manually.)
+        if ($args[0]->name !== null && $args[0]->name->toLowerString() !== 'column') {
+            return null;
+        }
+
+        self::$whereColumnArgumentIds[\spl_object_id($args[0]->value)] = true;
+
+        return null;
+    }
+
+    /**
+     * Remove the `sql` taint when the analysed expression is a where-family first argument (recorded
+     * by {@see beforeExpressionAnalysis}) AND its type is the value-binding keyed-map shape.
+     */
+    #[\Override]
+    public static function removeTaints(AddRemoveTaintsEvent $event): int
+    {
+        $expr = $event->getExpr();
+
+        // Nested `ArrayItem` dispatches (from ArrayAnalyzer) carry an element, not the argument node.
+        if ($expr instanceof \PhpParser\Node\ArrayItem) {
+            return 0;
+        }
+
+        // The load-bearing scoping check #1218 lacked — before the analyzer instanceof so the empty-set
+        // common path is near-free.
+        if (!isset(self::$whereColumnArgumentIds[\spl_object_id($expr)])) {
+            return 0;
+        }
+
+        $statements_source = $event->getStatementsSource();
+
+        if (!$statements_source instanceof StatementsAnalyzer) {
+            return 0;
+        }
+
+        $type = $statements_source->node_data->getType($expr);
+
+        if (!$type instanceof Union || !self::isBoundValueMap($type)) {
+            return 0;
+        }
+
+        return TaintKind::INPUT_SQL;
+    }
+
+    /**
+     * Flush the recorded argument ids at file START. This bounds the footprint, prevents cross-file
+     * `spl_object_id` reuse (ASTs are GC'd per file) from colliding a stale record with a fresh node,
+     * and — unlike an end-of-file flush — survives a mid-file analysis throw. See the class docblock
+     * for why this is per-file rather than per-function-like.
+     *
+     * @psalm-external-mutation-free
+     */
+    #[\Override]
+    public static function beforeAnalyzeFile(BeforeFileAnalysisEvent $event): void
+    {
+        self::$whereColumnArgumentIds = [];
+    }
+
+    /**
+     * True only for the keyed-MAP form `['col' => $value]` — a single, SEALED `TKeyedArray` with all
+     * string keys. Any numeric key (int or numeric-string, a list / nested-condition literal) makes an
+     * element a column, and an unsealed shape can carry dynamic user-controlled keys — either way the
+     * sink must stand.
+     *
+     * @psalm-mutation-free
+     */
+    private static function isBoundValueMap(Union $type): bool
+    {
+        if (!$type->isSingle()) {
+            return false;
+        }
+
+        $atomic = $type->getSingleAtomic();
+
+        // Sealed only, via `fallback_params` not the Psalm-7-only `isSealed()` (3.x backport
+        // portability): an unsealed keyed array has extra entries with unknown keys, which become columns.
+        if (!$atomic instanceof TKeyedArray || $atomic->fallback_params !== null) {
+            return false;
+        }
+
+        foreach (\array_keys($atomic->properties) as $key) {
+            // Reject int AND numeric-string keys (e.g. '1.5', '01', which PHP keeps as strings). This
+            // mirrors addArrayOfWheres' own `is_numeric($key) && is_array($value)` dispatch: a numeric
+            // key routes to the nested-column branch where element 0 is a raw column identifier. So the
+            // strip does not rely on Psalm's current inability to track depth-2 nested taint; rejecting a
+            // numeric-string key with a scalar value is conservative (keeps the sink, the FP-safe
+            // direction, and is an absurd shape anyway).
+            if (\is_numeric($key)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -137,6 +137,11 @@ final class Plugin implements PluginEntryPointInterface
         $registration->registerHooksFromClass(Handlers\Eloquent\ModelRegistrationHandler::class);
         $registration->registerHooksFromClass(Handlers\Eloquent\BuilderSubclassQueryMixinHandler::class);
         $registration->registerHooksFromClass(Handlers\Eloquent\BuilderNativeStaticReturnTypeHandler::class);
+        // Strips the `sql` taint from a where-family `$column` argument when it is a keyed-MAP
+        // (`where(['col' => $v])` binds each value — #734/#733 false positive), scoped to the exact
+        // argument nodes recorded by its Before-expression hook. See the handler docblock.
+        require_once __DIR__ . '/Handlers/Eloquent/WhereColumnTaintHandler.php';
+        $registration->registerHooksFromClass(Handlers\Eloquent\WhereColumnTaintHandler::class);
         $registration->registerHooksFromClass(Handlers\Eloquent\ModelFactoryMethodTypeProvider::class);
         $registration->registerHooksFromClass(Handlers\Eloquent\FactoryCountTypeProvider::class);
 

--- a/tests/Type/tests/TaintAnalysis/SafeSqlEloquentWhereArrayValues.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeSqlEloquentWhereArrayValues.phpt
@@ -1,0 +1,20 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+class ArrayWhereConversation extends \Illuminate\Database\Eloquent\Model {}
+
+/**
+ * The static model form (via `@mixin Builder`) forwards to Eloquent\Builder::where.
+ * The keyed-array form binds its values, so a tainted value must not be flagged. #734
+ *
+ * @psalm-suppress MixedAssignment
+ */
+function safeEloquentArrayWhere(\Illuminate\Http\Request $request): void {
+    $fromId = $request->input('from_id');
+
+    ArrayWhereConversation::where(['status_id' => 1, 'from_id' => $fromId]);
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeSqlFirstWhereArrayValues.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeSqlFirstWhereArrayValues.phpt
@@ -1,0 +1,20 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+class FirstWhereDriver extends \Illuminate\Database\Eloquent\Model {}
+
+/**
+ * firstWhere(['col' => $value]) delegates to where()->first(), so the keyed-array values
+ * are PDO-bound too. Regression guard for #733 (closed as a duplicate of #734).
+ *
+ * @psalm-suppress MixedAssignment
+ */
+function safeFirstWhereArray(\Illuminate\Http\Request $request): void {
+    $driverId = $request->input('driver_id');
+
+    FirstWhereDriver::firstWhere(['driver_id' => $driverId, 'active' => 1]);
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeSqlOrWhereNotArrayValues.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeSqlOrWhereNotArrayValues.phpt
@@ -1,0 +1,20 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Representative or-variant. The keyed-map strip is scoped to a per-method-name allowlist
+ * (where/orWhere/whereNot/orWhereNot/firstWhere), so this pins that orWhereNot is covered — the
+ * value-binding map form is safe on it too. #734
+ *
+ * @psalm-suppress TooFewArguments, MixedAssignment
+ */
+function safeOrWhereNotArray(\Illuminate\Http\Request $request): void {
+    $builder = new \Illuminate\Database\Query\Builder();
+    $status = $request->input('status');
+
+    $builder->orWhereNot(['status_id' => $status]);
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeSqlWhereArrayClosureValue.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeSqlWhereArrayClosureValue.phpt
@@ -1,0 +1,34 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+class ClosureReceiverModel extends \Illuminate\Database\Eloquent\Model {}
+
+/**
+ * Regression guard for the flush lifecycle. A closure/arrow-fn completes a FunctionLikeAnalyzer
+ * BETWEEN the Before-hook recording the map argument node and its removeTaints dispatch; a
+ * per-function-like flush would wipe the record there and the #734 FP would return. The flush must be
+ * per-FILE. Two triggers, one file:
+ *
+ *  1. arrow-fn in the receiver chain (analyzed before the outer where's args);
+ *  2. closure invoked among the map values (analyzed before processTaintedness).
+ */
+function safeClosureInReceiverChain(\Illuminate\Http\Request $request): void {
+    $status = (string) $request->input('status');
+
+    ClosureReceiverModel::whereHas('roles', static fn (): bool => true)
+        ->where(['status_id' => $status]);
+}
+
+/**
+ * @psalm-suppress TooFewArguments
+ */
+function safeClosureAmongMapValues(\Illuminate\Http\Request $request): void {
+    $status = (string) $request->input('status');
+
+    $builder = new \Illuminate\Database\Query\Builder();
+    $builder->where(['status_id' => $status, 'flag' => (static fn (): int => 1)()]);
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeSqlWhereArrayValues.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeSqlWhereArrayValues.phpt
@@ -1,0 +1,46 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * where(['col' => $value]) routes through addArrayOfWheres(), which binds each value as a
+ * PDO parameter (where($key, '=', $value)). A tainted value is never interpolated as a column
+ * identifier, so the keyed-array form must not be flagged. Regression guard for #734.
+ *
+ * @psalm-suppress TooFewArguments, MixedAssignment
+ */
+function safeArrayColumnWhere(\Illuminate\Http\Request $request): void {
+    $builder = new \Illuminate\Database\Query\Builder();
+    $status = $request->input('status');
+
+    $builder->where(['status_id' => $status, 'to_id' => 1]);
+}
+
+/**
+ * orWhere map form — a distinct WHERE_MAP_METHODS entry, so it gets its own coverage (a typo in the
+ * allowlist would otherwise ship unnoticed).
+ *
+ * @psalm-suppress TooFewArguments, MixedAssignment
+ */
+function safeArrayColumnOrWhere(\Illuminate\Http\Request $request): void {
+    $builder = new \Illuminate\Database\Query\Builder();
+    $status = $request->input('status');
+
+    $builder->orWhere(['status_id' => $status]);
+}
+
+/**
+ * whereNot map form — another distinct WHERE_MAP_METHODS entry, pinned so dropping 'wherenot' from the
+ * allowlist cannot stay green.
+ *
+ * @psalm-suppress TooFewArguments, MixedAssignment
+ */
+function safeArrayColumnWhereNot(\Illuminate\Http\Request $request): void {
+    $builder = new \Illuminate\Database\Query\Builder();
+    $status = $request->input('status');
+
+    $builder->whereNot(['status_id' => $status]);
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeSqlWhereArrayVariable.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeSqlWhereArrayVariable.phpt
@@ -1,0 +1,23 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Prophylactic CANARY for the variable-form argument edge (`$conds = [...]; where($conds)`). Psalm
+ * does not currently flag this shape even without the strip, so it stays green with the handler
+ * disabled. It documents that the map-form FP must not appear for the variable form either, and would
+ * catch a future upstream change that started flowing the sink through a local. It does not, on its
+ * own, prove the variable-form recording fires (the inline literal form is the load-bearing pin). #734
+ *
+ * @psalm-suppress TooFewArguments, MixedAssignment
+ */
+function safeArrayVariableWhere(\Illuminate\Http\Request $request): void {
+    $builder = new \Illuminate\Database\Query\Builder();
+    $status = $request->input('status');
+
+    $conds = ['status_id' => $status];
+    $builder->where($conds);
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeSqlWhereFirstClassCallable.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeSqlWhereFirstClassCallable.phpt
@@ -1,0 +1,20 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * A first-class-callable `where(...)` has no arguments; `getArgs()` throws on it, so the Before-hook
+ * must skip via `isFirstClassCallable()`. Pins that crash guard (expect analysis to complete with no
+ * output).
+ *
+ * @psalm-suppress TooFewArguments
+ */
+function safeFirstClassCallableWhere(): void {
+    $builder = new \Illuminate\Database\Query\Builder();
+
+    $fn = $builder->where(...);
+    $fn('status', 'active');
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeSqlWhereNullsafeArrayValues.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeSqlWhereNullsafeArrayValues.phpt
@@ -1,0 +1,18 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Upstream-behavior CANARY, not a pin. Psalm does not currently dispatch the `sql` sink through a
+ * nullsafe call `$builder?->where([...])`, so this stays green even with the handler disabled. The
+ * Before-hook still handles the NullsafeMethodCall branch, so if a future Psalm starts flowing sinks
+ * through nullsafe calls this test catches the resulting map-form FP before it reaches users.
+ */
+function safeNullsafeArrayWhere(\Illuminate\Http\Request $request, ?\Illuminate\Database\Query\Builder $builder): void {
+    $status = (string) $request->input('status');
+
+    $builder?->where(['status_id' => $status]);
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/TaintedShellWhereValueFlowPreserved.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedShellWhereValueFlowPreserved.phpt
@@ -1,0 +1,29 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * The `Query\Builder::where()` stub (the one exercised here) keeps `@psalm-flow ($operator, $value) ->
+ * return` and deliberately does NOT carry `@psalm-taint-specialize`, which would silently break
+ * propagation of non-SQL taint kinds through the value positions (see WhereColumnTaintHandler /
+ * docs/contributing/taint-analysis.md). Guard: a non-SQL (shell) taint on a where VALUE must still flow
+ * through the returned builder. If a future change adds `@psalm-taint-specialize` to this stub, this
+ * stops reporting. (Some Eloquent stubs such as firstWhere DO carry `@psalm-taint-specialize`; this
+ * guard is scoped to the Query\Builder where stub under test.)
+ */
+class WhereValueShellRunner {
+    /** @psalm-taint-sink shell $cmd */
+    public function run(mixed $cmd): void {}
+}
+
+/** @psalm-suppress TooFewArguments */
+function shellFlowsThroughWhereValue(\Illuminate\Http\Request $request): void {
+    $value = (string) $request->input('q');
+    $builder = (new \Illuminate\Database\Query\Builder())->where('col', $value);
+
+    (new WhereValueShellRunner())->run($builder);
+}
+?>
+--EXPECTF--
+%ATaintedShell on line %d: Detected tainted shell code

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlFirstWhereColumnSink.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlFirstWhereColumnSink.phpt
@@ -1,0 +1,21 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+class FirstWhereColumnSinkModel extends \Illuminate\Database\Eloquent\Model {}
+
+/**
+ * String-form column injection through firstWhere() must still report (#733). firstWhere is a plain
+ * method on Eloquent\Builder (vendor Eloquent/Builder.php:380) with its OWN `@psalm-taint-sink sql
+ * $column` stub (Eloquent/Builder.phpstub:413) and its own WHERE_MAP_METHODS entry, so it is pinned
+ * separately from where().
+ */
+function unsafeFirstWhereColumn(\Illuminate\Http\Request $request): void {
+    $column = $request->input('column');
+
+    FirstWhereColumnSinkModel::firstWhere($column, 'safe-value');
+}
+?>
+--EXPECTF--
+%ATaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlFirstWhereUnsealedMap.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlFirstWhereUnsealedMap.phpt
@@ -1,0 +1,32 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+class UnsealedMapModel extends \Illuminate\Database\Eloquent\Model {}
+
+/**
+ * A GENUINE unsealed keyed array: the declared shape keeps a `...<string, mixed>` fallback whose extra
+ * keys are unknown, possibly user-controlled column names. `firstWhere()` receives this shape, so
+ * isBoundValueMap must reject it on `fallback_params !== null` and the sink must stand. This is the
+ * only coverage of that branch (TaintedSqlWhereWholeArrayInput uses a plain `array<string, mixed>` /
+ * TArray, which is not a TKeyedArray at all).
+ *
+ * The `+ $request->all()` union is a plain array at runtime, so the declared shape is more specific
+ * than Psalm infers for the body (MixedReturnTypeCoercion). That is intentional. It is what carries
+ * the unsealed TKeyedArray to the call site as the argument's type.
+ *
+ * @return array{status: int, ...<string, mixed>}
+ *
+ * @psalm-suppress MixedReturnTypeCoercion
+ */
+function unsealedFilters(\Illuminate\Http\Request $request): array {
+    return ['status' => 1] + $request->all();
+}
+
+function unsafeUnsealedMapFirstWhere(\Illuminate\Http\Request $request): void {
+    UnsealedMapModel::firstWhere(unsealedFilters($request));
+}
+?>
+--EXPECTF--
+%ATaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlHavingMap.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlHavingMap.phpt
@@ -1,0 +1,24 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * having() is deliberately NOT in WHERE_MAP_METHODS: Laravel's having() has no `is_array($column)`
+ * branch, so an array column is never value-bound (it compiles raw into the havings clause). A tainted
+ * value in a having map must therefore still flag. Pins that exclusion — a future "having looks like
+ * where" addition to the allowlist would silently create a false negative here.
+ *
+ * (having()'s `$column` stub type is `Expression|Closure|string`, so the array literal also draws an
+ * InvalidArgument; that is a separate stub concern, suppressed so the taint assertion stands alone.)
+ *
+ * @psalm-suppress TooFewArguments, InvalidArgument
+ */
+function unsafeHavingMap(\Illuminate\Http\Request $request): void {
+    $builder = new \Illuminate\Database\Query\Builder();
+
+    $builder->having(['total' => (string) $request->input('t')], null);
+}
+?>
+--EXPECTF--
+%ATaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlMapAssignmentFlow.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlMapAssignmentFlow.phpt
@@ -1,0 +1,17 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * The false-negative regression guard PR #1218 lacked. A keyed map whose value flows OUT via
+ * `$conds['name']` into a raw SQL sink must KEEP its taint — the strip is scoped to where-family
+ * argument nodes only, so an assignment/element-read here is untouched. #734
+ */
+function mapValueFlowsToRawSink(\Illuminate\Http\Request $request): void {
+    $conds = ['name' => (string) $request->input('n')];
+    \Illuminate\Support\Facades\DB::statement('select * from users where name = ' . $conds['name']);
+}
+?>
+--EXPECTF--
+%ATaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlMapReturnFlow.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlMapReturnFlow.phpt
@@ -1,0 +1,22 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * A keyed map returned from a function and then interpolated into a raw SQL sink must keep its taint.
+ * PR #1218's unscoped strip removed `sql` from every sealed string-key map (including this return
+ * expression), a false negative; the scoped strip fires only on where-family argument nodes. #734
+ *
+ * @return array{clause: string}
+ */
+function buildFilter(\Illuminate\Http\Request $request): array {
+    return ['clause' => (string) $request->input('x')];
+}
+
+function useBuiltFilter(\Illuminate\Http\Request $request): void {
+    \Illuminate\Support\Facades\DB::statement('select * from t where ' . buildFilter($request)['clause']);
+}
+?>
+--EXPECTF--
+%ATaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereAllMap.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereAllMap.phpt
@@ -1,0 +1,21 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * `whereAll` is NOT in the strip's method allowlist: the values of a whereAll array are COLUMN
+ * identifiers, not bound values, so `whereAll(['status_id' => $tainted])` must keep flagging. This is
+ * the name-exclusion soundness win over PR #1218's method-agnostic strip. #734
+ *
+ * @psalm-suppress TooFewArguments
+ */
+function whereAllKeyedMapFlags(\Illuminate\Http\Request $request): void {
+    $builder = new \Illuminate\Database\Query\Builder();
+    $column = (string) $request->input('column');
+
+    $builder->whereAll(['status_id' => $column]);
+}
+?>
+--EXPECTF--
+%ATaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereArrayTaintedKey.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereArrayTaintedKey.phpt
@@ -1,0 +1,23 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * A tainted DYNAMIC key is a column identifier and must still flag. `[$tainted => 1]` has a
+ * non-literal string key, so its type is `array<string, int>` (not a sealed TKeyedArray) and
+ * isBoundValueMap rejects it — the sink stands. Uses orWhereNot, not where(): an upstream batch
+ * artifact suppresses the where() variant when many taint tests run in one psalm process (see the
+ * note in TaintedSqlWhereWholeArrayInput.phpt).
+ *
+ * @psalm-suppress TooFewArguments
+ */
+function unsafeTaintedKeyMap(\Illuminate\Http\Request $request): void {
+    $builder = new \Illuminate\Database\Query\Builder();
+    $column = (string) $request->input('column');
+
+    $builder->orWhereNot([$column => 1]);
+}
+?>
+--EXPECTF--
+%ATaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereNotListForm.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereNotListForm.phpt
@@ -1,0 +1,21 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * The int-key branch of isBoundValueMap. A LIST literal `whereNot([$tainted])` (integer key 0) is a
+ * nested-condition form whose element[0] is a raw column, so it must still flag — the only coverage of
+ * both the integer-key rejection AND of whereNot.
+ *
+ * @psalm-suppress TooFewArguments
+ */
+function unsafeListFormWhereNot(\Illuminate\Http\Request $request): void {
+    $builder = new \Illuminate\Database\Query\Builder();
+    $column = (string) $request->input('column');
+
+    $builder->whereNot([$column]);
+}
+?>
+--EXPECTF--
+%ATaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereNumericStringKey.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereNumericStringKey.phpt
@@ -1,0 +1,22 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * A numeric-string key ('1.5', which PHP keeps as a string) must NOT be treated as a bound-value map:
+ * Laravel's addArrayOfWheres dispatches on `is_numeric($key)`, routing a numeric key to the
+ * nested-column branch where the value would be a raw column identifier. isBoundValueMap therefore
+ * rejects any numeric key (int or numeric-string) like an int key, so the sink stands and this flags.
+ * Uses whereNot per the batch-artifact guidance (see TaintedSqlWhereWholeArrayInput.phpt).
+ *
+ * @psalm-suppress TooFewArguments
+ */
+function unsafeNumericStringKeyMap(\Illuminate\Http\Request $request): void {
+    $builder = new \Illuminate\Database\Query\Builder();
+
+    $builder->whereNot(['1.5' => (string) $request->input('c')]);
+}
+?>
+--EXPECTF--
+%ATaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereUnpackedArray.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereUnpackedArray.phpt
@@ -1,0 +1,22 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * A spread argument (`where(...$args)`) unpacks a string-keyed array as NAMED arguments, so a tainted
+ * value lands in the `$column` parameter directly — a real identifier injection. The Before-hook skips
+ * unpacked first args (`$args[0]->unpack`), so nothing is recorded and the sink stands. Pins that
+ * guard.
+ *
+ * @psalm-suppress TooFewArguments
+ */
+function unsafeUnpackedArrayWhere(\Illuminate\Http\Request $request): void {
+    $builder = new \Illuminate\Database\Query\Builder();
+    $args = ['column' => (string) $request->input('column')];
+
+    $builder->where(...$args);
+}
+?>
+--EXPECTF--
+%ATaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereWholeArrayInput.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereWholeArrayInput.phpt
@@ -1,0 +1,25 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * where($request->all()) is NOT the safe keyed-literal form: the array KEYS become column
+ * identifiers and here they are entirely user-controlled, so this must still be flagged.
+ * This is why the safe gate is a keyed-array literal (TKeyedArray), not is_array().
+ *
+ * Authoring note: whole-node taint into a shared sink arg node (here Query\Builder::where#1) can
+ * suppress OTHER files' array-composition-edge taint into the SAME node when the suite is batch-analyzed
+ * in one psalm process — an upstream Psalm artifact. Prefer whereNot/orWhereNot sinks for new
+ * keep-taint tests of map/key shapes (see TaintedSqlWhereArrayTaintedKey.phpt).
+ *
+ * @psalm-suppress TooFewArguments
+ */
+function unsafeWholeArrayWhere(\Illuminate\Http\Request $request): void {
+    $builder = new \Illuminate\Database\Query\Builder();
+
+    $builder->where($request->all());
+}
+?>
+--EXPECTF--
+%ATaintedSql on line %d: Detected tainted SQL


### PR DESCRIPTION
## Issue to Solve

`@psalm-taint-sink sql $column` on the where family is correct for the string form (`where($userControlledColumn)` interpolates the column as a raw identifier, a real injection vector) but also fired on the keyed-map form:

```php
$query->where(['status_id' => $request->input('status')]); // false TaintedSql
```

The map form routes through `Illuminate\Database\Query\Builder::addArrayOfWheres()`, which for a string key calls `where($key, '=', $value)`: the literal KEY is the column and each VALUE is PDO-bound, never interpolated. Confirmed false positive in pixelfed and monica.

The sink annotation cannot express "sink only when the argument is a string", and adding `@psalm-taint-specialize` to these stubs silently breaks `@psalm-flow` propagation of non-SQL taint kinds (html/shell/secret) through the `$value` positions. The stubs must stay byte-identical (and do: zero stub diffs in this PR).

## Related

Closes #734
References #733 (firstWhere, closed as a duplicate)
Supersedes #1218

## Solution Description

### Why this supersedes #1218

#1218 registered an unscoped `RemoveTaintsInterface` handler that stripped `sql` taint from ANY expression typed as a sealed all-string-key `TKeyedArray`. Psalm dispatches `RemoveTaints` from ~17 analyzers (assignment, return, variable/property fetch, binary ops, ...), so the strip fired far outside call-argument context and caused empirically confirmed false negatives on real SQL injections, for example:

```php
$conds = ['name' => (string) $request->input('n')];
DB::statement('select * from users where name = ' . $conds['name']); // silent with #1218
```

Both #1218 false-negative scenarios (map value read out via an element fetch, and a map returned from a function) are now regression tests: `TaintedSqlMapAssignmentFlow.phpt`, `TaintedSqlMapReturnFlow.phpt`.

### The scoped design

One new handler, `WhereColumnTaintHandler`, three hooks:

- `BeforeExpressionAnalysisInterface` records `spl_object_id` of the first-argument node of where-family calls (`where`, `orWhere`, `whereNot`, `orWhereNot`, `firstWhere`; method-name allowlist derived from the stubs carrying `@psalm-taint-sink sql $column` whose array form routes through `addArrayOfWheres()`). Recording is gated on `Codebase::$taint_flow_graph`, so non-taint runs pay near zero.
- `RemoveTaintsInterface` strips `TaintKind::INPUT_SQL` only when the dispatched expression IS one of those recorded nodes and its type is a sealed all-string-key `TKeyedArray` (any int key or unsealed fallback keeps the sink: those shapes carry column identifiers or unknown keys). Because the strip is keyed to the exact argument node, it applies only to that argument edge; the same value used anywhere else keeps its taint.
- `BeforeFileAnalysisInterface` flushes the set per file. A per-function-like flush (the sibling `ValidationTaintHandler` pattern) is deliberately NOT used: a closure completing between record and read (e.g. `whereHas('roles', fn ($q) => ...)->where([...])`) would wipe the record and resurrect the false positive; pinned by `SafeSqlWhereArrayClosureValue.phpt`.

`having`/`orHaving` carry the same sink but are excluded: `having()` has no `is_array($column)` branch in Laravel (verified 12.x and 13.x), so an array column never binds values, and the sink must stand (`TaintedSqlHavingMap.phpt`).

Design bonus over #1218: `whereAll(['col' => $tainted])` now keeps flagging (`TaintedSqlWhereAllMap.phpt`); #1218 had to document that exact case as a known limitation because its strip was method-agnostic.

### Verification

19 taint type tests (5 safe map-form pins, one per allowlisted method; false-negative regression guards; exclusion pins for whereAll/having; guard pins for arg unpacking, first-class callables, int-key lists, unsealed maps, tainted dynamic keys; a shell-taint flow guard against anyone re-adding `@psalm-taint-specialize`). Soundness-critical tests were teeth-verified: removing the corresponding handler check makes each fail. Full unit suite, Psalm self-analysis at 100% inferred types, cs and rector clean.

### Follow-ups

- Upstream: `ArgumentAnalyzer::processTaintedness()` already has the method id and argument offset in scope where `AddRemoveTaintsEvent` is constructed. An upstream PR adding them to the event retires the Before-expression shim (the handler then gates on the event field), same auto-retiring pattern as `ConditionableWhenHandler`.
- Backport: the same design ports to `3.x` (Psalm 6); `BeforeExpressionAnalysisInterface` exists there, only the `removeTaints` return type differs (`list<string>` vs int bitmask). Separate PR.

## Checklist
- [x] Tests cover the change (19 type tests in `tests/Type/tests/TaintAnalysis/`)
- [x] Documentation is updated (`docs/contributing/taint-analysis.md`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786129953&installation_id=141955579&pr_number=1221&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1221&signature=73f30c878972e59388e4b37500458fafcd99dda3e97e981938d7ba546a7a3b43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->