### PR TITLE
Fix `whereDate` two-argument overload

### DIFF
--- a/stubs/common/Database/Eloquent/Builder.phpstub
+++ b/stubs/common/Database/Eloquent/Builder.phpstub
@@ -105,7 +105,7 @@ class Builder implements BuilderContract
 
     /**
      * @param  string  $column
-     * @param  string  $operator
+     * @param  \DateTimeInterface|string|null  $operator
      * @param  \DateTimeInterface|string|null  $value
      * @param  string  $boolean
      * @return $this

--- a/tests/Type/tests/Builder/WhereDateOverloadsTest.phpt
+++ b/tests/Type/tests/Builder/WhereDateOverloadsTest.phpt
@@ -1,0 +1,28 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use Carbon\CarbonImmutable;
+use DateTimeImmutable;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Regression test for #1246. Laravel treats the second argument as the value
+ * when whereDate() is called with two arguments, and as the operator when the
+ * third argument is present.
+ */
+function where_date_accepts_two_argument_datetime_value(): void
+{
+    $_query = Customer::query()->whereDate('created_at', CarbonImmutable::now());
+    /** @psalm-check-type-exact $_query = Builder<Customer>&static */
+
+    Customer::query()->whereDate('created_at', new DateTimeImmutable());
+}
+
+function where_date_accepts_three_argument_operator_and_datetime_value(): void
+{
+    $_query = Customer::query()->whereDate('created_at', '>=', CarbonImmutable::now());
+    /** @psalm-check-type-exact $_query = Builder<Customer>&static */
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Summary

- widen `Eloquent\Builder::whereDate()`'s second parameter to accept date values in Laravel's two-argument form
- add type-test coverage for Carbon, native `DateTimeImmutable`, and the three-argument operator form

## Root cause

Laravel moves the second argument into the value position when `whereDate()` receives two arguments. The plugin stub typed that position as `string`, so Psalm rejected the common `whereDate($column, $date)` form when `$date` implements `DateTimeInterface`.

## Impact

Calls such as `Post::query()->whereDate('created_at', CarbonImmutable::now())` now type-check while preserving the existing date-value contract.

Fixes #1246.

## Validation

- `vendor/bin/phpunit --testsuite=type --filter WhereDateOverloadsTest`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786453567&installation_id=141955579&pr_number=1247&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1247&signature=1bad35c44e67e49edc0a63deac938b704a14a03b1180c637b4840a0bfdf9338e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->