### PR TITLE
Make partial Laravel boot loud: warn by default, fail with `failOnInternalError`

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -220,6 +220,8 @@ PSALM_LARAVEL_PLUGIN_CACHE_PATH=/path/to/cache ./vendor/bin/psalm
 When the plugin encounters an internal error (e.g. failing to boot the Laravel app or generate stubs), it prints a warning and disables itself for that run.
 Set this to `true` to throw the exception instead.
 
+This also covers partial boots. When the app's `bootstrap()` throws partway (for example, a `config/*.php` file that calls `parse_url(env('UNSET'))`), the plugin normally keeps running in a degraded mode (service providers never booted, so model, facade and container inference is reduced) and prints a warning about it. With `failOnInternalError` enabled, that swallowed bootstrap failure fails the run instead of degrading silently.
+
 **Recommended for CI.** Without this, a misconfigured environment causes the plugin to silently disable itself — your pipeline passes but without any plugin analysis.
 With `failOnInternalError`, the Psalm run fails immediately, so you know the plugin isn't working.
 

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -44,6 +44,8 @@ flowchart TD
 
 The whole `__invoke` body is wrapped in a try/catch: on any internal error the plugin reports a warning and disables itself for the run (or rethrows when `failOnInternalError` is set). See `src/Internal/InternalErrorReporter.php`.
 
+Bootstrap failures are a special case: `ApplicationProvider` swallows a `bootstrap()` throw to keep the run alive (one bad `config/*.php` must not disable the plugin), so they never reach the try/catch above. `Plugin::__invoke` checks `ApplicationProvider::getBootstrapError()` right after boot and routes it through `InternalErrorReporter::reportDegradedBoot()`: a "degraded mode" warning by default, or escalation to the regular internal-error path when `failOnInternalError` is set (issue #1096). Note that Psalm's `--no-progress` flag installs a `VoidProgress`, which silences all `Progress::warning()` output, including these.
+
 ## Getting started
 
 ```bash

--- a/src/Internal/InternalErrorReporter.php
+++ b/src/Internal/InternalErrorReporter.php
@@ -53,4 +53,38 @@ final class InternalErrorReporter
             throw $throwable;
         }
     }
+
+    /**
+     * Surfaces a bootstrap failure that {@see \Psalm\LaravelPlugin\Bootstrap\ApplicationProvider}
+     * swallowed to keep the run alive (crash resistance: one bad `config/*.php` must not
+     * disable the plugin for the whole run). Unlike {@see report()}, the plugin stays
+     * active — handlers still register against the partially-booted app — so the output
+     * is a "degraded" warning trio rather than a "disabled" notice.
+     *
+     * With `failOnInternalError` enabled the swallowed error is escalated instead of
+     * warned about: rethrowing here lands in `Plugin::__invoke()`'s catch, which routes
+     * through {@see report()} for the full treatment (issue URL + final rethrow into
+     * Psalm). A half-booted app is an internal error when the user opted into failing.
+     *
+     * @throws \Throwable when {@see PluginConfig::$failOnInternalError} is on
+     */
+    public static function reportDegradedBoot(\Throwable $throwable, Progress $output, PluginConfig $pluginConfig): void
+    {
+        if ($pluginConfig->failOnInternalError) {
+            throw $throwable;
+        }
+
+        $output->warning("Laravel plugin: application bootstrap failed partway: {$throwable->getMessage()}");
+
+        $hint = InternalErrorClassifier::hint($throwable);
+        if ($hint !== null) {
+            $output->warning("Laravel plugin: {$hint}");
+        }
+
+        $output->warning(
+            'Laravel plugin is running in degraded mode: service providers never booted, so '
+            . 'model, facade and container inference is reduced. '
+            . 'Run `vendor/bin/psalm-laravel diagnose` for details.',
+        );
+    }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -33,6 +33,15 @@ final class Plugin implements PluginEntryPointInterface
         try {
             ApplicationProvider::bootApp();
 
+            // bootstrap() failures are swallowed inside ApplicationProvider (crash
+            // resistance: one bad config file must not disable the plugin for the
+            // whole run). Surface them here so a degraded boot is visible in a normal
+            // psalm run rather than only via `psalm-laravel diagnose` (#1096).
+            $bootstrapError = ApplicationProvider::getBootstrapError();
+            if ($bootstrapError instanceof \Throwable) {
+                InternalErrorReporter::reportDegradedBoot($bootstrapError, $output, $pluginConfig);
+            }
+
             if ($pluginConfig->shouldUseMigrations()) {
                 $this->buildSchema($pluginConfig);
             }

--- a/tests/Unit/Util/InternalErrorReporterTest.php
+++ b/tests/Unit/Util/InternalErrorReporterTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Util;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Config\PluginConfig;
+use Psalm\LaravelPlugin\Internal\InternalErrorReporter;
+use Psalm\Progress\Progress;
+
+#[CoversClass(InternalErrorReporter::class)]
+final class InternalErrorReporterTest extends TestCase
+{
+    #[Test]
+    public function degraded_boot_warns_with_error_message_and_diagnose_pointer(): void
+    {
+        $progress = $this->collectingProgress();
+
+        InternalErrorReporter::reportDegradedBoot(
+            new \RuntimeException('parse_url(): Argument #1 ($url) must be of type string, null given'),
+            $progress,
+            PluginConfig::fromXml(null),
+        );
+
+        $this->assertNotEmpty($progress->warnings);
+        $this->assertStringContainsString(
+            'application bootstrap failed partway: parse_url()',
+            $progress->warnings[0],
+        );
+
+        $last = $progress->warnings[\count($progress->warnings) - 1];
+        $this->assertStringContainsString('degraded mode', $last);
+        $this->assertStringContainsString('psalm-laravel diagnose', $last);
+    }
+
+    #[Test]
+    public function degraded_boot_includes_classifier_hint_when_available(): void
+    {
+        $progress = $this->collectingProgress();
+
+        // Thrown from this test file — classified as user application code
+        // (not vendor/, not the plugin's src/), so a hint line is emitted
+        // between the error message and the degraded-mode notice.
+        InternalErrorReporter::reportDegradedBoot(
+            new \RuntimeException('boom'),
+            $progress,
+            PluginConfig::fromXml(null),
+        );
+
+        $this->assertCount(3, $progress->warnings);
+        $this->assertStringContainsString('originated inside your application code', $progress->warnings[1]);
+    }
+
+    #[Test]
+    public function degraded_boot_rethrows_and_stays_silent_when_fail_on_internal_error_is_on(): void
+    {
+        $progress = $this->collectingProgress();
+        $config = PluginConfig::fromXml(
+            new \SimpleXMLElement('<pluginClass><failOnInternalError value="true" /></pluginClass>'),
+        );
+        $bootstrapError = new \RuntimeException('boom');
+
+        try {
+            InternalErrorReporter::reportDegradedBoot($bootstrapError, $progress, $config);
+            $this->fail('Expected the swallowed bootstrap error to be rethrown');
+        } catch (\RuntimeException $runtimeException) {
+            // Same instance escalates so Plugin::__invoke()'s catch reports it once,
+            // with the original trace intact.
+            $this->assertSame($bootstrapError, $runtimeException);
+        }
+
+        $this->assertSame([], $progress->warnings, 'Escalation path must not double-report warnings');
+    }
+
+    /**
+     * @return Progress&object{warnings: list<string>}
+     */
+    private function collectingProgress(): Progress
+    {
+        return new class extends Progress {
+            /** @var list<string> */
+            public array $warnings = [];
+
+            #[\Override]
+            public function warning(string $message): void
+            {
+                $this->warnings[] = $message;
+            }
+
+            #[\Override]
+            public function debug(string $message): void {}
+
+            #[\Override]
+            public function startPhase(\Psalm\Progress\Phase $phase, int $threads = 1): void {}
+
+            #[\Override]
+            public function expand(int $number_of_tasks): void {}
+
+            #[\Override]
+            public function taskDone(int $level): void {}
+
+            #[\Override]
+            public function finish(): void {}
+
+            #[\Override]
+            public function alterFileDone(string $file_name): void {}
+        };
+    }
+}


### PR DESCRIPTION
## Issue to Solve

When the analyzed app's `bootstrap()` throws partway (e.g. a `config/*.php` file calling `parse_url(env('UNSET'))`), `ApplicationProvider` swallows the error and returns a partially booted app. Service providers never register, so the plugin runs effectively inert, yet Psalm reports a clean run, even with `failOnInternalError=true`. The degraded state was only observable via `psalm-laravel diagnose`.

## Related

Fixes #1096

## Solution Description

The swallow itself stays (crash resistance: one bad config file must not disable the plugin for the whole run). Only the observability changes, at a single choke point: `Plugin::__invoke` checks `ApplicationProvider::getBootstrapError()` right after `bootApp()` and routes it through the new `InternalErrorReporter::reportDegradedBoot()`:

- `failOnInternalError=false` (default): a warning trio via `Progress::warning()`: the original error message, an `InternalErrorClassifier` hint (points at the offending file), and a degraded-mode notice referring to `psalm-laravel diagnose`. Analysis continues.
- `failOnInternalError=true`: the swallowed error is rethrown and lands in the existing `__invoke` catch → `InternalErrorReporter::report()` → rethrow into Psalm, so the run fails. No new escalation machinery; a half-booted app is treated as an internal error when the user opted into failing.

Verified with unit tests plus an end-to-end run on a fresh Laravel 13 app with a throwing config file: the default config prints all three warnings and keeps analyzing; with `failOnInternalError=true` Psalm exits non-zero with the bootstrap error and a pre-filled issue URL. A healthy boot is unaffected (`composer test:app` passes).

Note: Psalm's `--no-progress` installs a `VoidProgress` whose `warning()` is a no-op, so these warnings (like all existing plugin warnings) are only visible in runs without `--no-progress`. For CI, `failOnInternalError=true` remains the loud signal (docs already recommend it, and `tests/Application/laravel-test-psalm.xml` sets it, so a degraded boot now fails the application test).

## Checklist
- [x] Tests cover the change (unit test in `tests/Unit/`)
- [x] Documentation is updated (`docs/config.md`, `docs/contributing/README.md`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786143179&installation_id=141955579&pr_number=1226&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1226&signature=261866309095148782be3b2a8d0fdbece906cb491b8c4ac4769c57656c9162aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->