### PR TITLE
fix: stop UndefinedModelRelationHandler autoloading receiver classes

### DIFF
--- a/src/Handlers/Rules/UndefinedModelRelationHandler.php
+++ b/src/Handlers/Rules/UndefinedModelRelationHandler.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use Psalm\Codebase;
 use Psalm\CodeLocation;
+use Psalm\Exception\UnpopulatedClasslikeException;
 use Psalm\IssueBuffer;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Support\ModelPropertyResolver;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Support\RelationResolver;
@@ -64,6 +65,11 @@ use Psalm\Type\Union;
  *
  * The `withCount()` / `withSum()` family (relation + ` as alias` aggregate
  * sub-selects) is intentionally out of scope for this first pass.
+ *
+ * **No autoloading class checks.** Ancestry is resolved via {@see isClassOrSubclassOf()} /
+ * {@see concreteModel()} off Psalm's reflection, never `\is_a($class, X::class, true)` — that
+ * autoloads $class, and a deprecation raised while loading crashes the whole run (Psalm's error
+ * handler turns it into an exception).
  *
  * @see https://github.com/psalm/psalm-plugin-laravel/issues/643
  * @see https://github.com/larastan/larastan RelationExistenceRule — Larastan's analogue
@@ -232,7 +238,7 @@ final class UndefinedModelRelationHandler implements AfterExpressionAnalysisInte
      * skipped.
      *
      * @return ?class-string<Model>
-     * @psalm-mutation-free
+     * @psalm-external-mutation-free
      */
     private static function resolveModelFromType(Codebase $codebase, Union $type): ?string
     {
@@ -264,29 +270,56 @@ final class UndefinedModelRelationHandler implements AfterExpressionAnalysisInte
      * model as their first generic parameter; a `Model` atomic is the model itself.
      *
      * @return ?class-string<Model>
-     * @psalm-mutation-free
+     * @psalm-external-mutation-free
      */
     private static function modelFromAtomic(Codebase $codebase, Atomic $atomic): ?string
     {
         if ($atomic instanceof TGenericObject) {
-            if (\is_a($atomic->value, EloquentBuilder::class, true) || \is_a($atomic->value, Relation::class, true)) {
+            if (
+                self::isClassOrSubclassOf($codebase, $atomic->value, EloquentBuilder::class)
+                || self::isClassOrSubclassOf($codebase, $atomic->value, Relation::class)
+            ) {
                 $model = ModelPropertyResolver::extractModelFromUnion($atomic->type_params[0] ?? null);
 
                 return $model !== null ? self::concreteModel($codebase, $model) : null;
             }
 
-            if (\is_a($atomic->value, Model::class, true)) {
+            if (self::isClassOrSubclassOf($codebase, $atomic->value, Model::class)) {
                 return self::concreteModel($codebase, $atomic->value);
             }
 
             return null;
         }
 
-        if ($atomic instanceof TNamedObject && \is_a($atomic->value, Model::class, true)) {
+        if ($atomic instanceof TNamedObject && self::isClassOrSubclassOf($codebase, $atomic->value, Model::class)) {
             return self::concreteModel($codebase, $atomic->value);
         }
 
         return null;
+    }
+
+    /**
+     * $class is $ancestor or a subclass, without autoloading (unlike `\is_a(..., true)` — see class
+     * docblock). classExtends() is non-reflexive → identity checked first. All ancestors here
+     * (Builder, Relation, Model) are classes, so classExtends() alone suffices, no classImplements().
+     *
+     * @psalm-external-mutation-free
+     */
+    private static function isClassOrSubclassOf(Codebase $codebase, string $class, string $ancestor): bool
+    {
+        if (\strtolower($class) === \strtolower($ancestor)) {
+            return true;
+        }
+
+        if (!$codebase->classExists($class)) {
+            return false;
+        }
+
+        try {
+            return $codebase->classExtends($class, $ancestor);
+        } catch (\InvalidArgumentException|UnpopulatedClasslikeException) {
+            return false;
+        }
     }
 
     /**
@@ -296,17 +329,22 @@ final class UndefinedModelRelationHandler implements AfterExpressionAnalysisInte
      * them would be a false positive.
      *
      * @return ?class-string<Model>
-     * @psalm-mutation-free
+     * @psalm-external-mutation-free
      */
     private static function concreteModel(Codebase $codebase, string $fqcn): ?string
     {
-        if (!\is_a($fqcn, Model::class, true) || $fqcn === Model::class) {
+        // classExtends() non-reflexive → already excludes Model itself; no autoload.
+        if (!$codebase->classExists($fqcn)) {
             return null;
         }
 
         try {
+            if (!$codebase->classExtends($fqcn, Model::class)) {
+                return null;
+            }
+
             $storage = $codebase->classlike_storage_provider->get($fqcn);
-        } catch (\InvalidArgumentException) {
+        } catch (\InvalidArgumentException|UnpopulatedClasslikeException) {
             return null;
         }
 

--- a/tests/Unit/Handlers/Fixtures/UndefinedRelationAutoloadCrash/app/DeprecatedOnLoad.php
+++ b/tests/Unit/Handlers/Fixtures/UndefinedRelationAutoloadCrash/app/DeprecatedOnLoad.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoloadCrashFixture;
+
+// Not @-suppressed: Psalm's error handler turns this into a thrown exception, crashing the run.
+// Not a Model subclass: ModelRegistrationHandler autoloads every Model on its own, which would
+// crash here first and defeat the repro's isolation of this handler's fix.
+\trigger_error('deprecated on load', \E_USER_DEPRECATED);
+
+class DeprecatedOnLoad
+{
+    public static function with(string $relation): static
+    {
+        return new static();
+    }
+}

--- a/tests/Unit/Handlers/Fixtures/UndefinedRelationAutoloadCrash/app/DeprecatedOnLoadInstance.php
+++ b/tests/Unit/Handlers/Fixtures/UndefinedRelationAutoloadCrash/app/DeprecatedOnLoadInstance.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoloadCrashFixture;
+
+// Dedicated class for the instance-call path (modelFromAtomic() -> isClassOrSubclassOf()), kept
+// separate from DeprecatedOnLoad (the static-call path): a crash is fatal, so once one class's
+// autoload site crashes, no later statement in the file runs — sharing one class would let a fix
+// on one site mask a regression on the other.
+\trigger_error('deprecated on load', \E_USER_DEPRECATED);
+
+class DeprecatedOnLoadInstance
+{
+    public function with(string $relation): static
+    {
+        return $this;
+    }
+}

--- a/tests/Unit/Handlers/Fixtures/UndefinedRelationAutoloadCrash/app/usage.php
+++ b/tests/Unit/Handlers/Fixtures/UndefinedRelationAutoloadCrash/app/usage.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoloadCrashFixture;
+
+// Drives resolveBaseModel() -> concreteModel(), the pre-fix autoload site.
+DeprecatedOnLoad::with('posts');
+
+// Drives resolveModelFromType() -> modelFromAtomic() -> isClassOrSubclassOf(), the other pre-fix
+// autoload site.
+function drive_instance_path(DeprecatedOnLoadInstance $x): void
+{
+    $x->with('posts');
+}

--- a/tests/Unit/Handlers/Fixtures/UndefinedRelationAutoloadCrash/autoload.php
+++ b/tests/Unit/Handlers/Fixtures/UndefinedRelationAutoloadCrash/autoload.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+// Psalm's scanner only parses the AST, never `require`s the file — so the class stays unloaded
+// until an autoloading call (the pre-fix bug) fires it here.
+\spl_autoload_register(static function (string $class): void {
+    $prefix = 'AutoloadCrashFixture\\';
+
+    if (!\str_starts_with($class, $prefix)) {
+        return;
+    }
+
+    $relative = \str_replace('\\', '/', \substr($class, \strlen($prefix)));
+    $file = __DIR__ . '/app/' . $relative . '.php';
+
+    if (\is_file($file)) {
+        require_once $file;
+    }
+});

--- a/tests/Unit/Handlers/Fixtures/UndefinedRelationAutoloadCrash/psalm.xml
+++ b/tests/Unit/Handlers/Fixtures/UndefinedRelationAutoloadCrash/psalm.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="1"
+    autoloader="autoload.php"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+>
+    <projectFiles>
+        <directory name="app" />
+    </projectFiles>
+    <plugins>
+        <pluginClass class="Psalm\LaravelPlugin\Plugin" />
+    </plugins>
+</psalm>

--- a/tests/Unit/Handlers/UndefinedRelationAutoloadCrashTest.php
+++ b/tests/Unit/Handlers/UndefinedRelationAutoloadCrashTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Handlers\Rules\UndefinedModelRelationHandler;
+use Symfony\Component\Process\Process;
+
+/**
+ * Regression guard for {@see UndefinedModelRelationHandler}'s pre-fix `\is_a($fqcn, Model::class,
+ * true)`, which autoloaded the receiver class and let a load-time deprecation crash the whole run.
+ *
+ * Not reproducible as a `.phpt`: phpt-declared classes aren't Composer-autoloadable, so
+ * `is_a(..., true)` never fires their file. Forks a real `vendor/bin/psalm` over a self-contained
+ * fixture instead, like {@see UnknownModelAttributeEmissionTest}.
+ */
+#[CoversClass(UndefinedModelRelationHandler::class)]
+final class UndefinedRelationAutoloadCrashTest extends TestCase
+{
+    #[Test]
+    public function it_does_not_crash_when_the_relation_receiver_class_deprecates_on_load(): void
+    {
+        $projectRoot = \dirname(__DIR__, 3);
+        $fixtureDir = __DIR__ . '/Fixtures/UndefinedRelationAutoloadCrash';
+        $psalmBinary = $projectRoot . '/vendor/bin/psalm';
+
+        $this->assertFileExists($psalmBinary, 'Psalm binary not found — run composer install.');
+
+        $process = new Process(
+            [\PHP_BINARY, $psalmBinary, '-c', 'psalm.xml', '--no-cache', '--threads=1', '--no-progress', '--output-format=json'],
+            $fixtureDir,
+        );
+        $process->setTimeout(300);
+        // Non-zero exit on findings is fine here; do not mustRun().
+        $process->run();
+
+        $stdout = $process->getOutput();
+        $stderr = $process->getErrorOutput();
+        $combined = $stdout . "\n" . $stderr;
+
+        $this->assertStringNotContainsString(
+            'crashed due to an uncaught Throwable',
+            $combined,
+            "Psalm crashed instead of completing analysis.\nstdout:\n{$stdout}\nstderr:\n{$stderr}",
+        );
+        $this->assertStringNotContainsString(
+            'Uncaught',
+            $combined,
+            "Psalm crashed instead of completing analysis.\nstdout:\n{$stdout}\nstderr:\n{$stderr}",
+        );
+
+        $decoded = \json_decode($stdout, true);
+        $this->assertIsArray(
+            $decoded,
+            "Psalm did not return a JSON array — analysis likely crashed.\nstdout:\n{$stdout}\nstderr:\n{$stderr}",
+        );
+    }
+}


### PR DESCRIPTION
## Problem

`UndefinedModelRelationHandler` resolved a relation-call receiver's class with `\is_a($class, X::class, true)`. The `true` (`$allow_string`) makes PHP **autoload** `$class`. During analysis the plugin has the target app's Composer autoloader registered (it boots the real app), so this executes the class's file. A class that emits `E_USER_DEPRECATED` on load (a deprecated trait, a top-level `trigger_error()`) has that deprecation converted into a thrown exception by Psalm's own error handler, which propagates out of the analysis worker and crashes the entire run. Reported on a large Laravel app; the crash landed in `is_a(...)` inside this handler while resolving a request-typed call receiver.

## Fix

- Replace the four autoloading `is_a(...,true)` sites with non-autoloading `$codebase->classExists()` + `$codebase->classExtends()` off Psalm's reflection, matching sibling rule handlers (`ImplicitQueryBuilderCall`, `UnknownModelAttribute`, `ModelMake`).
- A small `isClassOrSubclassOf()` helper covers the identity-or-subclass sites (`classExtends` is non-reflexive, so identity is checked first); `concreteModel()` uses the strict-subclass form inline.
- Behavior-preserving on real apps (models are both scanned and autoloadable) and strictly more conservative for unscanned classes, matching the handler's existing defer philosophy. The existing `UndefinedModelRelation*` type tests confirm firing behavior is unchanged.

## Regression coverage

- A subprocess test forks real `vendor/bin/psalm` over a self-contained fixture whose autoloader lazily loads a deprecation-on-load class. A `.phpt` cannot reproduce this: phpt-declared classes are not Composer-autoloadable, so `is_a(...,true)` never executes their file.
- Separate fixture classes independently guard the instance (helper) and static (inline) paths. A fatal crash consumes the one-time autoload of a shared class, so one class per path is required to prove each site crashes when broken in isolation.
- Verified: reverting the whole fix reproduces the crash; reverting only the helper crashes via the instance path; both green with the fix. Self-analysis clean, 100% type coverage, full unit + type suites green.

## Scope

This handler only. Other autoloading `is_a(...,true)` / `class_exists(...,true)` sites (~34 across ~11 files) share the same latent crash — notably `ModelRegistrationHandler` autoloads every model on `AfterCodebasePopulated`, so a deprecating model can still crash a run through that path. Tracked in #1252.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786489572&installation_id=141955579&pr_number=1253&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1253&signature=3d3dd311882e9c40d1fc847c35c49f4dedd1fdefa8811c2a3e2fc3d9ac79ccbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->