### PR TITLE
Narrow integer fields from `min`/`max`/`between` rule bounds and type the `integer()` accessor from rules

### DIFF
--- a/src/Handlers/Validation/InlineValidateRulesCollector.php
+++ b/src/Handlers/Validation/InlineValidateRulesCollector.php
@@ -564,6 +564,8 @@ final class InlineValidateRulesCollector implements
                 $existing[$field]->nullable,
                 $existing[$field]->sometimes,
                 $existing[$field]->required,
+                $existing[$field]->hasIntegerRule,
+                $existing[$field]->excluded,
             );
         }
 

--- a/src/Handlers/Validation/ResolvedRule.php
+++ b/src/Handlers/Validation/ResolvedRule.php
@@ -19,6 +19,8 @@ final readonly class ResolvedRule
      * @param bool  $nullable          Whether the 'nullable' modifier was present
      * @param bool  $sometimes         Whether the field may be absent from validated output
      * @param bool  $required          Whether 'required' (or similar presence rule) was present
+     * @param bool  $hasIntegerRule    Whether an explicit 'integer' rule was present
+     * @param bool  $excluded          Whether an exclude/exclude_if/exclude_unless/exclude_with/exclude_without rule was present
      */
     public function __construct(
         public Union $type,
@@ -26,12 +28,17 @@ final readonly class ResolvedRule
         public bool $nullable,
         public bool $sometimes,
         public bool $required = false,
+        public bool $hasIntegerRule = false,
+        public bool $excluded = false,
     ) {}
 
     /**
      * Whether the rule unconditionally guarantees that the field will be
      * present in the validated output — `required` / `present` / `accepted`
-     * / `declined` without a `sometimes` override.
+     * / `declined` without a `sometimes` override, and without an
+     * exclude/exclude_if/exclude_unless/exclude_with/exclude_without rule
+     * (Laravel's Validator skips the field's other rules entirely once an
+     * unconditional `exclude` fires, so no presence/type guarantee survives).
      *
      * Source of truth for the gate that drives both type narrowing and
      * taint escape on `$this->input('key')` / `$this->key` reads: the two
@@ -42,6 +49,6 @@ final readonly class ResolvedRule
      */
     public function guaranteesPresence(): bool
     {
-        return $this->required && !$this->sometimes;
+        return $this->required && !$this->sometimes && !$this->excluded;
     }
 }

--- a/src/Handlers/Validation/ValidatedTypeHandler.php
+++ b/src/Handlers/Validation/ValidatedTypeHandler.php
@@ -9,6 +9,7 @@ use Psalm\LaravelPlugin\Internal\Arg;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
 use Psalm\Type;
+use Psalm\Type\Atomic\TInt;
 use Psalm\Type\Atomic\TKeyedArray;
 use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Atomic\TNamedObject;
@@ -21,6 +22,8 @@ use Psalm\Type\Union;
  * - FormRequest::safe([...])         → partial array shape for specified keys
  * - Request::validate([...])         → array shape from inline rules argument
  * - ValidatedInput::input('field')   → single field type (via generic TRequest parameter)
+ * - $this->input()/$this->integer() (or $request->...) → single field type,
+ *   gated on presence (see {@see resolveSelfAccessorRule})
  *
  * ValidatedInput is generic: ValidatedInput<TRequest of FormRequest>. When safe() returns
  * ValidatedInput<static>, the template parameter carries the concrete FormRequest class,
@@ -53,6 +56,9 @@ final class ValidatedTypeHandler implements MethodReturnTypeProviderInterface
             // resolveSelfInput dispatch below never fires for
             // `$this->input(...)` inside a FormRequest subclass. See #1015.
             \Illuminate\Http\Concerns\InteractsWithInput::class,
+            // Same #1015 reasoning — integer()/float()/boolean()/string()/str()
+            // also live on a trait, not FormRequest/Request directly.
+            \Illuminate\Support\Traits\InteractsWithData::class,
         ];
     }
 
@@ -73,50 +79,86 @@ final class ValidatedTypeHandler implements MethodReturnTypeProviderInterface
             'safe' => self::resolveSafe($event),
             'validate' => self::resolveInlineValidate($event),
             'input' => self::resolveSelfInput($event),
+            'integer' => self::resolveSelfInteger($event),
             default => null,
         };
     }
 
     /**
-     * FormRequest subclass::input('field') → rule type, when the field's rule
-     * guarantees presence (required / present / accepted / declined).
+     * $this->input('field') → rule type, via {@see resolveSelfAccessorRule()}.
+     * Covers `$this->input(...)` inside the FormRequest itself (also
+     * prepareForValidation/withValidator/etc.) — see #1015.
      *
-     * Covers `$this->input(...)` called inside the FormRequest itself
-     * (prepareForValidation, passedValidation, withValidator, custom helpers)
-     * — the controller-side narrowing already flows through `validated()` and
-     * `safe()->input()`. See issue #1015.
-     *
-     * Soundness window: only fields with an unconditional presence rule
-     * (required / present / accepted / declined, and only when `sometimes`
-     * is absent) narrow — the field is guaranteed to exist post-validation,
-     * matching the validated() trade-off. Optional fields, `sometimes|required`,
-     * and conditional-presence siblings (required_if, present_with, …) fall
-     * through to the stub's mixed return. Mirrors the `required`-gated
-     * `setPossiblyUndefined` branch in {@see buildUnionFromTree}.
-     *
-     * Pre-validation unsoundness (deliberate, documented): reads in
-     * prepareForValidation() / authorize() / rules() callbacks run BEFORE
-     * the validator has constrained the value, so `required|integer` does
-     * not yet imply the runtime value is `int|numeric-string`. This narrowing
-     * matches the existing validated()-style "trust the rule" precedent for
-     * analysis precision; downstream consumers in pre-validation contexts
-     * (notably `header()` sinks) carry the same residual false-negative
-     * surface that the controller-side narrowing has always had.
-     *
-     * Inheritance gate: `getRulesForCalledClass` only resolves `rules()`
-     * via the codebase classlike storage, so a custom Request subclass
-     * (or other unrelated class) that happens to define `rules()` could in
-     * principle slip through. We require the called class to actually
-     * extend `FormRequest` to keep the narrowing scoped to the framework
-     * contract it models.
-     *
-     * The taint flow for the narrowed expression is restored in
-     * {@see ValidatedFieldReadResolver} — Psalm drops
-     * the stub's @psalm-taint-source when a return-type override fires,
-     * so the taint handler explicitly re-emits ALL_INPUT for `input()` on
-     * a FormRequest caller.
+     * Taint is restored in {@see ValidatedFieldReadResolver} (the stub's
+     * @psalm-taint-source is dropped when a return-type override fires).
+     * integer() needs none: it was never a taint source.
      */
     private static function resolveSelfInput(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        $resolved = self::resolveSelfAccessorRule($event);
+
+        if ($resolved === null) {
+            return null;
+        }
+
+        [, $rules] = $resolved;
+
+        return self::resolveFieldType($rules, $event->getCallArgs(), $event);
+    }
+
+    /**
+     * $this->integer('field') → int component (TIntRange/TLiteralInt/TInt),
+     * via {@see resolveSelfAccessorRule()} for presence + rules() lookup.
+     * $default is never unioned in — with presence guaranteed it's never
+     * consulted, unlike validated($key, $default).
+     *
+     * Nullable bail (kept out of the shared helper): (int) null = 0, which
+     * can fall outside the range even with presence guaranteed — unlike
+     * input(), where null is a legitimately valid raw return value.
+     *
+     * Explicit-integer gate: only narrows when the field's rule includes a
+     * literal `integer` — (int) projects float/string atomics onto int, so
+     * e.g. `accepted` alone (TLiteralInt(1) in its type) or `numeric` (any
+     * float) would otherwise infer a value the cast can't actually produce
+     * ((int) "yes" = 0, (int) "0.5" = 0). Only `integer` forces the raw
+     * value to already be int-formatted, making the cast lossless.
+     *
+     * Falls through to plain `int` when the field is unknown, absent-
+     * capable, nullable, has no explicit `integer` rule, or has no int
+     * component.
+     */
+    private static function resolveSelfInteger(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        $resolved = self::resolveSelfAccessorRule($event);
+
+        if ($resolved === null) {
+            return null;
+        }
+
+        [$rule] = $resolved;
+
+        if (!$rule->hasIntegerRule || $rule->type->isNullable()) {
+            return null;
+        }
+
+        return self::extractIntComponent($rule->type);
+    }
+
+    /**
+     * Shared prefix for resolveSelfInput()/resolveSelfInteger(): resolves
+     * the rule-covered field for `$this->...`/`$request->...`.
+     *
+     * Presence gate: narrows only when the rule unconditionally guarantees
+     * the field exists (required/present/accepted/declined, no `sometimes`)
+     * — an absent field's fallback default isn't derived from the rule.
+     *
+     * Pre-validation caveat (applies to every caller): reads before the
+     * validator runs (prepareForValidation() etc.) trust the rule anyway,
+     * same tradeoff as validated().
+     *
+     * @return array{0: ResolvedRule, 1: array<string, ResolvedRule>}|null
+     */
+    private static function resolveSelfAccessorRule(MethodReturnTypeProviderEvent $event): ?array
     {
         $callArgs = $event->getCallArgs();
 
@@ -124,10 +166,8 @@ final class ValidatedTypeHandler implements MethodReturnTypeProviderInterface
             return null;
         }
 
-        // Cheap literal-key check first — dynamic-key call sites are common and
-        // skipping the rules() AST walk for them avoids a per-expression hit
-        // (extractRulesFromClass walks parent_class via classlike storage; not
-        // free even after the per-class memoization).
+        // Cheap literal-key check first — avoids the rules() AST walk for
+        // the common dynamic-key case.
         $nodeTypeProvider = $event->getSource()->getNodeTypeProvider();
         $firstArgType = $nodeTypeProvider->getType($callArgs[0]->value);
 
@@ -135,10 +175,34 @@ final class ValidatedTypeHandler implements MethodReturnTypeProviderInterface
             return null;
         }
 
-        // Inheritance gate: limit narrowing to genuine FormRequest subclasses.
-        // InteractsWithInput is also used by plain Request and by user-authored
-        // traits that pair an unrelated `rules()` method with the trait — none
-        // of those should be narrowed under the FormRequest validation contract.
+        $rules = self::getRulesForSelfAccessor($event);
+
+        if ($rules === null) {
+            return null;
+        }
+
+        $key = $firstArgType->getSingleStringLiteral()->value;
+        $rule = $rules[$key] ?? null;
+
+        // sometimes|required: field can be absent even when required.
+        if ($rule === null || !$rule->guaranteesPresence()) {
+            return null;
+        }
+
+        return [$rule, $rules];
+    }
+
+    /**
+     * rules() for a self-accessor call site, called from
+     * {@see resolveSelfAccessorRule()}.
+     *
+     * Inheritance gate: InteractsWithInput/InteractsWithData are also used
+     * by plain Request — only narrow genuine FormRequest subclasses.
+     *
+     * @return array<string, ResolvedRule>|null
+     */
+    private static function getRulesForSelfAccessor(MethodReturnTypeProviderEvent $event): ?array
+    {
         $calledClass = $event->getCalledFqClasslikeName();
 
         if ($calledClass === null) {
@@ -163,30 +227,33 @@ final class ValidatedTypeHandler implements MethodReturnTypeProviderInterface
             return null;
         }
 
-        // `classExtends` succeeded above (no UnpopulatedClasslikeException), so
-        // Psalm has metadata for `$calledClass`. Narrow to `class-string` here
-        // since `getCalledFqClasslikeName()` is typed as plain `string`.
+        // classExtends succeeded, so Psalm has metadata; narrow to class-string.
         /** @var class-string $calledClass */
-        $rules = ValidationRuleAnalyzer::getRulesForFormRequest($calledClass);
+        return ValidationRuleAnalyzer::getRulesForFormRequest($calledClass);
+    }
 
-        if ($rules === null) {
+    /**
+     * Int-family atomics (TIntRange/TLiteralInt/TInt) only; drops numeric-
+     * string/float siblings, mirroring what (int) cares about. Null (→
+     * plain `int` stub) when there's no int component.
+     *
+     * @psalm-pure
+     */
+    private static function extractIntComponent(Union $type): ?Union
+    {
+        $intAtomics = [];
+
+        foreach ($type->getAtomicTypes() as $atomic) {
+            if ($atomic instanceof TInt) {
+                $intAtomics[] = $atomic;
+            }
+        }
+
+        if ($intAtomics === []) {
             return null;
         }
 
-        $key = $firstArgType->getSingleStringLiteral()->value;
-        $rule = $rules[$key] ?? null;
-
-        // Bail when the field has no rule or the rule does not guarantee
-        // presence. Laravel's `sometimes|required` means "if the field is
-        // present it must be valid", so the field can still be legitimately
-        // absent at the input() call site — same treatment {@see buildUnionFromTree}
-        // gives the validated() output (marks the field possibly_undefined
-        // when `sometimes || !required`).
-        if ($rule === null || !$rule->guaranteesPresence()) {
-            return null;
-        }
-
-        return self::resolveFieldType($rules, $callArgs, $event);
+        return new Union($intAtomics);
     }
 
     /**
@@ -484,7 +551,7 @@ final class ValidatedTypeHandler implements MethodReturnTypeProviderInterface
                 }
 
                 $fieldType = $child->rule->type;
-                if ($child->rule->sometimes || !$child->rule->required) {
+                if (!$child->rule->guaranteesPresence()) {
                     $fieldType = $fieldType->setPossiblyUndefined(true);
                 }
 
@@ -496,7 +563,7 @@ final class ValidatedTypeHandler implements MethodReturnTypeProviderInterface
             $nested = self::buildUnionFromTree($child);
 
             if ($nested instanceof Union) {
-                if ($child->rule !== null && ($child->rule->sometimes || !$child->rule->required)) {
+                if ($child->rule !== null && !$child->rule->guaranteesPresence()) {
                     $nested = $nested->setPossiblyUndefined(true);
                 }
 

--- a/src/Handlers/Validation/ValidationRuleAnalyzer.php
+++ b/src/Handlers/Validation/ValidationRuleAnalyzer.php
@@ -13,6 +13,7 @@ use Psalm\Type\Atomic\TArray;
 use Psalm\Type\Atomic\TFalse;
 use Psalm\Type\Atomic\TFloat;
 use Psalm\Type\Atomic\TInt;
+use Psalm\Type\Atomic\TIntRange;
 use Psalm\Type\Atomic\TKeyedArray;
 use Psalm\Type\Atomic\TLiteralInt;
 use Psalm\Type\Atomic\TLiteralString;
@@ -250,6 +251,17 @@ final class ValidationRuleAnalyzer
         $nullable = false;
         $sometimes = false;
         $required = false;
+        // Numeric-range accumulator; order-independent (min:1|integer == integer|min:1).
+        $hasNumericRule = false;
+        $lower = null;
+        $upper = null;
+        // Explicit 'integer' rule only (narrower than $hasNumericRule above) —
+        // gates integer()'s int-component extraction: 'numeric'/'accepted'/etc.
+        // can produce int-family atoms without forcing the raw value to be
+        // int-formatted, so (int) casting it isn't lossless.
+        $hasIntegerRule = false;
+        // exclude* rule present — see guaranteesPresence()'s docblock.
+        $excluded = false;
 
         foreach ($segments as $segment) {
             $segment = \trim($segment);
@@ -290,6 +302,27 @@ final class ValidationRuleAnalyzer
                 $required = true;
             }
 
+            // exclude/exclude_if/exclude_unless/exclude_with/exclude_without —
+            // simple prefix match (Laravel has no other rule name starting with
+            // "exclude"). Any of these present, unconditionally or not, means
+            // the Validator may skip this field's other rules entirely once it
+            // fires — so presence can no longer be treated as guaranteed.
+            if (\str_starts_with($ruleName, 'exclude')) {
+                $excluded = true;
+            }
+
+            // Gate: min/max/etc. are overloaded (string length, array count,
+            // file size) elsewhere — only narrow when integer/numeric is present.
+            if ($ruleName === 'integer' || $ruleName === 'numeric') {
+                $hasNumericRule = true;
+            }
+
+            if ($ruleName === 'integer') {
+                $hasIntegerRule = true;
+            }
+
+            [$lower, $upper] = self::accumulateRangeBound($ruleName, $ruleParam, $lower, $upper);
+
             // Type-bearing rules (first one wins for type, all accumulate taint)
             $ruleType = self::ruleToType($ruleName, $ruleParam);
 
@@ -303,12 +336,183 @@ final class ValidationRuleAnalyzer
         // Default: if no type rule matched, return mixed (don't narrow)
         $type ??= Type::getMixed();
 
+        if ($hasNumericRule) {
+            $type = self::applyNumericRangeNarrowing($type, $lower, $upper);
+        }
+
         // nullable modifier: add null to type union
         if ($nullable) {
             $type = Type::combineUnionTypes($type, Type::getNull());
         }
 
-        return new ResolvedRule($type, $removedTaints, $nullable, $sometimes, $required);
+        return new ResolvedRule($type, $removedTaints, $nullable, $sometimes, $required, $hasIntegerRule, $excluded);
+    }
+
+    /**
+     * Replaces the bare `int` atomic with the accumulated range; float/
+     * numeric-string untouched. Exact-class match (not `instanceof`) since
+     * TLiteralInt/TIntRange extend TInt — an earlier rule's literal
+     * (accepted/boolean) would otherwise get widened instead of kept.
+     *
+     * @psalm-pure
+     */
+    private static function applyNumericRangeNarrowing(Union $type, ?int $lower, ?int $upper): Union
+    {
+        if ($lower === null && $upper === null) {
+            return $type;
+        }
+
+        // Conflicting bounds (min:5|max:3) — keep the un-ranged type.
+        if ($lower !== null && $upper !== null && $lower > $upper) {
+            return $type;
+        }
+
+        $rangeAtomic = $lower !== null && $lower === $upper
+            ? new TLiteralInt($lower)
+            : new TIntRange($lower, $upper);
+
+        $atomics = [];
+
+        foreach ($type->getAtomicTypes() as $atomic) {
+            $atomics[] = $atomic::class === TInt::class ? $rangeAtomic : $atomic;
+        }
+
+        return new Union($atomics);
+    }
+
+    /**
+     * Folds one range rule into [lower, upper]. A malformed param
+     * ({@see intLiteralParam()}) is skipped, not an abort.
+     *
+     * @return array{0: ?int, 1: ?int}
+     * @psalm-pure
+     */
+    private static function accumulateRangeBound(string $rule, ?string $param, ?int $lower, ?int $upper): array
+    {
+        return match ($rule) {
+            'min', 'gte' => [self::tightenLower($lower, self::intLiteralParam($param)), $upper],
+            'max', 'lte' => [$lower, self::tightenUpper($upper, self::intLiteralParam($param))],
+            // gt/lt are exclusive — shift one step in (PHP_INT_MAX/MIN guarded).
+            'gt' => [self::tightenLower($lower, self::exclusiveLowerBound($param)), $upper],
+            'lt' => [$lower, self::tightenUpper($upper, self::exclusiveUpperBound($param))],
+            'size' => self::accumulateExactBound($param, $lower, $upper),
+            'between' => self::accumulateBetweenBound($param, $lower, $upper),
+            default => [$lower, $upper],
+        };
+    }
+
+    /** @psalm-pure */
+    private static function exclusiveLowerBound(?string $param): ?int
+    {
+        $value = self::intLiteralParam($param);
+
+        return $value === null || $value === \PHP_INT_MAX ? null : $value + 1;
+    }
+
+    /** @psalm-pure */
+    private static function exclusiveUpperBound(?string $param): ?int
+    {
+        $value = self::intLiteralParam($param);
+
+        return $value === null || $value === \PHP_INT_MIN ? null : $value - 1;
+    }
+
+    /**
+     * size:N sets both bounds to N.
+     *
+     * @return array{0: ?int, 1: ?int}
+     * @psalm-pure
+     */
+    private static function accumulateExactBound(?string $param, ?int $lower, ?int $upper): array
+    {
+        $value = self::intLiteralParam($param);
+
+        if ($value === null) {
+            return [$lower, $upper];
+        }
+
+        return [self::tightenLower($lower, $value), self::tightenUpper($upper, $value)];
+    }
+
+    /**
+     * between:A,B — exactly two comma-separated integer literals, else skipped.
+     *
+     * @return array{0: ?int, 1: ?int}
+     * @psalm-pure
+     */
+    private static function accumulateBetweenBound(?string $param, ?int $lower, ?int $upper): array
+    {
+        if ($param === null) {
+            return [$lower, $upper];
+        }
+
+        $parts = \explode(',', $param);
+
+        if (\count($parts) !== 2) {
+            return [$lower, $upper];
+        }
+
+        $min = self::intLiteralParam($parts[0]);
+        $max = self::intLiteralParam($parts[1]);
+
+        if ($min === null || $max === null) {
+            return [$lower, $upper];
+        }
+
+        return [self::tightenLower($lower, $min), self::tightenUpper($upper, $max)];
+    }
+
+    /**
+     * Larger of the two; an absent bound loses to a present one.
+     *
+     * @psalm-pure
+     */
+    private static function tightenLower(?int $current, ?int $candidate): ?int
+    {
+        if ($candidate === null) {
+            return $current;
+        }
+
+        return $current === null ? $candidate : \max($current, $candidate);
+    }
+
+    /**
+     * Smaller of the two; an absent bound loses to a present one.
+     *
+     * @psalm-pure
+     */
+    private static function tightenUpper(?int $current, ?int $candidate): ?int
+    {
+        if ($candidate === null) {
+            return $current;
+        }
+
+        return $current === null ? $candidate : \min($current, $candidate);
+    }
+
+    /**
+     * Integer-literal param, or null (e.g. `1.5`, `gt:other_field`).
+     *
+     * @psalm-pure
+     */
+    private static function intLiteralParam(?string $param): ?int
+    {
+        if ($param === null || \preg_match('/^-?\d+$/', $param) !== 1) {
+            return null;
+        }
+
+        $value = (int) $param;
+
+        // Reject non-round-tripping params: an overflowing digit string
+        // (e.g. lt:9223372036854775808, one past PHP_INT_MAX) silently
+        // saturates via the cast instead of erroring, which would produce a
+        // wrong bound. Also rejects leading-zero forms (min:007) — no bound
+        // contributed is sound, just slightly less precise.
+        if ((string) $value !== $param) {
+            return null;
+        }
+
+        return $value;
     }
 
     /**
@@ -735,6 +939,8 @@ final class ValidationRuleAnalyzer
                 $parentRule?->nullable ?? false,
                 $parentRule?->sometimes ?? false,
                 $parentRule?->required ?? false,
+                false,
+                $parentRule?->excluded ?? false,
             );
         }
 
@@ -752,7 +958,7 @@ final class ValidationRuleAnalyzer
             foreach ($children as $childField => $childRule) {
                 $childType = $childRule->type;
 
-                if ($childRule->sometimes || !$childRule->required) {
+                if (!$childRule->guaranteesPresence()) {
                     $childType = $childType->setPossiblyUndefined(true);
                 }
 
@@ -782,6 +988,8 @@ final class ValidationRuleAnalyzer
                 $parentRule?->nullable ?? false,
                 $parentRule?->sometimes ?? false,
                 $parentRule?->required ?? false,
+                false,
+                $parentRule?->excluded ?? false,
             );
         }
 

--- a/tests/Type/tests/ValidationRuleNumericRangeTest.phpt
+++ b/tests/Type/tests/ValidationRuleNumericRangeTest.phpt
@@ -1,0 +1,167 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Issue #1234: numeric range narrowing (min/max/between/size/gt/gte/lt/lte)
+ * on integer()/float()/boolean() accessors — see
+ * ValidationRuleAnalyzer::applyNumericRangeNarrowing() and
+ * ValidatedTypeHandler::resolveSelfInteger().
+ */
+class NumericRangeRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'portions' => ['bail', 'required', 'integer', 'min:1'],
+            'age_range' => 'required|integer|between:0,24',
+            'negative_offset' => 'required|integer|min:-5',
+            'price' => 'required|numeric|min:0',
+            'confirmed' => 'required|boolean',
+            'label' => 'required|string',
+            'quota' => 'required|integer|size:5',
+            'stock' => 'required|integer|gt:0',
+            'quantity' => 'integer|min:1', // no required — may be absent
+            'age' => 'required|nullable|integer|min:18', // nullable value
+            'terms' => 'accepted', // no explicit integer rule
+            'discount' => 'required|numeric|gt:0', // no explicit integer rule
+        ];
+    }
+
+    /**
+     * @return positive-int
+     */
+    public function getPortions(): int
+    {
+        // int<1, max> IS positive-int internally — no MoreSpecificReturnType.
+        return $this->integer('portions');
+    }
+
+    public function selfAccessorNarrowing(): void
+    {
+        $_portions = $this->integer('portions');
+        /** @psalm-check-type-exact $_portions = int<1, max> */
+
+        $_ageRange = $this->integer('age_range');
+        /** @psalm-check-type-exact $_ageRange = int<0, 24> */
+
+        $_negativeOffset = $this->integer('negative_offset');
+        /** @psalm-check-type-exact $_negativeOffset = int<-5, max> */
+
+        $_quota = $this->integer('quota');
+        /** @psalm-check-type-exact $_quota = 5 */
+
+        // No explicit `integer` rule (#1237) — (int) can project a float
+        // outside the rule-derived range (e.g. (int) "0.5" = 0), so a bare
+        // `numeric` rule no longer authorizes integer() narrowing.
+        $_price = $this->integer('price');
+        /** @psalm-check-type-exact $_price = int */
+
+        // No float-range type in Psalm — float() always plain float.
+        $_priceFloat = $this->float('price');
+        /** @psalm-check-type-exact $_priceFloat = float */
+
+        // No narrowing target — boolean() always plain bool.
+        $_confirmed = $this->boolean('confirmed');
+        /** @psalm-check-type-exact $_confirmed = bool */
+
+        // No int component (string rule) — falls through to plain int.
+        $_label = $this->integer('label');
+        /** @psalm-check-type-exact $_label = int */
+
+        $_unknown = $this->integer('does_not_exist');
+        /** @psalm-check-type-exact $_unknown = int */
+
+        // gt:0 exclusive bound → lower = 1 (±1 math unit-tested separately).
+        $_stock = $this->integer('stock');
+        /** @psalm-check-type-exact $_stock = int<1, max> */
+
+        // No required — absent field would cast default 0, outside int<1, max>.
+        $_quantity = $this->integer('quantity');
+        /** @psalm-check-type-exact $_quantity = int */
+
+        // nullable → (int) null = 0, outside int<18, max>.
+        $_age = $this->integer('age');
+        /** @psalm-check-type-exact $_age = int */
+
+        // accepted alone: TLiteralInt(1) exists in the rule type, but
+        // 'yes'/'on' also pass and (int) "yes" = 0 — no explicit integer rule.
+        $_terms = $this->integer('terms');
+        /** @psalm-check-type-exact $_terms = int */
+
+        // numeric|gt:0: infers int<1, max> at the type level, but 0.5 passes
+        // and (int) "0.5" = 0 — no explicit integer rule.
+        $_discount = $this->integer('discount');
+        /** @psalm-check-type-exact $_discount = int */
+    }
+
+    public function dynamicKeyFallsThrough(string $key): int
+    {
+        // Non-literal key — falls through to plain int.
+        $_dynamic = $this->integer($key);
+        /** @psalm-check-type-exact $_dynamic = int */
+
+        return $_dynamic;
+    }
+}
+
+function fromController(NumericRangeRequest $request): void
+{
+    // External call — dispatch keys off the receiver's static type, not $this.
+    $_portions = $request->integer('portions');
+    /** @psalm-check-type-exact $_portions = int<1, max> */
+
+    // validated() narrows via the range accumulator directly.
+    $_portionsValidated = $request->validated('portions');
+    /** @psalm-check-type-exact $_portionsValidated = int<1, max>|numeric-string */
+
+    $_ageRange = $request->integer('age_range');
+    /** @psalm-check-type-exact $_ageRange = int<0, 24> */
+
+    // Deliberate scope boundary: resolveValidatedInputMethod() only narrows
+    // 'input' on ValidatedInput — integer()/float()/boolean() there is a follow-up.
+    $_portionsSafe = $request->safe()->integer('portions');
+    /** @psalm-check-type-exact $_portionsSafe = int */
+}
+
+/**
+ * Issue #1237: exclude/exclude_if/exclude_unless/exclude_with/exclude_without
+ * defeat the presence guarantee — Laravel's Validator skips a field's other
+ * rules entirely once an unconditional exclude fires, so 'required' alongside
+ * it guarantees nothing. See ResolvedRule::guaranteesPresence().
+ */
+class ExcludedFieldRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'legacy_id' => 'exclude|required|integer|min:1',
+            'name' => 'required|string',
+        ];
+    }
+
+    public function excludedFieldNarrowing(): void
+    {
+        // Falls through to plain int, not int<1, max>.
+        $_legacyId = $this->integer('legacy_id');
+        /** @psalm-check-type-exact $_legacyId = int */
+
+        // Same gate applies to input() — falls through to mixed.
+        $_legacyIdInput = $this->input('legacy_id');
+        /** @psalm-check-type-exact $_legacyIdInput = mixed */
+    }
+}
+
+function fromControllerExcluded(ExcludedFieldRequest $request): void
+{
+    // Full-shape validated(): 'legacy_id' is now possibly_undefined — Laravel's
+    // exclude mechanism means it may never reach validated() output, 'required'
+    // notwithstanding.
+    $_all = $request->validated();
+    /** @psalm-check-type-exact $_all = array{legacy_id?: int<1, max>|numeric-string, name: string} */
+}
+?>
+--EXPECTF--

--- a/tests/Unit/Handlers/Validation/ValidationRuleAnalyzerTest.php
+++ b/tests/Unit/Handlers/Validation/ValidationRuleAnalyzerTest.php
@@ -375,10 +375,10 @@ final class ValidationRuleAnalyzerTest extends TestCase
     #[Test]
     public function array_format_rules_resolve_correctly(): void
     {
-        // Simulates ['required', 'integer', 'max:100']
+        // Simulates ['required', 'integer', 'max:100'] — max:100 narrows (#1234).
         $rule = ValidationRuleAnalyzer::resolveRuleSegments(['required', 'integer', 'max:100']);
 
-        $this->assertSame('int|numeric-string', $rule->type->getId());
+        $this->assertSame('int<min, 100>|numeric-string', $rule->type->getId());
         $this->assertSame(TaintKind::ALL_INPUT, $rule->removedTaints);
     }
 
@@ -666,5 +666,401 @@ final class ValidationRuleAnalyzerTest extends TestCase
         ];
 
         $this->assertSame($exactRule, ValidationRuleAnalyzer::lookupRuleByKey($rules, 'items.0'));
+    }
+
+    // --- Numeric range narrowing (#1234) ---
+
+    #[Test]
+    public function integer_with_min_narrows_to_int_range(): void
+    {
+        $rule = $this->resolve('integer|min:1');
+
+        $this->assertSame('int<1, max>|numeric-string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function integer_with_min_zero_narrows_to_int_range(): void
+    {
+        $rule = $this->resolve('integer|min:0');
+
+        $this->assertSame('int<0, max>|numeric-string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function integer_with_max_narrows_to_int_range(): void
+    {
+        $rule = $this->resolve('integer|max:10');
+
+        $this->assertSame('int<min, 10>|numeric-string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function integer_with_between_narrows_to_int_range(): void
+    {
+        $rule = $this->resolve('integer|between:0,24');
+
+        $this->assertSame('int<0, 24>|numeric-string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function integer_with_size_narrows_to_literal_int(): void
+    {
+        // Collapsed [N, N] → TLiteralInt, not TIntRange(N, N).
+        $rule = $this->resolve('integer|size:5');
+
+        $this->assertSame('5|numeric-string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function integer_with_gt_narrows_to_int_range(): void
+    {
+        // gt:0 exclusive → inclusive range starts one above.
+        $rule = $this->resolve('integer|gt:0');
+
+        $this->assertSame('int<1, max>|numeric-string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function integer_with_gte_narrows_to_int_range(): void
+    {
+        $rule = $this->resolve('integer|gte:0');
+
+        $this->assertSame('int<0, max>|numeric-string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function integer_with_lt_narrows_to_int_range(): void
+    {
+        // lt:100 exclusive → inclusive range ends one below.
+        $rule = $this->resolve('integer|lt:100');
+
+        $this->assertSame('int<min, 99>|numeric-string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function integer_with_lte_narrows_to_int_range(): void
+    {
+        $rule = $this->resolve('integer|lte:100');
+
+        $this->assertSame('int<min, 100>|numeric-string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function integer_with_min_and_max_narrows_to_int_range(): void
+    {
+        $rule = $this->resolve('integer|min:1|max:10');
+
+        $this->assertSame('int<1, 10>|numeric-string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function numeric_with_min_narrows_only_the_int_component(): void
+    {
+        // float/numeric-string siblings untouched — only int gets ranged.
+        $rule = $this->resolve('numeric|min:1');
+
+        $this->assertSame('float|int<1, max>|numeric-string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function string_with_min_is_not_narrowed(): void
+    {
+        // Gate: no integer/numeric rule — 'min' contributes nothing.
+        $rule = $this->resolve('string|min:3');
+
+        $this->assertSame('string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function min_alone_contributes_no_type(): void
+    {
+        // No type-bearing rule at all — 'min' never narrows on its own.
+        $rule = $this->resolve('min:1');
+
+        $this->assertTrue($rule->type->isMixed());
+    }
+
+    #[Test]
+    public function integer_with_conflicting_min_max_skips_narrowing(): void
+    {
+        // min:5|max:3 — impossible interval, keep un-ranged.
+        $rule = $this->resolve('integer|min:5|max:3');
+
+        $this->assertSame('int|numeric-string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function integer_with_non_integer_min_param_skips_narrowing(): void
+    {
+        // min:1.5 is not an integer literal — contributes no bound.
+        $rule = $this->resolve('integer|min:1.5');
+
+        $this->assertSame('int|numeric-string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function integer_with_gt_field_reference_skips_narrowing(): void
+    {
+        // gt/gte/lt/lte can reference a field name — only literals narrow.
+        $rule = $this->resolve('integer|gt:other_field');
+
+        $this->assertSame('int|numeric-string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function integer_with_negative_min_narrows_to_int_range(): void
+    {
+        $rule = $this->resolve('integer|min:-5');
+
+        $this->assertSame('int<-5, max>|numeric-string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function range_narrowing_is_order_independent(): void
+    {
+        $ruleA = $this->resolve('min:1|integer');
+        $ruleB = $this->resolve('integer|min:1');
+
+        $this->assertSame($ruleA->type->getId(), $ruleB->type->getId());
+        $this->assertSame('int<1, max>|numeric-string', $ruleA->type->getId());
+    }
+
+    #[Test]
+    public function integer_with_malformed_between_single_param_skips_narrowing(): void
+    {
+        $rule = $this->resolve('integer|between:5');
+
+        $this->assertSame('int|numeric-string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function integer_with_malformed_between_three_params_skips_narrowing(): void
+    {
+        $rule = $this->resolve('integer|between:1,2,3');
+
+        $this->assertSame('int|numeric-string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function integer_with_between_non_integer_component_skips_narrowing(): void
+    {
+        $rule = $this->resolve('integer|between:1,abc');
+
+        $this->assertSame('int|numeric-string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function integer_with_gt_php_int_max_skips_bound(): void
+    {
+        // No representable N+1 at PHP_INT_MAX — bound dropped.
+        $rule = $this->resolve('integer|gt:' . \PHP_INT_MAX);
+
+        $this->assertSame('int|numeric-string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function integer_with_lt_php_int_min_skips_bound(): void
+    {
+        $rule = $this->resolve('integer|lt:' . \PHP_INT_MIN);
+
+        $this->assertSame('int|numeric-string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function multiple_min_rules_keep_the_larger_bound(): void
+    {
+        $rule = $this->resolve('integer|min:1|min:5');
+
+        $this->assertSame('int<5, max>|numeric-string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function multiple_max_rules_keep_the_smaller_bound(): void
+    {
+        $rule = $this->resolve('integer|max:10|max:3');
+
+        $this->assertSame('int<min, 3>|numeric-string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function pre_existing_literal_ints_are_not_widened_by_an_unrelated_range_gate(): void
+    {
+        // Regression guard for the exact-class fix (TLiteralInt/TIntRange
+        // extend TInt — see applyNumericRangeNarrowing()). Uses boolean+min,
+        // not the originally-suggested in:1,2,3, since `in:` never yields
+        // TLiteralInt.
+        $rule = ValidationRuleAnalyzer::resolveRuleSegments(['boolean', 'numeric', 'min:0']);
+
+        $this->assertSame('0|1|bool', $rule->type->getId());
+    }
+
+    #[Test]
+    public function pre_existing_literal_int_from_accepted_rule_is_not_widened(): void
+    {
+        // Same guard via 'accepted' — single literal, not a pair.
+        $rule = ValidationRuleAnalyzer::resolveRuleSegments(['accepted', 'integer', 'min:1']);
+
+        $this->assertSame('1|true', $rule->type->getId());
+    }
+
+    #[Test]
+    public function bare_integer_atom_still_narrows_when_no_prior_literal_exists(): void
+    {
+        // Contrast: bare TInt (no prior literal) still narrows normally.
+        $rule = $this->resolve('integer|min:1');
+
+        $this->assertSame('int<1, max>|numeric-string', $rule->type->getId());
+    }
+
+    // --- Explicit integer-rule tracking for integer() casts (#1237) ---
+
+    #[Test]
+    public function integer_rule_sets_has_integer_rule_flag(): void
+    {
+        $rule = $this->resolve('integer|min:1');
+
+        $this->assertTrue($rule->hasIntegerRule);
+    }
+
+    #[Test]
+    public function numeric_rule_alone_does_not_set_has_integer_rule_flag(): void
+    {
+        // Analyzer-level type narrowing (validated()/input()) is unaffected —
+        // raw values aren't cast there, so the range stays sound. Only the
+        // handler-level integer() cast needs this flag (see
+        // ValidatedTypeHandler::resolveSelfInteger()): (int) "0.5" = 0 falls
+        // outside int<1, max>, so 'numeric' alone must not authorize the cast.
+        $rule = $this->resolve('numeric|min:1');
+
+        $this->assertFalse($rule->hasIntegerRule);
+        $this->assertSame('float|int<1, max>|numeric-string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function accepted_rule_alone_does_not_set_has_integer_rule_flag(): void
+    {
+        // (int) "yes" = 0 — the TLiteralInt(1) in accepted's type is not an
+        // authoritative cast target on its own.
+        $rule = $this->resolve('accepted');
+
+        $this->assertFalse($rule->hasIntegerRule);
+    }
+
+    #[Test]
+    public function accepted_with_explicit_integer_sets_has_integer_rule_flag(): void
+    {
+        // accepted|integer IS sound (intersection {1, '1', true} → 1) —
+        // the flag follows the explicit 'integer' rule regardless of which
+        // rule won the type slot.
+        $rule = $this->resolve('accepted|integer');
+
+        $this->assertTrue($rule->hasIntegerRule);
+    }
+
+    // --- exclude* rules defeat the presence guarantee (#1237) ---
+
+    #[Test]
+    public function exclude_rule_defeats_presence_guarantee(): void
+    {
+        $rule = $this->resolve('exclude|required|integer|min:1');
+
+        $this->assertTrue($rule->excluded);
+        $this->assertFalse($rule->guaranteesPresence());
+    }
+
+    #[Test]
+    public function exclude_if_rule_defeats_presence_guarantee(): void
+    {
+        $rule = ValidationRuleAnalyzer::resolveRuleSegments(['exclude_if:other,value', 'required', 'string']);
+
+        $this->assertFalse($rule->guaranteesPresence());
+    }
+
+    #[Test]
+    public function exclude_unless_rule_defeats_presence_guarantee(): void
+    {
+        $rule = ValidationRuleAnalyzer::resolveRuleSegments(['exclude_unless:other,value', 'required', 'string']);
+
+        $this->assertFalse($rule->guaranteesPresence());
+    }
+
+    #[Test]
+    public function exclude_with_rule_defeats_presence_guarantee(): void
+    {
+        $rule = ValidationRuleAnalyzer::resolveRuleSegments(['exclude_with:other', 'required', 'string']);
+
+        $this->assertFalse($rule->guaranteesPresence());
+    }
+
+    #[Test]
+    public function exclude_without_rule_defeats_presence_guarantee(): void
+    {
+        $rule = ValidationRuleAnalyzer::resolveRuleSegments(['exclude_without:other', 'required', 'string']);
+
+        $this->assertFalse($rule->guaranteesPresence());
+    }
+
+    #[Test]
+    public function required_without_exclude_still_guarantees_presence(): void
+    {
+        // Contrast: the new exclude gate must not regress the existing feature.
+        $rule = $this->resolve('required|string');
+
+        $this->assertFalse($rule->excluded);
+        $this->assertTrue($rule->guaranteesPresence());
+    }
+
+    // --- Overflow-safe int-literal params (#1237) ---
+
+    #[Test]
+    public function min_beyond_php_int_max_contributes_no_bound(): void
+    {
+        // (int) "9223372036854775808" (PHP_INT_MAX + 1) silently saturates
+        // to PHP_INT_MAX via the cast instead of erroring — round-trip
+        // rejection catches what the earlier exact-PHP_INT_MAX guard doesn't.
+        $rule = $this->resolve('integer|min:9223372036854775808');
+
+        $this->assertSame('int|numeric-string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function max_beyond_php_int_max_contributes_no_bound(): void
+    {
+        $rule = $this->resolve('integer|max:9223372036854775808');
+
+        $this->assertSame('int|numeric-string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function gt_beyond_php_int_max_contributes_no_bound(): void
+    {
+        $rule = $this->resolve('integer|gt:9223372036854775808');
+
+        $this->assertSame('int|numeric-string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function lt_beyond_php_int_max_contributes_no_bound(): void
+    {
+        $rule = $this->resolve('integer|lt:9223372036854775808');
+
+        $this->assertSame('int|numeric-string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function min_beyond_php_int_min_contributes_no_bound(): void
+    {
+        $rule = $this->resolve('integer|min:-9223372036854775809');
+
+        $this->assertSame('int|numeric-string', $rule->type->getId());
+    }
+
+    #[Test]
+    public function leading_zero_param_contributes_no_bound(): void
+    {
+        // Documented, acceptable precision loss — see intLiteralParam().
+        $rule = $this->resolve('integer|min:007');
+
+        $this->assertSame('int|numeric-string', $rule->type->getId());
     }
 }


### PR DESCRIPTION
## Issue to Solve

`integer|min:1` fields were inferred as plain `int` (or `int|numeric-string`), so an accurate docblock like `@return positive-int` on a `FormRequest` accessor tripped `MoreSpecificReturnType`. Two gaps: `ValidationRuleAnalyzer` ignored numeric-range rule params, and `integer()` was not a narrowed accessor at all.

## Related

Closes #1234

## Solution Description

**Range accumulation in `ValidationRuleAnalyzer`.** `min`/`max`/`between`/`size`/`gt`/`gte`/`lt`/`lte` fold into running `[lower, upper]` bounds (order-independent, multiple rules combine via max-of-lowers / min-of-uppers). After the segment loop the field's bare `TInt` atomic is replaced with `TIntRange` (or `TLiteralInt` when the range collapses, e.g. `size:5`). Guard rails, each unit-tested:

- narrowing applies only when the field also carries `integer`/`numeric` — `min`/`max`/`size` are overloaded (string length, array count, file size), so a bare `min:3` contributes nothing;
- bounds require integer-literal params that survive an int round-trip: `gt:other_field`, `min:1.5`, and overflow values like `lt:9223372036854775808` (which would cast-saturate and wrongly exclude `PHP_INT_MAX`) contribute no bound;
- `gt`/`lt` translate to inclusive bounds with `PHP_INT_MAX`/`MIN` overflow guards; conflicting bounds (`min:5|max:3`) skip narrowing instead of emitting an uninhabited range;
- exact-class `TInt` swap only — pre-existing `TLiteralInt` atoms (from `boolean`/`accepted`) are never widened.

**`integer()` accessor dispatch in `ValidatedTypeHandler`.** `$this->integer('field')` / `$request->integer('field')` return the rule-derived int component only when the cast is provably lossless and the field provably present:

- **explicit `integer` rule required** (`ResolvedRule::$hasIntegerRule`): Laravel's `integer()` is `(int) $this->data($key, $default)`, and the cast projects other carriers onto int unsoundly — `accepted` admits `"yes"` (casts to `0`, not the rule type's literal `1`), `numeric|gt:0` admits `"0.5"` (casts to `0`, outside `int<1, max>`). Passing `FILTER_VALIDATE_INT` (the `integer` rule) guarantees a lossless cast;
- **presence guaranteed**: absent fields return the cast of Laravel's rule-independent `$default` (`0`). `guaranteesPresence()` now also accounts for `exclude`/`exclude_if`/`exclude_unless`/`exclude_with`/`exclude_without` (`ResolvedRule::$excluded`) — Laravel short-circuits an excluded attribute's remaining rules entirely, so `exclude|required|integer|min:1` passes validation with the field absent and unvalidated. The exclude-awareness propagates to every `guaranteesPresence()` consumer: `input()` narrowing, magic-property reads, and `validated()` array shapes (excluded keys become `key?:` optional);
- **non-nullable rules**: `required|nullable|integer|min:18` validates `null`, and `(int) null = 0`.

`InteractsWithData::class` joins `getClassLikeNames()` (same reasoning as the existing `InteractsWithInput` entry, #1015). The shared setup path of the two self-accessors is extracted into `resolveSelfAccessorRule()`. `float()`/`boolean()` gain regression assertions but no handler arms: Psalm has no float range type and `bool` has no narrowing target — the stub types are already exact.

Verified by: phpt (`ValidationRuleNumericRangeTest`) covering the issue reproducer (`@return positive-int` no longer flagged), external + `$this` receivers, `gt` end-to-end, optional/nullable/excluded fallbacks, cast-unsound `accepted` and `numeric|gt:0` fields, the excluded-key optional array shape, and the `safe()->integer()` boundary; 44 new unit tests covering the full rule matrix and every guard; full unit + type suites, Psalm self-analysis (100% type coverage) all green.

## Follow-up

`safe()->integer('field')` (the `ValidatedInput` path) deliberately keeps the plain stub `int` — `resolveValidatedInputMethod()` narrows `input()` only today. Locked in by a phpt assertion; extending `ValidatedInput` dispatch to the cast accessors (with the same rule-provenance/presence/nullable gate stack) is a separate change.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)
