### PR TITLE
Adapt the `#1219` builder-static port for Psalm 6 and Laravel 11 CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You can read more about how the plugin's taint analysis works and what vulnerabi
 ### Step 1: Install
 
 ```bash
-composer require --dev psalm/plugin-laravel:^3.8
+composer require --dev "psalm/plugin-laravel:^3.14"
 ```
 
 ### Step 2: Generate a Laravel-tailored `psalm.xml`

--- a/src/Handlers/Eloquent/BuilderNativeStaticReturnTypeHandler.php
+++ b/src/Handlers/Eloquent/BuilderNativeStaticReturnTypeHandler.php
@@ -30,6 +30,13 @@ use Psalm\Type\Union;
  * {@see BuilderSubclassQueryMixinHandler}), which also catches abstract intermediate builders no
  * model references directly.
  *
+ * 3.x (Psalm 6) port of the master handler (#1219). The bug reproduces identically on Psalm 6
+ * (verified: without this handler the chain collapses to `FavoriteableBuilder<Model>` and the subclass
+ * method surfaces as UndefinedMagicMethod). The only delta is spelling the docblock-static with a named
+ * argument: Psalm 6's `TNamedObject` 3rd constructor parameter is `$definite_class`, where Psalm 7 had
+ * `is_static_resolved`. The named form (`from_docblock: true`, everything else default) is identical
+ * across both majors and avoids a misleading positional argument.
+ *
  * @see https://github.com/psalm/psalm-plugin-laravel/issues/1216
  */
 final class BuilderNativeStaticReturnTypeHandler implements AfterCodebasePopulatedInterface
@@ -77,7 +84,7 @@ final class BuilderNativeStaticReturnTypeHandler implements AfterCodebasePopulat
                     static fn(Atomic $atomic): Atomic => self::isNativeStaticReturn($atomic)
                         // The docblock `@return static` representation: value='static',
                         // from_docblock=true (mirrors how TypeParser stores `@return static`).
-                        ? new TNamedObject('static', false, false, [], true)
+                        ? new TNamedObject('static', from_docblock: true)
                         : $atomic,
                     $atomics,
                 ));

--- a/tests/Type/tests/Builder/CustomBuilderSubclassChainTest.phpt
+++ b/tests/Type/tests/Builder/CustomBuilderSubclassChainTest.phpt
@@ -1,3 +1,9 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// #[UseEloquentBuilder] (used by the scanned App\Models\Artist) is Laravel 12.19+; the attribute
+// class does not exist on Laravel 11, so the asserted output cannot be produced there.
+\Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipBelow('12.19.0');
 --FILE--
 <?php declare(strict_types=1);
 


### PR DESCRIPTION
## Issue to Solve

The direct `master` → `3.x` merge (19a4dd85) landed #1219 unadapted for Psalm 6 / Laravel 11, leaving two latent CI breaks and one stale doc line. The merge itself only ran a single check (direct branch push), so the full matrix never validated it.

## Related

Follow-up to the v4.14.10 → 3.x backport merge (19a4dd85); adapts #1219 (issue #1216).

## Solution Description

- `CustomBuilderSubclassChainTest.phpt`: add `LaravelVersion::skipBelow('12.19.0')` SKIPIF. The scanned `App\Models\Artist` uses `#[UseEloquentBuilder]` (Laravel 12.19+), which does not exist on the Laravel 11 CI cell.
- `BuilderNativeStaticReturnTypeHandler`: build the docblock-static via `new TNamedObject('static', from_docblock: true)` instead of Psalm 7 positional args (Psalm 6's third constructor parameter is `$definite_class` where Psalm 7 had `is_static_resolved`; the named form is identical on both majors). Docblock now records that the #1216 TypeExpander bug reproduces identically on Psalm 6 (verified: without the handler the chain collapses to `FavoriteableBuilder<Model>` with a false `UndefinedMagicMethod`), so the handler is needed here too.
- README: install line `^3.8` → `^3.14` (3.x counterpart of a15f65d4, resolved away by the merge).

Verified in a Psalm 6 worktree: the phpt passes, Psalm self-analysis exits 0 at 100% inferred types, cs and rector clean.

## Checklist
- [x] Tests cover the change (SKIPIF-gated type test)
- [x] Documentation is updated (README install line)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786139915&installation_id=141955579&pr_number=1223&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1223&signature=72db59a614c5845d9890d0033dbe29c3431223d5e4c80b1379f1d7c1cef0adea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->