### PR TITLE
Improve Composer source-root handling

### DIFF
--- a/src/Cli/InitCommand.php
+++ b/src/Cli/InitCommand.php
@@ -154,8 +154,8 @@ final class InitCommand extends Command
 
         $composer = $this->readComposerJson($cwd);
         $hasPhpunitPlugin = $this->composerHasPackage($composer, 'psalm/plugin-phpunit');
-        [$directories, $files] = $this->detectSourceRoots($cwd, $composer, $hasPhpunitPlugin);
-        $ignores = $this->detectIgnoreDirs($cwd, $composer);
+        [$directories, $files, $directoryCandidates] = $this->detectSourceRoots($cwd, $composer, $hasPhpunitPlugin);
+        $ignores = $this->detectIgnoreDirs($cwd, $composer, $hasPhpunitPlugin, $directoryCandidates);
 
         $contents = \strtr(self::PSALM_XML_TEMPLATE, [
             '{{LEVEL}}' => $level,
@@ -166,7 +166,17 @@ final class InitCommand extends Command
             return Command::FAILURE;
         }
 
-        $this->reportSuccess($io, $cwd, $targetPath, $existingPath !== null, $level, $directories, $files);
+        $this->reportSuccess(
+            $io,
+            $cwd,
+            $targetPath,
+            $existingPath !== null,
+            $level,
+            $directories,
+            $files,
+            $directoryCandidates,
+            $hasPhpunitPlugin,
+        );
         return Command::SUCCESS;
     }
 
@@ -238,6 +248,7 @@ final class InitCommand extends Command
     /**
      * @param list<string> $directories
      * @param list<string> $files
+     * @param list<SourceRootCandidate> $directoryCandidates
      */
     private function reportSuccess(
         SymfonyStyle $io,
@@ -247,6 +258,8 @@ final class InitCommand extends Command
         string $level,
         array $directories,
         array $files,
+        array $directoryCandidates,
+        bool $hasPhpunitPlugin,
     ): void {
         $io->success(\sprintf(
             '%s %s.',
@@ -262,7 +275,12 @@ final class InitCommand extends Command
 
         // Mirror inline XML hint when tests/ exists but isn't scanned,
         // usually because psalm/plugin-phpunit isn't installed.
-        if (!\in_array('tests', $directories, true) && \is_dir($cwd . \DIRECTORY_SEPARATOR . 'tests')) {
+        $projectRoot = $this->canonicalProjectRoot($cwd);
+        $tests = SourceRootCandidate::resolve($projectRoot, 'tests');
+        if ($tests instanceof \Psalm\LaravelPlugin\Cli\SourceRootCandidate
+            && !$this->hasRoot($tests, $directoryCandidates)
+            && (!$hasPhpunitPlugin || !$this->hasCoveringRoot($tests, $directoryCandidates))
+        ) {
             $io->writeln('');
             $io->writeln(
                 '<comment>Note:</comment> tests/ dir skipped. To scan it: <info>composer require --dev psalm/plugin-phpunit</info> and add tests dir to <projectFiles>',
@@ -271,7 +289,8 @@ final class InitCommand extends Command
 
         // Path-repo monorepos not enumerated in root composer autoload can't be
         // auto-detected; warn loudly so a packages/ tree isn't left silently unanalysed. #1224
-        if (\is_dir($cwd . \DIRECTORY_SEPARATOR . 'packages') && !$this->hasRootUnder('packages', $directories)) {
+        $packages = SourceRootCandidate::resolve($projectRoot, 'packages');
+        if ($packages instanceof \Psalm\LaravelPlugin\Cli\SourceRootCandidate && !$this->hasOverlappingRoot($packages, $directoryCandidates)) {
             $io->writeln('');
             $io->writeln(
                 '<comment>Note:</comment> packages/ exists but no source root under it is scanned. If this is a monorepo, add each package source dir (e.g. packages/*/src) to <projectFiles> — otherwise Psalm analyses almost nothing.',
@@ -288,30 +307,51 @@ final class InitCommand extends Command
      * which is what surfaces the monorepo packages/*\/src the app branch misses. See #1224.
      *
      * @param ComposerJson|null $composer
-     * @return array{0: list<string>, 1: list<string>} [directories, files]
+     * @return array{0: list<string>, 1: list<string>, 2: list<SourceRootCandidate>}
+     *     [clean directories, files, resolved directory candidates]
      */
     private function detectSourceRoots(string $cwd, ?array $composer, bool $hasPhpunitPlugin): array
     {
+        $projectRoot = $this->canonicalProjectRoot($cwd);
         $isLaravelApp = \is_file($cwd . \DIRECTORY_SEPARATOR . 'artisan');
 
         [$conventional, $files] = $isLaravelApp
-            ? $this->detectLaravelAppRoots($cwd)
-            : $this->detectPackageConventions($cwd);
+            ? $this->detectLaravelAppRoots($projectRoot)
+            : $this->detectPackageConventions($projectRoot);
+        $composerRoots = $this->detectComposerRoots($projectRoot, $composer);
+
+        // Package layout last resort: src/ is independent of other conventions.
+        // A config/ directory must not hide it when Composer contributed no usable
+        // production root.
+        if (!$isLaravelApp && $composerRoots === []) {
+            $src = SourceRootCandidate::resolve($projectRoot, 'src');
+            if ($src instanceof \Psalm\LaravelPlugin\Cli\SourceRootCandidate) {
+                $conventional[] = $src;
+            }
+        }
 
         // Exact canonical dedupe only. A nested root (e.g. mapped database/factories
         // under database/) is kept: Psalm keys files by path, so redundancy costs a
         // little traversal, never double analysis, and never suppresses a real root.
-        $directories = [];
-        foreach ([...$conventional, ...$this->detectComposerRoots($cwd, $composer)] as $dir) {
-            if (!\in_array($dir, $directories, true)) {
-                $directories[] = $dir;
+        $directoryCandidates = [];
+        foreach ([...$conventional, ...$composerRoots] as $candidate) {
+            if (!$this->hasRoot($candidate, $directoryCandidates)) {
+                $directoryCandidates[] = $candidate;
             }
         }
 
-        // Package layout last resort: scan src/ when nothing else was found.
-        if (!$isLaravelApp && $directories === [] && \is_dir($cwd . \DIRECTORY_SEPARATOR . 'src')) {
-            $directories[] = 'src';
+        $tests = SourceRootCandidate::resolve($projectRoot, 'tests');
+        if (!$hasPhpunitPlugin && $tests instanceof \Psalm\LaravelPlugin\Cli\SourceRootCandidate) {
+            $directoryCandidates = \array_values(\array_filter(
+                $directoryCandidates,
+                static fn(SourceRootCandidate $candidate): bool => !$candidate->isWithin($tests),
+            ));
         }
+
+        $directories = \array_map(
+            static fn(SourceRootCandidate $candidate): string => $candidate->cleanPath,
+            $directoryCandidates,
+        );
 
         // Ultimate fallback so the template still validates.
         if ($directories === [] && $files === []) {
@@ -322,24 +362,26 @@ final class InitCommand extends Command
         // Scanning tests/ without psalm/plugin-phpunit floods output with PHPUnit-magic
         // false positives, so opt in only when the plugin is already wired up.
         if ($hasPhpunitPlugin
-            && \is_dir($cwd . \DIRECTORY_SEPARATOR . 'tests')
-            && !\in_array('tests', $directories, true)
+            && ($tests = SourceRootCandidate::resolve($projectRoot, 'tests')) instanceof \Psalm\LaravelPlugin\Cli\SourceRootCandidate
+            && !$this->hasRoot($tests, $directoryCandidates)
         ) {
-            $directories[] = 'tests';
+            $directoryCandidates[] = $tests;
+            $directories[] = $tests->cleanPath;
         }
 
-        return [$directories, $files];
+        return [$directories, $files, $directoryCandidates];
     }
 
     /**
-     * @return array{0: list<string>, 1: list<string>}
+     * @return array{0: list<SourceRootCandidate>, 1: list<string>}
      */
     private function detectLaravelAppRoots(string $cwd): array
     {
         $directories = [];
         foreach (self::LARAVEL_APP_DIRS as $dir) {
-            if (\is_dir($cwd . \DIRECTORY_SEPARATOR . $dir)) {
-                $directories[] = $dir;
+            $candidate = SourceRootCandidate::resolve($cwd, $dir);
+            if ($candidate instanceof \Psalm\LaravelPlugin\Cli\SourceRootCandidate) {
+                $directories[] = $candidate;
             }
         }
 
@@ -357,13 +399,15 @@ final class InitCommand extends Command
      * Conventional roots for a non-artisan package: config/ only. The composer map
      * (detectComposerRoots) and the src/ fallback are handled by the pipeline.
      *
-     * @return array{0: list<string>, 1: list<string>}
+     * @return array{0: list<SourceRootCandidate>, 1: list<string>}
+     * @psalm-impure Filesystem state determines which conventional roots exist.
      */
     private function detectPackageConventions(string $cwd): array
     {
         $directories = [];
-        if (\is_dir($cwd . \DIRECTORY_SEPARATOR . 'config')) {
-            $directories[] = 'config';
+        $config = SourceRootCandidate::resolve($cwd, 'config');
+        if ($config instanceof \Psalm\LaravelPlugin\Cli\SourceRootCandidate) {
+            $directories[] = $config;
         }
 
         return [$directories, []];
@@ -371,19 +415,21 @@ final class InitCommand extends Command
 
     /**
      * On-disk source roots from the root composer autoload.psr-4 map — the shared
-     * contributor for both layouts (paths canonicalised by extractComposerAutoloadDirs).
+     * contributor for both layouts. Candidate resolution canonicalises through the
+     * filesystem without changing symlink-plus-`..` semantics.
      * Reads only autoload.psr-4; test dirs live in autoload-dev, opt-in via plugin-phpunit.
      * Emits the exact mapped src roots, so each package's vendor/ and tests/ stay out.
      *
      * @param ComposerJson|null $composer
-     * @return list<string>
+     * @return list<SourceRootCandidate>
      */
     private function detectComposerRoots(string $cwd, ?array $composer): array
     {
         $roots = [];
         foreach ($this->extractComposerAutoloadDirs($composer) as $dir) {
-            if (\is_dir($cwd . \DIRECTORY_SEPARATOR . $dir) && !\in_array($dir, $roots, true)) {
-                $roots[] = $dir;
+            $candidate = SourceRootCandidate::resolve($cwd, $dir);
+            if ($candidate instanceof \Psalm\LaravelPlugin\Cli\SourceRootCandidate && !$this->hasRoot($candidate, $roots)) {
+                $roots[] = $candidate;
             }
         }
 
@@ -396,10 +442,15 @@ final class InitCommand extends Command
      * right path.
      *
      * @param ComposerJson|null $composer
+     * @param list<SourceRootCandidate> $directoryCandidates
      * @return list<string>
      */
-    private function detectIgnoreDirs(string $cwd, ?array $composer): array
-    {
+    private function detectIgnoreDirs(
+        string $cwd,
+        ?array $composer,
+        bool $hasPhpunitPlugin,
+        array $directoryCandidates,
+    ): array {
         $vendorDir = $this->resolveVendorDir($composer);
 
         $present = [];
@@ -409,6 +460,16 @@ final class InitCommand extends Command
             if (\is_dir($cwd . \DIRECTORY_SEPARATOR . $candidate) && !\in_array($candidate, $present, true)) {
                 $present[] = $candidate;
             }
+        }
+
+        $projectRoot = $this->canonicalProjectRoot($cwd);
+        $tests = SourceRootCandidate::resolve($projectRoot, 'tests');
+        if (!$hasPhpunitPlugin
+            && $tests instanceof \Psalm\LaravelPlugin\Cli\SourceRootCandidate
+            && $this->hasCoveringRoot($tests, $directoryCandidates)
+            && !\in_array($tests->cleanPath, $present, true)
+        ) {
+            $present[] = $tests->cleanPath;
         }
 
         return $present;
@@ -482,11 +543,9 @@ final class InitCommand extends Command
     }
 
     /**
-     * Extract `autoload.psr-4` directories from composer.json. Order preserved,
-     * duplicates removed, each path canonicalised (leading `./` and `.`/`..`
-     * segments collapsed) so downstream containment/dedup compare like-for-like —
-     * e.g. `./app` dedupes against `app`, and `app/../packages/x` is not misread
-     * as covered by `app`. A leading `..` that escapes the root is kept.
+     * Extract raw `autoload.psr-4` directories from composer.json in declaration
+     * order. Filesystem resolution and canonical deduplication happen afterwards,
+     * when the project root is available.
      *
      * @param ComposerJson|null $composer
      * @return list<string>
@@ -500,26 +559,7 @@ final class InitCommand extends Command
         foreach ($psr4 as $paths) {
             $items = \is_string($paths) ? [$paths] : $paths;
             foreach ($items as $candidate) {
-                $segments = [];
-                foreach (\explode('/', $candidate) as $segment) {
-                    if ($segment === '' || $segment === '.') {
-                        continue;
-                    }
-
-                    if ($segment === '..' && $segments !== [] && $segments[\array_key_last($segments)] !== '..') {
-                        \array_pop($segments);
-                        continue;
-                    }
-
-                    $segments[] = $segment;
-                }
-
-                $dir = \implode('/', $segments);
-                if ($dir === '' || \in_array($dir, $dirs, true)) {
-                    continue;
-                }
-
-                $dirs[] = $dir;
+                $dirs[] = $candidate;
             }
         }
 
@@ -527,21 +567,61 @@ final class InitCommand extends Command
     }
 
     /**
-     * True when at least one detected root lives under $prefix. Lets reportSuccess()
-     * warn when a packages/ dir exists yet nothing beneath it is scanned.
+     * True when a detected root is equal to, above, or below the supplied directory.
+     * This captures both a precise package root and a broader root that already scans it.
      *
-     * @param list<string> $directories
-     * @psalm-pure
+     * @param list<SourceRootCandidate> $directories
+     * @psalm-mutation-free
      */
-    private function hasRootUnder(string $prefix, array $directories): bool
+    private function hasOverlappingRoot(SourceRootCandidate $directory, array $directories): bool
     {
         foreach ($directories as $dir) {
-            if (\str_starts_with($dir . '/', $prefix . '/')) {
+            if ($dir->isWithin($directory) || $directory->isWithin($dir)) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    /**
+     * @param list<SourceRootCandidate> $directories
+     * @psalm-mutation-free
+     */
+    private function hasCoveringRoot(SourceRootCandidate $candidate, array $directories): bool
+    {
+        foreach ($directories as $directory) {
+            if ($candidate->isWithin($directory)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param list<SourceRootCandidate> $directories
+     * @psalm-mutation-free
+     */
+    private function hasRoot(SourceRootCandidate $candidate, array $directories): bool
+    {
+        foreach ($directories as $directory) {
+            if ($candidate->isSame($directory)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function canonicalProjectRoot(string $cwd): string
+    {
+        $canonical = \realpath($cwd);
+        if ($canonical === false || !\is_dir($canonical)) {
+            throw new \RuntimeException(\sprintf('Project root does not exist: %s', $cwd));
+        }
+
+        return $canonical;
     }
 
     /**

--- a/src/Cli/SourceRootCandidate.php
+++ b/src/Cli/SourceRootCandidate.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Cli;
+
+/**
+ * An existing source directory with separate filesystem and presentation paths.
+ *
+ * @internal
+ */
+final readonly class SourceRootCandidate
+{
+    /** @psalm-mutation-free */
+    private function __construct(
+        public string $cleanPath,
+        public string $canonicalPath,
+    ) {}
+
+    /**
+     * Resolve the path through the filesystem before deriving its display form.
+     * This deliberately leaves `..` intact until realpath() has traversed any
+     * preceding symlink, because lexical normalisation can select another directory.
+     *
+     * @psalm-impure Filesystem state determines whether and where the path resolves.
+     */
+    public static function resolve(string $projectRoot, string $path): ?self
+    {
+        $absolutePath = self::isAbsolute($path)
+            ? $path
+            : $projectRoot . \DIRECTORY_SEPARATOR . ($path === '' ? '.' : $path);
+        $resolvedPath = \realpath($absolutePath);
+        if ($resolvedPath === false || !\is_dir($resolvedPath)) {
+            return null;
+        }
+
+        // realpath() resolves symlinks and dot segments but can retain caller casing
+        // on case-insensitive filesystems. Re-read directory entries so the path is
+        // also stable for exact comparisons without relying on non-portable inode keys.
+        $canonicalPath = self::canonicalizeCase($resolvedPath);
+        $canonicalProjectRoot = self::canonicalizeCase($projectRoot);
+        if ($canonicalPath === $canonicalProjectRoot) {
+            return new self('.', $canonicalPath);
+        }
+
+        $projectPrefix = \rtrim($canonicalProjectRoot, \DIRECTORY_SEPARATOR) . \DIRECTORY_SEPARATOR;
+        if (\str_starts_with($canonicalPath, $projectPrefix)) {
+            $relativePath = \substr($canonicalPath, \strlen($projectPrefix));
+
+            return new self(\str_replace(\DIRECTORY_SEPARATOR, '/', $relativePath), $canonicalPath);
+        }
+
+        return new self($canonicalPath, $canonicalPath);
+    }
+
+    /**
+     * True when both candidates resolve to the same filesystem directory.
+     *
+     * @psalm-mutation-free
+     */
+    public function isSame(self $other): bool
+    {
+        return $this->canonicalPath === $other->canonicalPath;
+    }
+
+    /**
+     * True when this directory is the supplied directory or one of its descendants.
+     *
+     * @psalm-mutation-free
+     */
+    public function isWithin(self $directory): bool
+    {
+        if ($this->isSame($directory)) {
+            return true;
+        }
+
+        $prefix = \rtrim($directory->canonicalPath, \DIRECTORY_SEPARATOR) . \DIRECTORY_SEPARATOR;
+
+        return \str_starts_with($this->canonicalPath, $prefix);
+    }
+
+    /** @psalm-pure */
+    private static function isAbsolute(string $path): bool
+    {
+        if ($path === '') {
+            return false;
+        }
+
+        return $path[0] === '/'
+            || (\DIRECTORY_SEPARATOR === '\\'
+                && ($path[0] === '\\' || \preg_match('/^[A-Za-z]:[\\\\\/]/', $path) === 1));
+    }
+
+    /** Rebuild an absolute path with the casing stored in each parent directory. */
+    private static function canonicalizeCase(string $path): string
+    {
+        $segments = [];
+        $current = $path;
+        while (true) {
+            $parent = \dirname($current);
+            if ($parent === $current) {
+                break;
+            }
+
+            $name = \basename($current);
+            $entries = @\scandir($parent);
+            if ($entries !== false && !\in_array($name, $entries, true)) {
+                $targetMetadata = @\stat($current);
+                foreach ($entries as $entry) {
+                    $entryMetadata = @\stat(
+                        \rtrim($parent, \DIRECTORY_SEPARATOR) . \DIRECTORY_SEPARATOR . $entry,
+                    );
+                    // Exact names always win above. Identity is only a fallback
+                    // among siblings, where it recovers the stored spelling for
+                    // non-ASCII aliases without becoming a global inode key.
+                    if ($targetMetadata !== false
+                        && $entryMetadata !== false
+                        && $entryMetadata['dev'] === $targetMetadata['dev']
+                        && $entryMetadata['ino'] === $targetMetadata['ino']
+                    ) {
+                        $name = $entry;
+                        break;
+                    }
+                }
+            }
+
+            $segments[] = $name;
+            $current = $parent;
+        }
+
+        foreach (\array_reverse($segments) as $segment) {
+            $current = \rtrim($current, \DIRECTORY_SEPARATOR) . \DIRECTORY_SEPARATOR . $segment;
+        }
+
+        return $current;
+    }
+}

--- a/tests/Unit/Cli/InitCommandTest.php
+++ b/tests/Unit/Cli/InitCommandTest.php
@@ -8,14 +8,19 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psalm\LaravelPlugin\Cli\InitCommand;
+use Psalm\LaravelPlugin\Cli\SourceRootCandidate;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
 #[CoversClass(InitCommand::class)]
+#[CoversClass(SourceRootCandidate::class)]
 final class InitCommandTest extends TestCase
 {
     private string $tempDir;
+
+    /** @var list<string> */
+    private array $externalPaths = [];
 
     protected function setUp(): void
     {
@@ -28,6 +33,9 @@ final class InitCommandTest extends TestCase
     protected function tearDown(): void
     {
         $this->removeRecursively($this->tempDir);
+        foreach ($this->externalPaths as $path) {
+            $this->removeRecursively($path);
+        }
     }
 
     private function removeRecursively(string $path): void
@@ -434,6 +442,369 @@ final class InitCommandTest extends TestCase
     }
 
     #[Test]
+    public function empty_composer_root_emits_the_project_root(): void
+    {
+        \file_put_contents(
+            $this->tempDir . \DIRECTORY_SEPARATOR . 'composer.json',
+            (string) \json_encode(['autoload' => ['psr-4' => ['Acme\\' => '']]]),
+        );
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $this->assertSame(1, \substr_count($contents, '<directory name="."/>'));
+    }
+
+    #[Test]
+    public function dot_composer_root_emits_the_project_root(): void
+    {
+        \file_put_contents(
+            $this->tempDir . \DIRECTORY_SEPARATOR . 'composer.json',
+            (string) \json_encode(['autoload' => ['psr-4' => ['Acme\\' => '.']]]),
+        );
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $this->assertSame(1, \substr_count($contents, '<directory name="."/>'));
+    }
+
+    #[Test]
+    public function project_root_mapping_ignores_tests_without_phpunit_plugin(): void
+    {
+        $this->makeDir('tests');
+        \file_put_contents(
+            $this->tempDir . \DIRECTORY_SEPARATOR . 'composer.json',
+            (string) \json_encode(['autoload' => ['psr-4' => ['Acme\\' => '.']]]),
+        );
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $this->assertStringContainsString('<directory name="."/>', $contents);
+        $this->assertStringContainsString('<ignoreFiles allowMissingFiles="true">', $contents);
+        $this->assertStringContainsString('<directory name="tests"/>', $contents);
+        $this->assertStringContainsString('tests/ dir skipped', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function project_root_mapping_scans_tests_with_phpunit_plugin(): void
+    {
+        $this->makeDir('tests');
+        \file_put_contents(
+            $this->tempDir . \DIRECTORY_SEPARATOR . 'composer.json',
+            (string) \json_encode([
+                'autoload' => ['psr-4' => ['Acme\\' => '.']],
+                'require-dev' => ['psalm/plugin-phpunit' => '^0.1'],
+            ]),
+        );
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $this->assertStringContainsString('<directory name="."/>', $contents);
+        $this->assertStringContainsString('<directory name="tests"/>', $contents);
+        $this->assertStringNotContainsString('<ignoreFiles allowMissingFiles="true">', $contents);
+        $this->assertStringNotContainsString('tests/ dir skipped', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function project_root_mapping_counts_as_packages_coverage(): void
+    {
+        $this->makeDir('packages/acme/src');
+        \file_put_contents(
+            $this->tempDir . \DIRECTORY_SEPARATOR . 'composer.json',
+            (string) \json_encode(['autoload' => ['psr-4' => ['Acme\\' => '.']]]),
+        );
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $this->assertStringNotContainsString(
+            'packages/ exists but no source root under it is scanned',
+            $tester->getDisplay(),
+        );
+    }
+
+    #[Test]
+    public function absolute_composer_root_inside_project_is_emitted_relative(): void
+    {
+        $this->makeDir('lib');
+        $absoluteRoot = $this->tempDir . \DIRECTORY_SEPARATOR . 'lib';
+        \file_put_contents(
+            $this->tempDir . \DIRECTORY_SEPARATOR . 'composer.json',
+            (string) \json_encode(['autoload' => ['psr-4' => ['Acme\\' => $absoluteRoot]]]),
+        );
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $this->assertStringContainsString('<directory name="lib"/>', $contents);
+        $this->assertStringNotContainsString(\htmlspecialchars($absoluteRoot, \ENT_QUOTES | \ENT_XML1, 'UTF-8'), $contents);
+    }
+
+    #[Test]
+    public function absolute_composer_root_outside_project_stays_canonical_and_valid_xml(): void
+    {
+        $outside = $this->makeExternalDir('Outside & Source');
+        \file_put_contents(
+            $this->tempDir . \DIRECTORY_SEPARATOR . 'composer.json',
+            (string) \json_encode(['autoload' => ['psr-4' => ['Acme\\' => $outside]]]),
+        );
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $escapedOutside = \htmlspecialchars((string) \realpath($outside), \ENT_QUOTES | \ENT_XML1, 'UTF-8');
+        $this->assertStringContainsString('<directory name="' . $escapedOutside . '"/>', $contents);
+        $this->assertNotFalse(\simplexml_load_string($contents));
+    }
+
+    #[Test]
+    public function package_src_fallback_is_not_suppressed_by_config(): void
+    {
+        $this->makeDir('config');
+        $this->makeDir('src');
+        \file_put_contents(
+            $this->tempDir . \DIRECTORY_SEPARATOR . 'composer.json',
+            (string) \json_encode(['autoload' => ['psr-4' => ['Acme\\' => 'missing']]]),
+        );
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $configPosition = \strpos($contents, '<directory name="config"/>');
+        $srcPosition = \strpos($contents, '<directory name="src"/>');
+        $this->assertIsInt($configPosition);
+        $this->assertIsInt($srcPosition);
+        $this->assertLessThan($srcPosition, $configPosition);
+    }
+
+    #[Test]
+    public function composer_roots_are_exactly_deduplicated_by_canonical_path(): void
+    {
+        $this->makeDir('src');
+        \file_put_contents(
+            $this->tempDir . \DIRECTORY_SEPARATOR . 'composer.json',
+            (string) \json_encode(['autoload' => ['psr-4' => ['Acme\\' => ['src', './src/']]]]),
+        );
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $this->assertSame(1, \substr_count($contents, '<directory name="src"/>'));
+    }
+
+    #[Test]
+    public function composer_alias_is_deduplicated_against_conventional_root(): void
+    {
+        \file_put_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'artisan', "#!/usr/bin/env php\n");
+        $this->makeDir('app');
+        $this->makeSymlink(
+            $this->tempDir . \DIRECTORY_SEPARATOR . 'app',
+            $this->tempDir . \DIRECTORY_SEPARATOR . 'source-alias',
+        );
+        \file_put_contents(
+            $this->tempDir . \DIRECTORY_SEPARATOR . 'composer.json',
+            (string) \json_encode(['autoload' => ['psr-4' => ['App\\' => 'source-alias']]]),
+        );
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $this->assertSame(1, \substr_count($contents, '<directory name="app"/>'));
+        $this->assertStringNotContainsString('source-alias', $contents);
+    }
+
+    #[Test]
+    public function symlink_followed_by_parent_segment_uses_filesystem_resolution(): void
+    {
+        $outside = $this->makeExternalDir('symlink-parent');
+        $nested = $outside . \DIRECTORY_SEPARATOR . 'nested';
+        \mkdir($nested);
+        $this->makeSymlink($nested, $this->tempDir . \DIRECTORY_SEPARATOR . 'linked');
+        \file_put_contents(
+            $this->tempDir . \DIRECTORY_SEPARATOR . 'composer.json',
+            (string) \json_encode(['autoload' => ['psr-4' => ['Acme\\' => 'linked/..']]]),
+        );
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $escapedOutside = \htmlspecialchars((string) \realpath($outside), \ENT_QUOTES | \ENT_XML1, 'UTF-8');
+        $this->assertStringContainsString('<directory name="' . $escapedOutside . '"/>', $contents);
+        $this->assertStringNotContainsString('<directory name="."/>', $contents);
+    }
+
+    #[Test]
+    public function package_warning_uses_canonical_path_reached_through_symlink(): void
+    {
+        $this->makeDir('packages/acme/src');
+        $this->makeSymlink(
+            $this->tempDir . \DIRECTORY_SEPARATOR . 'packages' . \DIRECTORY_SEPARATOR . 'acme' . \DIRECTORY_SEPARATOR . 'src',
+            $this->tempDir . \DIRECTORY_SEPARATOR . 'package-alias',
+        );
+        \file_put_contents(
+            $this->tempDir . \DIRECTORY_SEPARATOR . 'composer.json',
+            (string) \json_encode(['autoload' => ['psr-4' => ['Acme\\' => './package-alias']]]),
+        );
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $this->assertStringContainsString('packages/acme/src', (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml'));
+        $this->assertStringNotContainsString('packages/ exists but no source root under it is scanned', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function filesystem_identity_handles_case_variants_when_supported(): void
+    {
+        $this->makeDir('packages/acme/src');
+        if (!\is_dir($this->tempDir . \DIRECTORY_SEPARATOR . 'PACKAGES' . \DIRECTORY_SEPARATOR . 'ACME' . \DIRECTORY_SEPARATOR . 'SRC')) {
+            $this->markTestSkipped('The filesystem is case-sensitive, so equivalent case variants cannot be exercised.');
+        }
+
+        \file_put_contents(
+            $this->tempDir . \DIRECTORY_SEPARATOR . 'composer.json',
+            (string) \json_encode(['autoload' => ['psr-4' => ['Acme\\' => [
+                'packages/acme/src',
+                'PACKAGES/ACME/SRC',
+            ]]]]),
+        );
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $this->assertSame(1, \substr_count($contents, '<directory name="packages/acme/src"/>'));
+        $this->assertStringNotContainsString('PACKAGES/ACME/SRC', $contents);
+        $this->assertStringNotContainsString('packages/ exists but no source root under it is scanned', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function canonical_paths_deduplicate_non_ascii_case_variants_when_supported(): void
+    {
+        $this->makeDir('packages/Äcme/src');
+        if (!\is_dir($this->tempDir . \DIRECTORY_SEPARATOR . 'packages' . \DIRECTORY_SEPARATOR . 'äCME' . \DIRECTORY_SEPARATOR . 'SRC')) {
+            $this->markTestSkipped('The filesystem does not resolve the non-ASCII case variant equivalently.');
+        }
+
+        \file_put_contents(
+            $this->tempDir . \DIRECTORY_SEPARATOR . 'composer.json',
+            (string) \json_encode(['autoload' => ['psr-4' => ['Acme\\' => [
+                'packages/Äcme/src',
+                'packages/äCME/SRC',
+            ]]]], \JSON_UNESCAPED_UNICODE),
+        );
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $this->assertSame(1, \substr_count($contents, '<directory name="packages/Äcme/src"/>'));
+        $this->assertStringNotContainsString('packages/äCME/SRC', $contents);
+        $this->assertStringNotContainsString('packages/ exists but no source root under it is scanned', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function scanned_external_tests_symlink_does_not_report_tests_as_skipped(): void
+    {
+        $outside = $this->makeExternalDir('external-tests');
+        $this->makeSymlink($outside, $this->tempDir . \DIRECTORY_SEPARATOR . 'tests');
+        \file_put_contents(
+            $this->tempDir . \DIRECTORY_SEPARATOR . 'composer.json',
+            (string) \json_encode(['require-dev' => ['psalm/plugin-phpunit' => '^0.1']]),
+        );
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $escapedOutside = \htmlspecialchars((string) \realpath($outside), \ENT_QUOTES | \ENT_XML1, 'UTF-8');
+        $this->assertStringContainsString('<directory name="' . $escapedOutside . '"/>', $contents);
+        $this->assertStringNotContainsString('tests/ dir skipped', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function preserves_nested_roots_and_conventional_then_composer_order(): void
+    {
+        \file_put_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'artisan', "#!/usr/bin/env php\n");
+        $this->makeDir('app');
+        $this->makeDir('config');
+        $this->makeDir('database/factories');
+        $this->makeDir('z-source');
+        $this->makeDir('a-source');
+        \file_put_contents(
+            $this->tempDir . \DIRECTORY_SEPARATOR . 'composer.json',
+            (string) \json_encode(['autoload' => ['psr-4' => [
+                'Z\\' => 'z-source',
+                'A\\' => 'a-source',
+                'Factories\\' => 'database/factories',
+            ]]]),
+        );
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $expected = ['app', 'config', 'database', 'z-source', 'a-source', 'database/factories'];
+        $lastPosition = -1;
+        foreach ($expected as $directory) {
+            $position = \strpos($contents, '<directory name="' . $directory . '"/>');
+            $this->assertIsInt($position, \sprintf('Expected %s in generated XML.', $directory));
+            $this->assertGreaterThan($lastPosition, $position);
+            $lastPosition = $position;
+        }
+    }
+
+    #[Test]
+    public function missing_composer_directories_are_skipped(): void
+    {
+        $this->makeDir('src');
+        \file_put_contents(
+            $this->tempDir . \DIRECTORY_SEPARATOR . 'composer.json',
+            (string) \json_encode(['autoload' => ['psr-4' => [
+                'Missing\\' => 'does-not-exist',
+                'Present\\' => 'src',
+            ]]]),
+        );
+
+        $tester = $this->makeTester();
+        $exit = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $contents = (string) \file_get_contents($this->tempDir . \DIRECTORY_SEPARATOR . 'psalm.xml');
+        $this->assertStringNotContainsString('does-not-exist', $contents);
+        $this->assertStringContainsString('<directory name="src"/>', $contents);
+    }
+
+    #[Test]
     public function escapes_xml_special_chars_in_emitted_paths(): void
     {
         // A path with XML-special chars must be escaped, or init reports success while
@@ -467,6 +838,25 @@ final class InitCommandTest extends TestCase
         $path = $this->tempDir . \DIRECTORY_SEPARATOR . \str_replace('/', \DIRECTORY_SEPARATOR, $relative);
         if (! \is_dir($path) && ! \mkdir($path, 0o777, true) && ! \is_dir($path)) {
             throw new \RuntimeException(\sprintf('Failed to create directory %s', $path));
+        }
+    }
+
+    private function makeExternalDir(string $suffix): string
+    {
+        $path = $this->tempDir . '-' . $suffix;
+        if (!\mkdir($path) && !\is_dir($path)) {
+            throw new \RuntimeException(\sprintf('Failed to create directory %s', $path));
+        }
+
+        $this->externalPaths[] = $path;
+
+        return $path;
+    }
+
+    private function makeSymlink(string $target, string $link): void
+    {
+        if (!\function_exists('symlink') || !@\symlink($target, $link)) {
+            $this->markTestSkipped('The platform or filesystem does not permit creating symbolic links.');
         }
     }
 


### PR DESCRIPTION
## Issue to Solve
Composer source roots added in #1235 were normalized lexically, which mishandled empty, absolute, symlink-plus-parent, and equivalent filesystem paths. It also let `config/` suppress the package `src/` fallback and made package coverage warnings spelling-dependent.

## Related
Follow-up to #1235.

## Solution Description
Introduce `SourceRootCandidate` to retain a clean XML path and a filesystem-resolved canonical path. Use canonical paths for existence, exact deduplication, conventional/Composer comparisons, and package warning coverage while keeping conventional-first ordering and distinct nested roots.

Resolve Composer mappings through the filesystem before cleaning their display paths, including empty and dot roots, absolute inside/outside roots, list mappings, dot segments, symlinks followed by `..`, and case variants. Keep `tests/` conditional on `psalm/plugin-phpunit`, and add `src/` whenever a package has no usable Composer production root.

Verification:
- `composer test:unit -- --no-progress --colors=never --display-errors --display-warnings`
- `composer psalm -- --no-progress --no-suggestions --output-format=compact`
- `composer cs -- --show-progress=none --no-ansi -n`
- `composer rector -- --no-progress-bar --no-ansi`
- `git diff --check`

## Checklist
- [x] Tests cover the change

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786392264&installation_id=141955579&pr_number=1238&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1238&signature=844fd19a806ebddf3973b0b28b5010d59dcbbdf14d211049002fcc8983084259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->