### PR TITLE
Keep plugin warnings visible without progress

### DIFF
--- a/src/Handlers/Auth/GuardTaintHandler.php
+++ b/src/Handlers/Auth/GuardTaintHandler.php
@@ -6,6 +6,7 @@ namespace Psalm\LaravelPlugin\Handlers\Auth;
 
 use Illuminate\Auth\SessionGuard;
 use Illuminate\Auth\TokenGuard;
+use Psalm\LaravelPlugin\Internal\WarningReporter;
 use Psalm\Plugin\EventHandler\AfterClassLikeVisitInterface;
 use Psalm\Plugin\EventHandler\Event\AfterClassLikeVisitEvent;
 use Psalm\Storage\ClassLikeStorage;
@@ -85,7 +86,8 @@ final class GuardTaintHandler implements AfterClassLikeVisitInterface
         $method_storage = $storage->methods[$method] ?? null;
 
         if ($method_storage === null) {
-            $event->getCodebase()->progress->warning(
+            WarningReporter::emit(
+                $event->getCodebase()->progress,
                 "Laravel plugin: {$storage->name}::{$method}() not found — guard taint annotation skipped. "
                 . 'The Laravel method signature may have changed; please report this against psalm-plugin-laravel.',
             );

--- a/src/Handlers/Eloquent/ModelRegistrationHandler.php
+++ b/src/Handlers/Eloquent/ModelRegistrationHandler.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Psalm\Codebase;
 use Psalm\Internal\MethodIdentifier;
 use Psalm\LaravelPlugin\Internal\AnonymousClassNameDetector;
+use Psalm\LaravelPlugin\Internal\WarningReporter;
 use Psalm\Plugin\EventHandler\AfterCodebasePopulatedInterface;
 use Psalm\Plugin\EventHandler\Event\AfterCodebasePopulatedEvent;
 use Psalm\Storage\ClassLikeStorage;
@@ -90,13 +91,15 @@ final class ModelRegistrationHandler implements AfterCodebasePopulatedInterface
             // reflection works in property handlers (e.g. getTable(), getCasts())
             try {
                 if (!\class_exists($storage->name, true)) {
-                    $codebase->progress->warning(
+                    WarningReporter::emit(
+                        $codebase->progress,
                         "Laravel plugin: skipping model '{$storage->name}': class could not be loaded by autoloader",
                     );
                     continue;
                 }
             } catch (\Error|\Exception $error) {
-                $codebase->progress->warning(
+                WarningReporter::emit(
+                    $codebase->progress,
                     "Laravel plugin: skipping model '{$storage->name}': {$error->getMessage()}",
                 );
                 continue;

--- a/src/Handlers/Eloquent/Schema/MigrationSchemaBuilder.php
+++ b/src/Handlers/Eloquent/Schema/MigrationSchemaBuilder.php
@@ -7,6 +7,7 @@ namespace Psalm\LaravelPlugin\Handlers\Eloquent\Schema;
 use Illuminate\Foundation\Application;
 use Psalm\Codebase;
 use Psalm\LaravelPlugin\Bootstrap\ApplicationProvider;
+use Psalm\LaravelPlugin\Internal\WarningReporter;
 use Psalm\Progress\Progress;
 
 /**
@@ -67,7 +68,7 @@ final class MigrationSchemaBuilder
             try {
                 $aggregator->addStatements($this->codebase->getStatementsForFile($file));
             } catch (\InvalidArgumentException|\UnexpectedValueException $e) {
-                $progress->warning("Laravel plugin: skipping migration '{$file}': {$e->getMessage()}");
+                WarningReporter::emit($progress, "Laravel plugin: skipping migration '{$file}': {$e->getMessage()}");
             }
         }
 
@@ -83,12 +84,12 @@ final class MigrationSchemaBuilder
         } else {
             $writeFailure = $this->cache->getWriteFailureReason();
             $detail = $writeFailure !== null ? ": {$writeFailure}" : ' — check directory permissions';
-            $progress->warning("Laravel plugin: parsed migration schema (cache write failed{$detail})");
+            WarningReporter::emit($progress, "Laravel plugin: parsed migration schema (cache write failed{$detail})");
         }
 
         $readFailure = $this->cache->getReadFailureReason();
         if ($readFailure !== null) {
-            $progress->warning("Laravel plugin: {$readFailure}");
+            WarningReporter::emit($progress, "Laravel plugin: {$readFailure}");
         }
     }
 
@@ -151,7 +152,7 @@ final class MigrationSchemaBuilder
                 $sql = \file_get_contents($file);
 
                 if ($sql === false) {
-                    $progress->warning("Laravel plugin: could not read SQL schema dump '{$file}'");
+                    WarningReporter::emit($progress, "Laravel plugin: could not read SQL schema dump '{$file}'");
                     continue;
                 }
 
@@ -159,7 +160,10 @@ final class MigrationSchemaBuilder
             } catch (\RuntimeException $exception) {
                 // SqlSchemaParser is pure string processing and shouldn't throw.
                 // This catch is a safety net for unexpected runtime issues (e.g. memory).
-                $progress->warning("Laravel plugin: skipping SQL schema dump '{$file}': {$exception->getMessage()}");
+                WarningReporter::emit(
+                    $progress,
+                    "Laravel plugin: skipping SQL schema dump '{$file}': {$exception->getMessage()}",
+                );
             }
         }
     }
@@ -177,7 +181,8 @@ final class MigrationSchemaBuilder
         try {
             $iterator = new \DirectoryIterator($directory);
         } catch (\UnexpectedValueException $unexpectedValueException) {
-            $progress->warning(
+            WarningReporter::emit(
+                $progress,
                 "Laravel plugin: could not read schema directory '{$directory}': {$unexpectedValueException->getMessage()}",
             );
             return [];
@@ -217,7 +222,7 @@ final class MigrationSchemaBuilder
         $defaultDirectory = $this->app->databasePath('migrations');
 
         if (!$this->app->bound('migrator')) {
-            $progress->warning($this->migratorUnavailableWarning());
+            WarningReporter::emit($progress, $this->migratorUnavailableWarning());
 
             return [$defaultDirectory];
         }
@@ -267,7 +272,8 @@ final class MigrationSchemaBuilder
                 \FilesystemIterator::SKIP_DOTS,
             ));
         } catch (\UnexpectedValueException $unexpectedValueException) {
-            $progress->warning(
+            WarningReporter::emit(
+                $progress,
                 "Laravel plugin: could not read migration directory '{$directory}': {$unexpectedValueException->getMessage()}",
             );
             return [];
@@ -289,7 +295,8 @@ final class MigrationSchemaBuilder
             }
         } catch (\UnexpectedValueException $unexpectedValueException) {
             // RecursiveIteratorIterator can throw during iteration on unreadable subdirectories
-            $progress->warning(
+            WarningReporter::emit(
+                $progress,
                 "Laravel plugin: error scanning migration directory '{$directory}': {$unexpectedValueException->getMessage()}",
             );
         }

--- a/src/Handlers/Encryption/EncrypterTaintHandler.php
+++ b/src/Handlers/Encryption/EncrypterTaintHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Psalm\LaravelPlugin\Handlers\Encryption;
 
 use Illuminate\Encryption\Encrypter;
+use Psalm\LaravelPlugin\Internal\WarningReporter;
 use Psalm\Plugin\EventHandler\AfterClassLikeVisitInterface;
 use Psalm\Plugin\EventHandler\Event\AfterClassLikeVisitEvent;
 use Psalm\Storage\ClassLikeStorage;
@@ -119,7 +120,8 @@ final class EncrypterTaintHandler implements AfterClassLikeVisitInterface
         $method_storage = $storage->methods[$method] ?? null;
 
         if ($method_storage === null) {
-            $event->getCodebase()->progress->warning(
+            WarningReporter::emit(
+                $event->getCodebase()->progress,
                 "Laravel plugin: {$storage->name}::{$method}() not found — encrypter taint annotation skipped. "
                 . 'The Laravel method signature may have changed; please report this against psalm-plugin-laravel.',
             );

--- a/src/Handlers/Facades/AppFacadeRegistrationHandler.php
+++ b/src/Handlers/Facades/AppFacadeRegistrationHandler.php
@@ -7,6 +7,7 @@ namespace Psalm\LaravelPlugin\Handlers\Facades;
 use Illuminate\Support\Facades\Facade;
 use Psalm\Codebase;
 use Psalm\LaravelPlugin\Internal\AnonymousClassNameDetector;
+use Psalm\LaravelPlugin\Internal\WarningReporter;
 use Psalm\Plugin\EventHandler\AfterClassLikeVisitInterface;
 use Psalm\Plugin\EventHandler\AfterCodebasePopulatedInterface;
 use Psalm\Plugin\EventHandler\Event\AfterClassLikeVisitEvent;
@@ -149,13 +150,17 @@ final class AppFacadeRegistrationHandler implements AfterClassLikeVisitInterface
                     // warning (not debug) — debug is a no-op in the default progress, and a user
                     // facade silently losing method resolution is exactly the class of failure
                     // issue #787 was filed to fix. Match ModelRegistrationHandler's convention.
-                    $progress->warning(
+                    WarningReporter::emit(
+                        $progress,
                         "Laravel plugin: skipping facade '{$storage->name}': class could not be loaded by autoloader",
                     );
                     continue;
                 }
             } catch (\Error|\Exception $error) {
-                $progress->warning("Laravel plugin: skipping facade '{$storage->name}': {$error->getMessage()}");
+                WarningReporter::emit(
+                    $progress,
+                    "Laravel plugin: skipping facade '{$storage->name}': {$error->getMessage()}",
+                );
                 continue;
             }
 
@@ -212,9 +217,13 @@ final class AppFacadeRegistrationHandler implements AfterClassLikeVisitInterface
         try {
             if (!\is_subclass_of($facadeClass, Facade::class)) {
                 self::$failedFacades[$facadeClass] = true;
-                $progress?->warning(
-                    "Laravel plugin: skipping facade '{$facadeClass}': not a subclass of " . Facade::class,
-                );
+                if ($progress instanceof \Psalm\Progress\Progress) {
+                    WarningReporter::emit(
+                        $progress,
+                        "Laravel plugin: skipping facade '{$facadeClass}': not a subclass of " . Facade::class,
+                    );
+                }
+
                 return null;
             }
 
@@ -225,18 +234,26 @@ final class AppFacadeRegistrationHandler implements AfterClassLikeVisitInterface
 
             if ($rootClass === null) {
                 self::$failedFacades[$facadeClass] = true;
-                $progress?->warning(
-                    "Laravel plugin: skipping facade '{$facadeClass}': getFacadeRoot() returned a non-object value",
-                );
+                if ($progress instanceof \Psalm\Progress\Progress) {
+                    WarningReporter::emit(
+                        $progress,
+                        "Laravel plugin: skipping facade '{$facadeClass}': getFacadeRoot() returned a non-object value",
+                    );
+                }
+
                 return null;
             }
 
             return $rootClass;
         } catch (\Throwable $throwable) {
             self::$failedFacades[$facadeClass] = true;
-            $progress?->warning(
-                "Laravel plugin: getFacadeRoot() failed for '{$facadeClass}': {$throwable->getMessage()}",
-            );
+            if ($progress instanceof \Psalm\Progress\Progress) {
+                WarningReporter::emit(
+                    $progress,
+                    "Laravel plugin: getFacadeRoot() failed for '{$facadeClass}': {$throwable->getMessage()}",
+                );
+            }
+
             return null;
         }
     }

--- a/src/Handlers/Magic/MacroRegistry.php
+++ b/src/Handlers/Magic/MacroRegistry.php
@@ -7,6 +7,7 @@ namespace Psalm\LaravelPlugin\Handlers\Magic;
 use Psalm\Codebase;
 use Psalm\LaravelPlugin\Internal\Ast\CachedClosureTypeFactory;
 use Psalm\LaravelPlugin\Internal\Ast\ClosureTypeFactory;
+use Psalm\LaravelPlugin\Internal\WarningReporter;
 use Psalm\Progress\Progress;
 use Psalm\Storage\FunctionLikeParameter;
 use Psalm\Storage\FunctionLikeStorage;
@@ -147,7 +148,8 @@ final class MacroRegistry
                 // `\Error`, not `ReflectionException`. Catch broadly so a single bad
                 // class — including one whose static initialiser throws — cannot
                 // abort discovery for the rest.
-                $progress->warning(
+                WarningReporter::emit(
+                    $progress,
                     "Laravel plugin: MacroRegistry could not read \$macros on {$className}: {$exception->getMessage()}",
                 );
                 continue;
@@ -616,7 +618,8 @@ final class MacroRegistry
             // malformed `static $macros` shapes (see the array branch above), and
             // any other engine error. Mirrors the broad catch in `init()`: a single
             // bad callable should not abort the whole discovery pass.
-            $progress->warning(
+            WarningReporter::emit(
+                $progress,
                 "Laravel plugin: MacroRegistry could not reflect callable for {$declaringClass}::{$name}: {$throwable->getMessage()}",
             );
         }

--- a/src/Handlers/Rules/NoEnvOutsideConfigHandler.php
+++ b/src/Handlers/Rules/NoEnvOutsideConfigHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Psalm\LaravelPlugin\Handlers\Rules;
 
 use Psalm\IssueBuffer;
+use Psalm\LaravelPlugin\Internal\WarningReporter;
 use Psalm\LaravelPlugin\Issues\NoEnvOutsideConfig;
 use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
@@ -87,7 +88,8 @@ final class NoEnvOutsideConfigHandler implements FunctionReturnTypeProviderInter
         self::$configDirectories = \array_values(\array_unique($resolved));
 
         if ($directories !== [] && self::$configDirectories === [] && $progress instanceof \Psalm\Progress\Progress) {
-            $progress->warning(
+            WarningReporter::emit(
+                $progress,
                 'Laravel plugin: NoEnvOutsideConfig has no resolvable config directories — '
                 . "every env() call will be flagged. Inputs: '"
                 . \implode("', '", $directories)

--- a/src/Internal/InternalErrorReporter.php
+++ b/src/Internal/InternalErrorReporter.php
@@ -8,7 +8,7 @@ use Psalm\LaravelPlugin\Config\PluginConfig;
 use Psalm\Progress\Progress;
 
 /**
- * Surfaces a plugin-initialisation failure as a {@see Progress::warning()} pair —
+ * Surfaces a plugin-initialisation failure as a warning pair —
  * one for the original error, one with a pre-filled issue-tracker URL so users
  * can report it with environment details attached.
  *
@@ -22,14 +22,14 @@ final class InternalErrorReporter
     /** @throws \Throwable when {@see PluginConfig::$failOnInternalError} is on */
     public static function report(\Throwable $throwable, Progress $output, PluginConfig $pluginConfig): void
     {
-        $output->warning("Laravel plugin error on initialisation: {$throwable->getMessage()}");
+        WarningReporter::emit($output, "Laravel plugin error on initialisation: {$throwable->getMessage()}");
 
         // Best-effort classification: tells the user whether the failure
         // looks like an app-level config issue, a plugin bug, a Laravel
         // framework problem, or a Testbench fallback issue.
         $hint = InternalErrorClassifier::hint($throwable);
         if ($hint !== null) {
-            $output->warning("Laravel plugin: {$hint}");
+            WarningReporter::emit($output, "Laravel plugin: {$hint}");
         }
 
         // URL generation is best-effort — a secondary failure here (e.g. a
@@ -41,13 +41,17 @@ final class InternalErrorReporter
         try {
             $url = IssueUrlGenerator::generate($throwable, $pluginConfig);
         } catch (\Throwable $urlGenerationFailure) {
-            $output->warning(
+            WarningReporter::emit(
+                $output,
                 "Laravel plugin failed to build a detailed report URL: {$urlGenerationFailure->getMessage()}",
             );
             $url = 'https://github.com/psalm/psalm-plugin-laravel/issues';
         }
 
-        $output->warning('Laravel plugin has been disabled for this run, please report about this issue: ' . $url);
+        WarningReporter::emit(
+            $output,
+            'Laravel plugin has been disabled for this run, please report about this issue: ' . $url,
+        );
 
         if ($pluginConfig->failOnInternalError) {
             throw $throwable;
@@ -74,14 +78,18 @@ final class InternalErrorReporter
             throw $throwable;
         }
 
-        $output->warning("Laravel plugin: application bootstrap failed partway: {$throwable->getMessage()}");
+        WarningReporter::emit(
+            $output,
+            "Laravel plugin: application bootstrap failed partway: {$throwable->getMessage()}",
+        );
 
         $hint = InternalErrorClassifier::hint($throwable);
         if ($hint !== null) {
-            $output->warning("Laravel plugin: {$hint}");
+            WarningReporter::emit($output, "Laravel plugin: {$hint}");
         }
 
-        $output->warning(
+        WarningReporter::emit(
+            $output,
             'Laravel plugin is running in degraded mode: service providers never booted, so '
             . 'model, facade and container inference is reduced. '
             . 'Run `vendor/bin/psalm-laravel diagnose` for details.',

--- a/src/Internal/WarningReporter.php
+++ b/src/Internal/WarningReporter.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Internal;
+
+use Psalm\Progress\Progress;
+use Psalm\Progress\VoidProgress;
+
+/**
+ * Keeps plugin diagnostic warnings visible independently of Psalm's progress UI.
+ *
+ * Psalm deliberately makes {@see VoidProgress::write()} a no-op for
+ * `--no-progress`. Because {@see Progress::warning()} delegates to write(),
+ * warnings would otherwise disappear along with progress bars. Keep using the
+ * configured progress implementation when it is active, but preserve warnings
+ * on STDERR when Psalm installs VoidProgress.
+ *
+ * @internal
+ */
+final class WarningReporter
+{
+    /**
+     * @param resource|null $fallbackStream Test seam for the VoidProgress path.
+     */
+    public static function emit(Progress $progress, string $message, mixed $fallbackStream = null): void
+    {
+        if (!$progress instanceof VoidProgress) {
+            $progress->warning($message);
+
+            return;
+        }
+
+        $fallbackStream ??= \STDERR;
+
+        // Warning output must never replace the diagnostic it is trying to
+        // surface. Psalm promotes PHP warnings to exceptions, and fwrite()
+        // can also throw a TypeError for a stream that was closed meanwhile.
+        try {
+            @\fwrite($fallbackStream, 'Warning: ' . $message . \PHP_EOL);
+        } catch (\Throwable) {
+            // There is no secondary output channel left to report this failure.
+        }
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -10,6 +10,7 @@ use Psalm\LaravelPlugin\Bootstrap\ApplicationProvider;
 use Psalm\LaravelPlugin\Config\PluginConfig;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaStateProvider;
 use Psalm\LaravelPlugin\Internal\InternalErrorReporter;
+use Psalm\LaravelPlugin\Internal\WarningReporter;
 use Psalm\LaravelPlugin\Stubs\AliasStubProvider;
 use Psalm\LaravelPlugin\Stubs\CarbonStubProvider;
 use Psalm\LaravelPlugin\Stubs\FacadeMapProvider;
@@ -429,7 +430,8 @@ final class Plugin implements PluginEntryPointInterface
             // Only warn when the user explicitly opted into missing translation detection —
             // without it, they just lose the bonus type narrowing, which isn't worth a warning
             if ($reportMissing) {
-                $output->warning(
+                WarningReporter::emit(
+                    $output,
                     'Laravel plugin: findMissingTranslations is enabled but the translator service is not bound. '
                     . 'The MissingTranslation check will be skipped.',
                 );
@@ -442,7 +444,8 @@ final class Plugin implements PluginEntryPointInterface
 
         if (!$translator instanceof \Illuminate\Translation\Translator) {
             if ($reportMissing) {
-                $output->warning(
+                WarningReporter::emit(
+                    $output,
                     'Laravel plugin: findMissingTranslations is enabled but the translator is not an instance of '
                     . 'Illuminate\Translation\Translator. The MissingTranslation check will be skipped.',
                 );
@@ -473,7 +476,8 @@ final class Plugin implements PluginEntryPointInterface
             $factory = $app->make('view');
 
             if (!$factory instanceof \Illuminate\View\Factory) {
-                $output->warning(
+                WarningReporter::emit(
+                    $output,
                     'Laravel plugin: findMissingViews is enabled but the view factory is not a standard instance. '
                     . 'The MissingView check will be skipped.',
                 );
@@ -483,7 +487,8 @@ final class Plugin implements PluginEntryPointInterface
 
             $finder = $factory->getFinder();
         } else {
-            $output->warning(
+            WarningReporter::emit(
+                $output,
                 'Laravel plugin: findMissingViews is enabled but the view finder service is not bound. '
                 . 'The MissingView check will be skipped.',
             );
@@ -492,7 +497,8 @@ final class Plugin implements PluginEntryPointInterface
         }
 
         if (!$finder instanceof \Illuminate\View\FileViewFinder) {
-            $output->warning(
+            WarningReporter::emit(
+                $output,
                 'Laravel plugin: findMissingViews is enabled but the view finder is not an instance of '
                 . 'Illuminate\View\FileViewFinder. The MissingView check will be skipped.',
             );

--- a/src/Stubs/CarbonStubProvider.php
+++ b/src/Stubs/CarbonStubProvider.php
@@ -6,6 +6,7 @@ namespace Psalm\LaravelPlugin\Stubs;
 
 use Composer\InstalledVersions;
 use Composer\Semver\VersionParser;
+use Psalm\LaravelPlugin\Internal\WarningReporter;
 use Psalm\Plugin\RegistrationInterface;
 use Psalm\Progress\Progress;
 
@@ -75,7 +76,8 @@ final class CarbonStubProvider
                 // is silently dropped. Downstream code then sees MissingDependency. See #922.
                 $registration->addStubFile($realPath);
             } else {
-                $output->warning(
+                WarningReporter::emit(
+                    $output,
                     "Laravel plugin: Carbon lazy stub not found at '{$stub}'. "
                     . 'CarbonPeriod / Translator / MessageFormatterMapper types may not resolve.',
                 );

--- a/src/Stubs/FacadeMapProvider.php
+++ b/src/Stubs/FacadeMapProvider.php
@@ -6,6 +6,7 @@ namespace Psalm\LaravelPlugin\Stubs;
 
 use Illuminate\Foundation\AliasLoader;
 use Illuminate\Support\Facades\Facade;
+use Psalm\LaravelPlugin\Internal\WarningReporter;
 
 /**
  * Maps Laravel service classes to their facade and root alias class names.
@@ -189,7 +190,8 @@ final class FacadeMapProvider
                     continue;
                 }
             } catch (\Throwable $e) {
-                $progress->warning(
+                WarningReporter::emit(
+                    $progress,
                     "Laravel plugin: FacadeMapProvider could not load multi-target concrete {$concrete}: {$e->getMessage()}",
                 );
                 continue;
@@ -213,7 +215,7 @@ final class FacadeMapProvider
                     if (!\class_exists($facadeClass)) {
                         $message = "Laravel plugin: FacadeMapProvider skipped multi-target facade {$facadeClass}: class not found\n";
                         if ($isCanonicalFqcn) {
-                            $progress->warning(\rtrim($message));
+                            WarningReporter::emit($progress, \rtrim($message));
                         } else {
                             $progress->debug($message);
                         }
@@ -221,7 +223,8 @@ final class FacadeMapProvider
                         continue;
                     }
                 } catch (\Throwable $e) {
-                    $progress->warning(
+                    WarningReporter::emit(
+                        $progress,
                         "Laravel plugin: FacadeMapProvider could not load multi-target facade {$facadeClass}: {$e->getMessage()}",
                     );
                     continue;

--- a/src/Stubs/StubFileFinder.php
+++ b/src/Stubs/StubFileFinder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Stubs;
 
+use Psalm\LaravelPlugin\Internal\WarningReporter;
 use Psalm\Progress\Progress;
 
 /**
@@ -12,7 +13,7 @@ use Psalm\Progress\Progress;
  * Splits responsibility from {@see \Psalm\LaravelPlugin\Plugin}: filesystem
  * traversal and version-directory selection live in this utility so they can
  * be exercised by unit tests without booting the plugin, while warning
- * reporting still uses Psalm's {@see Progress} output interface.
+ * reporting still follows the plugin-wide {@see WarningReporter} policy.
  *
  * @internal
  */
@@ -66,7 +67,8 @@ final class StubFileFinder
             // RecursiveIteratorIterator can throw during iteration on unreadable subdirectories.
             // Return whatever stubs were collected before the error — partial results from
             // readable subdirectories are better than none.
-            $output->warning(
+            WarningReporter::emit(
+                $output,
                 "Laravel plugin: error scanning stub directory '{$directory}': {$unexpectedValueException->getMessage()}",
             );
         }

--- a/tests/Unit/Util/Fixtures/NoProgressWarning/app/entry.php
+++ b/tests/Unit/Util/Fixtures/NoProgressWarning/app/entry.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+function no_progress_warning_fixture(): void {}

--- a/tests/Unit/Util/Fixtures/NoProgressWarning/bootstrap/app.php
+++ b/tests/Unit/Util/Fixtures/NoProgressWarning/bootstrap/app.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Application;
+
+return Application::configure(basePath: \dirname(__DIR__))->create();

--- a/tests/Unit/Util/Fixtures/NoProgressWarning/config/app.php
+++ b/tests/Unit/Util/Fixtures/NoProgressWarning/config/app.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+throw new RuntimeException('no-progress warning fixture');

--- a/tests/Unit/Util/Fixtures/NoProgressWarning/psalm.xml
+++ b/tests/Unit/Util/Fixtures/NoProgressWarning/psalm.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+>
+    <projectFiles>
+        <directory name="app" />
+    </projectFiles>
+    <plugins>
+        <pluginClass class="Psalm\LaravelPlugin\Plugin" />
+    </plugins>
+</psalm>

--- a/tests/Unit/Util/WarningReporterTest.php
+++ b/tests/Unit/Util/WarningReporterTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Util;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Internal\WarningReporter;
+use Psalm\Progress\Progress;
+use Psalm\Progress\VoidProgress;
+use Symfony\Component\Process\Process;
+
+#[CoversClass(WarningReporter::class)]
+final class WarningReporterTest extends TestCase
+{
+    #[Test]
+    public function delegates_to_an_active_progress_reporter(): void
+    {
+        $progress = new class extends Progress {
+            public string $output = '';
+
+            #[\Override]
+            public function write(string $message): void
+            {
+                $this->output .= $message;
+            }
+
+            #[\Override]
+            public function debug(string $message): void {}
+
+            #[\Override]
+            public function startPhase(\Psalm\Progress\Phase $phase, int $threads = 1): void {}
+
+            #[\Override]
+            public function expand(int $number_of_tasks): void {}
+
+            #[\Override]
+            public function taskDone(int $level): void {}
+
+            #[\Override]
+            public function finish(): void {}
+
+            #[\Override]
+            public function alterFileDone(string $file_name): void {}
+        };
+        $fallback = $this->memoryStream();
+
+        WarningReporter::emit($progress, 'Laravel plugin: diagnostic', $fallback);
+
+        $this->assertSame("Warning: Laravel plugin: diagnostic\n", $progress->output);
+        $this->assertSame('', $this->streamContents($fallback));
+    }
+
+    #[Test]
+    public function writes_warnings_to_the_fallback_stream_for_void_progress(): void
+    {
+        $fallback = $this->memoryStream();
+
+        WarningReporter::emit(new VoidProgress(), 'Laravel plugin: degraded analysis', $fallback);
+
+        $this->assertSame(
+            "Warning: Laravel plugin: degraded analysis\n",
+            $this->streamContents($fallback),
+        );
+    }
+
+    #[Test]
+    public function a_broken_fallback_stream_does_not_replace_the_original_diagnostic(): void
+    {
+        $fallback = $this->memoryStream();
+        \fclose($fallback);
+
+        WarningReporter::emit(new VoidProgress(), 'Laravel plugin: original diagnostic', $fallback);
+
+        $this->addToAssertionCount(1);
+    }
+
+    #[Test]
+    public function plugin_warnings_reach_stderr_when_psalm_runs_without_progress(): void
+    {
+        $projectRoot = \dirname(__DIR__, 3);
+        $fixtureDir = __DIR__ . '/Fixtures/NoProgressWarning';
+        $psalmBinary = $projectRoot . '/vendor/bin/psalm';
+
+        $this->assertFileExists($psalmBinary, 'Psalm binary not found — run composer install.');
+
+        $process = new Process(
+            [
+                \PHP_BINARY,
+                $psalmBinary,
+                '-c',
+                'psalm.xml',
+                '--no-cache',
+                '--threads=1',
+                '--no-progress',
+                '--output-format=json',
+            ],
+            $fixtureDir,
+        );
+        $process->setTimeout(300);
+        $process->run();
+
+        $stderr = $process->getErrorOutput();
+        $this->assertStringContainsString(
+            'Warning: Laravel plugin: application bootstrap failed partway: no-progress warning fixture',
+            $stderr,
+        );
+        $this->assertStringContainsString('Laravel plugin is running in degraded mode', $stderr);
+
+        $stdout = $process->getOutput();
+        $this->assertIsArray(
+            \json_decode($stdout, true),
+            "Psalm did not keep its JSON report on STDOUT.\nstdout:\n{$stdout}\nstderr:\n{$stderr}",
+        );
+    }
+
+    #[Test]
+    public function all_plugin_warnings_are_routed_through_the_reporter(): void
+    {
+        $sourceRoot = \dirname(__DIR__, 3) . '/src';
+        $directCalls = [];
+
+        $files = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($sourceRoot));
+        foreach ($files as $file) {
+            if (!$file->isFile() || $file->getExtension() !== 'php' || $file->getFilename() === 'WarningReporter.php') {
+                continue;
+            }
+
+            $contents = \file_get_contents($file->getPathname());
+            if ($contents === false) {
+                throw new \RuntimeException("Could not read {$file->getPathname()}.");
+            }
+
+            $tokens = \token_get_all($contents);
+            foreach ($tokens as $index => $token) {
+                if (!\is_array($token) || !\in_array($token[0], [\T_OBJECT_OPERATOR, \T_NULLSAFE_OBJECT_OPERATOR], true)) {
+                    continue;
+                }
+
+                $next = $tokens[$index + 1] ?? null;
+                if (\is_array($next) && $next[0] === \T_STRING && $next[1] === 'warning') {
+                    $directCalls[] = $file->getPathname() . ':' . $token[2];
+                }
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $directCalls,
+            'Plugin warnings must use WarningReporter so --no-progress cannot discard them.',
+        );
+    }
+
+    /** @return resource */
+    private function memoryStream(): mixed
+    {
+        $stream = \fopen('php://memory', 'w+b');
+        if ($stream === false) {
+            throw new \RuntimeException('Could not open an in-memory stream.');
+        }
+
+        return $stream;
+    }
+
+    /** @param resource $stream */
+    private function streamContents(mixed $stream): string
+    {
+        \rewind($stream);
+        $contents = \stream_get_contents($stream);
+
+        if ($contents === false) {
+            throw new \RuntimeException('Could not read the in-memory stream.');
+        }
+
+        return $contents;
+    }
+}


### PR DESCRIPTION
## Issue to Solve

Plugin diagnostic warnings are emitted through Psalm `Progress`; `VoidProgress` discards them under `--no-progress`, so degraded analysis can continue silently in CI.

## Related

Fixes #1227

## Solution Description

- Add an internal `WarningReporter` that delegates to active progress reporters and falls back to best-effort STDERR output for `VoidProgress`.
- Route every plugin warning through the shared reporter while leaving debug and stats output progress-controlled.
- Add an end-to-end broken-bootstrap fixture proving warnings reach STDERR under `--no-progress` while JSON remains on STDOUT.
- Guard against failed fallback writes and future direct warning calls with focused unit tests.

Verified with unit tests, type tests, Psalm self-analysis, PHP-CS-Fixer, Rector, and the fresh Laravel application test.

## Checklist
- [x] Tests cover the change (unit and end-to-end subprocess coverage)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786377448&installation_id=141955579&pr_number=1232&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1232&signature=ac0f08cc193732da717814b1f042a4bb05f86283162abaadae0cb069cc548f11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->