### PR TITLE
Narrow `safe()->integer()` and `boolean()` from validation rules

### DIFF
--- a/src/Handlers/Validation/ResolvedRule.php
+++ b/src/Handlers/Validation/ResolvedRule.php
@@ -21,6 +21,8 @@ final readonly class ResolvedRule
      * @param bool  $required          Whether 'required' (or similar presence rule) was present
      * @param bool  $hasIntegerRule    Whether an explicit 'integer' rule was present
      * @param bool  $excluded          Whether an exclude/exclude_if/exclude_unless/exclude_with/exclude_without rule was present
+     * @param bool  $hasAcceptedRule   Whether an explicit unconditional 'accepted' rule was present (not accepted_if)
+     * @param bool  $hasDeclinedRule   Whether an explicit unconditional 'declined' rule was present (not declined_if)
      */
     public function __construct(
         public Union $type,
@@ -30,6 +32,8 @@ final readonly class ResolvedRule
         public bool $required = false,
         public bool $hasIntegerRule = false,
         public bool $excluded = false,
+        public bool $hasAcceptedRule = false,
+        public bool $hasDeclinedRule = false,
     ) {}
 
     /**

--- a/src/Handlers/Validation/ValidatedTypeHandler.php
+++ b/src/Handlers/Validation/ValidatedTypeHandler.php
@@ -22,8 +22,9 @@ use Psalm\Type\Union;
  * - FormRequest::safe([...])         → partial array shape for specified keys
  * - Request::validate([...])         → array shape from inline rules argument
  * - ValidatedInput::input('field')   → single field type (via generic TRequest parameter)
- * - $this->input()/$this->integer() (or $request->...) → single field type,
- *   gated on presence (see {@see resolveSelfAccessorRule})
+ * - ValidatedInput::integer('field') → int component, same integer-cast gate stack
+ * - $this->input()/$this->integer()/$this->boolean() (or $request->...) →
+ *   single field type, gated on presence (see {@see resolveSelfAccessorRule})
  *
  * ValidatedInput is generic: ValidatedInput<TRequest of FormRequest>. When safe() returns
  * ValidatedInput<static>, the template parameter carries the concrete FormRequest class,
@@ -80,6 +81,7 @@ final class ValidatedTypeHandler implements MethodReturnTypeProviderInterface
             'validate' => self::resolveInlineValidate($event),
             'input' => self::resolveSelfInput($event),
             'integer' => self::resolveSelfInteger($event),
+            'boolean' => self::resolveSelfBoolean($event),
             default => null,
         };
     }
@@ -145,8 +147,54 @@ final class ValidatedTypeHandler implements MethodReturnTypeProviderInterface
     }
 
     /**
-     * Shared prefix for resolveSelfInput()/resolveSelfInteger(): resolves
-     * the rule-covered field for `$this->...`/`$request->...`.
+     * $this->boolean('field') → TTrue/TFalse literal, when the field's rules
+     * unconditionally require `accepted` or `declined` (#1234 follow-up item 6).
+     *
+     * Sound because boolean() is `filter_var(..., FILTER_VALIDATE_BOOLEAN)`:
+     * every value Laravel's `accepted` rule admits (yes/on/1/"1"/true/"true")
+     * filters to true, and every `declined`-admitted value (no/off/0/"0"/
+     * false/"false") filters to false — see
+     * `Illuminate\Validation\Concerns\ValidatesAttributes::validateAccepted()`
+     * / `validateDeclined()`. `accepted_if`/`declined_if` are conditional and
+     * never set {@see ResolvedRule::$hasAcceptedRule}/`$hasDeclinedRule` (see
+     * {@see \Psalm\LaravelPlugin\Handlers\Validation\ValidationRuleAnalyzer::resolveRuleSegments()}),
+     * so they fall through here too.
+     *
+     * Nullable bail (same rationale as resolveSelfInteger()):
+     * `filter_var(null, FILTER_VALIDATE_BOOLEAN) = false`, which falls
+     * outside a claimed literal `true`.
+     *
+     * Falls through to plain `bool` when the field is unknown, absent-
+     * capable, nullable, or has no unconditional accepted/declined rule.
+     */
+    private static function resolveSelfBoolean(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        $resolved = self::resolveSelfAccessorRule($event);
+
+        if ($resolved === null) {
+            return null;
+        }
+
+        [$rule] = $resolved;
+
+        if ($rule->type->isNullable()) {
+            return null;
+        }
+
+        if ($rule->hasAcceptedRule && !$rule->hasDeclinedRule) {
+            return Type::getTrue();
+        }
+
+        if ($rule->hasDeclinedRule && !$rule->hasAcceptedRule) {
+            return Type::getFalse();
+        }
+
+        return null;
+    }
+
+    /**
+     * Shared prefix for resolveSelfInput()/resolveSelfInteger()/resolveSelfBoolean():
+     * resolves the rule-covered field for `$this->...`/`$request->...`.
      *
      * Presence gate: narrows only when the rule unconditionally guarantees
      * the field exists (required/present/accepted/declined, no `sometimes`)

--- a/src/Handlers/Validation/ValidatedTypeHandler.php
+++ b/src/Handlers/Validation/ValidatedTypeHandler.php
@@ -355,19 +355,25 @@ final class ValidatedTypeHandler implements MethodReturnTypeProviderInterface
     }
 
     /**
-     * ValidatedInput::input('field'), ::str('field'), etc. → resolve via TRequest template.
+     * ValidatedInput::input('field'), ::integer('field'), ::str('field'), etc.
+     * → resolve via TRequest template.
      *
      * When safe() returns ValidatedInput<StoreUserRequest>, Psalm carries the template
      * parameter. We extract it here to look up the FormRequest's rules.
+     *
+     * float()/boolean() get no arm here: no float-range type exists to narrow
+     * to, and ValidatedInput's boolean() has no literal-precision case —
+     * ValidatedInput can only be built from already-validated data, so
+     * there's no separate "unvalidated read" surface to cover.
      */
     private static function resolveValidatedInputMethod(MethodReturnTypeProviderEvent $event): ?Union
     {
         $methodName = $event->getMethodNameLowercase();
 
-        // Only narrow input() — it returns the raw value, so the validation rule type applies.
-        // str()/string() always return Stringable, collect() always returns Collection,
-        // regardless of the validation rule — let those fall through to the stub return type.
-        if ($methodName !== 'input') {
+        // str()/string() always return Stringable, collect() always returns
+        // Collection, regardless of the validation rule — let those fall
+        // through to the stub return type.
+        if ($methodName !== 'input' && $methodName !== 'integer') {
             return null;
         }
 
@@ -396,7 +402,49 @@ final class ValidatedTypeHandler implements MethodReturnTypeProviderInterface
             return null;
         }
 
+        if ($methodName === 'integer') {
+            return self::resolveValidatedInputInteger($rules, $callArgs, $event);
+        }
+
         return self::resolveFieldType($rules, $callArgs, $event);
+    }
+
+    /**
+     * ValidatedInput::integer('field') → int component, mirroring
+     * {@see resolveSelfInteger()}'s gate stack (explicit `integer` rule +
+     * guaranteed presence + non-nullable).
+     *
+     * Presence still needs an explicit check here even though ValidatedInput
+     * only ever holds validated data: an optional (non-`required`) field's
+     * rule is satisfied by the field being entirely ABSENT from validated()
+     * output, in which case ValidatedInput::integer() falls back to its own
+     * `$default` (0) — the same "(int) $default = 0 escapes the range"
+     * hazard {@see resolveSelfAccessorRule()} guards against for the live
+     * Request, just reached via a missing array key instead of a raw null.
+     *
+     * @param array<string, ResolvedRule> $rules
+     * @param list<\PhpParser\Node\Arg> $callArgs
+     */
+    private static function resolveValidatedInputInteger(
+        array $rules,
+        array $callArgs,
+        MethodReturnTypeProviderEvent $event,
+    ): ?Union {
+        $nodeTypeProvider = $event->getSource()->getNodeTypeProvider();
+        $firstArgType = $nodeTypeProvider->getType($callArgs[0]->value);
+
+        if (!$firstArgType instanceof Union || !$firstArgType->isSingleStringLiteral()) {
+            return null;
+        }
+
+        $key = $firstArgType->getSingleStringLiteral()->value;
+        $rule = $rules[$key] ?? null;
+
+        if ($rule === null || !$rule->guaranteesPresence() || !$rule->hasIntegerRule || $rule->type->isNullable()) {
+            return null;
+        }
+
+        return self::extractIntComponent($rule->type);
     }
 
     /**

--- a/src/Handlers/Validation/ValidationRuleAnalyzer.php
+++ b/src/Handlers/Validation/ValidationRuleAnalyzer.php
@@ -262,6 +262,11 @@ final class ValidationRuleAnalyzer
         $hasIntegerRule = false;
         // exclude* rule present — see guaranteesPresence()'s docblock.
         $excluded = false;
+        // Explicit unconditional 'accepted'/'declined' rule only (not the
+        // _if variants) — gates boolean()'s literal-precision narrowing in
+        // ValidatedTypeHandler::resolveSelfBoolean(). #1234 follow-up item 6.
+        $hasAcceptedRule = false;
+        $hasDeclinedRule = false;
 
         foreach ($segments as $segment) {
             $segment = \trim($segment);
@@ -300,6 +305,17 @@ final class ValidationRuleAnalyzer
             // Keep in sync with Laravel's validation rules in Illuminate\Validation\Concerns\ValidatesAttributes.
             if (\in_array($ruleName, ['required', 'present', 'accepted', 'declined'], true)) {
                 $required = true;
+            }
+
+            // Bare 'accepted'/'declined' only — accepted_if/declined_if are
+            // conditional, so the literal they'd otherwise authorize isn't
+            // guaranteed either way.
+            if ($ruleName === 'accepted') {
+                $hasAcceptedRule = true;
+            }
+
+            if ($ruleName === 'declined') {
+                $hasDeclinedRule = true;
             }
 
             // exclude/exclude_if/exclude_unless/exclude_with/exclude_without —
@@ -345,7 +361,17 @@ final class ValidationRuleAnalyzer
             $type = Type::combineUnionTypes($type, Type::getNull());
         }
 
-        return new ResolvedRule($type, $removedTaints, $nullable, $sometimes, $required, $hasIntegerRule, $excluded);
+        return new ResolvedRule(
+            $type,
+            $removedTaints,
+            $nullable,
+            $sometimes,
+            $required,
+            $hasIntegerRule,
+            $excluded,
+            $hasAcceptedRule,
+            $hasDeclinedRule,
+        );
     }
 
     /**

--- a/tests/Type/tests/ValidationRuleBooleanLiteralTest.phpt
+++ b/tests/Type/tests/ValidationRuleBooleanLiteralTest.phpt
@@ -1,0 +1,82 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * #1234 follow-up item 6: boolean() literal precision — an unconditional
+ * `accepted` rule narrows to literal `true`, `declined` to literal `false`.
+ * See ValidatedTypeHandler::resolveSelfBoolean().
+ */
+class BooleanLiteralRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'terms' => 'required|accepted',
+            'newsletter' => 'required|declined',
+            // Conditional — never authorizes literal precision.
+            'promo' => 'accepted_if:plan,pro',
+            // No `required` — presence not guaranteed.
+            'optional_terms' => 'sometimes|accepted',
+            // nullable → filter_var(null, FILTER_VALIDATE_BOOLEAN) = false,
+            // outside the claimed literal `true`.
+            'nullable_terms' => 'required|nullable|accepted',
+            // Plain `boolean` rule — no literal to narrow to.
+            'flag' => 'required|boolean',
+            // Contradictory (both present) — the mutual-exclusion guard in
+            // resolveSelfBoolean() must fall through to plain bool rather
+            // than pick either literal.
+            'contradictory' => 'required|accepted|declined',
+        ];
+    }
+
+    public function booleanNarrowing(): void
+    {
+        $_terms = $this->boolean('terms');
+        /** @psalm-check-type-exact $_terms = true */
+
+        $_newsletter = $this->boolean('newsletter');
+        /** @psalm-check-type-exact $_newsletter = false */
+
+        $_promo = $this->boolean('promo');
+        /** @psalm-check-type-exact $_promo = bool */
+
+        $_optionalTerms = $this->boolean('optional_terms');
+        /** @psalm-check-type-exact $_optionalTerms = bool */
+
+        $_nullableTerms = $this->boolean('nullable_terms');
+        /** @psalm-check-type-exact $_nullableTerms = bool */
+
+        $_flag = $this->boolean('flag');
+        /** @psalm-check-type-exact $_flag = bool */
+
+        $_contradictory = $this->boolean('contradictory');
+        /** @psalm-check-type-exact $_contradictory = bool */
+
+        $_unknown = $this->boolean('does_not_exist');
+        /** @psalm-check-type-exact $_unknown = bool */
+    }
+
+    public function dynamicKeyFallsThrough(string $key): bool
+    {
+        $_dynamic = $this->boolean($key);
+        /** @psalm-check-type-exact $_dynamic = bool */
+
+        return $_dynamic;
+    }
+}
+
+function fromController(BooleanLiteralRequest $request): void
+{
+    // External call — dispatch keys off the receiver's static type, not $this.
+    $_terms = $request->boolean('terms');
+    /** @psalm-check-type-exact $_terms = true */
+
+    $_newsletter = $request->boolean('newsletter');
+    /** @psalm-check-type-exact $_newsletter = false */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/ValidationRuleNumericRangeTest.phpt
+++ b/tests/Type/tests/ValidationRuleNumericRangeTest.phpt
@@ -10,6 +10,9 @@ use Illuminate\Foundation\Http\FormRequest;
  * on integer()/float()/boolean() accessors — see
  * ValidationRuleAnalyzer::applyNumericRangeNarrowing() and
  * ValidatedTypeHandler::resolveSelfInteger().
+ *
+ * #1234 follow-up item 1: the same gate stack on safe()->integer() — see
+ * ValidatedTypeHandler::resolveValidatedInputInteger().
  */
 class NumericRangeRequest extends FormRequest
 {
@@ -121,10 +124,24 @@ function fromController(NumericRangeRequest $request): void
     $_ageRange = $request->integer('age_range');
     /** @psalm-check-type-exact $_ageRange = int<0, 24> */
 
-    // Deliberate scope boundary: resolveValidatedInputMethod() only narrows
-    // 'input' on ValidatedInput — integer()/float()/boolean() there is a follow-up.
+    // safe()->integer() (#1234 follow-up item 1) — same gate stack as the
+    // live Request's integer(), applied to ValidatedInput's rules lookup.
     $_portionsSafe = $request->safe()->integer('portions');
-    /** @psalm-check-type-exact $_portionsSafe = int */
+    /** @psalm-check-type-exact $_portionsSafe = int<1, max> */
+
+    // Optional field (no `required`) — ValidatedInput::integer() would fall
+    // back to its own $default (0) if the field is absent from safe() output.
+    $_quantitySafe = $request->safe()->integer('quantity');
+    /** @psalm-check-type-exact $_quantitySafe = int */
+
+    // Nullable field — (int) null = 0, outside int<18, max>.
+    $_ageSafe = $request->safe()->integer('age');
+    /** @psalm-check-type-exact $_ageSafe = int */
+
+    // numeric|gt:0, no explicit `integer` rule — (int) "0.5" = 0 would
+    // escape the inferred int<1, max>.
+    $_discountSafe = $request->safe()->integer('discount');
+    /** @psalm-check-type-exact $_discountSafe = int */
 }
 
 /**
@@ -162,6 +179,10 @@ function fromControllerExcluded(ExcludedFieldRequest $request): void
     // notwithstanding.
     $_all = $request->validated();
     /** @psalm-check-type-exact $_all = array{legacy_id?: int<1, max>|numeric-string, name: string} */
+
+    // Excluded field — same gate applies to safe()->integer() (#1234 follow-up item 1).
+    $_legacyIdSafe = $request->safe()->integer('legacy_id');
+    /** @psalm-check-type-exact $_legacyIdSafe = int */
 }
 ?>
 --EXPECTF--

--- a/tests/Unit/Handlers/Validation/ValidationRuleAnalyzerTest.php
+++ b/tests/Unit/Handlers/Validation/ValidationRuleAnalyzerTest.php
@@ -1010,6 +1010,65 @@ final class ValidationRuleAnalyzerTest extends TestCase
         $this->assertTrue($rule->guaranteesPresence());
     }
 
+    // --- Explicit accepted/declined-rule tracking for boolean() literal precision (#1234 follow-up item 6) ---
+
+    #[Test]
+    public function accepted_rule_sets_has_accepted_rule_flag(): void
+    {
+        $rule = $this->resolve('required|accepted');
+
+        $this->assertTrue($rule->hasAcceptedRule);
+        $this->assertFalse($rule->hasDeclinedRule);
+    }
+
+    #[Test]
+    public function declined_rule_sets_has_declined_rule_flag(): void
+    {
+        $rule = $this->resolve('required|declined');
+
+        $this->assertTrue($rule->hasDeclinedRule);
+        $this->assertFalse($rule->hasAcceptedRule);
+    }
+
+    #[Test]
+    public function accepted_if_rule_does_not_set_has_accepted_rule_flag(): void
+    {
+        // Conditional — the runtime shape depends on a value we can't
+        // evaluate statically, so the literal isn't guaranteed either way.
+        $rule = ValidationRuleAnalyzer::resolveRuleSegments(['accepted_if:plan,pro']);
+
+        $this->assertFalse($rule->hasAcceptedRule);
+    }
+
+    #[Test]
+    public function declined_if_rule_does_not_set_has_declined_rule_flag(): void
+    {
+        $rule = ValidationRuleAnalyzer::resolveRuleSegments(['declined_if:plan,free']);
+
+        $this->assertFalse($rule->hasDeclinedRule);
+    }
+
+    #[Test]
+    public function plain_boolean_rule_does_not_set_either_flag(): void
+    {
+        $rule = $this->resolve('required|boolean');
+
+        $this->assertFalse($rule->hasAcceptedRule);
+        $this->assertFalse($rule->hasDeclinedRule);
+    }
+
+    #[Test]
+    public function accepted_and_declined_together_set_both_flags(): void
+    {
+        // Contradictory in practice (no value satisfies both), but the
+        // analyzer just reports what rules are present — resolveSelfBoolean()'s
+        // mutual-exclusion guard is what decides not to narrow, not this flag.
+        $rule = $this->resolve('required|accepted|declined');
+
+        $this->assertTrue($rule->hasAcceptedRule);
+        $this->assertTrue($rule->hasDeclinedRule);
+    }
+
     // --- Overflow-safe int-literal params (#1237) ---
 
     #[Test]


### PR DESCRIPTION
## Issue to Solve

Two follow-ups to the validation cast-accessor narrowing shipped in #1237:

1. `$request->safe()->integer('field')` (`ValidatedInput::integer()`) still returned plain `int` even when the field's rules already inferred a numeric range — only the live Request's `integer()` was narrowed.
2. `$request->boolean('field')` always returned plain `bool`, even when the field's rules unconditionally require `accepted` (always `true`) or `declined` (always `false`).

## Related

Follow-up to #1234 / #1237.

## Solution Description

**`safe()->integer()`**: `ValidatedTypeHandler::resolveValidatedInputMethod()` now handles `'integer'` alongside `'input'`, dispatching to a new `resolveValidatedInputInteger()` that reuses the same gate stack `#1237` established for the live Request's `integer()`: explicit `integer` rule present, presence guaranteed, and non-nullable. The presence check still matters here even though `ValidatedInput` only holds validated data — an optional field can be entirely absent from `safe()`'s output, in which case `integer()` falls back to its own default (`0`), which can fall outside the inferred range.

**`boolean()` literal precision**: `ResolvedRule` gained two new flags, `hasAcceptedRule`/`hasDeclinedRule`, set in `ValidationRuleAnalyzer::resolveRuleSegments()` only for the bare `accepted`/`declined` rule names (never the conditional `accepted_if`/`declined_if`). `ValidatedTypeHandler::resolveSelfBoolean()` narrows to `true`/`false` when exactly one flag is set, under the same presence/nullable gates as `integer()`. This is sound because `boolean()` is `filter_var(..., FILTER_VALIDATE_BOOLEAN)`, and every value Laravel's `accepted` rule admits filters to `true` (verified against `Illuminate\Validation\Concerns\ValidatesAttributes`), every `declined`-admitted value to `false`.

Verified with:
- New type tests: rows added to `ValidationRuleNumericRangeTest.phpt` (optional/nullable/excluded/numeric-without-integer fields, all falling back to plain `int`), and a new `ValidationRuleBooleanLiteralTest.phpt` covering `accepted`/`declined`/`accepted_if`/optional/nullable/contradictory (`accepted|declined` together) cases.
- New unit tests in `ValidationRuleAnalyzerTest.php` for the two new `ResolvedRule` flags.
- Full unit suite, full type/phpt suite (including taint-analysis), `composer psalm` self-analysis (no `--no-suggestions`), `composer cs`, and the 100%-type-coverage check all pass clean.

A third follow-up item (narrowing `$request->integer()`/`boolean()` after an inline `$request->validate([...])` call, for plain non-FormRequest requests) was scoped out after review — it required a materially more complex and higher-risk extension to the taint-sensitive `InlineValidateRulesCollector` for a narrower real-world payoff than these two items, so it's left for a separate, dedicated PR if pursued.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)
- [x] Documentation is updated (if needed, otherwise remove this item) — no handler registration changed, so `docs/contributing/README.md` needed no update.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786394037&installation_id=141955579&pr_number=1239&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1239&signature=da478fca9b0841a5ef9d7f8f1ef423dfe906278649d6e824d1f58e296063fd3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->