### PR TITLE
Reset stateful handlers between plugin invocations

### DIFF
--- a/docs/contributing/decisions.md
+++ b/docs/contributing/decisions.md
@@ -28,6 +28,12 @@ Decisions made during development of the plugin. Contributors should follow thes
 
 **Why:** Runtime reflection requires booting a real Laravel app, which adds startup cost, can fail in misconfigured projects, and couples the plugin to the user's environment. Static inference is faster, more predictable, and works in CI without a running app. But some Laravel conventions (dynamic table names, programmatic casts, container bindings) are only knowable at runtime.
 
+## Plugin invocation state
+
+**Decision:** Mutable static state derived from the Laravel application, plugin XML, aliases, filesystem, Psalm Codebase, or files under analysis must have an explicit idempotent `reset()` and be reset by `Plugin::resetInvocationState()` before boot or any optional initialization branch.
+
+**Why:** Psalm can reuse a PHP process (notably in the language server). An `init()` call is not a substitute: an optional feature may be disabled or a service may be absent on the next invocation, leaving a previous application's state live. App-independent immutable values may survive only when the owning class documents why their meaning cannot vary between applications or Codebases. Event-handler scratch state may instead use a reliable file/function lifecycle hook, with that lifecycle documented beside the cache.
+
 ## Eloquent Model
 
 ### `@property` PHPDoc takes priority over plugin inference

--- a/src/Bootstrap/ApplicationProvider.php
+++ b/src/Bootstrap/ApplicationProvider.php
@@ -80,7 +80,7 @@ final class ApplicationProvider
         /** @psalm-suppress ImpureMethodCall framework global reset */
         \Illuminate\Foundation\AliasLoader::getInstance()->setAliases([]);
         /** @psalm-suppress ImpureMethodCall framework global reset */
-        \Illuminate\Container\Container::setInstance(null);
+        \Illuminate\Container\Container::setInstance();
     }
 
     /**

--- a/src/Bootstrap/ApplicationProvider.php
+++ b/src/Bootstrap/ApplicationProvider.php
@@ -56,6 +56,30 @@ final class ApplicationProvider
     }
 
     /**
+     * Forget the Laravel application and framework globals from a previous plugin
+     * invocation. This must run before the next boot: a failed or optional init
+     * path must not keep resolving services or aliases from the old application.
+     *
+     * @psalm-external-mutation-free
+     */
+    public static function reset(): void
+    {
+        self::$app = null;
+        self::$bootMode = null;
+        self::$bootPath = null;
+        self::$bootstrapError = null;
+        self::$booted = false;
+
+        /** @psalm-suppress ImpureMethodCall framework global reset */
+        \Illuminate\Support\Facades\Facade::clearResolvedInstances();
+        /** @psalm-suppress ImpureMethodCall framework global reset */
+        \Illuminate\Support\Facades\Facade::setFacadeApplication(null);
+        /** @psalm-suppress ImpureMethodCall framework global reset */
+        /** @psalm-suppress NullArgument Laravel permits clearing the singleton with null */
+        \Illuminate\Foundation\AliasLoader::setInstance(null);
+    }
+
+    /**
      * Throwable raised during eager Laravel bootstrap (LoadConfiguration etc.).
      * Null when no bootstrap was attempted yet, or when bootstrap succeeded.
      *

--- a/src/Bootstrap/ApplicationProvider.php
+++ b/src/Bootstrap/ApplicationProvider.php
@@ -74,9 +74,13 @@ final class ApplicationProvider
         \Illuminate\Support\Facades\Facade::clearResolvedInstances();
         /** @psalm-suppress ImpureMethodCall framework global reset */
         \Illuminate\Support\Facades\Facade::setFacadeApplication(null);
+        // Keep the one registered loader and clear its aliases. Replacing the
+        // singleton leaves its bound load() closure on PHP's autoload stack, so a
+        // name that belonged only to the previous application could still resolve.
         /** @psalm-suppress ImpureMethodCall framework global reset */
-        /** @psalm-suppress NullArgument Laravel permits clearing the singleton with null */
-        \Illuminate\Foundation\AliasLoader::setInstance(null);
+        \Illuminate\Foundation\AliasLoader::getInstance()->setAliases([]);
+        /** @psalm-suppress ImpureMethodCall framework global reset */
+        \Illuminate\Container\Container::setInstance(null);
     }
 
     /**

--- a/src/Handlers/Application/ContainerResolver.php
+++ b/src/Handlers/Application/ContainerResolver.php
@@ -21,6 +21,12 @@ final class ContainerResolver
      */
     private static array $cache = [];
 
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$cache = [];
+    }
+
     /**
      * @psalm-return class-string|string|null
      */

--- a/src/Handlers/Auth/AuthConfigAnalyzer.php
+++ b/src/Handlers/Auth/AuthConfigAnalyzer.php
@@ -11,6 +11,12 @@ final class AuthConfigAnalyzer
 {
     private static ?AuthConfigAnalyzer $instance = null;
 
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$instance = null;
+    }
+
     /**
      * Memoizes `getGuardFQCN()` so the per-call-site Psalm hook avoids
      * re-walking `auth.guards.<name>.driver` through `Repository::get()`.

--- a/src/Handlers/Auth/GuardClassResolver.php
+++ b/src/Handlers/Auth/GuardClassResolver.php
@@ -36,6 +36,12 @@ final class GuardClassResolver
      */
     private static array $union_cache = [];
 
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$union_cache = [];
+    }
+
     public static function resolve(string $guardName): ?Type\Union
     {
         $fqcn = AuthConfigAnalyzer::instance()->getGuardFQCN($guardName);

--- a/src/Handlers/Config/ConfigKeyResolver.php
+++ b/src/Handlers/Config/ConfigKeyResolver.php
@@ -72,8 +72,8 @@ final class ConfigKeyResolver
     }
 
     /**
-     * Test-only. The booted Repository is immutable for the Psalm process
-     * lifetime, so production never invalidates.
+     * The repository is owned by the current booted application, so every plugin
+     * invocation drops the singleton before booting the next application.
      *
      * @psalm-api
      * @psalm-external-mutation-free

--- a/src/Handlers/Console/CommandDefinitionAnalyzer.php
+++ b/src/Handlers/Console/CommandDefinitionAnalyzer.php
@@ -27,6 +27,12 @@ final class CommandDefinitionAnalyzer
     /** @var array<string, InputDefinition|null> */
     private static array $cache = [];
 
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$cache = [];
+    }
+
     /**
      * Get the InputDefinition for a command class by reading its $signature from the AST.
      *

--- a/src/Handlers/Eloquent/CustomBuilderMethodHandler.php
+++ b/src/Handlers/Eloquent/CustomBuilderMethodHandler.php
@@ -58,6 +58,13 @@ final class CustomBuilderMethodHandler
      */
     private static array $traitBuilderMethods = [];
 
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$builderToModelMap = [];
+        self::$traitBuilderMethods = [];
+    }
+
     /**
      * Register the builder-to-model reverse mapping.
      *

--- a/src/Handlers/Eloquent/CustomCollectionHandler.php
+++ b/src/Handlers/Eloquent/CustomCollectionHandler.php
@@ -58,6 +58,12 @@ final class CustomCollectionHandler implements MethodReturnTypeProviderInterface
      */
     private static array $modelToCollectionMap = [];
 
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$modelToCollectionMap = [];
+    }
+
     /**
      * Builder methods that return `Eloquent\Collection<int, TModel>` and should
      * be narrowed to the custom collection type.

--- a/src/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php
+++ b/src/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php
@@ -136,9 +136,7 @@ final class ModelMetadataRegistryBuilder
     }
 
     /**
-     * Clear all cached metadata and the captured Progress handle.
-     *
-     * @internal for tests under `tests/Unit/`
+     * Clear all state derived from the current Laravel app and Psalm Codebase.
      * @psalm-external-mutation-free
      */
     public static function reset(): void

--- a/src/Handlers/Eloquent/ModelAggregatePropertyHandler.php
+++ b/src/Handlers/Eloquent/ModelAggregatePropertyHandler.php
@@ -91,7 +91,6 @@ final class ModelAggregatePropertyHandler
         self::$pseudoPropertyCache = [];
         self::$suffixCache = [];
         self::$relationMethodCache = [];
-        self::$typeCache = [];
     }
 
     public static function doesPropertyExist(PropertyExistenceProviderEvent $event): ?bool

--- a/src/Handlers/Eloquent/ModelAggregatePropertyHandler.php
+++ b/src/Handlers/Eloquent/ModelAggregatePropertyHandler.php
@@ -85,6 +85,15 @@ final class ModelAggregatePropertyHandler
      */
     private static array $typeCache = [];
 
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$pseudoPropertyCache = [];
+        self::$suffixCache = [];
+        self::$relationMethodCache = [];
+        self::$typeCache = [];
+    }
+
     public static function doesPropertyExist(PropertyExistenceProviderEvent $event): ?bool
     {
         if (!$event->isReadMode()) {

--- a/src/Handlers/Eloquent/ModelFactoryMethodTypeProvider.php
+++ b/src/Handlers/Eloquent/ModelFactoryMethodTypeProvider.php
@@ -58,6 +58,12 @@ final class ModelFactoryMethodTypeProvider implements MethodReturnTypeProviderIn
      */
     private static array $factoryUnionCache = [];
 
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$factoryUnionCache = [];
+    }
+
     /**
      * @return list<string>
      * @psalm-pure

--- a/src/Handlers/Eloquent/ModelPropertyAccessorHandler.php
+++ b/src/Handlers/Eloquent/ModelPropertyAccessorHandler.php
@@ -36,6 +36,12 @@ final class ModelPropertyAccessorHandler
     /** @var array<string, bool> Cache for hasNativeProperty() keyed by "class::property". */
     private static array $nativePropertyCache = [];
 
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$nativePropertyCache = [];
+    }
+
     public static function doesPropertyExist(PropertyExistenceProviderEvent $event): ?bool
     {
         $source = $event->getSource();

--- a/src/Handlers/Eloquent/ModelPropertyHandler.php
+++ b/src/Handlers/Eloquent/ModelPropertyHandler.php
@@ -287,6 +287,13 @@ final class ModelPropertyHandler
     /** @var array<string, bool> Cache for hasNativeProperty() keyed by "class::property" */
     private static array $nativePropertyCache = [];
 
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$tableNameCache = [];
+        self::$nativePropertyCache = [];
+    }
+
     /**
      * Uses property_exists() instead of Reflection — cheaper and avoids exception overhead
      * on the non-existence path. Cached because this fires up to 3× per property access

--- a/src/Handlers/Eloquent/ModelRegistrationHandler.php
+++ b/src/Handlers/Eloquent/ModelRegistrationHandler.php
@@ -54,6 +54,12 @@ final class ModelRegistrationHandler implements AfterCodebasePopulatedInterface
     private static bool $useMigrations = false;
 
     /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$useMigrations = false;
+    }
+
+    /** @psalm-external-mutation-free */
     public static function enableMigrations(): void
     {
         self::$useMigrations = true;

--- a/src/Handlers/Eloquent/ModelRelationReturnTypeHandler.php
+++ b/src/Handlers/Eloquent/ModelRelationReturnTypeHandler.php
@@ -105,6 +105,12 @@ final class ModelRelationReturnTypeHandler
      */
     private static array $unionCache = [];
 
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$unionCache = [];
+    }
+
     /**
      * Closure target registered per-class by {@see ModelRegistrationHandler}.
      *

--- a/src/Handlers/Eloquent/ModelRelationshipPropertyHandler.php
+++ b/src/Handlers/Eloquent/ModelRelationshipPropertyHandler.php
@@ -40,6 +40,15 @@ final class ModelRelationshipPropertyHandler
     /** @var array<string, bool> Cache for hasUserPseudoProperty() keyed by "class::$property" */
     private static array $pseudoPropertyCache = [];
 
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$relationExistsCache = [];
+        self::$methodReturnTypeCache = [];
+        self::$propertyTypeCache = [];
+        self::$pseudoPropertyCache = [];
+    }
+
     /**
      * Relation classes that return a collection of models when accessed as a property.
      * All other Relation subclasses return a single nullable model (?TRelatedModel).

--- a/src/Handlers/Eloquent/RelationMethodParser.php
+++ b/src/Handlers/Eloquent/RelationMethodParser.php
@@ -64,6 +64,12 @@ final class RelationMethodParser
      */
     private static array $cache = [];
 
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$cache = [];
+    }
+
     /** @var list<string> Types that should not be resolved as class names in generic params */
     private const NON_CLASS_TYPES = [
         'static',

--- a/src/Handlers/Eloquent/Schema/SchemaStateProvider.php
+++ b/src/Handlers/Eloquent/Schema/SchemaStateProvider.php
@@ -19,6 +19,12 @@ final class SchemaStateProvider
     private static ?SchemaAggregator $schema = null;
 
     /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$schema = null;
+    }
+
+    /** @psalm-external-mutation-free */
     public static function setSchema(SchemaAggregator $schema): void
     {
         self::$schema = $schema;

--- a/src/Handlers/Eloquent/Support/RelationResolver.php
+++ b/src/Handlers/Eloquent/Support/RelationResolver.php
@@ -45,6 +45,13 @@ final class RelationResolver
     /** @var array<string, ?string> Cache for relatedModel() keyed by "class::lowername" */
     private static array $relatedModelCache = [];
 
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$methodExistsCache = [];
+        self::$relatedModelCache = [];
+    }
+
     /**
      * Whether a method with this name exists on the model — either a real
      * method (including inherited / trait methods) or a `@method` pseudo-method.

--- a/src/Handlers/Facades/AppFacadeRegistrationHandler.php
+++ b/src/Handlers/Facades/AppFacadeRegistrationHandler.php
@@ -55,6 +55,12 @@ final class AppFacadeRegistrationHandler implements AfterClassLikeVisitInterface
      */
     private static array $failedFacades = [];
 
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$failedFacades = [];
+    }
+
     /**
      * Probe `Facade::getFacadeRoot()` at scan time and queue the resolved root class for
      * scanning. We can't do this in {@see self::afterCodebasePopulated()} because by then

--- a/src/Handlers/Facades/DateFacadeHandler.php
+++ b/src/Handlers/Facades/DateFacadeHandler.php
@@ -60,6 +60,13 @@ final class DateFacadeHandler implements MethodReturnTypeProviderInterface, Meth
     /** @var array<string, ?Union> retyped return type per method, cached for the run */
     private static array $returnCache = [];
 
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$configuredClass = null;
+        self::$returnCache = [];
+    }
+
     /**
      * @inheritDoc
      * @return list<string>

--- a/src/Handlers/Facades/FacadeMethodHandler.php
+++ b/src/Handlers/Facades/FacadeMethodHandler.php
@@ -50,6 +50,13 @@ final class FacadeMethodHandler
      */
     private static array $pseudoMethodCache = [];
 
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$methodCache = [];
+        self::$pseudoMethodCache = [];
+    }
+
     /** @param class-string $rootClass */
     public static function doesMethodExist(MethodExistenceProviderEvent $event, string $rootClass): ?bool
     {

--- a/src/Handlers/Filesystem/StorageHandler.php
+++ b/src/Handlers/Filesystem/StorageHandler.php
@@ -102,6 +102,13 @@ final class StorageHandler implements MethodReturnTypeProviderInterface, MethodP
      */
     private static ?array $facade_disk_params = null;
 
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$adapter_return_type = null;
+        self::$facade_disk_params = null;
+    }
+
     /**
      * Register for every surface that exposes `disk()` / `drive()`:
      * - the `Storage` facade (calls go through `__callStatic` → forwarded by Laravel's `@method`),

--- a/src/Handlers/Helpers/NowTodayHandler.php
+++ b/src/Handlers/Helpers/NowTodayHandler.php
@@ -29,6 +29,12 @@ final class NowTodayHandler implements FunctionReturnTypeProviderInterface
      */
     private static array $resolvedClasses = [];
 
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$resolvedClasses = [];
+    }
+
     /**
      * @inheritDoc
      * @psalm-pure

--- a/src/Handlers/Jobs/DispatchableHandler.php
+++ b/src/Handlers/Jobs/DispatchableHandler.php
@@ -61,6 +61,12 @@ final class DispatchableHandler implements AfterExpressionAnalysisInterface
      */
     private static array $dispatchableCache = [];
 
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$dispatchableCache = [];
+    }
+
     /** @inheritDoc */
     #[\Override]
     public static function afterExpressionAnalysis(AfterExpressionAnalysisEvent $event): ?bool

--- a/src/Handlers/Rules/NoEnvOutsideConfigHandler.php
+++ b/src/Handlers/Rules/NoEnvOutsideConfigHandler.php
@@ -36,6 +36,12 @@ final class NoEnvOutsideConfigHandler implements FunctionReturnTypeProviderInter
      */
     private static array $configDirectories = [];
 
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$configDirectories = [];
+    }
+
     /**
      * Resolve user-provided config directory paths into absolute, glob-expanded paths.
      *

--- a/src/Handlers/Translations/TranslationKeyHandler.php
+++ b/src/Handlers/Translations/TranslationKeyHandler.php
@@ -70,6 +70,20 @@ final class TranslationKeyHandler implements FunctionReturnTypeProviderInterface
     /** @var array<class-string, Union> cache of the zero-arg trans() concrete union, keyed by resolved translator class (Psalm 7 unions are immutable) */
     private static array $zeroArgTransUnions = [];
 
+    /**
+     * Forget the current app's translator and translation lookup results. The
+     * zero-argument unions are keyed solely by concrete class and immutable, so
+     * they can safely remain cached between invocations.
+     *
+     * @psalm-external-mutation-free
+     */
+    public static function reset(): void
+    {
+        self::$translator = null;
+        self::$reportMissing = false;
+        self::$resolvedKeys = [];
+    }
+
     /** @psalm-external-mutation-free */
     public static function init(Translator $translator, bool $reportMissing): void
     {

--- a/src/Handlers/Validation/FormRequestPropertyHandler.php
+++ b/src/Handlers/Validation/FormRequestPropertyHandler.php
@@ -50,6 +50,13 @@ final class FormRequestPropertyHandler implements AfterCodebasePopulatedInterfac
      */
     private static array $cache = [];
 
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$formRequestClasses = [];
+        self::$cache = [];
+    }
+
     /**
      * @inheritDoc
      *

--- a/src/Handlers/Validation/ValidationRuleAnalyzer.php
+++ b/src/Handlers/Validation/ValidationRuleAnalyzer.php
@@ -123,6 +123,13 @@ final class ValidationRuleAnalyzer
      */
     private static array $classTaintCache = [];
 
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$cache = [];
+        self::$classTaintCache = [];
+    }
+
     /**
      * Get resolved rules for a FormRequest subclass by reading its rules() method from AST.
      *

--- a/src/Handlers/Views/MissingViewHandler.php
+++ b/src/Handlers/Views/MissingViewHandler.php
@@ -70,6 +70,22 @@ final class MissingViewHandler implements FunctionReturnTypeProviderInterface, M
     private static ?Union $spreadUnion = null;
 
     /**
+     * Return to the disabled state before each application boot. The narrowed and
+     * spread unions are immutable and independent of the application, so they are
+     * deliberately retained.
+     *
+     * @psalm-external-mutation-free
+     */
+    public static function reset(): void
+    {
+        self::$viewPaths = [];
+        self::$extensions = ['blade.php', 'php'];
+        self::$enabled = false;
+        self::$resolvedViews = [];
+        self::$factoryClass = null;
+    }
+
+    /**
      * @param list<string> $viewPaths Absolute paths to view directories (from config('view.paths'))
      * @param list<string> $extensions File extensions without leading dot (from FileViewFinder::getExtensions())
      * @psalm-external-mutation-free

--- a/src/Internal/ProxyMethodReturnTypeProvider.php
+++ b/src/Internal/ProxyMethodReturnTypeProvider.php
@@ -22,6 +22,12 @@ final class ProxyMethodReturnTypeProvider
      */
     private static array $cache = [];
 
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$cache = [];
+    }
+
     /**
      * Psalm struggles with saying "this method returns whatever class X with the same method returns. This performs
      * a fake method call to get the analyzed proxy method return type

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -126,6 +126,7 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Eloquent/ModelRegistrationHandler.php';
         require_once __DIR__ . '/Handlers/Eloquent/RelationMethodParser.php';
         require_once __DIR__ . '/Handlers/Eloquent/Schema/SchemaStateProvider.php';
+        require_once __DIR__ . '/Handlers/Eloquent/Support/RelationResolver.php';
         require_once __DIR__ . '/Handlers/Facades/AppFacadeRegistrationHandler.php';
         require_once __DIR__ . '/Handlers/Facades/DateFacadeHandler.php';
         require_once __DIR__ . '/Handlers/Facades/FacadeMethodHandler.php';
@@ -171,6 +172,7 @@ final class Plugin implements PluginEntryPointInterface
         Handlers\Eloquent\ModelRelationshipPropertyHandler::reset();
         Handlers\Eloquent\ModelRegistrationHandler::reset();
         Handlers\Eloquent\RelationMethodParser::reset();
+        Handlers\Eloquent\Support\RelationResolver::reset();
         SchemaStateProvider::reset();
         Handlers\Facades\AppFacadeRegistrationHandler::reset();
         Handlers\Facades\DateFacadeHandler::reset();

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -37,6 +37,7 @@ final class Plugin implements PluginEntryPointInterface
         ExperimentalIssuePolicy::apply($pluginConfig->experimental);
         $output = $this->getProgress($registration);
         $this->loadInitializationHandlers();
+        $this->resetInvocationState();
 
         try {
             ApplicationProvider::bootApp();
@@ -108,6 +109,83 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Rules/NoEnvOutsideConfigHandler.php';
         require_once __DIR__ . '/Handlers/Translations/TranslationKeyHandler.php';
         require_once __DIR__ . '/Handlers/Views/MissingViewHandler.php';
+        require_once __DIR__ . '/Handlers/Application/ContainerResolver.php';
+        require_once __DIR__ . '/Handlers/Auth/AuthConfigAnalyzer.php';
+        require_once __DIR__ . '/Handlers/Auth/GuardClassResolver.php';
+        require_once __DIR__ . '/Handlers/Console/CommandDefinitionAnalyzer.php';
+        require_once __DIR__ . '/Handlers/Eloquent/Metadata/ModelMetadataRegistry.php';
+        require_once __DIR__ . '/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php';
+        require_once __DIR__ . '/Handlers/Eloquent/CustomBuilderMethodHandler.php';
+        require_once __DIR__ . '/Handlers/Eloquent/CustomCollectionHandler.php';
+        require_once __DIR__ . '/Handlers/Eloquent/ModelAggregatePropertyHandler.php';
+        require_once __DIR__ . '/Handlers/Eloquent/ModelFactoryMethodTypeProvider.php';
+        require_once __DIR__ . '/Handlers/Eloquent/ModelPropertyAccessorHandler.php';
+        require_once __DIR__ . '/Handlers/Eloquent/ModelPropertyHandler.php';
+        require_once __DIR__ . '/Handlers/Eloquent/ModelRelationReturnTypeHandler.php';
+        require_once __DIR__ . '/Handlers/Eloquent/ModelRelationshipPropertyHandler.php';
+        require_once __DIR__ . '/Handlers/Eloquent/ModelRegistrationHandler.php';
+        require_once __DIR__ . '/Handlers/Eloquent/RelationMethodParser.php';
+        require_once __DIR__ . '/Handlers/Eloquent/Schema/SchemaStateProvider.php';
+        require_once __DIR__ . '/Handlers/Facades/AppFacadeRegistrationHandler.php';
+        require_once __DIR__ . '/Handlers/Facades/DateFacadeHandler.php';
+        require_once __DIR__ . '/Handlers/Facades/FacadeMethodHandler.php';
+        require_once __DIR__ . '/Handlers/Helpers/NowTodayHandler.php';
+        require_once __DIR__ . '/Handlers/Jobs/DispatchableHandler.php';
+        require_once __DIR__ . '/Handlers/Magic/MacroRegistry.php';
+        require_once __DIR__ . '/Handlers/Producers/ProducerReturnTypeHandler.php';
+        require_once __DIR__ . '/Handlers/Config/ConfigKeyResolver.php';
+        require_once __DIR__ . '/Handlers/Filesystem/StorageHandler.php';
+        require_once __DIR__ . '/Handlers/Validation/FormRequestPropertyHandler.php';
+        require_once __DIR__ . '/Handlers/Validation/ValidationRuleAnalyzer.php';
+        require_once __DIR__ . '/Internal/ProxyMethodReturnTypeProvider.php';
+        require_once __DIR__ . '/Stubs/FacadeMapProvider.php';
+    }
+
+    /**
+     * Reset all plugin-owned state whose meaning depends on the previous Laravel
+     * application, XML configuration, filesystem, aliases, or Psalm Codebase.
+     *
+     * This deliberately precedes boot and every optional initialization branch:
+     * `init()` may be skipped, so it cannot be responsible for overwriting a
+     * previous invocation's state.
+     *
+     * @psalm-external-mutation-free
+     */
+    private function resetInvocationState(): void
+    {
+        ApplicationProvider::reset();
+        FacadeMapProvider::reset();
+        Handlers\Application\ContainerResolver::reset();
+        Handlers\Auth\AuthConfigAnalyzer::reset();
+        Handlers\Auth\GuardClassResolver::reset();
+        Handlers\Config\ConfigKeyResolver::reset();
+        Handlers\Console\CommandDefinitionAnalyzer::reset();
+        Handlers\Eloquent\CustomBuilderMethodHandler::reset();
+        Handlers\Eloquent\CustomCollectionHandler::reset();
+        Handlers\Eloquent\Metadata\ModelMetadataRegistryBuilder::reset();
+        Handlers\Eloquent\ModelAggregatePropertyHandler::reset();
+        Handlers\Eloquent\ModelFactoryMethodTypeProvider::reset();
+        Handlers\Eloquent\ModelPropertyAccessorHandler::reset();
+        Handlers\Eloquent\ModelPropertyHandler::reset();
+        Handlers\Eloquent\ModelRelationReturnTypeHandler::reset();
+        Handlers\Eloquent\ModelRelationshipPropertyHandler::reset();
+        Handlers\Eloquent\ModelRegistrationHandler::reset();
+        Handlers\Eloquent\RelationMethodParser::reset();
+        SchemaStateProvider::reset();
+        Handlers\Facades\AppFacadeRegistrationHandler::reset();
+        Handlers\Facades\DateFacadeHandler::reset();
+        Handlers\Facades\FacadeMethodHandler::reset();
+        Handlers\Helpers\NowTodayHandler::reset();
+        Handlers\Jobs\DispatchableHandler::reset();
+        Handlers\Magic\MacroRegistry::reset();
+        Handlers\Producers\ProducerReturnTypeHandler::reset();
+        Handlers\Rules\NoEnvOutsideConfigHandler::reset();
+        Handlers\Translations\TranslationKeyHandler::reset();
+        Handlers\Filesystem\StorageHandler::reset();
+        Handlers\Validation\FormRequestPropertyHandler::reset();
+        Handlers\Validation\ValidationRuleAnalyzer::reset();
+        Handlers\Views\MissingViewHandler::reset();
+        Internal\ProxyMethodReturnTypeProvider::reset();
     }
 
     private function registerStubs(

--- a/src/Stubs/FacadeMapProvider.php
+++ b/src/Stubs/FacadeMapProvider.php
@@ -91,6 +91,12 @@ final class FacadeMapProvider
     /** @var array<lowercase-string, list<class-string>> service class → facade + alias classes */
     private static array $serviceToFacades = [];
 
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$serviceToFacades = [];
+    }
+
     /**
      * Build the map from the booted Laravel app's alias registry.
      *

--- a/tests/Unit/Handlers/Translations/TranslationKeyHandlerTest.php
+++ b/tests/Unit/Handlers/Translations/TranslationKeyHandlerTest.php
@@ -71,6 +71,16 @@ final class TranslationKeyHandlerTest extends TestCase
         $this->assertSame(['__', 'trans'], TranslationKeyHandler::getFunctionIds());
     }
 
+    #[Test]
+    public function reset_forgets_the_translator_and_resolved_keys(): void
+    {
+        $this->assertInstanceOf(Union::class, TranslationKeyHandler::getFunctionReturnType($this->createEvent('auth.failed')));
+
+        TranslationKeyHandler::reset();
+
+        $this->assertNotInstanceOf(Union::class, TranslationKeyHandler::getFunctionReturnType($this->createEvent('auth.failed')));
+    }
+
     /**
      * @return iterable<string, array{string}>
      */

--- a/tests/Unit/Handlers/Views/MissingViewHandlerTest.php
+++ b/tests/Unit/Handlers/Views/MissingViewHandlerTest.php
@@ -153,6 +153,20 @@ final class MissingViewHandlerTest extends TestCase
     }
 
     #[Test]
+    public function reset_disables_diagnostics_and_view_factory_narrowing(): void
+    {
+        MissingViewHandler::initViewFactory(CustomViewFactoryStub::class);
+        MissingViewHandler::reset();
+
+        $this->assertNotInstanceOf(Union::class, MissingViewHandler::getFunctionReturnType(
+            $this->createFunctionEvent('nonexistent'),
+        ));
+
+        $method = new \ReflectionMethod(MissingViewHandler::class, 'narrowedHelperReturn');
+        $this->assertNull($method->invoke(null, 0));
+    }
+
+    #[Test]
     public function skips_no_arguments(): void
     {
         $source = $this->createStub(StatementsSource::class);

--- a/tests/Unit/PluginInitializationHandlerLoadingTest.php
+++ b/tests/Unit/PluginInitializationHandlerLoadingTest.php
@@ -27,11 +27,26 @@ final class PluginInitializationHandlerLoadingTest extends TestCase
         $this->assertIsString($source);
 
         $loadCall = \strpos($source, '$this->loadInitializationHandlers();');
+        $resetCall = \strpos($source, '$this->resetInvocationState();');
         $try = \strpos($source, '        try {');
 
         $this->assertIsInt($loadCall);
+        $this->assertIsInt($resetCall);
         $this->assertIsInt($try);
         $this->assertLessThan($try, $loadCall);
+        $this->assertLessThan($try, $resetCall);
+        $this->assertLessThan($resetCall, $loadCall);
+
+        $resetMethod = $this->methodBody($source, 'resetInvocationState');
+        foreach ([
+            'ApplicationProvider::reset()',
+            'FacadeMapProvider::reset()',
+            'Handlers\\Translations\\TranslationKeyHandler::reset()',
+            'Handlers\\Views\\MissingViewHandler::reset()',
+            'Handlers\\Eloquent\\Metadata\\ModelMetadataRegistryBuilder::reset()',
+        ] as $reset) {
+            $this->assertStringContainsString($reset, $resetMethod);
+        }
 
         $loadMethod = $this->methodBody($source, 'loadInitializationHandlers');
         foreach ([

--- a/tests/Unit/PluginInvocationStateTest.php
+++ b/tests/Unit/PluginInvocationStateTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\View\Engines\EngineResolver;
+use Illuminate\View\Engines\PhpEngine;
+use Illuminate\View\Factory;
+use Illuminate\View\FileViewFinder;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\CodeLocation;
+use Psalm\Config;
+use Psalm\Context;
+use Psalm\LaravelPlugin\Bootstrap\ApplicationProvider;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Support\RelationResolver;
+use Psalm\LaravelPlugin\Handlers\Translations\TranslationKeyHandler;
+use Psalm\LaravelPlugin\Handlers\Views\MissingViewHandler;
+use Psalm\LaravelPlugin\Plugin;
+use Psalm\LaravelPlugin\Stubs\FacadeMapProvider;
+use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
+use Psalm\Plugin\RegistrationInterface;
+use Psalm\StatementsSource;
+use Psalm\Type\Union;
+
+#[CoversClass(Plugin::class)]
+final class PluginInvocationStateTest extends TestCase
+{
+    private string $originalCwd;
+
+    /** @var list<string> */
+    private array $roots = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $cwd = \getcwd();
+        \assert(\is_string($cwd));
+        $this->originalCwd = $cwd;
+        Config::loadFromXML($cwd, '<?xml version="1.0"?><psalm xmlns="https://getpsalm.org/schema/config" />');
+        ApplicationProvider::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        ApplicationProvider::reset();
+        \chdir($this->originalCwd);
+
+        foreach ($this->roots as $root) {
+            $this->removeDirectory($root);
+        }
+
+        (new \ReflectionClass(Config::class))->getProperty('instance')->setValue(null, null);
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function plugin_resets_state_between_real_application_invocations(): void
+    {
+        $firstRoot = $this->makeApplicationRoot(
+            viewBinding: '\\' . InvocationStateViewFactory::class,
+            bindTranslator: true,
+            alias: 'InvocationStateViewAlias',
+        );
+        $secondRoot = $this->makeApplicationRoot(
+            viewBinding: '\\' . InvocationStateUnsupportedViewFactory::class,
+            bindTranslator: false,
+            alias: null,
+        );
+        $plugin = new Plugin();
+
+        \chdir($firstRoot);
+        $plugin($this->createStub(RegistrationInterface::class), new \SimpleXMLElement(
+            '<plugin><modelProperties columnFallback="none" /><findMissingViews value="true" /><findMissingTranslations value="true" /></plugin>',
+        ));
+
+        $this->assertInstanceOf(InvocationStateViewFactory::class, ApplicationProvider::getApp()->make('view'));
+        $this->assertTrue(ApplicationProvider::getApp()->bound('translator'));
+        $this->assertContains(
+            'InvocationStateViewAlias',
+            FacadeMapProvider::getFacadeClasses(InvocationStateViewFactory::class),
+        );
+        (new \ReflectionProperty(RelationResolver::class, 'methodExistsCache'))->setValue(null, ['App\\Models\\Post::comments' => true]);
+        (new \ReflectionProperty(RelationResolver::class, 'relatedModelCache'))->setValue(null, ['App\\Models\\Post::comments' => 'App\\Models\\Comment']);
+
+        \chdir($secondRoot);
+        $plugin($this->createStub(RegistrationInterface::class), new \SimpleXMLElement(
+            '<plugin><modelProperties columnFallback="none" /><findMissingViews value="false" /><findMissingTranslations value="true" /></plugin>',
+        ));
+
+        $this->assertNull($this->functionReturn('view', 'only-in-first-application'));
+        $this->assertNull((new \ReflectionProperty(TranslationKeyHandler::class, 'translator'))->getValue());
+        $this->assertInstanceOf(InvocationStateUnsupportedViewFactory::class, ApplicationProvider::getApp()->make('view'));
+        $this->assertSame([], (new \ReflectionProperty(RelationResolver::class, 'methodExistsCache'))->getValue());
+        $this->assertSame([], (new \ReflectionProperty(RelationResolver::class, 'relatedModelCache'))->getValue());
+        $this->assertNotContains(
+            'InvocationStateViewAlias',
+            FacadeMapProvider::getFacadeClasses(InvocationStateViewFactory::class),
+        );
+    }
+
+    private function functionReturn(string $function, ?string $viewName = null): ?Union
+    {
+        $source = $this->createStub(StatementsSource::class);
+        $source->method('getFilePath')->willReturn('/app/example.php');
+        $source->method('getFileName')->willReturn('example.php');
+
+        $call = new FuncCall(new Name($function));
+        $call->setAttribute('startFilePos', 0);
+        $call->setAttribute('endFilePos', 10);
+        $call->args = $viewName === null ? [] : [new Arg(new String_($viewName))];
+        $event = new FunctionReturnTypeProviderEvent(
+            $source,
+            $function,
+            $call,
+            new Context(),
+            new CodeLocation($source, $call),
+        );
+
+        return MissingViewHandler::getFunctionReturnType($event);
+    }
+
+    private function makeApplicationRoot(string $viewBinding, bool $bindTranslator, ?string $alias): string
+    {
+        $root = \sys_get_temp_dir() . '/psalm-laravel-invocation-' . \str_replace('.', '', \uniqid('', true));
+        \mkdir($root . '/bootstrap/cache', 0777, true);
+        \mkdir($root . '/config', 0777, true);
+        $this->roots[] = $root;
+
+        $translator = $bindTranslator
+            ? "\$app->singleton('translator', static fn(): \\Illuminate\\Translation\\Translator => new \\Illuminate\\Translation\\Translator(new \\Illuminate\\Translation\\ArrayLoader(), 'en'));"
+            : '';
+        $applicationClass = $bindTranslator
+            ? '\\Illuminate\\Foundation\\Application'
+            : '\\' . InvocationStateNoTranslatorApplication::class;
+        $aliasRegistration = $alias === null
+            ? ''
+            : "\\Illuminate\\Foundation\\AliasLoader::getInstance()->alias('{$alias}', \\Illuminate\\Support\\Facades\\View::class);";
+        $viewSetup = "\$app->afterBootstrapping(\\Illuminate\\Foundation\\Bootstrap\\BootProviders::class, static function (\\Illuminate\\Foundation\\Application \$app): void { \$app->forgetInstance('view'); \$app->offsetUnset('view'); \$app->singleton('view', static fn(\\Illuminate\\Foundation\\Application \$app): {$viewBinding} => new {$viewBinding}(\$app['events'])); });";
+        $bootstrap = "<?php\n"
+            . "\$app = {$applicationClass}::configure(basePath: " . \var_export($root, true) . ")->create();\n"
+            . $viewSetup . "\n"
+            . $translator . "\n"
+            . $aliasRegistration . "\n"
+            . "return \$app;\n";
+        \file_put_contents($root . '/bootstrap/app.php', $bootstrap);
+
+        return $root;
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        if (!\is_dir($directory)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($iterator as $file) {
+            $file->isDir() ? \rmdir($file->getPathname()) : \unlink($file->getPathname());
+        }
+
+        \rmdir($directory);
+    }
+}
+
+final class InvocationStateViewFactory extends Factory
+{
+    public function __construct(Dispatcher $events)
+    {
+        $filesystem = new Filesystem();
+        $engines = new EngineResolver();
+        $engines->register('php', static fn(): PhpEngine => new PhpEngine($filesystem));
+
+        parent::__construct($engines, new FileViewFinder($filesystem, []), $events);
+    }
+}
+
+final class InvocationStateUnsupportedViewFactory
+{
+    public function __construct(Dispatcher $events) {}
+}
+
+final class InvocationStateNoTranslatorApplication extends \Illuminate\Foundation\Application
+{
+    public function bound($abstract): bool
+    {
+        return $abstract !== 'translator' && parent::bound($abstract);
+    }
+}

--- a/tests/Unit/PluginInvocationStateTest.php
+++ b/tests/Unit/PluginInvocationStateTest.php
@@ -119,6 +119,7 @@ final class PluginInvocationStateTest extends TestCase
         $call->setAttribute('startFilePos', 0);
         $call->setAttribute('endFilePos', 10);
         $call->args = $viewName === null ? [] : [new Arg(new String_($viewName))];
+
         $event = new FunctionReturnTypeProviderEvent(
             $source,
             $function,
@@ -189,10 +190,7 @@ final class InvocationStateViewFactory extends Factory
     }
 }
 
-final class InvocationStateUnsupportedViewFactory
-{
-    public function __construct(Dispatcher $events) {}
-}
+final class InvocationStateUnsupportedViewFactory {}
 
 final class InvocationStateNoTranslatorApplication extends \Illuminate\Foundation\Application
 {

--- a/tests/Unit/Providers/ApplicationProviderInvocationResetTest.php
+++ b/tests/Unit/Providers/ApplicationProviderInvocationResetTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Providers;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Bootstrap\ApplicationProvider;
+
+#[CoversClass(ApplicationProvider::class)]
+final class ApplicationProviderInvocationResetTest extends TestCase
+{
+    #[Test]
+    public function reset_forces_the_next_invocation_to_boot_a_fresh_application(): void
+    {
+        ApplicationProvider::reset();
+        ApplicationProvider::bootApp();
+        $first = ApplicationProvider::getApp();
+
+        ApplicationProvider::reset();
+
+        $this->assertNull(\Illuminate\Support\Facades\Facade::getFacadeApplication());
+
+        ApplicationProvider::bootApp();
+
+        $this->assertNotSame($first, ApplicationProvider::getApp());
+    }
+}

--- a/tests/Unit/Providers/ApplicationProviderInvocationResetTest.php
+++ b/tests/Unit/Providers/ApplicationProviderInvocationResetTest.php
@@ -18,10 +18,17 @@ final class ApplicationProviderInvocationResetTest extends TestCase
         ApplicationProvider::reset();
         ApplicationProvider::bootApp();
         $first = ApplicationProvider::getApp();
+        $oldAlias = 'PsalmLaravelPluginOldInvocationAlias' . \str_replace('.', '', \uniqid('', true));
+        $loader = \Illuminate\Foundation\AliasLoader::getInstance();
+        $loader->alias($oldAlias, \stdClass::class);
+        $loader->register();
 
         ApplicationProvider::reset();
 
         $this->assertNull(\Illuminate\Support\Facades\Facade::getFacadeApplication());
+        $this->assertNotSame($first, \Illuminate\Container\Container::getInstance());
+        $this->assertArrayNotHasKey($oldAlias, \Illuminate\Foundation\AliasLoader::getInstance()->getAliases());
+        $this->assertFalse(\class_exists($oldAlias));
 
         ApplicationProvider::bootApp();
 

--- a/tests/Unit/Providers/FacadeMapProviderTest.php
+++ b/tests/Unit/Providers/FacadeMapProviderTest.php
@@ -16,6 +16,19 @@ use Psalm\Progress\VoidProgress;
 #[CoversClass(FacadeMapProvider::class)]
 final class FacadeMapProviderTest extends TestCase
 {
+    #[Test]
+    public function reset_discards_the_previous_application_alias_map(): void
+    {
+        ApplicationProvider::bootApp();
+        FacadeMapProvider::init(new VoidProgress());
+
+        $this->assertNotEmpty(FacadeMapProvider::getFacadeClasses(\Illuminate\Routing\Router::class));
+
+        FacadeMapProvider::reset();
+
+        $this->assertSame([], FacadeMapProvider::getFacadeClasses(\Illuminate\Routing\Router::class));
+    }
+
     /**
      * Reproduces issue #745: the mateffy/laravel-introspect package publishes
      * a self-referential alias via composer.json:

--- a/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
+++ b/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
@@ -338,6 +338,8 @@ final class ModelMetadataRegistryTest extends TestCase
     #[Test]
     public function reset_clears_cached_metadata(): void
     {
+        $progress = new VoidProgress();
+        ModelMetadataRegistry::init($progress);
         ModelMetadataRegistryBuilder::overrideForTesting(
             WorkOrder::class,
             $this->makeStubMetadata(WorkOrder::class),
@@ -346,6 +348,7 @@ final class ModelMetadataRegistryTest extends TestCase
         ModelMetadataRegistryBuilder::reset();
 
         $this->assertNull(ModelMetadataRegistry::for(WorkOrder::class));
+        $this->assertNull(ModelMetadataRegistry::getProgress());
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

Resets plugin-owned mutable static state before each Laravel application boot, preventing a previous application's configuration, aliases, filesystem results, services, and Codebase-derived caches from leaking into a reused Psalm process.

- Adds an explicit invocation reset boundary before optional initialization.
- Resets the application provider, framework facade and alias globals, and affected handler caches.
- Documents the lifecycle convention and preserves immutable Union caches plus hook-local scratch state.
- Adds same-process reset coverage for views, translations, aliases, metadata/progress, application booting, and lifecycle ordering.

Closes #1244.

## Root cause

Optional initialization can be skipped on a later invocation. Existing `init()` methods therefore could not reliably overwrite state retained from a previous booted application.
