### PR TITLE
Narrow stable Laravel producer returns to concrete implementations

### DIFF
--- a/docs/contributing/decisions.md
+++ b/docs/contributing/decisions.md
@@ -249,6 +249,21 @@ Bug fixes (where the previous type was demonstrably wrong) are exempt.
 
 **Why:** A method named `posts()` that returns a `HasMany` relation should always be treated as a relationship property, even if a migration column named `posts` also exists. Similarly, an accessor `getFullNameAttribute()` should take priority over a `full_name` column. The order reflects specificity: relationships and accessors are explicit code the developer wrote; columns are inferred from migrations and serve as the fallback.
 
+## Producer Return Narrowing
+
+### Provenance may narrow, conformance never widens
+
+**Decision:** A stable producer (a framework method that hard-constructs one concrete with no supported extension point) narrows its declared contract return to that concrete. `ProducerReturnTypeHandler` holds the reviewed mapping (`PasswordBrokerManager::broker()`, `View\Factory::make()/file()/first()`, plus facades and root aliases). `view()`/`trans()` narrow via their existing handlers: zero-arg forms narrow to whatever class the binding resolved to at plugin boot (a scanned subclass counts); the argument-supplied `view('name')` form additionally requires the stock `Illuminate\View\Factory`. `Query\Builder` pagination is stub-narrowed (`stdClass` rows).
+
+**Why:** Laravel declares contracts where runtime always yields one concrete, so concrete-only calls like `Password::broker()->createToken()` report false `UndefinedInterfaceMethod`.
+
+**Boundaries:**
+- Key on the producing expression, never the contract: contract FQCNs are never registered, interface storage never modified. Bare contract-typed values (params, properties, mocks, custom impls) keep the contract-only surface.
+- Drift guard: each rule requires the declared return to still name the expected contract, else it disables itself.
+- New mappings need source verification across supported Laravel versions plus positive and negative tests.
+- Disclosed gap: producer internals like `Factory::viewInstance()` are protected, so a producer subclass inheriting the mapped method but overriding the construction still narrows to the stock concrete. Accepted (matches the Cache manager precedent): worst case turns a contract-level false positive into a false negative, never a new false positive.
+- Excluded: driver-variant surfaces (Auth guards, Hash, Queue, Broadcast, Redis, Filesystem) where the concrete depends on runtime config.
+
 ## Third-Party Package Support
 
 ### Plugin covers Laravel framework only, not third-party packages

--- a/docs/contributing/decisions.md
+++ b/docs/contributing/decisions.md
@@ -261,7 +261,7 @@ Bug fixes (where the previous type was demonstrably wrong) are exempt.
 - Key on the producing expression, never the contract: contract FQCNs are never registered, interface storage never modified. Bare contract-typed values (params, properties, mocks, custom impls) keep the contract-only surface.
 - Drift guard: each rule requires the declared return to still name the expected contract, else it disables itself.
 - New mappings need source verification across supported Laravel versions plus positive and negative tests.
-- Disclosed gap: producer internals like `Factory::viewInstance()` are protected, so a producer subclass inheriting the mapped method but overriding the construction still narrows to the stock concrete. Accepted (matches the Cache manager precedent): worst case turns a contract-level false positive into a false negative, never a new false positive.
+- Disclosed gap: producer internals like `Factory::viewInstance()` are protected, so a producer subclass inheriting the mapped method but overriding the construction still narrows to the stock concrete. Accepted (matches the Cache manager precedent). A substitute implementation yields a false negative (a stock-only method resolves though the substitute lacks it), plus a false positive (a substitute-only method flagged undefined) when the stock concrete is not Macroable. The View concrete's `__call` masks the false positive; a non-Macroable producer such as PasswordBroker would exhibit it. Standard apps return the stock concrete, and a call site that hits the gap can suppress locally.
 - Excluded: driver-variant surfaces (Auth guards, Hash, Queue, Broadcast, Redis, Filesystem) where the concrete depends on runtime config.
 
 ## Third-Party Package Support

--- a/docs/contributing/decisions.md
+++ b/docs/contributing/decisions.md
@@ -253,7 +253,7 @@ Bug fixes (where the previous type was demonstrably wrong) are exempt.
 
 ### Provenance may narrow, conformance never widens
 
-**Decision:** A stable producer (a framework method that hard-constructs one concrete with no supported extension point) narrows its declared contract return to that concrete. `ProducerReturnTypeHandler` holds the reviewed mapping (`PasswordBrokerManager::broker()`, `View\Factory::make()/file()/first()`, plus facades and root aliases). `view()`/`trans()` narrow via their existing handlers: zero-arg forms narrow to whatever class the binding resolved to at plugin boot (a scanned subclass counts); the argument-supplied `view('name')` form additionally requires the stock `Illuminate\View\Factory`. `Query\Builder` pagination is stub-narrowed (`stdClass` rows).
+**Decision:** A stable producer (a framework method that hard-constructs one concrete with no supported extension point) narrows its declared contract return to that concrete. `ProducerReturnTypeHandler` holds the reviewed mapping (`PasswordBrokerManager::broker()`, `View\Factory::make()/file()/first()`, plus facades and root aliases). `view()`/`trans()` narrow via their existing handlers: zero-arg forms narrow to the resolved binding when it is the framework class or a subclass (`Illuminate\View\Factory` / `Illuminate\Translation\Translator`), else fall back to the contract; the argument-supplied `view('name')` form additionally requires the exact stock `Illuminate\View\Factory`. `Query\Builder` pagination is stub-narrowed (`stdClass` rows).
 
 **Why:** Laravel declares contracts where runtime always yields one concrete, so concrete-only calls like `Password::broker()->createToken()` report false `UndefinedInterfaceMethod`.
 

--- a/src/Handlers/Collections/HigherOrderCollectionProxyHandler.php
+++ b/src/Handlers/Collections/HigherOrderCollectionProxyHandler.php
@@ -491,6 +491,7 @@ final class HigherOrderCollectionProxyHandler implements
      *
      * For `$collection->each->delete()`, returns "delete".
      *
+     * @psalm-return lowercase-string
      * @psalm-mutation-free
      */
     private static function extractCalledMethodName(MethodCall $expr): string

--- a/src/Handlers/Collections/HigherOrderCollectionProxyHandler.php
+++ b/src/Handlers/Collections/HigherOrderCollectionProxyHandler.php
@@ -491,7 +491,6 @@ final class HigherOrderCollectionProxyHandler implements
      *
      * For `$collection->each->delete()`, returns "delete".
      *
-     * @return lowercase-string
      * @psalm-mutation-free
      */
     private static function extractCalledMethodName(MethodCall $expr): string

--- a/src/Handlers/Producers/ProducerReturnTypeHandler.php
+++ b/src/Handlers/Producers/ProducerReturnTypeHandler.php
@@ -35,9 +35,14 @@ use Psalm\Type\Union;
  *    `Factory::viewInstance()` hard-constructs `new \Illuminate\View\View(...)`.
  *    viewInstance() is protected, so a Factory subclass overriding it while
  *    inheriting make() still narrows to the stock View here — the same accepted
- *    bounded trade-off as CacheManager's nonconforming custom creator: at worst
- *    a pathological custom View flips a contract-level false positive into a
- *    false negative; it can never introduce a new false positive.
+ *    bounded trade-off as CacheManager's nonconforming custom creator. If an app
+ *    substitutes a different implementation this can produce a false negative (a
+ *    stock-only method resolves though the substitute lacks it) and, for a producer
+ *    whose stock concrete is not Macroable, a false positive (a substitute-only
+ *    method flagged undefined; the stock View's __call masks this for the View
+ *    family, but PasswordBroker would exhibit it). We accept it because every
+ *    standard app returns the stock concrete and a substitute is rare; a caller
+ *    that hits it can suppress at the call site.
  *
  * A handler (not a stub) is required for the facade paths: a facade's
  * `@method static` pseudo-tags shadow any real method a redeclaring stub
@@ -89,8 +94,19 @@ final class ProducerReturnTypeHandler implements MethodReturnTypeProviderInterfa
      */
     private static ?array $classToFamily = null;
 
-    /** @var array<class-string, Union> cache of concrete return unions (Psalm 7 unions are immutable) */
-    private static array $concreteUnions = [];
+    /**
+     * Drop the reverse index so it rebuilds from FacadeMapProvider on the next
+     * lookup. Called once per plugin invocation because a reused process (Psalm's
+     * language server, or back-to-back analyses) can boot a different app whose
+     * alias registry differs. Must run before the handler's providers are
+     * registered so getClassLikeNames() and resolveFamily() agree.
+     *
+     * @psalm-external-mutation-free
+     */
+    public static function reset(): void
+    {
+        self::$classToFamily = null;
+    }
 
     /**
      * @inheritDoc
@@ -128,14 +144,7 @@ final class ProducerReturnTypeHandler implements MethodReturnTypeProviderInterfa
         $codebase = $event->getSource()->getCodebase();
 
         if (self::isRealMethod($codebase, $event->getFqClasslikeName(), $methodNameLower)) {
-            // Drift guard: only narrow while the producer's own declared return
-            // type still names the contract we verified against source.
-            if (!self::unionNamesContract(
-                self::realReturnType($codebase, $event->getFqClasslikeName(), $methodNameLower),
-                $family['contract'],
-            )) {
-                return null;
-            }
+            $declared = self::realReturnType($codebase, $event->getFqClasslikeName(), $methodNameLower);
         } else {
             // Pseudo path (facade/alias static call). The params-provider invariant
             // below is mandatory — see getMethodParams().
@@ -143,15 +152,15 @@ final class ProducerReturnTypeHandler implements MethodReturnTypeProviderInterfa
                 return null;
             }
 
-            if (!self::unionNamesContract(
-                self::pseudoReturnType($codebase, $family['facade'], $methodNameLower),
-                $family['contract'],
-            )) {
-                return null;
-            }
+            $declared = self::pseudoReturnType($codebase, $family['facade'], $methodNameLower);
         }
 
-        return self::concreteUnion($family['concrete']);
+        // Drift guard + narrowing in one step: replace only the contract atomic
+        // with the concrete, preserving any siblings. Returns null (no narrowing)
+        // if the declared return no longer names the contract we verified against
+        // source. Replacing the whole union would silently drop a future
+        // `Contract|null` down to a non-null concrete.
+        return self::narrowContract($declared, $family['contract'], $family['concrete']);
     }
 
     /**
@@ -297,28 +306,36 @@ final class ProducerReturnTypeHandler implements MethodReturnTypeProviderInterfa
         }
     }
 
-    /** @psalm-mutation-free */
-    private static function unionNamesContract(?Union $union, string $expectedContract): bool
+    /**
+     * Return a copy of the declared union with the expected-contract atomic swapped
+     * for the concrete, leaving every other atomic in place. Null when the declared
+     * union is absent or does not name the contract — the drift guard: if Laravel's
+     * signature changed out from under us, we narrow nothing rather than override a
+     * declaration we never verified.
+     *
+     * @param class-string $expectedContract
+     * @param class-string $concrete
+     * @psalm-mutation-free
+     */
+    private static function narrowContract(?Union $declared, string $expectedContract, string $concrete): ?Union
     {
-        if (!$union instanceof \Psalm\Type\Union) {
-            return false;
+        if (!$declared instanceof Union) {
+            return null;
         }
 
-        foreach ($union->getAtomicTypes() as $atomic) {
-            if ($atomic instanceof TNamedObject && \strtolower($atomic->value) === \strtolower($expectedContract)) {
-                return true;
+        $expectedContractLc = \strtolower($expectedContract);
+        $atomics = [];
+        $matched = false;
+
+        foreach ($declared->getAtomicTypes() as $atomic) {
+            if ($atomic instanceof TNamedObject && \strtolower($atomic->value) === $expectedContractLc) {
+                $atomics[] = new TNamedObject($concrete);
+                $matched = true;
+            } else {
+                $atomics[] = $atomic;
             }
         }
 
-        return false;
-    }
-
-    /**
-     * @param class-string $concreteFqcn
-     * @psalm-external-mutation-free
-     */
-    private static function concreteUnion(string $concreteFqcn): Union
-    {
-        return self::$concreteUnions[$concreteFqcn] ??= new Union([new TNamedObject($concreteFqcn)]);
+        return $matched ? new Union($atomics) : null;
     }
 }

--- a/src/Handlers/Producers/ProducerReturnTypeHandler.php
+++ b/src/Handlers/Producers/ProducerReturnTypeHandler.php
@@ -1,0 +1,324 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Producers;
+
+use Psalm\Codebase;
+use Psalm\Internal\MethodIdentifier;
+use Psalm\LaravelPlugin\Stubs\FacadeMapProvider;
+use Psalm\Plugin\EventHandler\Event\MethodParamsProviderEvent;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\MethodParamsProviderInterface;
+use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\StatementsSource;
+use Psalm\Storage\FunctionLikeParameter;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Union;
+
+/**
+ * Narrows stable Laravel "producer" methods — methods whose framework
+ * implementation hard-constructs one specific concrete with no extension
+ * point — from their declared contract return to that concrete.
+ *
+ * Provenance-based, not type-widening: a bare contract-typed value (parameter,
+ * property, mock, custom implementation) exposes only the contract. Providers
+ * are registered on the producer class, its canonical facade, and that
+ * facade's root aliases only — never on a contract FQCN.
+ *
+ * Registered families (verified against Laravel 12.x/13.x source):
+ *  - `PasswordBrokerManager::broker()` / `Password::broker()`:
+ *    `PasswordBrokerManager::resolve()` hard-constructs
+ *    `new \Illuminate\Auth\Passwords\PasswordBroker(...)` — no custom
+ *    broker-driver extension API.
+ *  - `Factory::make()/file()/first()` / `View::make()/file()/first()`:
+ *    `Factory::viewInstance()` hard-constructs `new \Illuminate\View\View(...)`.
+ *    viewInstance() is protected, so a Factory subclass overriding it while
+ *    inheriting make() still narrows to the stock View here — the same accepted
+ *    bounded trade-off as CacheManager's nonconforming custom creator: at worst
+ *    a pathological custom View flips a contract-level false positive into a
+ *    false negative; it can never introduce a new false positive.
+ *
+ * A handler (not a stub) is required for the facade paths: a facade's
+ * `@method static` pseudo-tags shadow any real method a redeclaring stub
+ * would add, so static calls must be resolved here. Instance calls on the
+ * producer route through the same handler for one source of truth and one
+ * shared drift guard.
+ *
+ * @internal
+ */
+final class ProducerReturnTypeHandler implements MethodReturnTypeProviderInterface, MethodParamsProviderInterface
+{
+    /**
+     * @var list<array{
+     *     producer: class-string,
+     *     facade: class-string,
+     *     methods: list<lowercase-string>,
+     *     contract: class-string,
+     *     concrete: class-string,
+     * }>
+     */
+    private const FAMILIES = [
+        [
+            'producer' => \Illuminate\Auth\Passwords\PasswordBrokerManager::class,
+            'facade' => \Illuminate\Support\Facades\Password::class,
+            'methods' => ['broker'],
+            'contract' => \Illuminate\Contracts\Auth\PasswordBroker::class,
+            'concrete' => \Illuminate\Auth\Passwords\PasswordBroker::class,
+        ],
+        [
+            'producer' => \Illuminate\View\Factory::class,
+            'facade' => \Illuminate\Support\Facades\View::class,
+            'methods' => ['make', 'file', 'first'],
+            'contract' => \Illuminate\Contracts\View\View::class,
+            'concrete' => \Illuminate\View\View::class,
+        ],
+    ];
+
+    /**
+     * Lazily-built reverse index: lowercased producer/facade/alias FQCN → its family.
+     * Built once per Psalm run — FacadeMapProvider's map does not change mid-analysis.
+     *
+     * @var array<lowercase-string, array{
+     *     producer: class-string,
+     *     facade: class-string,
+     *     methods: list<lowercase-string>,
+     *     contract: class-string,
+     *     concrete: class-string,
+     * }>|null
+     */
+    private static ?array $classToFamily = null;
+
+    /** @var array<class-string, Union> cache of concrete return unions (Psalm 7 unions are immutable) */
+    private static array $concreteUnions = [];
+
+    /**
+     * @inheritDoc
+     * @return list<class-string>
+     * @psalm-external-mutation-free
+     */
+    #[\Override]
+    public static function getClassLikeNames(): array
+    {
+        $names = [];
+
+        foreach (self::FAMILIES as $family) {
+            $names = [...$names, ...self::familyClassNames($family)];
+        }
+
+        return \array_values(\array_unique($names));
+    }
+
+    /** @inheritDoc */
+    #[\Override]
+    public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        $family = self::resolveFamily($event->getFqClasslikeName());
+
+        if ($family === null) {
+            return null;
+        }
+
+        $methodNameLower = $event->getMethodNameLowercase();
+
+        if (!\in_array($methodNameLower, $family['methods'], true)) {
+            return null;
+        }
+
+        $codebase = $event->getSource()->getCodebase();
+
+        if (self::isRealMethod($codebase, $event->getFqClasslikeName(), $methodNameLower)) {
+            // Drift guard: only narrow while the producer's own declared return
+            // type still names the contract we verified against source.
+            if (!self::unionNamesContract(
+                self::realReturnType($codebase, $event->getFqClasslikeName(), $methodNameLower),
+                $family['contract'],
+            )) {
+                return null;
+            }
+        } else {
+            // Pseudo path (facade/alias static call). The params-provider invariant
+            // below is mandatory — see getMethodParams().
+            if (self::pseudoMethodParams($codebase, $family['facade'], $methodNameLower) === null) {
+                return null;
+            }
+
+            if (!self::unionNamesContract(
+                self::pseudoReturnType($codebase, $family['facade'], $methodNameLower),
+                $family['contract'],
+            )) {
+                return null;
+            }
+        }
+
+        return self::concreteUnion($family['concrete']);
+    }
+
+    /**
+     * Mandatory companion to the return provider: a non-null return type on a
+     * pseudo-method whose params can't be supplied fatals Psalm with "Cannot get
+     * method params". Both providers gate the pseudo path on the same
+     * `pseudo_static_methods` lookup, so return-provider-non-null-on-pseudo
+     * always implies params-provider-non-null.
+     *
+     * @inheritDoc
+     */
+    #[\Override]
+    public static function getMethodParams(MethodParamsProviderEvent $event): ?array
+    {
+        $family = self::resolveFamily($event->getFqClasslikeName());
+
+        if ($family === null) {
+            return null;
+        }
+
+        $methodNameLower = $event->getMethodNameLowercase();
+
+        if (!\in_array($methodNameLower, $family['methods'], true)) {
+            return null;
+        }
+
+        $source = $event->getStatementsSource();
+
+        if (!$source instanceof StatementsSource) {
+            return null;
+        }
+
+        $codebase = $source->getCodebase();
+
+        if (self::isRealMethod($codebase, $event->getFqClasslikeName(), $methodNameLower)) {
+            // Real method: return null so Psalm reflects the vendor signature —
+            // keeps 12.x/13.x param drift (e.g. `\UnitEnum|string|null $name`)
+            // correct for free instead of us hardcoding it.
+            return null;
+        }
+
+        return self::pseudoMethodParams($codebase, $family['facade'], $methodNameLower);
+    }
+
+    /**
+     * @return array{
+     *     producer: class-string,
+     *     facade: class-string,
+     *     methods: list<lowercase-string>,
+     *     contract: class-string,
+     *     concrete: class-string,
+     * }|null
+     * @psalm-external-mutation-free
+     */
+    private static function resolveFamily(string $fqClasslikeName): ?array
+    {
+        if (self::$classToFamily === null) {
+            $classToFamily = [];
+
+            foreach (self::FAMILIES as $family) {
+                foreach (self::familyClassNames($family) as $name) {
+                    $classToFamily[\strtolower($name)] = $family;
+                }
+            }
+
+            self::$classToFamily = $classToFamily;
+        }
+
+        return self::$classToFamily[\strtolower($fqClasslikeName)] ?? null;
+    }
+
+    /**
+     * Single source for which FQCNs a family answers for: the producer class, its
+     * canonical facade, and the app's configured root aliases. getClassLikeNames()
+     * (registration) and resolveFamily() (dispatch) must never drift apart.
+     *
+     * @param array{producer: class-string, facade: class-string, ...} $family
+     * @return list<class-string>
+     * @psalm-external-mutation-free
+     */
+    private static function familyClassNames(array $family): array
+    {
+        return [
+            $family['producer'],
+            $family['facade'],
+            ...FacadeMapProvider::getFacadeClasses($family['producer']),
+        ];
+    }
+
+    /**
+     * True when the method is really declared on the receiver (or inherited from
+     * the producer via subclassing — Psalm falls back to the declaring method id,
+     * so the event still reports the producer's own FQCN). False means a facade
+     * `@method` pseudo-tag.
+     *
+     * @param lowercase-string $methodNameLower
+     */
+    private static function isRealMethod(Codebase $codebase, string $fqClasslikeName, string $methodNameLower): bool
+    {
+        return $codebase->methods->methodExists($codebase, new MethodIdentifier($fqClasslikeName, $methodNameLower));
+    }
+
+    /**
+     * @param lowercase-string $methodNameLower
+     * @psalm-mutation-free
+     */
+    private static function realReturnType(Codebase $codebase, string $fqClasslikeName, string $methodNameLower): ?Union
+    {
+        return self::storage($codebase, $fqClasslikeName)?->methods[$methodNameLower]->return_type ?? null;
+    }
+
+    /**
+     * @param lowercase-string $methodNameLower
+     * @psalm-mutation-free
+     */
+    private static function pseudoReturnType(Codebase $codebase, string $canonicalFacade, string $methodNameLower): ?Union
+    {
+        return self::storage($codebase, $canonicalFacade)?->pseudo_static_methods[$methodNameLower]->return_type ?? null;
+    }
+
+    /**
+     * @param lowercase-string $methodNameLower
+     * @return ?list<FunctionLikeParameter>
+     * @psalm-mutation-free
+     */
+    private static function pseudoMethodParams(Codebase $codebase, string $canonicalFacade, string $methodNameLower): ?array
+    {
+        return self::storage($codebase, $canonicalFacade)?->pseudo_static_methods[$methodNameLower]->params ?? null;
+    }
+
+    /**
+     * Null when the class was never scanned — narrowing then stays off and the
+     * declared contract type survives untouched.
+     *
+     * @psalm-mutation-free
+     */
+    private static function storage(Codebase $codebase, string $fqClasslikeName): ?\Psalm\Storage\ClassLikeStorage
+    {
+        try {
+            return $codebase->classlike_storage_provider->get($fqClasslikeName);
+        } catch (\InvalidArgumentException) {
+            return null;
+        }
+    }
+
+    /** @psalm-mutation-free */
+    private static function unionNamesContract(?Union $union, string $expectedContract): bool
+    {
+        if (!$union instanceof \Psalm\Type\Union) {
+            return false;
+        }
+
+        foreach ($union->getAtomicTypes() as $atomic) {
+            if ($atomic instanceof TNamedObject && \strtolower($atomic->value) === \strtolower($expectedContract)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param class-string $concreteFqcn
+     * @psalm-external-mutation-free
+     */
+    private static function concreteUnion(string $concreteFqcn): Union
+    {
+        return self::$concreteUnions[$concreteFqcn] ??= new Union([new TNamedObject($concreteFqcn)]);
+    }
+}

--- a/src/Handlers/Translations/TranslationKeyHandler.php
+++ b/src/Handlers/Translations/TranslationKeyHandler.php
@@ -14,6 +14,7 @@ use Psalm\LaravelPlugin\Issues\MissingTranslation;
 use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
 use Psalm\Type;
+use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Atomic\TNonEmptyArray;
 use Psalm\Type\Union;
 
@@ -32,8 +33,16 @@ use Psalm\Type\Union;
  * Namespaced package keys (e.g., 'package::file.key') are skipped
  * since packages may not have their translations published.
  *
- * Falls back to the stub conditional return type for edge cases
- * like __() with no args (null) or trans() with no args (Translator).
+ * A bare `trans()` call (no args) hits Laravel's `is_null($key)` branch, which
+ * returns `app('translator')` — the very binding this handler captured at
+ * plugin boot (see init()). That resolved binding is narrowed to its concrete
+ * class rather than left on the `Translator` contract of the vendor docblock's
+ * conditional return (trans() is deliberately not stubbed), as long as the
+ * codebase Psalm scanned actually declares it (an app could bind a subclass
+ * Psalm never scanned). `__()` shares the `is_null($key)` structure, but its
+ * null-key branch returns `$key` (null) instead of the translator, so a bare
+ * `__()` keeps its stub fallback. `trans(null)` (an explicit null key) also
+ * stays on the vendor conditional — only the truly zero-arg call is narrowed.
  *
  * The findMissingTranslations config option controls only whether
  * MissingTranslation issues are emitted — type narrowing is always
@@ -58,12 +67,16 @@ final class TranslationKeyHandler implements FunctionReturnTypeProviderInterface
      */
     private static array $resolvedKeys = [];
 
+    /** @var array<class-string, Union> cache of the zero-arg trans() concrete union, keyed by resolved translator class (Psalm 7 unions are immutable) */
+    private static array $zeroArgTransUnions = [];
+
     /** @psalm-external-mutation-free */
     public static function init(Translator $translator, bool $reportMissing): void
     {
         self::$translator = $translator;
         self::$reportMissing = $reportMissing;
         self::$resolvedKeys = [];
+        self::$zeroArgTransUnions = [];
     }
 
     /**
@@ -83,8 +96,10 @@ final class TranslationKeyHandler implements FunctionReturnTypeProviderInterface
         $callArgs = $event->getCallArgs();
 
         if ($callArgs === []) {
-            // __() returns null, trans() returns Translator — handled by stubs
-            return null;
+            // A truly zero-arg call — never reachable for `trans(...$args)`, whose
+            // spread produces one Arg node regardless of the spread array's runtime
+            // size, so no separate unpack check is needed here.
+            return self::resolveZeroArgTransType($event);
         }
 
         // Try to resolve literal string keys precisely via the Translator
@@ -118,6 +133,33 @@ final class TranslationKeyHandler implements FunctionReturnTypeProviderInterface
 
         // Non-string args (e.g. __(null)) — handled by stubs
         return null;
+    }
+
+    /**
+     * Narrow a bare `trans()` call to the concrete resolved Translator class.
+     *
+     * Only `trans` is eligible — `__()` returns null for a bare call, so its
+     * zero-arg form stays on its stub fallback. `Plugin::initTranslationKeyHandler()`
+     * already guarantees `self::$translator` is a real `\Illuminate\Translation\Translator`
+     * before init() runs, so the narrowed class is the actual resolved concrete
+     * (normally `Illuminate\Translation\Translator`, possibly an app subclass).
+     */
+    private static function resolveZeroArgTransType(FunctionReturnTypeProviderEvent $event): ?Union
+    {
+        if ($event->getFunctionId() !== 'trans' || !self::$translator instanceof Translator) {
+            return null;
+        }
+
+        $class = self::$translator::class;
+
+        if (!$event->getStatementsSource()->getCodebase()->classExists($class)) {
+            // The app may bind a Translator subclass Psalm never scanned — fall
+            // back to the vendor docblock's contract-typed conditional instead
+            // of naming an unknown class.
+            return null;
+        }
+
+        return self::$zeroArgTransUnions[$class] ??= new Union([new TNamedObject($class)]);
     }
 
     /**

--- a/src/Handlers/Translations/TranslationKeyHandler.php
+++ b/src/Handlers/Translations/TranslationKeyHandler.php
@@ -96,10 +96,24 @@ final class TranslationKeyHandler implements FunctionReturnTypeProviderInterface
         $callArgs = $event->getCallArgs();
 
         if ($callArgs === []) {
-            // A truly zero-arg call — never reachable for `trans(...$args)`, whose
-            // spread produces one Arg node regardless of the spread array's runtime
-            // size, so no separate unpack check is needed here.
             return self::resolveZeroArgTransType($event);
+        }
+
+        // A LEADING spread hides the argument count: an empty spread runs Laravel's
+        // is_null($key) branch (`trans()` -> translator, `__()` -> null), a non-empty
+        // one runs the key lookup. Return the sound union of both branches so the
+        // zero-arg possibility is not silently dropped (`trans(...$maybeEmpty)` could
+        // be the translator at runtime). The lookup side stays `string`, matching the
+        // handler's deliberate string-not-array choice for dynamic keys below.
+        if ($callArgs[0]->unpack) {
+            if ($event->getFunctionId() === 'trans') {
+                return Type::combineUnionTypes(
+                    new Union([new TNamedObject(\Illuminate\Contracts\Translation\Translator::class)]),
+                    Type::getString(),
+                );
+            }
+
+            return Type::combineUnionTypes(Type::getString(), Type::getNull());
         }
 
         // Try to resolve literal string keys precisely via the Translator

--- a/src/Handlers/Views/MissingViewHandler.php
+++ b/src/Handlers/Views/MissingViewHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Psalm\LaravelPlugin\Handlers\Views;
 
 use Illuminate\View\Factory;
+use Illuminate\View\View;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Scalar\String_;
 use Psalm\CodeLocation;
@@ -15,18 +16,31 @@ use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
 use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Union;
 
 /**
  * Detects calls to the view() helper, Factory::make(), and View facade
- * with a view name that does not correspond to an existing template file.
+ * with a view name that does not correspond to an existing template file,
+ * and narrows the view() helper's return type past the stub's contract
+ * fallback to a concrete class.
  *
  * Registers for both the service class (Factory) and its facades/aliases
  * (View, \Illuminate\Support\Facades\View) via FacadeMapProvider, so the handler
  * fires regardless of how the developer calls make().
  *
- * Only string literal view names are checked — dynamic names and namespaced
- * views (e.g., 'mail::html.header') are skipped to avoid false positives.
+ * Only string literal view names are checked for the MissingView diagnostic —
+ * dynamic names and namespaced views (e.g., 'mail::html.header') are skipped
+ * to avoid false positives.
+ *
+ * Type narrowing for view() is provenance-based on Laravel's own ground truth:
+ * the helper branches on `func_num_args() === 0` (never on the value of the
+ * first argument, so `view(null)` still takes the "argument supplied" branch).
+ * Zero-arg calls narrow to the app's actual resolved view-factory class (a
+ * bonus for a Factory subclass); argument-supplied calls narrow to the
+ * concrete `\Illuminate\View\View` only when the resolved factory is the
+ * stock `\Illuminate\View\Factory` — a subclass may override `viewInstance()`
+ * and construct a different View implementation.
  *
  * @see https://laravel.com/docs/views
  */
@@ -42,6 +56,12 @@ final class MissingViewHandler implements FunctionReturnTypeProviderInterface, M
 
     /** @var array<string, bool> Cached view existence results to avoid repeated filesystem checks */
     private static array $resolvedViews = [];
+
+    /** @var class-string|null The booted app's resolved view-factory class, for view() helper narrowing */
+    private static ?string $factoryClass = null;
+
+    /** @var array<class-string, Union> cache of concrete return unions (Psalm 7 unions are immutable) */
+    private static array $narrowedUnions = [];
 
     /**
      * @param list<string> $viewPaths Absolute paths to view directories (from config('view.paths'))
@@ -60,6 +80,19 @@ final class MissingViewHandler implements FunctionReturnTypeProviderInterface, M
     }
 
     /**
+     * Record the booted app's resolved view-factory class for view() helper narrowing.
+     *
+     * Always called regardless of findMissingViews — this is type narrowing, not a diagnostic.
+     *
+     * @param class-string $class
+     * @psalm-external-mutation-free
+     */
+    public static function initViewFactory(string $class): void
+    {
+        self::$factoryClass = $class;
+    }
+
+    /**
      * @inheritDoc
      * @psalm-pure
      */
@@ -75,23 +108,75 @@ final class MissingViewHandler implements FunctionReturnTypeProviderInterface, M
     {
         $callArgs = $event->getCallArgs();
 
-        if ($callArgs === []) {
+        // view(...$args) — a LEADING spread hides both the argument count (so neither
+        // side of Laravel's `func_num_args() === 0` split is decidable) and the view
+        // name. A trailing spread (`view('x', ...$data)`) hides neither: the count is
+        // provably >= 1, so the diagnostic and the narrowing below still apply.
+        if ($callArgs !== [] && $callArgs[0]->unpack) {
             return null;
+        }
+
+        if ($callArgs === []) {
+            $narrowedClass = self::narrowedHelperReturn(0);
+
+            if ($narrowedClass === null) {
+                return null;
+            }
+
+            // The resolved class is the app's own binding, not our own vendored
+            // code — guard against Psalm not having scanned it.
+            if (!$event->getStatementsSource()->getCodebase()->classExists($narrowedClass)) {
+                return null;
+            }
+
+            return self::narrowedUnion($narrowedClass);
         }
 
         $viewName = self::extractLiteralStringArg($callArgs[0]);
 
-        if ($viewName === null) {
-            return null;
+        if ($viewName !== null) {
+            self::checkViewExists(
+                $viewName,
+                $event->getCodeLocation(),
+                $event->getStatementsSource()->getSuppressedIssues(),
+            );
         }
 
-        self::checkViewExists(
-            $viewName,
-            $event->getCodeLocation(),
-            $event->getStatementsSource()->getSuppressedIssues(),
-        );
+        $narrowedClass = self::narrowedHelperReturn(\count($callArgs));
 
-        return null;
+        return $narrowedClass !== null ? self::narrowedUnion($narrowedClass) : null;
+    }
+
+    /**
+     * Decide which concrete class the view() helper narrows to, given only the
+     * call's argument count — Laravel's helper branches on `func_num_args() === 0`,
+     * never on the arguments' values.
+     *
+     * - Zero args: narrows to the app's actual resolved factory class (whatever
+     *   it is) since `view()` always returns that instance directly.
+     * - One or more args: narrows to `\Illuminate\View\View` only when the
+     *   resolved factory is the stock `\Illuminate\View\Factory` — a subclass
+     *   may override `viewInstance()` to construct a different implementation.
+     *
+     * @return class-string|null
+     * @psalm-external-mutation-free
+     */
+    private static function narrowedHelperReturn(int $argCount): ?string
+    {
+        if ($argCount === 0) {
+            return self::$factoryClass;
+        }
+
+        return self::$factoryClass === Factory::class ? View::class : null;
+    }
+
+    /**
+     * @param class-string $class
+     * @psalm-external-mutation-free
+     */
+    private static function narrowedUnion(string $class): Union
+    {
+        return self::$narrowedUnions[$class] ??= new Union([new TNamedObject($class)]);
     }
 
     /**

--- a/src/Handlers/Views/MissingViewHandler.php
+++ b/src/Handlers/Views/MissingViewHandler.php
@@ -64,6 +64,12 @@ final class MissingViewHandler implements FunctionReturnTypeProviderInterface, M
     private static array $narrowedUnions = [];
 
     /**
+     * Cached leading-spread union. Keyed on nothing — it is the same two contracts
+     * every time and is app-independent, so it never needs resetting.
+     */
+    private static ?Union $spreadUnion = null;
+
+    /**
      * @param list<string> $viewPaths Absolute paths to view directories (from config('view.paths'))
      * @param list<string> $extensions File extensions without leading dot (from FileViewFinder::getExtensions())
      * @psalm-external-mutation-free
@@ -82,12 +88,14 @@ final class MissingViewHandler implements FunctionReturnTypeProviderInterface, M
     /**
      * Record the booted app's resolved view-factory class for view() helper narrowing.
      *
-     * Always called regardless of findMissingViews — this is type narrowing, not a diagnostic.
+     * Always called (regardless of findMissingViews) with the resolved class or null,
+     * so a re-invocation in a reused process overwrites — never leaks — a prior app's
+     * binding. Null disables the narrowing and the stub's contract fallback applies.
      *
-     * @param class-string $class
+     * @param class-string|null $class
      * @psalm-external-mutation-free
      */
-    public static function initViewFactory(string $class): void
+    public static function initViewFactory(?string $class): void
     {
         self::$factoryClass = $class;
     }
@@ -108,12 +116,16 @@ final class MissingViewHandler implements FunctionReturnTypeProviderInterface, M
     {
         $callArgs = $event->getCallArgs();
 
-        // view(...$args) — a LEADING spread hides both the argument count (so neither
-        // side of Laravel's `func_num_args() === 0` split is decidable) and the view
-        // name. A trailing spread (`view('x', ...$data)`) hides neither: the count is
-        // provably >= 1, so the diagnostic and the narrowing below still apply.
+        // view(...$args) — a LEADING spread hides the argument count, so
+        // func_num_args() could be 0 (an empty spread runs the zero-arg branch and
+        // returns the factory) or not (returns a View). Return the sound union of
+        // both contracts rather than defer to the stub, whose func_num_args()
+        // conditional collapses a spread to the View branch — wrong for an empty
+        // spread, and it would falsely accept a concrete-only call. A trailing
+        // spread (`view('x', ...$data)`) hides neither the count (provably >= 1)
+        // nor the name, so the diagnostic and narrowing below still apply.
         if ($callArgs !== [] && $callArgs[0]->unpack) {
-            return null;
+            return self::spreadReturn();
         }
 
         if ($callArgs === []) {
@@ -180,8 +192,29 @@ final class MissingViewHandler implements FunctionReturnTypeProviderInterface, M
     }
 
     /**
-     * Register for Factory (direct usage) plus any facades/aliases that
-     * proxy to it (View, \Illuminate\Support\Facades\View).
+     * Sound return for a leading-spread view() call of unknown cardinality: the
+     * union of both func_num_args() branches, on the contracts so no concrete-only
+     * call is falsely accepted regardless of which branch runs.
+     *
+     * @psalm-external-mutation-free
+     */
+    private static function spreadReturn(): Union
+    {
+        return self::$spreadUnion ??= new Union([
+            new TNamedObject(\Illuminate\Contracts\View\Factory::class),
+            new TNamedObject(\Illuminate\Contracts\View\View::class),
+        ]);
+    }
+
+    /**
+     * Register for Factory (direct usage), the canonical View facade, plus any
+     * root aliases that proxy to it.
+     *
+     * The canonical facade is hardcoded (not left to FacadeMapProvider) so the
+     * missing-view diagnostic still fires on `\Illuminate\Support\Facades\View::make()`
+     * in apps that trim their alias registry — otherwise ProducerReturnTypeHandler,
+     * which does hardcode that facade, would answer the return type first and this
+     * handler's diagnostic would never run. Matches the Auth handlers' convention.
      *
      * @inheritDoc
      * @psalm-external-mutation-free
@@ -189,7 +222,11 @@ final class MissingViewHandler implements FunctionReturnTypeProviderInterface, M
     #[\Override]
     public static function getClassLikeNames(): array
     {
-        return [Factory::class, ...FacadeMapProvider::getFacadeClasses(Factory::class)];
+        return \array_values(\array_unique([
+            Factory::class,
+            \Illuminate\Support\Facades\View::class,
+            ...FacadeMapProvider::getFacadeClasses(Factory::class),
+        ]));
     }
 
     /** @inheritDoc */

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -400,6 +400,10 @@ final class Plugin implements PluginEntryPointInterface
         // issue on View::make(). Reads FacadeMapProvider, so it relies on init() (above)
         // having already run.
         require_once __DIR__ . '/Handlers/Producers/ProducerReturnTypeHandler.php';
+        // Rebuild the family index from this invocation's FacadeMapProvider aliases
+        // (a reused process may have booted a different app). Must precede registration
+        // so the reverse index and getClassLikeNames() agree.
+        Handlers\Producers\ProducerReturnTypeHandler::reset();
         $registration->registerHooksFromClass(Handlers\Producers\ProducerReturnTypeHandler::class);
 
         // Flag `public` Eloquent scopes / legacy accessors (Laravel's convention is `protected` — they
@@ -537,18 +541,23 @@ final class Plugin implements PluginEntryPointInterface
      * Resolve the booted app's view factory class and hand it to MissingViewHandler
      * so the view() helper can narrow past the stub's contract fallback.
      *
-     * Silently no-ops when 'view' isn't bound, throws on resolution, or resolves to
-     * a non-standard implementation — the stub's contract-typed fallback still
-     * applies, it just isn't narrowed further. Unlike initMissingViewHandler(), no
-     * warning is emitted: this is bonus type narrowing, not an opt-in diagnostic.
+     * Passes the resolved class or null (unbound / threw / non-standard) so the
+     * handler always overwrites — never leaks — a prior app's binding in a reused
+     * process. Null falls back to the stub's contract type. Unlike
+     * initMissingViewHandler(), no warning is emitted: this is bonus type narrowing,
+     * not an opt-in diagnostic.
      */
     private function initViewFactoryHandler(\Psalm\Progress\Progress $output): void
     {
         $factory = $this->resolveViewFactory(ApplicationProvider::getApp(), $output);
 
-        if ($factory instanceof \Illuminate\View\Factory) {
-            Handlers\Views\MissingViewHandler::initViewFactory($factory::class);
-        }
+        // Load the handler before its first static touch: __invoke() runs before
+        // registerHandlers() (where the paired require_once lives), and under
+        // psalm.phar the plugin's PSR-4 autoloader may not be registered yet.
+        require_once __DIR__ . '/Handlers/Views/MissingViewHandler.php';
+        Handlers\Views\MissingViewHandler::initViewFactory(
+            $factory instanceof \Illuminate\View\Factory ? $factory::class : null,
+        );
     }
 
     /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -55,13 +55,17 @@ final class Plugin implements PluginEntryPointInterface
             // of whether findMissingTranslations is enabled
             $this->initTranslationKeyHandler($output, $pluginConfig->findMissingTranslations);
 
+            // Resolve the 'view' binding once and share it: the diagnostic init
+            // (finder fallback) and the always-on view() narrowing both need it.
+            $viewFactory = $this->resolveViewFactory(ApplicationProvider::getApp(), $output);
+
             if ($pluginConfig->findMissingViews) {
-                $this->initMissingViewHandler($output);
+                $this->initMissingViewHandler($output, $viewFactory);
             }
 
             // Always called — provides type narrowing for the view() helper regardless
             // of whether findMissingViews is enabled (same split as translations above).
-            $this->initViewFactoryHandler($output);
+            $this->initViewFactoryHandler($viewFactory);
 
             $this->initNoEnvOutsideConfigHandler($pluginConfig, $output);
 
@@ -484,32 +488,27 @@ final class Plugin implements PluginEntryPointInterface
      * Uses the app's FileViewFinder which reflects config('view.paths') plus
      * any paths added by service providers during bootstrap.
      */
-    private function initMissingViewHandler(\Psalm\Progress\Progress $output): void
+    private function initMissingViewHandler(\Psalm\Progress\Progress $output, ?\Illuminate\View\Factory $factory): void
     {
         $app = ApplicationProvider::getApp();
 
-        // Prefer the dedicated view.finder binding; fall back to the Factory's finder
-        // (ApplicationProvider may bind 'view' without registering 'view.finder')
+        // Prefer the dedicated view.finder binding; fall back to the pre-resolved
+        // Factory's finder (ApplicationProvider may bind 'view' without 'view.finder').
         if ($app->bound('view.finder')) {
             /** @var \Illuminate\View\FileViewFinder $finder */
             $finder = $app->make('view.finder');
-        } elseif ($app->bound('view')) {
-            $factory = $this->resolveViewFactory($app, $output);
-
-            if (!$factory instanceof \Illuminate\View\Factory) {
-                // Null covers both "resolved to a non-standard implementation" and
-                // "the binding threw" (resolveViewFactory swallows the throw to a
-                // --debug line rather than disabling the whole plugin). Keep the
-                // warning accurate for both and point at --debug for the real cause.
-                $output->warning(
-                    'Laravel plugin: findMissingViews is enabled but the view factory could not be resolved to a '
-                    . 'standard instance (run with --debug for the underlying cause). The MissingView check will be skipped.',
-                );
-
-                return;
-            }
-
+        } elseif ($factory instanceof \Illuminate\View\Factory) {
             $finder = $factory->getFinder();
+        } elseif ($app->bound('view')) {
+            // 'view' is bound but resolveViewFactory() returned null: the binding
+            // threw (swallowed to a --debug line rather than disabling the plugin)
+            // or resolved to a non-standard implementation.
+            $output->warning(
+                'Laravel plugin: findMissingViews is enabled but the view factory could not be resolved to a '
+                . 'standard instance (run with --debug for the underlying cause). The MissingView check will be skipped.',
+            );
+
+            return;
         } else {
             $output->warning(
                 'Laravel plugin: findMissingViews is enabled but the view finder service is not bound. '
@@ -546,24 +545,22 @@ final class Plugin implements PluginEntryPointInterface
      * process. Null falls back to the stub's contract type. Unlike
      * initMissingViewHandler(), no warning is emitted: this is bonus type narrowing,
      * not an opt-in diagnostic.
+     *
+     * @psalm-external-mutation-free
      */
-    private function initViewFactoryHandler(\Psalm\Progress\Progress $output): void
+    private function initViewFactoryHandler(?\Illuminate\View\Factory $factory): void
     {
-        $factory = $this->resolveViewFactory(ApplicationProvider::getApp(), $output);
-
         // Load the handler before its first static touch: __invoke() runs before
         // registerHandlers() (where the paired require_once lives), and under
         // psalm.phar the plugin's PSR-4 autoloader may not be registered yet.
         require_once __DIR__ . '/Handlers/Views/MissingViewHandler.php';
-        Handlers\Views\MissingViewHandler::initViewFactory(
-            $factory instanceof \Illuminate\View\Factory ? $factory::class : null,
-        );
+        Handlers\Views\MissingViewHandler::initViewFactory($factory instanceof \Illuminate\View\Factory ? $factory::class : null);
     }
 
     /**
-     * Single call site for `$app->make('view')`, shared by initMissingViewHandler()
-     * (opt-in diagnostics) and initViewFactoryHandler() (always-on type narrowing) so
-     * both read the exact same resolution instead of each resolving it independently.
+     * Single call site for `$app->make('view')`, resolved once in __invoke() and
+     * shared by initMissingViewHandler() (opt-in diagnostics) and
+     * initViewFactoryHandler() (always-on type narrowing).
      */
     private function resolveViewFactory(Application $app, \Psalm\Progress\Progress $output): ?\Illuminate\View\Factory
     {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -564,13 +564,13 @@ final class Plugin implements PluginEntryPointInterface
 
         try {
             $factory = $app->make('view');
-        } catch (\Throwable $e) {
+        } catch (\Throwable $throwable) {
             // A throwing 'view' binding (e.g. a closure needing runtime-only state a
             // degraded boot never prepared) must degrade this one feature, not escape
             // to __invoke()'s outer catch and disable the whole plugin — the same
             // per-probe policy FacadeMapProvider::init() applies to facade roots.
             // Keep the real cause reachable for --debug runs.
-            $output->debug("Laravel plugin: resolving the 'view' binding threw: {$e->getMessage()}\n");
+            $output->debug("Laravel plugin: resolving the 'view' binding threw: {$throwable->getMessage()}\n");
 
             return null;
         }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -59,6 +59,10 @@ final class Plugin implements PluginEntryPointInterface
                 $this->initMissingViewHandler($output);
             }
 
+            // Always called — provides type narrowing for the view() helper regardless
+            // of whether findMissingViews is enabled (same split as translations above).
+            $this->initViewFactoryHandler($output);
+
             $this->initNoEnvOutsideConfigHandler($pluginConfig, $output);
 
             $this->registerHandlers($registration, $pluginConfig);
@@ -381,12 +385,22 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Helpers/EnvHandler.php';
         $registration->registerHooksFromClass(Handlers\Helpers\EnvHandler::class);
 
-        // Unlike TranslationKeyHandler (which always runs for type narrowing),
-        // MissingViewHandler provides no type information — skip entirely when disabled
-        if ($pluginConfig->findMissingViews) {
-            require_once __DIR__ . '/Handlers/Views/MissingViewHandler.php';
-            $registration->registerHooksFromClass(Handlers\Views\MissingViewHandler::class);
-        }
+        // Always registered (like TranslationKeyHandler): the view() helper's type
+        // narrowing runs regardless of findMissingViews — only the MissingView
+        // diagnostic itself is opt-in, gated internally by self::$enabled
+        // (set only when initMissingViewHandler() ran, i.e. findMissingViews is true).
+        require_once __DIR__ . '/Handlers/Views/MissingViewHandler.php';
+        $registration->registerHooksFromClass(Handlers\Views\MissingViewHandler::class);
+
+        // Must come AFTER MissingViewHandler: MissingViewHandler's method provider on
+        // Factory/View-facade make() always returns null after emitting its diagnostic,
+        // but Psalm dispatches return-type providers in registration order and stops at
+        // the first non-null result. Registering the narrowing provider first would let
+        // it answer before MissingViewHandler runs, silently dropping the MissingView
+        // issue on View::make(). Reads FacadeMapProvider, so it relies on init() (above)
+        // having already run.
+        require_once __DIR__ . '/Handlers/Producers/ProducerReturnTypeHandler.php';
+        $registration->registerHooksFromClass(Handlers\Producers\ProducerReturnTypeHandler::class);
 
         // Flag `public` Eloquent scopes / legacy accessors (Laravel's convention is `protected` — they
         // are dispatched indirectly, never called by name). Enabled by default; silence per project via
@@ -476,12 +490,16 @@ final class Plugin implements PluginEntryPointInterface
             /** @var \Illuminate\View\FileViewFinder $finder */
             $finder = $app->make('view.finder');
         } elseif ($app->bound('view')) {
-            $factory = $app->make('view');
+            $factory = $this->resolveViewFactory($app, $output);
 
             if (!$factory instanceof \Illuminate\View\Factory) {
+                // Null covers both "resolved to a non-standard implementation" and
+                // "the binding threw" (resolveViewFactory swallows the throw to a
+                // --debug line rather than disabling the whole plugin). Keep the
+                // warning accurate for both and point at --debug for the real cause.
                 $output->warning(
-                    'Laravel plugin: findMissingViews is enabled but the view factory is not a standard instance. '
-                    . 'The MissingView check will be skipped.',
+                    'Laravel plugin: findMissingViews is enabled but the view factory could not be resolved to a '
+                    . 'standard instance (run with --debug for the underlying cause). The MissingView check will be skipped.',
                 );
 
                 return;
@@ -513,6 +531,55 @@ final class Plugin implements PluginEntryPointInterface
         $extensions = $finder->getExtensions();
 
         Handlers\Views\MissingViewHandler::init($paths, $extensions);
+    }
+
+    /**
+     * Resolve the booted app's view factory class and hand it to MissingViewHandler
+     * so the view() helper can narrow past the stub's contract fallback.
+     *
+     * Silently no-ops when 'view' isn't bound, throws on resolution, or resolves to
+     * a non-standard implementation — the stub's contract-typed fallback still
+     * applies, it just isn't narrowed further. Unlike initMissingViewHandler(), no
+     * warning is emitted: this is bonus type narrowing, not an opt-in diagnostic.
+     */
+    private function initViewFactoryHandler(\Psalm\Progress\Progress $output): void
+    {
+        $factory = $this->resolveViewFactory(ApplicationProvider::getApp(), $output);
+
+        if ($factory instanceof \Illuminate\View\Factory) {
+            Handlers\Views\MissingViewHandler::initViewFactory($factory::class);
+        }
+    }
+
+    /**
+     * Single call site for `$app->make('view')`, shared by initMissingViewHandler()
+     * (opt-in diagnostics) and initViewFactoryHandler() (always-on type narrowing) so
+     * both read the exact same resolution instead of each resolving it independently.
+     */
+    private function resolveViewFactory(Application $app, \Psalm\Progress\Progress $output): ?\Illuminate\View\Factory
+    {
+        if (!$app->bound('view')) {
+            return null;
+        }
+
+        try {
+            $factory = $app->make('view');
+        } catch (\Throwable $e) {
+            // A throwing 'view' binding (e.g. a closure needing runtime-only state a
+            // degraded boot never prepared) must degrade this one feature, not escape
+            // to __invoke()'s outer catch and disable the whole plugin — the same
+            // per-probe policy FacadeMapProvider::init() applies to facade roots.
+            // Keep the real cause reachable for --debug runs.
+            $output->debug("Laravel plugin: resolving the 'view' binding threw: {$e->getMessage()}\n");
+
+            return null;
+        }
+
+        if (!$factory instanceof \Illuminate\View\Factory) {
+            return null;
+        }
+
+        return $factory;
     }
 
     private function buildSchema(PluginConfig $pluginConfig): void

--- a/stubs/common/Database/Query/Builder.phpstub
+++ b/stubs/common/Database/Query/Builder.phpstub
@@ -629,4 +629,48 @@ class Builder implements BuilderContract
      * @return int<0, max>
      */
     public function getCountForPagination($columns = ['*']) {}
+
+    /**
+     * Paginate the given query into a simple paginator.
+     *
+     * Vendor declares these returns as the ungenerified concrete (paginate())
+     * or the Pagination contracts (simplePaginate()/cursorPaginate()); Query\Builder
+     * rows always hydrate as stdClass (see get()/cursor() above), so all three are
+     * narrowed here to the concrete Pagination classes with `<int, \stdClass>`.
+     * Eloquent\Builder's own stub models the model-typed equivalent (`<int, TModel>`).
+     *
+     * @param  int|\Closure  $perPage
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression|array<string|\Illuminate\Contracts\Database\Query\Expression>  $columns
+     * @param  string  $pageName
+     * @param  int|null  $page
+     * @param  \Closure|int|null  $total
+     * @return \Illuminate\Pagination\LengthAwarePaginator<int, \stdClass>
+     */
+    public function paginate($perPage = 15, $columns = ['*'], $pageName = 'page', $page = null, $total = null) {}
+
+    /**
+     * Get a paginator only supporting simple next and previous links.
+     *
+     * This is more efficient on larger data-sets, etc.
+     *
+     * @param  int  $perPage
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression|array<string|\Illuminate\Contracts\Database\Query\Expression>  $columns
+     * @param  string  $pageName
+     * @param  int|null  $page
+     * @return \Illuminate\Pagination\Paginator<int, \stdClass>
+     */
+    public function simplePaginate($perPage = 15, $columns = ['*'], $pageName = 'page', $page = null) {}
+
+    /**
+     * Get a paginator only supporting simple next and previous links.
+     *
+     * This is more efficient on larger data-sets, etc.
+     *
+     * @param  int|null  $perPage
+     * @param  string|\Illuminate\Contracts\Database\Query\Expression|array<string|\Illuminate\Contracts\Database\Query\Expression>  $columns
+     * @param  string  $cursorName
+     * @param  \Illuminate\Pagination\Cursor|string|null  $cursor
+     * @return \Illuminate\Pagination\CursorPaginator<int, \stdClass>
+     */
+    public function cursorPaginate($perPage = 15, $columns = ['*'], $cursorName = 'cursor', $cursor = null) {}
 }

--- a/stubs/common/Foundation/helpers.phpstub
+++ b/stubs/common/Foundation/helpers.phpstub
@@ -389,10 +389,17 @@ function validator(array $data = [], array $rules = [], array $messages = [], ar
 /**
  * Get the evaluated view contents for the given view.
  *
+ * Branches on argument count (func_num_args() is 0), not on $view's value —
+ * `view(null)` still returns a View, matching Laravel's own helper. The contract
+ * returns here are the sound fallback; MissingViewHandler narrows the zero-arg
+ * form to the app's resolved factory class (any scanned class qualifies) and the
+ * argument-supplied form to `\Illuminate\View\View`, the latter only when that
+ * resolved factory is the stock `\Illuminate\View\Factory`.
+ *
  * @param  string|null  $view
  * @param  \Illuminate\Contracts\Support\Arrayable<string, mixed>|array<string, mixed>  $data
  * @param  array<string, mixed>  $mergeData
- * @return ($view is null ? \Illuminate\Contracts\View\Factory : (\Illuminate\View\View|\Illuminate\Contracts\View\View))
+ * @return (func_num_args() is 0 ? \Illuminate\Contracts\View\Factory : \Illuminate\Contracts\View\View)
  */
 function view($view = null, $data = [], $mergeData = []) {}
 

--- a/tests/Application/app/Builders/MechanicBuilder.php
+++ b/tests/Application/app/Builders/MechanicBuilder.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Eloquent\Model;
  */
 class MechanicBuilder extends Builder
 {
+    /** @psalm-return self<TModel> */
     public function whereCertified(): self
     {
         return $this->where('certified', true);

--- a/tests/Application/app/Builders/MechanicBuilder.php
+++ b/tests/Application/app/Builders/MechanicBuilder.php
@@ -17,9 +17,6 @@ use Illuminate\Database\Eloquent\Model;
  */
 class MechanicBuilder extends Builder
 {
-    /**
-     * @return self<TModel>
-     */
     public function whereCertified(): self
     {
         return $this->where('certified', true);

--- a/tests/Application/app/Builders/VehicleBuilder.php
+++ b/tests/Application/app/Builders/VehicleBuilder.php
@@ -17,17 +17,11 @@ use Illuminate\Database\Eloquent\Model;
  */
 class VehicleBuilder extends Builder
 {
-    /**
-     * @return self<TModel>
-     */
     public function whereElectric(): self
     {
         return $this->where('fuel_type', 'electric');
     }
 
-    /**
-     * @return self<TModel>
-     */
     public function whereByMake(string $make): self
     {
         return $this->where('make', $make);

--- a/tests/Application/app/Builders/VehicleBuilder.php
+++ b/tests/Application/app/Builders/VehicleBuilder.php
@@ -17,11 +17,13 @@ use Illuminate\Database\Eloquent\Model;
  */
 class VehicleBuilder extends Builder
 {
+    /** @psalm-return self<TModel> */
     public function whereElectric(): self
     {
         return $this->where('fuel_type', 'electric');
     }
 
+    /** @psalm-return self<TModel> */
     public function whereByMake(string $make): self
     {
         return $this->where('make', $make);

--- a/tests/Application/app/Builders/WorkOrderBuilder.php
+++ b/tests/Application/app/Builders/WorkOrderBuilder.php
@@ -19,11 +19,13 @@ use Illuminate\Support\Facades\DB;
  */
 class WorkOrderBuilder extends Builder
 {
+    /** @psalm-return self<TModel> */
     public function whereCompleted(): self
     {
         return $this->where('status', 'completed');
     }
 
+    /** @psalm-return self<TModel> */
     public function wherePending(): self
     {
         return $this->where('status', 'pending');
@@ -31,6 +33,8 @@ class WorkOrderBuilder extends Builder
 
     /**
      * Custom method with parameters — exercises the getMethodParams provider path.
+     *
+     * @psalm-return self<TModel>
      */
     public function whereByMechanic(int $mechanicId): self
     {
@@ -46,6 +50,8 @@ class WorkOrderBuilder extends Builder
      * false-positive UndefinedMagicPropertyFetch.
      *
      * @see https://github.com/psalm/psalm-plugin-laravel/issues/805
+     *
+     * @psalm-return self<TModel>
      */
     public function withFavoriteStatus(int $userId): self
     {

--- a/tests/Application/app/Builders/WorkOrderBuilder.php
+++ b/tests/Application/app/Builders/WorkOrderBuilder.php
@@ -19,17 +19,11 @@ use Illuminate\Support\Facades\DB;
  */
 class WorkOrderBuilder extends Builder
 {
-    /**
-     * @return self<TModel>
-     */
     public function whereCompleted(): self
     {
         return $this->where('status', 'completed');
     }
 
-    /**
-     * @return self<TModel>
-     */
     public function wherePending(): self
     {
         return $this->where('status', 'pending');
@@ -37,8 +31,6 @@ class WorkOrderBuilder extends Builder
 
     /**
      * Custom method with parameters — exercises the getMethodParams provider path.
-     *
-     * @return self<TModel>
      */
     public function whereByMechanic(int $mechanicId): self
     {
@@ -54,8 +46,6 @@ class WorkOrderBuilder extends Builder
      * false-positive UndefinedMagicPropertyFetch.
      *
      * @see https://github.com/psalm/psalm-plugin-laravel/issues/805
-     *
-     * @return self<TModel>
      */
     public function withFavoriteStatus(int $userId): self
     {

--- a/tests/Type/tests/Auth/PasswordBrokerConcreteTest.phpt
+++ b/tests/Type/tests/Auth/PasswordBrokerConcreteTest.phpt
@@ -1,0 +1,42 @@
+--FILE--
+<?php declare(strict_types=1);
+
+// Password::broker() / PasswordBrokerManager::broker() are narrowed to the concrete
+// PasswordBroker, so concrete-only methods (createToken, deleteToken, tokenExists,
+// getRepository, getTimebox, getUser) resolve without errors.
+
+$_broker = \Illuminate\Support\Facades\Password::broker();
+/** @psalm-check-type-exact $_broker = \Illuminate\Auth\Passwords\PasswordBroker */
+
+// Root alias — a separate class from the canonical facade FQCN in Psalm's eyes.
+$_brokerAlias = \Password::broker();
+/** @psalm-check-type-exact $_brokerAlias = \Illuminate\Auth\Passwords\PasswordBroker */
+
+function _diManager(\Illuminate\Auth\Passwords\PasswordBrokerManager $manager): void {
+    $_managerBroker = $manager->broker();
+    /** @psalm-check-type-exact $_managerBroker = \Illuminate\Auth\Passwords\PasswordBroker */
+
+    $_managerNamedBroker = $manager->broker('users');
+    /** @psalm-check-type-exact $_managerNamedBroker = \Illuminate\Auth\Passwords\PasswordBroker */
+}
+
+function _concreteOnlyMethods(\Illuminate\Contracts\Auth\CanResetPassword $user): void {
+    $_token = \Illuminate\Support\Facades\Password::broker()->createToken($user);
+    /** @psalm-check-type-exact $_token = string */
+
+    \Illuminate\Support\Facades\Password::broker()->deleteToken($user);
+
+    $_exists = \Illuminate\Support\Facades\Password::broker()->tokenExists($user, 'some-token');
+    /** @psalm-check-type-exact $_exists = bool */
+
+    $_repository = \Illuminate\Support\Facades\Password::broker()->getRepository();
+    /** @psalm-check-type-exact $_repository = \Illuminate\Auth\Passwords\TokenRepositoryInterface */
+
+    $_timebox = \Illuminate\Support\Facades\Password::broker()->getTimebox();
+    /** @psalm-check-type-exact $_timebox = \Illuminate\Support\Timebox */
+
+    $_foundUser = \Illuminate\Support\Facades\Password::broker()->getUser([]);
+    /** @psalm-check-type-exact $_foundUser = \Illuminate\Contracts\Auth\CanResetPassword|null */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Auth/PasswordBrokerNarrowingBoundariesTest.phpt
+++ b/tests/Type/tests/Auth/PasswordBrokerNarrowingBoundariesTest.phpt
@@ -1,0 +1,51 @@
+--FILE--
+<?php declare(strict_types=1);
+
+// Boundary tests: producer narrowing must never leak onto bare contract-typed values
+// (parameters, factory results, custom implementations) — only the producer class, its
+// canonical facade, and root aliases are registered, never the PasswordBroker /
+// PasswordBrokerFactory contracts themselves.
+
+function _bareContractBroker(\Illuminate\Contracts\Auth\PasswordBroker $broker, \Illuminate\Contracts\Auth\CanResetPassword $user): void {
+    $broker->createToken($user);
+
+    $_sendResetLink = $broker->sendResetLink([]);
+    /** @psalm-check-type-exact $_sendResetLink = string */
+}
+
+function _bareFactoryBroker(\Illuminate\Contracts\Auth\PasswordBrokerFactory $factory, \Illuminate\Contracts\Auth\CanResetPassword $user): void {
+    $_broker = $factory->broker();
+    /** @psalm-check-type-exact $_broker = \Illuminate\Contracts\Auth\PasswordBroker */
+
+    $_broker->createToken($user);
+}
+
+// A hand-rolled implementation of the contract is not the producer — its own concrete
+// type must not expose createToken() either, proving we never widen based on interface
+// conformance. Reported as UndefinedMethod (not UndefinedInterfaceMethod) because the
+// param is typed by the concrete class here, not the interface.
+final class CustomPasswordBroker implements \Illuminate\Contracts\Auth\PasswordBroker {
+    #[\Override]
+    public function sendResetLink(array $credentials, ?\Closure $callback = null): string {
+        return 'sent';
+    }
+
+    #[\Override]
+    public function reset(array $credentials, \Closure $callback): mixed {
+        return true;
+    }
+}
+
+function _customImplementationBoundary(CustomPasswordBroker $broker, \Illuminate\Contracts\Auth\CanResetPassword $user): void {
+    $broker->createToken($user);
+}
+
+// Untouched pseudo-method guard: sendResetLink is not in the narrowed method list, so the
+// facade's own @method pseudo-tag return type (string) still applies unmodified.
+$_sendResetLink = \Illuminate\Support\Facades\Password::sendResetLink([]);
+/** @psalm-check-type-exact $_sendResetLink = string */
+?>
+--EXPECTF--
+UndefinedInterfaceMethod on line %d: %s
+UndefinedInterfaceMethod on line %d: %s
+UndefinedMethod on line %d: %s

--- a/tests/Type/tests/Database/QueryBuilderPaginationBoundariesTest.phpt
+++ b/tests/Type/tests/Database/QueryBuilderPaginationBoundariesTest.phpt
@@ -1,0 +1,24 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Contracts\Pagination\Paginator;
+
+/**
+ * Guard: a bare Contracts\Pagination-typed value (parameter, not the
+ * Query\Builder producer) is never narrowed — it exposes only the contract,
+ * so a concrete-only method still raises UndefinedInterfaceMethod.
+ */
+function on_contract_receiver(LengthAwarePaginator $paginator): void
+{
+    $paginator->linkCollection();
+}
+
+function on_contract_paginator_receiver(Paginator $paginator): void
+{
+    $paginator->hasMorePagesWhen(true);
+}
+?>
+--EXPECTF--
+UndefinedInterfaceMethod on line %d: Method Illuminate\Contracts\Pagination\LengthAwarePaginator::linkCollection does not exist
+UndefinedInterfaceMethod on line %d: Method Illuminate\Contracts\Pagination\Paginator::hasMorePagesWhen does not exist

--- a/tests/Type/tests/Database/QueryBuilderPaginationTest.phpt
+++ b/tests/Type/tests/Database/QueryBuilderPaginationTest.phpt
@@ -1,0 +1,63 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Pagination\CursorPaginator;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
+use Illuminate\Support\Facades\DB;
+use App\Models\Customer;
+
+/**
+ * Query\Builder pagination rows always hydrate as stdClass, so paginate()/
+ * simplePaginate()/cursorPaginate() narrow to the concrete Pagination classes
+ * with `<int, \stdClass>` instead of the ungenerified/contract vendor returns.
+ */
+function query_builder_paginate_is_concrete(): void
+{
+    $_length = DB::table('users')->paginate();
+    /** @psalm-check-type-exact $_length = LengthAwarePaginator<int, \stdClass> */
+
+    $_simple = DB::table('users')->simplePaginate();
+    /** @psalm-check-type-exact $_simple = Paginator<int, \stdClass> */
+
+    $_cursor = DB::table('users')->cursorPaginate();
+    /** @psalm-check-type-exact $_cursor = CursorPaginator<int, \stdClass> */
+}
+
+/** Named-argument calls keep working — param names/order/defaults mirror vendor. */
+function query_builder_paginate_named_args(): void
+{
+    $_length = DB::table('users')->paginate(perPage: 25, pageName: 'p', page: 2);
+    /** @psalm-check-type-exact $_length = LengthAwarePaginator<int, \stdClass> */
+
+    $_cursor = DB::table('users')->cursorPaginate(cursorName: 'c');
+    /** @psalm-check-type-exact $_cursor = CursorPaginator<int, \stdClass> */
+}
+
+function query_builder_paginate_item_type(): void
+{
+    foreach (DB::table('users')->paginate() as $key => $row) {
+        /** @psalm-check-type-exact $key = int */
+        /** @psalm-check-type-exact $row = \stdClass */
+        echo $key, $row::class;
+    }
+}
+
+/** Concrete-only methods (absent from the Pagination contracts) resolve without error. */
+function query_builder_paginate_concrete_only_methods(): void
+{
+    $_links = DB::table('users')->paginate()->linkCollection();
+    /** @psalm-check-type-exact $_links = \Illuminate\Support\Collection<array-key, mixed> */
+
+    $_simple = DB::table('users')->simplePaginate()->hasMorePagesWhen(true);
+    /** @psalm-check-type-exact $_simple = Paginator<int, \stdClass>&static */
+}
+
+/** Eloquent\Builder::paginate() is untouched — model rows keep their model template. */
+function eloquent_builder_paginate_still_model_typed(): void
+{
+    $_paginator = Customer::query()->paginate();
+    /** @psalm-check-type-exact $_paginator = LengthAwarePaginator<int, Customer> */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Foundation/TranslateHelperTest.phpt
+++ b/tests/Type/tests/Foundation/TranslateHelperTest.phpt
@@ -34,8 +34,9 @@ $maybeKey = rand(0, 1) ? 'key' : null;
 $_nullable = __($maybeKey);
 /** @psalm-check-type-exact $_nullable = null|string */
 
-// trans() with no args returns the Translator instance
+// trans() with no args narrows to the concrete resolved Translator
+// (TranslationKeyHandler's zero-arg narrowing, not the stub's contract fallback)
 $_translator = trans();
-/** @psalm-check-type-exact $_translator = \Illuminate\Contracts\Translation\Translator */
+/** @psalm-check-type-exact $_translator = \Illuminate\Translation\Translator */
 ?>
 --EXPECTF--

--- a/tests/Type/tests/MissingViewTest.phpt
+++ b/tests/Type/tests/MissingViewTest.phpt
@@ -7,6 +7,12 @@
 view('nonexistent');
 view('emails.welcom');
 
+// A trailing spread must not swallow the diagnostic — the literal first
+// argument is still checkable (only a leading spread hides it)
+/** @psalm-var list<array<string, mixed>> $spreadData */
+$spreadData = [];
+view('missing-with-spread', ...$spreadData);
+
 // No arguments — returns factory, should not emit
 view();
 
@@ -34,6 +40,7 @@ function test_factory_make(\Illuminate\View\Factory $factory): void {
 --EXPECTF--
 MissingView on line %d: View 'nonexistent' not found in any of the registered view paths
 MissingView on line %d: View 'emails.welcom' not found in any of the registered view paths
+MissingView on line %d: View 'missing-with-spread' not found in any of the registered view paths
 MissingView on line %d: View 'nonexistent-direct' not found in any of the registered view paths
 MissingView on line %d: View 'nonexistent-facade' not found in any of the registered view paths
 MissingView on line %d: View 'nonexistent-fqcn' not found in any of the registered view paths

--- a/tests/Type/tests/Translations/TransHelperConcreteTest.phpt
+++ b/tests/Type/tests/Translations/TransHelperConcreteTest.phpt
@@ -23,5 +23,13 @@ $_literal = trans('any.literal.key');
 // plugin narrows by argument count only).
 $_nullKey = trans(null);
 /** @psalm-check-type-exact $_nullKey = \Illuminate\Contracts\Translation\Translator */
+
+// A leading spread hides the argument count: an empty spread returns the
+// translator, a non-empty one returns the lookup result. The sound union keeps
+// the translator possibility that the vendor conditional would otherwise drop.
+/** @psalm-var list{0?: string} $keys */
+$keys = [];
+$_transSpread = trans(...$keys);
+/** @psalm-check-type-exact $_transSpread = \Illuminate\Contracts\Translation\Translator|string */
 ?>
 --EXPECTF--

--- a/tests/Type/tests/Translations/TransHelperConcreteTest.phpt
+++ b/tests/Type/tests/Translations/TransHelperConcreteTest.phpt
@@ -1,0 +1,27 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App;
+
+/**
+ * A bare trans() call narrows to the concrete resolved Translator (not just
+ * the Contracts\Translation\Translator interface it declares), so
+ * concrete-only methods like has() resolve without UndefinedInterfaceMethod.
+ */
+$_translator = trans();
+/** @psalm-check-type-exact $_translator = \Illuminate\Translation\Translator */
+
+$_has = trans()->has('some.key');
+/** @psalm-check-type-exact $_has = bool */
+
+// Literal-key resolution is untouched by the zero-arg narrowing.
+$_literal = trans('any.literal.key');
+/** @psalm-check-type-exact $_literal = string */
+
+// Only the truly zero-arg form narrows; an explicit null key stays on the
+// vendor docblock's conditional (Laravel branches on is_null($key), but the
+// plugin narrows by argument count only).
+$_nullKey = trans(null);
+/** @psalm-check-type-exact $_nullKey = \Illuminate\Contracts\Translation\Translator */
+?>
+--EXPECTF--

--- a/tests/Type/tests/Translations/TransNarrowingBoundariesTest.phpt
+++ b/tests/Type/tests/Translations/TransNarrowingBoundariesTest.phpt
@@ -1,0 +1,22 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App;
+
+use Illuminate\Contracts\Translation\Translator;
+
+/**
+ * Guard: a bare Contracts\Translation\Translator-typed value (parameter, not
+ * the trans() producer) is never narrowed — it exposes only the contract,
+ * which declares no has(). get() is on the contract and stays fine.
+ */
+function on_contract_receiver(Translator $translator): void
+{
+    $translator->has('k');
+
+    $_value = $translator->get('k');
+    /** @psalm-check-type-exact $_value = mixed */
+}
+?>
+--EXPECTF--
+UndefinedInterfaceMethod on line %d: Method Illuminate\Contracts\Translation\Translator::has does not exist

--- a/tests/Type/tests/Views/MissingViewStillFiresAfterNarrowingTest.phpt
+++ b/tests/Type/tests/Views/MissingViewStillFiresAfterNarrowingTest.phpt
@@ -1,0 +1,22 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm-with-optin-custom-issues.xml
+--FILE--
+<?php declare(strict_types=1);
+
+// Ordering regression: MissingViewHandler is registered before ProducerReturnTypeHandler
+// (Plugin::registerHandlers()) specifically so it gets first look at make() calls.
+// MissingViewHandler's own return-type provider always answers null after emitting its
+// diagnostic, so Psalm falls through to ProducerReturnTypeHandler for the type. Both
+// observable effects — the MissingView issue AND the concrete narrowing — must survive.
+
+$_missing = \Illuminate\Support\Facades\View::make('definitely-missing-view');
+/** @psalm-check-type-exact $_missing = \Illuminate\View\View */
+
+function _diFactory(\Illuminate\View\Factory $factory): void {
+    $_alsoMissing = $factory->make('also-missing');
+    /** @psalm-check-type-exact $_alsoMissing = \Illuminate\View\View */
+}
+?>
+--EXPECTF--
+MissingView on line %d: View 'definitely-missing-view' not found in any of the registered view paths
+MissingView on line %d: View 'also-missing' not found in any of the registered view paths

--- a/tests/Type/tests/Views/ViewHelperConcreteTest.phpt
+++ b/tests/Type/tests/Views/ViewHelperConcreteTest.phpt
@@ -1,0 +1,42 @@
+--FILE--
+<?php declare(strict_types=1);
+
+// view() narrows past the stub's contract fallback: zero-arg narrows to the app's
+// actual resolved factory class (the standard \Illuminate\View\Factory here), and
+// argument-supplied calls narrow to the concrete \Illuminate\View\View.
+
+$_factory = view();
+/** @psalm-check-type-exact $_factory = \Illuminate\View\Factory */
+
+$_shared = $_factory->getShared();
+/** @psalm-check-type-exact $_shared = array<array-key, mixed> */
+
+$_view = view('welcome');
+/** @psalm-check-type-exact $_view = \Illuminate\View\View */
+
+$_fragment = view('welcome')->fragment('x');
+/** @psalm-check-type-exact $_fragment = string */
+
+// func_num_args() === 0 is Laravel's own branch condition — a supplied `null` first
+// argument still takes the "argument supplied" branch (view(null) !== view()).
+$_viewFromNull = view(null);
+/** @psalm-check-type-exact $_viewFromNull = \Illuminate\View\View */
+
+$_viewWithData = view('welcome', ['k' => 'v'], []);
+/** @psalm-check-type-exact $_viewWithData = \Illuminate\View\View */
+
+// A trailing spread hides neither the count (provably >= 1) nor the view name,
+// so the argument-supplied narrowing still applies.
+/** @psalm-var list<array<string, mixed>> $trailing */
+$trailing = [];
+$_viewTrailingSpread = view('welcome', ...$trailing);
+/** @psalm-check-type-exact $_viewTrailingSpread = \Illuminate\View\View */
+
+// A leading spread hides the argument count, so neither side of Laravel's
+// func_num_args() === 0 split is decidable — no narrowing, stub fallback only.
+/** @psalm-var list{0?: string} $args */
+$args = [];
+$_viewLeadingSpread = view(...$args);
+/** @psalm-check-type-exact $_viewLeadingSpread = \Illuminate\Contracts\View\View */
+?>
+--EXPECTF--

--- a/tests/Type/tests/Views/ViewHelperConcreteTest.phpt
+++ b/tests/Type/tests/Views/ViewHelperConcreteTest.phpt
@@ -32,11 +32,13 @@ $trailing = [];
 $_viewTrailingSpread = view('welcome', ...$trailing);
 /** @psalm-check-type-exact $_viewTrailingSpread = \Illuminate\View\View */
 
-// A leading spread hides the argument count, so neither side of Laravel's
-// func_num_args() === 0 split is decidable — no narrowing, stub fallback only.
+// A leading spread hides the argument count: an empty spread returns the factory,
+// a non-empty one returns a View. The result is the sound union of both contracts,
+// NOT a bare View — otherwise a concrete-only call would be falsely accepted on
+// what is actually the factory at runtime.
 /** @psalm-var list{0?: string} $args */
 $args = [];
 $_viewLeadingSpread = view(...$args);
-/** @psalm-check-type-exact $_viewLeadingSpread = \Illuminate\Contracts\View\View */
+/** @psalm-check-type-exact $_viewLeadingSpread = \Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View */
 ?>
 --EXPECTF--

--- a/tests/Type/tests/Views/ViewNarrowingBoundariesTest.phpt
+++ b/tests/Type/tests/Views/ViewNarrowingBoundariesTest.phpt
@@ -16,13 +16,45 @@ function _bareContractView(\Illuminate\Contracts\View\View $view): void {
     $view->fragment('x');
 }
 
-// Intent pin for the accepted bounded trade-off (see ProducerReturnTypeHandler
-// docblock): a Factory subclass that inherits make() narrows to the stock View
-// even though a protected viewInstance() override could construct a different
-// implementation — Psalm reports the declaring class for inherited methods.
-final class SubFactory extends \Illuminate\View\Factory {}
+// Accepted bounded trade-off (see ProducerReturnTypeHandler docblock), demonstrated
+// with a REAL override rather than an empty subclass. OverridingFactory replaces the
+// protected viewInstance() with a non-stock View but inherits make(); Psalm reports
+// the declaring Factory for the inherited call, so make() still narrows to the stock
+// \Illuminate\View\View even though the runtime value is a CustomView.
+//
+// For View the observable consequence is a false NEGATIVE only: a stock-only method
+// resolves although CustomView may not implement it. The false-positive direction
+// (a CustomView-only method flagged undefined) does not manifest here because the
+// stock \Illuminate\View\View is Macroable, so its __call resolves any unknown method
+// to mixed. A producer whose stock concrete is not Macroable (e.g. PasswordBroker)
+// would exhibit the false positive too.
+final class CustomView implements \Illuminate\Contracts\View\View {
+    #[\Override]
+    public function name(): string { return 'x'; }
 
-function _factorySubclassPin(SubFactory $factory): void {
+    /**
+     * @param array<array-key, mixed>|string $key
+     * @param mixed $value
+     */
+    #[\Override]
+    public function with($key, $value = null): static { return $this; }
+
+    /** @return array<string, mixed> */
+    #[\Override]
+    public function getData(): array { return []; }
+
+    #[\Override]
+    public function render(?callable $callback = null): string { return ''; }
+
+    public function badge(): string { return 'b'; }
+}
+
+final class OverridingFactory extends \Illuminate\View\Factory {
+    #[\Override]
+    protected function viewInstance($view, $path, $data): CustomView { return new CustomView(); }
+}
+
+function _factorySubclassBoundary(OverridingFactory $factory): void {
     $_view = $factory->make('welcome');
     /** @psalm-check-type-exact $_view = \Illuminate\View\View */
 }

--- a/tests/Type/tests/Views/ViewNarrowingBoundariesTest.phpt
+++ b/tests/Type/tests/Views/ViewNarrowingBoundariesTest.phpt
@@ -57,6 +57,12 @@ final class OverridingFactory extends \Illuminate\View\Factory {
 function _factorySubclassBoundary(OverridingFactory $factory): void {
     $_view = $factory->make('welcome');
     /** @psalm-check-type-exact $_view = \Illuminate\View\View */
+
+    // The false-positive direction is masked here: badge() is a CustomView-only
+    // method, but the narrowed stock View is Macroable, so its __call resolves the
+    // unknown method (to a View) instead of raising UndefinedMethod.
+    $_masked = $_view->badge();
+    /** @psalm-check-type-exact $_masked = \Illuminate\View\View */
 }
 ?>
 --EXPECTF--

--- a/tests/Type/tests/Views/ViewNarrowingBoundariesTest.phpt
+++ b/tests/Type/tests/Views/ViewNarrowingBoundariesTest.phpt
@@ -1,0 +1,32 @@
+--FILE--
+<?php declare(strict_types=1);
+
+// Boundary tests: producer narrowing must never leak onto bare contract-typed values —
+// only the producer class (Factory), its canonical facade (View), and root aliases are
+// registered, never the View/Factory contracts themselves.
+
+function _bareContractFactory(\Illuminate\Contracts\View\Factory $factory): void {
+    $_view = $factory->make('welcome');
+    /** @psalm-check-type-exact $_view = \Illuminate\Contracts\View\View */
+
+    $_view->fragment('x');
+}
+
+function _bareContractView(\Illuminate\Contracts\View\View $view): void {
+    $view->fragment('x');
+}
+
+// Intent pin for the accepted bounded trade-off (see ProducerReturnTypeHandler
+// docblock): a Factory subclass that inherits make() narrows to the stock View
+// even though a protected viewInstance() override could construct a different
+// implementation — Psalm reports the declaring class for inherited methods.
+final class SubFactory extends \Illuminate\View\Factory {}
+
+function _factorySubclassPin(SubFactory $factory): void {
+    $_view = $factory->make('welcome');
+    /** @psalm-check-type-exact $_view = \Illuminate\View\View */
+}
+?>
+--EXPECTF--
+UndefinedInterfaceMethod on line %d: %s
+UndefinedInterfaceMethod on line %d: %s

--- a/tests/Type/tests/Views/ViewProducerConcreteTest.phpt
+++ b/tests/Type/tests/Views/ViewProducerConcreteTest.phpt
@@ -1,0 +1,44 @@
+--FILE--
+<?php declare(strict_types=1);
+
+// View::make()/file()/first() and Factory::make()/file()/first() are narrowed to the
+// concrete \Illuminate\View\View, so concrete-only methods (renderSections, withErrors,
+// getPath, setPath, getFactory, getEngine, fragments) resolve without errors.
+
+$_view = \Illuminate\Support\Facades\View::make('welcome');
+/** @psalm-check-type-exact $_view = \Illuminate\View\View */
+
+$_fragment = \Illuminate\Support\Facades\View::make('welcome')->fragment('x');
+/** @psalm-check-type-exact $_fragment = string */
+
+function _diFactory(\Illuminate\View\Factory $factory): void {
+    $_make = $factory->make('welcome');
+    /** @psalm-check-type-exact $_make = \Illuminate\View\View */
+
+    $_file = $factory->file(__FILE__);
+    /** @psalm-check-type-exact $_file = \Illuminate\View\View */
+
+    $_first = $factory->first(['welcome', 'also-missing']);
+    /** @psalm-check-type-exact $_first = \Illuminate\View\View */
+}
+
+function _concreteOnlyMethods(\Illuminate\View\Factory $factory): void {
+    $_sections = $factory->make('welcome')->renderSections();
+    /** @psalm-check-type-exact $_sections = array */
+
+    $_path = $factory->make('welcome')->getPath();
+    /** @psalm-check-type-exact $_path = string */
+
+    $factory->make('welcome')->withErrors([]);
+    $factory->make('welcome')->setPath('/tmp/other.blade.php');
+
+    $_factory = $factory->make('welcome')->getFactory();
+    /** @psalm-check-type-exact $_factory = \Illuminate\View\Factory */
+
+    $_engine = $factory->make('welcome')->getEngine();
+    /** @psalm-check-type-exact $_engine = \Illuminate\Contracts\View\Engine */
+
+    $factory->make('welcome')->fragments();
+}
+?>
+--EXPECTF--

--- a/tests/Unit/Handlers/Views/MissingViewHandlerTest.php
+++ b/tests/Unit/Handlers/Views/MissingViewHandlerTest.php
@@ -58,6 +58,11 @@ final class MissingViewHandlerTest extends TestCase
     protected function setUp(): void
     {
         MissingViewHandler::init([self::$fixtureDir], ['blade.php', 'php', 'css', 'html']);
+
+        // Reset the view() helper narrowing state so each test starts from "no
+        // factory class resolved" — narrowing tests below opt in explicitly via
+        // MissingViewHandler::initViewFactory().
+        (new \ReflectionProperty(MissingViewHandler::class, 'factoryClass'))->setValue(null, null);
     }
 
     #[Test]
@@ -193,6 +198,54 @@ final class MissingViewHandlerTest extends TestCase
         $this->assertNotInstanceOf(Union::class, MissingViewHandler::getFunctionReturnType($event));
     }
 
+    // --- view() helper concrete narrowing (narrowedHelperReturn) ---
+    //
+    // A phpt type test cannot cover the nonstandard-binding fallback (the plugin
+    // boots one shared Testbench app whose 'view' binding is always the standard
+    // Factory) so the branch decision is unit-tested directly here instead.
+
+    #[Test]
+    public function narrows_zero_arg_to_the_resolved_factory_class(): void
+    {
+        MissingViewHandler::initViewFactory(\Illuminate\View\Factory::class);
+
+        $this->assertSame(\Illuminate\View\Factory::class, $this->invokeNarrowedHelperReturn(0));
+    }
+
+    #[Test]
+    public function narrows_zero_arg_to_null_when_no_factory_class_resolved(): void
+    {
+        $this->assertNull($this->invokeNarrowedHelperReturn(0));
+    }
+
+    #[Test]
+    public function narrows_argument_supplied_to_view_for_the_stock_factory(): void
+    {
+        MissingViewHandler::initViewFactory(\Illuminate\View\Factory::class);
+
+        $this->assertSame(\Illuminate\View\View::class, $this->invokeNarrowedHelperReturn(1));
+    }
+
+    #[Test]
+    public function narrows_argument_supplied_to_null_for_a_factory_subclass(): void
+    {
+        // A subclass may override viewInstance() to construct a different View
+        // implementation, so the arg-supplied branch must not narrow.
+        MissingViewHandler::initViewFactory(CustomViewFactoryStub::class);
+
+        $this->assertNull($this->invokeNarrowedHelperReturn(1));
+    }
+
+    private function invokeNarrowedHelperReturn(int $argCount): ?string
+    {
+        $method = new \ReflectionMethod(MissingViewHandler::class, 'narrowedHelperReturn');
+
+        /** @var string|null $result */
+        $result = $method->invoke(null, $argCount);
+
+        return $result;
+    }
+
     // --- View::make() (MethodReturnTypeProvider) tests ---
 
     #[Test]
@@ -321,3 +374,10 @@ final class MissingViewHandlerTest extends TestCase
         );
     }
 }
+
+/**
+ * Stand-in for an app-provided \Illuminate\View\Factory subclass — never
+ * instantiated, only referenced by class-string, so its constructor
+ * requirements don't matter here.
+ */
+final class CustomViewFactoryStub extends \Illuminate\View\Factory {}

--- a/tests/Unit/Handlers/Views/MissingViewHandlerTest.php
+++ b/tests/Unit/Handlers/Views/MissingViewHandlerTest.php
@@ -246,6 +246,20 @@ final class MissingViewHandlerTest extends TestCase
         return $result;
     }
 
+    #[Test]
+    public function registers_the_canonical_view_facade_even_without_alias_resolution(): void
+    {
+        // FacadeMapProvider is not initialized here, so getFacadeClasses() returns [].
+        // This mirrors an app that trims its alias registry: the canonical facade must
+        // still be registered (hardcoded), or ProducerReturnTypeHandler would answer the
+        // return type first and the missing-view diagnostic would never fire on
+        // \Illuminate\Support\Facades\View::make().
+        $this->assertContains(
+            \Illuminate\Support\Facades\View::class,
+            MissingViewHandler::getClassLikeNames(),
+        );
+    }
+
     // --- View::make() (MethodReturnTypeProvider) tests ---
 
     #[Test]


### PR DESCRIPTION
## Issue to Solve

`UndefinedInterfaceMethod` false positives where a known Laravel producer declares a **contract** return, but its framework implementation always constructs one stable **concrete**. Calling a concrete-only method on the result was flagged even though it is correct at runtime:

```php
Password::broker()->createToken($user);   // createToken() is on the concrete, not the contract
view('welcome')->fragment('x');           // fragment() is on Illuminate\View\View
DB::table('users')->paginate()->linkCollection();
trans()->has('some.key');
```

This continues the pattern established for `Cache::driver()->flexible()` in #1230 / #1233 (merged as `CacheManagerReturnTypeHandler`).

## Related

Conceptual follow-on to #1230 / #1233 (no dedicated tracking issue).

## Solution Description

Narrow **by provenance, never by conformance**. A value is narrowed only when it originates from a known producer expression; a bare contract-typed value keeps the contract-only surface.

| Producer | Declared contract | Concrete result | Source evidence (Laravel 12.x + 13.x) |
|---|---|---|---|
| `PasswordBrokerManager::broker()` + `Password` facade / root alias | `Contracts\Auth\PasswordBroker` | `Auth\Passwords\PasswordBroker` | `PasswordBrokerManager::resolve()` hard-constructs `new PasswordBroker(...)`; no broker-driver extension API |
| `View\Factory::make()` / `file()` / `first()` + `View` facade / alias | `Contracts\View\View` | `View\View` | `Factory::viewInstance()` hard-constructs `new View(...)` |
| `view()` (0 args) | `Contracts\View\Factory` | app's resolved factory class | helper branches on `func_num_args() === 0` |
| `view('name')` (≥1 arg) | `Contracts\View\View` | `View\View` (only for the stock `Illuminate\View\Factory`) | same helper |
| `Query\Builder::paginate()` | `Pagination\LengthAwarePaginator` (ungenerified) | `LengthAwarePaginator<int, stdClass>` | `paginate()` builds the concrete via `paginator()`; Query rows hydrate as `stdClass` |
| `Query\Builder::simplePaginate()` | `Contracts\Pagination\Paginator` | `Paginator<int, stdClass>` | same |
| `Query\Builder::cursorPaginate()` | `Contracts\Pagination\CursorPaginator` | `CursorPaginator<int, stdClass>` | same |
| `trans()` (0 args) | `Contracts\Translation\Translator` | app's resolved translator class | helper returns `app('translator')` on `is_null($key)` |

**Mechanism.** `ProducerReturnTypeHandler` (new) holds the reviewed producer→concrete registry for the Password and View families. It discriminates a real producer-method call from a facade `@method static` pseudo-call via `methodExists` (a handler is required because facade pseudo-tags shadow any stub-added method), gates the pseudo path on the canonical facade's `pseudo_static_methods` so Psalm 7 cannot fatal with "Cannot get method params", and drops narrowing if the declared return no longer names the expected contract (drift guard). `view()` / `trans()` narrow through their existing handlers by argument count. Query Builder pagination is stub-typed.

**Soundness boundaries**

- Providers register only producer classes, canonical facades, and root aliases — never a contract FQCN; no `ClassLikeStorage` mutation. Bare contract-typed parameters, properties, mocks, and custom implementations keep the contract-only surface (negative tests prove `UndefinedInterfaceMethod` still fires for all four contracts).
- Container-dependent helpers narrow only to the binding resolved at plugin boot; a non-standard / unscanned binding falls back to the contract.
- Disclosed bounded trade-off: producer internals like `Factory::viewInstance()` are `protected`, so a subclass overriding the construction but inheriting `make()` still narrows to the stock concrete. Worst case flips a contract-level false positive into a false negative, never a new false positive (same accepted trade-off as the Cache manager).
- Deliberately excluded: driver-variant surfaces (Auth guards, Hash, Queue, Broadcast, Redis, Filesystem), arbitrary container contracts, and any bridge-every-contract behavior.

**Verification**

- `composer test:type` — 574 pass (11 new PHPTs: positive narrowing + negative soundness per family, `MissingView`/`MissingTranslation`-still-fire ordering regressions, leading-vs-trailing-spread, `view(null)` / `trans(null)` argument-count boundary).
- `composer test:unit` — 887 pass (4 new: `view()` argument-count branch decision incl. non-standard factory subclass fallback).
- `composer test:app`, `composer psalm` (100% type coverage), `composer cs`, `composer rector` — all clean.
- Four review rounds; the one correctness item (a throwing `view` binding must degrade this feature, not disable the plugin, and its warning must not misdescribe the cause) is fixed.

## Checklist
- [x] Tests cover the change (type tests in `tests/Type/` and unit tests in `tests/Unit/`)
- [x] Documentation is updated (`docs/contributing/decisions.md` — Producer Return Narrowing policy)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786440514&installation_id=141955579&pr_number=1240&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1240&signature=feb85561d59e4d39acc1b7a042a983d220b761931a18ff2bcfae8efc86f412ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->