### PR TITLE
Fix Laravel 12 metadata registry warm-up

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,6 +80,42 @@ jobs:
       - name: Run Unit tests
         run: composer test:unit
 
+  laravel_12_14_floor:
+    name: Laravel 12.14.0 floor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+        with:
+          php-version: 8.2
+          coverage: none
+          tools: composer:v2
+
+      - name: Install exact Laravel floor
+        # The supported floor may have published advisories; this isolated test install is never deployed.
+        run: >-
+          composer update --with="laravel/framework:12.14.0" --with-all-dependencies
+          --no-interaction --no-progress --prefer-dist --prefer-stable --no-blocking --no-audit
+
+      - name: Verify installed Laravel version
+        run: >-
+          php -r 'require "vendor/autoload.php";
+          exit(Composer\InstalledVersions::getPrettyVersion("laravel/framework") === "v12.14.0" ? 0 : 1);'
+
+      - name: Run Unit tests
+        # Testbench 10 resolves PHPUnit 11, which does not support --display-phpunit-notices.
+        run: vendor/bin/phpunit --testsuite=unit --display-deprecations --display-notices
+
 
   type_tests:
     runs-on: ubuntu-latest

--- a/src/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php
+++ b/src/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php
@@ -1304,10 +1304,28 @@ final class ModelMetadataRegistryBuilder
     private static function applyClassAttributeConfig(Codebase $codebase, \ReflectionClass $reflection, Model $instance): void
     {
         // Union-merge, mirroring mergeHidden() / mergeVisible() / mergeAppends() / mergeFillable().
-        $instance->mergeHidden(self::classAttribute($codebase, $reflection, Hidden::class)?->columns ?? []);
-        $instance->mergeVisible(self::classAttribute($codebase, $reflection, Visible::class)?->columns ?? []);
-        $instance->mergeAppends(self::classAttribute($codebase, $reflection, Appends::class)?->columns ?? []);
-        $instance->mergeFillable(self::classAttribute($codebase, $reflection, Fillable::class)?->columns ?? []);
+        // These four configuration attributes only exist from Laravel 13. On Laravel 12.14–12.24,
+        // mergeHidden() / mergeVisible() / mergeAppends() are unavailable (mergeFillable() exists), so
+        // calling the absent helpers with empty fallbacks crashes warm-up. An absent attribute has nothing to replay.
+        $hidden = self::classAttribute($codebase, $reflection, Hidden::class);
+        if ($hidden !== null) {
+            $instance->mergeHidden($hidden->columns);
+        }
+
+        $visible = self::classAttribute($codebase, $reflection, Visible::class);
+        if ($visible !== null) {
+            $instance->mergeVisible($visible->columns);
+        }
+
+        $appends = self::classAttribute($codebase, $reflection, Appends::class);
+        if ($appends !== null) {
+            $instance->mergeAppends($appends->columns);
+        }
+
+        $fillable = self::classAttribute($codebase, $reflection, Fillable::class);
+        if ($fillable !== null) {
+            $instance->mergeFillable($fillable->columns);
+        }
 
         self::applyGuardedAttribute($codebase, $reflection, $instance);
         self::applyConnectionAttribute($codebase, $reflection, $instance);

--- a/tests/Unit/Handlers/Eloquent/CustomBuilderDetectionTest.php
+++ b/tests/Unit/Handlers/Eloquent/CustomBuilderDetectionTest.php
@@ -11,6 +11,7 @@ use App\Models\Customer;
 use App\Models\Mechanic;
 use App\Models\Vehicle;
 use App\Models\WorkOrder;
+use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -47,6 +48,10 @@ final class CustomBuilderDetectionTest extends TestCase
     #[Test]
     public function it_registers_custom_builder_for_model_with_attribute(): void
     {
+        if (!class_exists(UseEloquentBuilder::class)) {
+            self::markTestSkipped('The UseEloquentBuilder attribute is unavailable on this Laravel version.');
+        }
+
         $this->resolveAndRegisterBuilder(WorkOrder::class);
 
         $this->assertSame(WorkOrderBuilder::class, $this->getRegisteredBuilder(WorkOrder::class));

--- a/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
+++ b/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
@@ -18,6 +18,7 @@ use App\Models\WorkOrder;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Casts\Attribute;
@@ -172,6 +173,25 @@ final class ModelMetadataRegistryTest extends TestCase
         $this->assertInstanceOf(ModelMetadata::class, $metadata, 'warm-up must not fail on $guarded = false');
         // `$guarded = false` means guard nothing → empty list (not the base default ['*']).
         $this->assertSame([], $metadata->guarded);
+    }
+
+    #[Test]
+    public function model_without_class_attributes_survives_warm_up_on_laravel_12(): void
+    {
+        // Regression for #1254: Laravel 12.14 has none of the four configuration attributes, while
+        // mergeHidden()/mergeVisible()/mergeAppends() are also unavailable. Attribute replay must be
+        // a no-op instead of calling one of those missing helpers with an empty list.
+        $codebase = $this->makeCodebase();
+        $this->registerStorage(ScalarFieldsModel::class);
+
+        ModelMetadataRegistryBuilder::warmUp($codebase, ScalarFieldsModel::class);
+
+        $metadata = ModelMetadataRegistry::for(ScalarFieldsModel::class);
+        $this->assertInstanceOf(ModelMetadata::class, $metadata, 'Laravel 12 model warm-up must succeed');
+        $this->assertSame(['Password'], $metadata->hidden);
+        $this->assertSame(['Name', 'EMAIL'], $metadata->visible);
+        $this->assertSame(['FullName'], $metadata->appends);
+        $this->assertSame(['Name', 'EMAIL'], $metadata->fillable);
     }
 
     #[Test]
@@ -939,7 +959,7 @@ final class ModelMetadataRegistryTest extends TestCase
     }
 
     #[Test]
-    public function custom_builder_and_collection_classes_are_populated(): void
+    public function custom_builder_and_collection_classes_follow_available_attributes(): void
     {
         // WorkOrder declares #[UseEloquentBuilder(WorkOrderBuilder)] and #[CollectedBy(WorkOrderCollection)].
         // The registry records both via the pure resolvers shared with ModelRegistrationHandler.
@@ -950,7 +970,12 @@ final class ModelMetadataRegistryTest extends TestCase
 
         $metadata = ModelMetadataRegistry::for(WorkOrder::class);
         $this->assertInstanceOf(\Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadata::class, $metadata);
-        $this->assertSame(WorkOrderBuilder::class, $metadata->customBuilder);
+        if (class_exists(UseEloquentBuilder::class)) {
+            $this->assertSame(WorkOrderBuilder::class, $metadata->customBuilder);
+        } else {
+            $this->assertNull($metadata->customBuilder);
+        }
+
         $this->assertSame(WorkOrderCollection::class, $metadata->customCollection);
     }
 


### PR DESCRIPTION
## Summary

- presence-gate Laravel 13 Eloquent configuration-attribute replay;
- add an exact Laravel 12.14.0 floor job that runs the unit suite;
- add regression coverage proving models without those attributes survive metadata warm-up;
- keep Laravel-version-specific custom-builder tests meaningful on the supported floor.

## Root cause

`applyClassAttributeConfig()` unconditionally called `mergeHidden()`, `mergeVisible()`, and `mergeAppends()` with an empty list when the corresponding Laravel 13 attribute was absent. Those helpers do not exist before Laravel 12.25, so every concrete model failed registry warm-up on supported Laravel 12.14 through 12.24 installations.

The calls now execute only when the corresponding attribute is present. Laravel 12 therefore performs a complete no-op, while Laravel 13 keeps the existing merge semantics and attribute-instantiation error handling.

## Compatibility coverage

The new CI job pins and verifies `laravel/framework` v12.14.0 rather than resolving the latest Laravel 12 release. It runs the full unit suite with PHPUnit 11-compatible flags. Laravel 13 attribute-present behavior remains covered by the existing unit tests.

## Validation

- Laravel 12.14.0 full unit suite: 1,024 tests, 2,536 assertions, 9 expected skips;
- Laravel 12.14.0 focused regression checks passed;
- Laravel 13.19.0 focused attribute-present checks: 4 tests, 16 assertions;
- PHP CS Fixer passed;
- Composer validation passed;
- workflow YAML parsing and `git diff --check` passed.

## Follow-up work

- #1255 tracks section-isolated registry construction and explicit completeness.
- #1256 tracks complete Laravel 13 model-attribute parity.
- #1252 tracks removal of analyzed-code autoloading.

Closes #1254.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786495855&installation_id=141955579&pr_number=1257&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1257&signature=8085357b7d5e96211f54b0f46eb8169469a6734bf6abc9e3e65cd48e15e655d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->