### PR TITLE
Make model metadata registry construction section-isolated

### DIFF
--- a/src/Handlers/Eloquent/Metadata/CustomTypeDetector.php
+++ b/src/Handlers/Eloquent/Metadata/CustomTypeDetector.php
@@ -38,11 +38,18 @@ final class CustomTypeDetector
      * @param class-string<Model> $className
      * @return class-string<Builder>|null The custom builder class, or null if using base Builder.
      */
-    public static function resolveCustomBuilderClass(Codebase $codebase, string $className): ?string
-    {
+    public static function resolveCustomBuilderClass(
+        Codebase $codebase,
+        string $className,
+        bool $failOnError = false,
+    ): ?string {
         try {
             $reflection = new \ReflectionClass($className);
         } catch (\ReflectionException $reflectionException) {
+            if ($failOnError) {
+                throw $reflectionException;
+            }
+
             $codebase->progress->debug(
                 "Laravel plugin: could not reflect model '{$className}' for custom builder detection: {$reflectionException->getMessage()}\n",
             );
@@ -55,7 +62,7 @@ final class CustomTypeDetector
 
         // 2. #[UseEloquentBuilder] attribute — checked first in the base newEloquentBuilder().
         if ($builderClass === null) {
-            $builderClass = self::resolveBuilderFromAttribute($reflection, $codebase);
+            $builderClass = self::resolveBuilderFromAttribute($reflection, $codebase, $failOnError);
         }
 
         // 3. Fall back to static $builder property.
@@ -71,6 +78,10 @@ final class CustomTypeDetector
         try {
             $isValid = \is_subclass_of($builderClass, Builder::class, true);
         } catch (\Error|\Exception $error) {
+            if ($failOnError) {
+                throw $error;
+            }
+
             $codebase->progress->debug(
                 "Laravel plugin: model '{$className}' builder '{$builderClass}' failed autoloading: {$error->getMessage()}\n",
             );
@@ -98,8 +109,15 @@ final class CustomTypeDetector
      *
      * @return class-string|null
      */
-    private static function resolveBuilderFromAttribute(\ReflectionClass $reflection, Codebase $codebase): ?string
-    {
+    private static function resolveBuilderFromAttribute(
+        \ReflectionClass $reflection,
+        Codebase $codebase,
+        bool $failOnError = false,
+    ): ?string {
+        if (!\class_exists(UseEloquentBuilder::class)) {
+            return null;
+        }
+
         $attributes = $reflection->getAttributes(UseEloquentBuilder::class);
         if ($attributes === []) {
             return null;
@@ -108,6 +126,10 @@ final class CustomTypeDetector
         try {
             return $attributes[0]->newInstance()->builderClass;
         } catch (\Error $error) {
+            if ($failOnError) {
+                throw $error;
+            }
+
             $codebase->progress->debug(
                 "Laravel plugin: #[UseEloquentBuilder] on '{$reflection->getName()}' failed to instantiate: {$error->getMessage()}\n",
             );
@@ -189,11 +211,18 @@ final class CustomTypeDetector
      * @param class-string<Model> $className
      * @return class-string<EloquentCollection>|null
      */
-    public static function resolveCustomCollectionClass(Codebase $codebase, string $className): ?string
-    {
+    public static function resolveCustomCollectionClass(
+        Codebase $codebase,
+        string $className,
+        bool $failOnError = false,
+    ): ?string {
         try {
             $reflection = new \ReflectionClass($className);
         } catch (\ReflectionException $reflectionException) {
+            if ($failOnError) {
+                throw $reflectionException;
+            }
+
             $codebase->progress->debug(
                 "Laravel plugin: could not reflect model '{$className}' for custom collection detection: {$reflectionException->getMessage()}\n",
             );
@@ -206,7 +235,7 @@ final class CustomTypeDetector
 
         // 2. #[CollectedBy] attribute — checked first in the base newCollection().
         if ($collectionClass === null) {
-            $collectionClass = self::resolveCollectionFromAttribute($reflection, $codebase);
+            $collectionClass = self::resolveCollectionFromAttribute($reflection, $codebase, $failOnError);
         }
 
         // 3. Fall back to static $collectionClass property.
@@ -223,6 +252,10 @@ final class CustomTypeDetector
         try {
             $isValid = \is_subclass_of($collectionClass, EloquentCollection::class, true);
         } catch (\Error|\Exception $error) {
+            if ($failOnError) {
+                throw $error;
+            }
+
             $codebase->progress->debug(
                 "Laravel plugin: model '{$className}' collection '{$collectionClass}' failed autoloading: {$error->getMessage()}\n",
             );
@@ -254,14 +287,25 @@ final class CustomTypeDetector
      *
      * @return class-string|null
      */
-    private static function resolveCollectionFromAttribute(\ReflectionClass $reflection, Codebase $codebase): ?string
-    {
+    private static function resolveCollectionFromAttribute(
+        \ReflectionClass $reflection,
+        Codebase $codebase,
+        bool $failOnError = false,
+    ): ?string {
+        if (!\class_exists(CollectedBy::class)) {
+            return null;
+        }
+
         $attributes = $reflection->getAttributes(CollectedBy::class);
         if ($attributes !== []) {
             try {
                 /** @psalm-var class-string */
                 return $attributes[0]->newInstance()->collectionClass;
             } catch (\Error $error) {
+                if ($failOnError) {
+                    throw $error;
+                }
+
                 $codebase->progress->debug(
                     "Laravel plugin: #[CollectedBy] on '{$reflection->getName()}' failed to instantiate: {$error->getMessage()}\n",
                 );
@@ -278,7 +322,7 @@ final class CustomTypeDetector
             && $parentClass->getName() !== Model::class
             && $parentClass->isSubclassOf(Model::class)
         ) {
-            return self::resolveCollectionFromAttribute($parentClass, $codebase);
+            return self::resolveCollectionFromAttribute($parentClass, $codebase, $failOnError);
         }
 
         return null;

--- a/src/Handlers/Eloquent/Metadata/MetadataSectionState.php
+++ b/src/Handlers/Eloquent/Metadata/MetadataSectionState.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Eloquent\Metadata;
+
+/** @internal */
+enum MetadataSectionState: string
+{
+    /** The section was evaluated successfully, including when its data is empty. */
+    case Complete = 'complete';
+
+    /** The section could not be evaluated because its input was not available. */
+    case Unavailable = 'unavailable';
+
+    /** The section was attempted but raised an unexpected failure. */
+    case Failed = 'failed';
+}

--- a/src/Handlers/Eloquent/Metadata/MetadataSectionUnavailable.php
+++ b/src/Handlers/Eloquent/Metadata/MetadataSectionUnavailable.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Eloquent\Metadata;
+
+/**
+ * Internal control flow for a section whose required input is legitimately absent.
+ * Unlike a failed section, this produces no user-visible warning.
+ *
+ * @internal
+ */
+final class MetadataSectionUnavailable extends \RuntimeException {}

--- a/src/Handlers/Eloquent/Metadata/ModelMetadata.php
+++ b/src/Handlers/Eloquent/Metadata/ModelMetadata.php
@@ -27,6 +27,8 @@ use Psalm\LaravelPlugin\Handlers\Eloquent\Support\EloquentModelMethods;
  */
 final readonly class ModelMetadata
 {
+    private ModelMetadataCompleteness $completenessData;
+
     /**
      * Attribute-name fields (`fillable` / `guarded` / `appends` / `hidden` / `visible`) preserve the
      * exact case the user declared — Eloquent's `isFillable` / `isGuarded` / `getHidden` / `getVisible`
@@ -72,7 +74,24 @@ final readonly class ModelMetadata
         private array $scopesData,
         private array $relationsData,
         private array $knownPropertiesData,
-    ) {}
+        ?ModelMetadataCompleteness $completenessData = null,
+    ) {
+        // Hand-built healthy fixtures stay concise. Production construction always passes the
+        // explicit section map produced by ModelMetadataRegistryBuilder.
+        $this->completenessData = $completenessData ?? ModelMetadataCompleteness::allComplete();
+    }
+
+    /** @psalm-mutation-free */
+    public function sectionStatus(ModelMetadataSection $section): ModelMetadataSectionStatus
+    {
+        return $this->completenessData->status($section);
+    }
+
+    /** @psalm-mutation-free */
+    public function isComplete(ModelMetadataSection ...$sections): bool
+    {
+        return $this->completenessData->isComplete(...$sections);
+    }
 
     public function schema(): TableSchema
     {

--- a/src/Handlers/Eloquent/Metadata/ModelMetadataCompleteness.php
+++ b/src/Handlers/Eloquent/Metadata/ModelMetadataCompleteness.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Eloquent\Metadata;
+
+/**
+ * Immutable completeness map for a model metadata snapshot.
+ *
+ * A complete section may contain no data; that is deliberately distinct from an
+ * unavailable input and from an attempted computation that failed.
+ *
+ * @psalm-immutable
+ * @internal
+ */
+final readonly class ModelMetadataCompleteness
+{
+    /**
+     * @param array<non-empty-string, ModelMetadataSectionStatus> $statuses
+     */
+    private function __construct(private array $statuses) {}
+
+    /**
+     * Ergonomic default for healthy hand-built metadata in tests and extensions.
+     *
+     * @psalm-pure
+     */
+    public static function allComplete(): self
+    {
+        $statuses = [];
+        foreach (ModelMetadataSection::cases() as $section) {
+            $statuses[$section->value] = ModelMetadataSectionStatus::complete();
+        }
+
+        return new self($statuses);
+    }
+
+    /**
+     * @param array<non-empty-string, ModelMetadataSectionStatus> $statuses
+     * @psalm-pure
+     */
+    public static function fromStatuses(array $statuses): self
+    {
+        foreach (ModelMetadataSection::cases() as $section) {
+            $statuses[$section->value] ??= ModelMetadataSectionStatus::unavailable('section was not evaluated');
+        }
+
+        return new self($statuses);
+    }
+
+    /** @psalm-mutation-free */
+    public function status(ModelMetadataSection $section): ModelMetadataSectionStatus
+    {
+        return $this->statuses[$section->value];
+    }
+
+    /**
+     * @psalm-api
+     * @psalm-mutation-free
+     */
+    public function withStatus(ModelMetadataSection $section, ModelMetadataSectionStatus $status): self
+    {
+        return new self([...$this->statuses, $section->value => $status]);
+    }
+
+    /** @psalm-mutation-free */
+    public function isComplete(ModelMetadataSection ...$sections): bool
+    {
+        foreach ($sections as $section) {
+            if (!$this->status($section)->isComplete()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php
+++ b/src/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php
@@ -76,8 +76,9 @@ final class ModelMetadataRegistryBuilder
      * Pre-compute metadata for a single model. Idempotent — re-computation
      * on a cached FQCN is a no-op.
      *
-     * Never throws: on any failure the method logs a warning through the
-     * codebase's progress handle and returns without storing an entry.
+     * Never throws: expected enrichment failures are isolated to their section and an entry
+     * containing every successful section is stored. The outer catch remains a last-resort guard
+     * for failures before a model identity/storage entry can be established.
      *
      * Accepts any `class-string` (not narrowed to `class-string<Model>`): the
      * runtime guard in `compute()` early-returns for non-Model classes, and
@@ -94,13 +95,8 @@ final class ModelMetadataRegistryBuilder
         try {
             $metadata = self::compute($codebase, $modelFqcn);
         } catch (\Throwable $throwable) {
-            // Safety net: warm-up must never crash the plugin. Log and skip this model — but a
-            // dropped model silently disables every registry-backed handler and rule for it
-            // (BuilderScopeHandler, ModelPropertyAccessorHandler, UnknownModelAttribute, ...), so
-            // the failure must reach the user. Progress::warning() writes to STDERR by default, but
-            // VoidProgress (selected by --no-progress, a common quiet-CI flag) makes write() a total
-            // no-op, silently swallowing the warning rather than merely hiding a progress bar. Write
-            // directly to STDERR in that case so the failure is never fully invisible.
+            // Safety net for validation/autoload/storage failures that happen before section-isolated
+            // construction can produce an entry. Section failures use warnSectionFailure() instead.
             $message = "Laravel plugin: ModelMetadataRegistry warm-up failed for '{$modelFqcn}': {$throwable->getMessage()} at {$throwable->getFile()}:{$throwable->getLine()}";
 
             $codebase->progress->warning($message);
@@ -172,24 +168,71 @@ final class ModelMetadataRegistryBuilder
 
         $storage = $storageProvider->get($modelFqcn);
 
-        try {
-            $reflection = new \ReflectionClass($modelFqcn);
-        } catch (\ReflectionException $reflectionException) {
-            // The caller already verified is_a(..., Model::class) + storage presence,
-            // so reflection failing here is unexpected — log at debug so --debug runs
-            // surface what model lost its metadata and why.
-            $codebase->progress->debug(
-                "Laravel plugin: ModelMetadataRegistry could not reflect '{$modelFqcn}': {$reflectionException->getMessage()}\n",
-            );
+        /** @var array<non-empty-string, ModelMetadataSectionStatus> $statuses */
+        $statuses = [];
 
-            return null;
+        // Storage-derived metadata is computed first and independently of reflection/runtime probes.
+        // It therefore survives a throwing model getter, malformed attribute, schema lookup, or cast.
+        $methodMetadata = self::computeSection(
+            $codebase,
+            $modelFqcn,
+            ModelMetadataSection::StorageMethods,
+            $statuses,
+            static fn(): array => self::computeMethodMetadata($storage, $storageProvider),
+            [[], [], []],
+        );
+        [$accessors, $mutators, $scopes] = $methodMetadata;
+
+        if (!self::codebaseMethodsInitialized($codebase)) {
+            $statuses[ModelMetadataSection::Relations->value] = ModelMetadataSectionStatus::unavailable(
+                'Psalm method/AST services are not initialized',
+            );
+            $relations = [];
+        } else {
+            $relations = self::computeSection(
+                $codebase,
+                $modelFqcn,
+                ModelMetadataSection::Relations,
+                $statuses,
+                static fn(): array => self::computeRelations($codebase, $modelFqcn, $storage),
+                [],
+            );
         }
 
-        // Custom builder / collection detection is reflection-based (abstract bases included). Warm-up
-        // is the SINGLE detection pass: registerHandlersForModel() (run AFTER warmUp) reads these off
-        // ModelMetadata and owns hook registration — no second reflection per model (Gotcha 8).
-        $customBuilder = CustomTypeDetector::resolveCustomBuilderClass($codebase, $modelFqcn);
-        $customCollection = CustomTypeDetector::resolveCustomCollectionClass($codebase, $modelFqcn);
+        try {
+            $reflection = new \ReflectionClass($modelFqcn);
+            $statuses[ModelMetadataSection::Reflection->value] = ModelMetadataSectionStatus::complete();
+        } catch (\Throwable $throwable) {
+            $statuses[ModelMetadataSection::Reflection->value] = ModelMetadataSectionStatus::failed($throwable);
+            self::warnSectionFailure($codebase, $modelFqcn, ModelMetadataSection::Reflection, $throwable);
+
+            return self::computeWithoutReflection(
+                $modelFqcn,
+                $storage,
+                $accessors,
+                $mutators,
+                $scopes,
+                $relations,
+                $statuses,
+            );
+        }
+
+        // Custom builder / collection detection is one isolated reflection-only pass. Strict mode
+        // propagates infrastructure/attribute failures so the section cannot be labelled complete
+        // after CustomTypeDetector swallowed a partial read.
+        /** @var array{0: class-string<\Illuminate\Database\Eloquent\Builder>|null, 1: class-string<\Illuminate\Database\Eloquent\Collection>|null} $customTypes */
+        $customTypes = self::computeSection(
+            $codebase,
+            $modelFqcn,
+            ModelMetadataSection::CustomTypes,
+            $statuses,
+            static fn(): array => [
+                CustomTypeDetector::resolveCustomBuilderClass($codebase, $modelFqcn, failOnError: true),
+                CustomTypeDetector::resolveCustomCollectionClass($codebase, $modelFqcn, failOnError: true),
+            ],
+            [null, null],
+        );
+        [$customBuilder, $customCollection] = $customTypes;
 
         // §6.3 step 2: an abstract base cannot be instantiated (newInstanceWithoutConstructor()
         // throws \Error, not \ReflectionException). Its instance-derived fields (schema, casts,
@@ -202,32 +245,26 @@ final class ModelMetadataRegistryBuilder
                 $reflection,
                 $customBuilder,
                 $customCollection,
-                $storageProvider,
+                $accessors,
+                $mutators,
+                $scopes,
+                $relations,
+                $statuses,
             );
-        }
-
-        try {
-            $instance = $reflection->newInstanceWithoutConstructor();
-        } catch (\ReflectionException $reflectionException) {
-            $codebase->progress->debug(
-                "Laravel plugin: ModelMetadataRegistry could not instantiate '{$modelFqcn}': {$reflectionException->getMessage()}\n",
-            );
-
-            return null;
-        }
-
-        if (!$instance instanceof Model) {
-            return null;
         }
 
         return self::computeForInstance(
             $codebase,
             $modelFqcn,
             $storage,
-            $instance,
             $reflection,
             $customBuilder,
             $customCollection,
+            $accessors,
+            $mutators,
+            $scopes,
+            $relations,
+            $statuses,
         );
     }
 
@@ -238,72 +275,130 @@ final class ModelMetadataRegistryBuilder
      * @param \ReflectionClass<Model>               $reflection
      * @param class-string<\Illuminate\Database\Eloquent\Builder>|null    $customBuilder
      * @param class-string<\Illuminate\Database\Eloquent\Collection>|null $customCollection
+     * @param array<non-empty-lowercase-string, AccessorInfo> $accessors
+     * @param array<non-empty-lowercase-string, MutatorInfo> $mutators
+     * @param array<non-empty-lowercase-string, ScopeInfo> $scopes
+     * @param array<non-empty-lowercase-string, RelationInfo> $relations
+     * @param array<non-empty-string, ModelMetadataSectionStatus> $statuses
      * @return ModelMetadata<Model>
      */
     private static function computeForInstance(
         Codebase $codebase,
         string $modelFqcn,
         ClassLikeStorage $storage,
-        Model $instance,
         \ReflectionClass $reflection,
         ?string $customBuilder,
         ?string $customCollection,
+        array $accessors,
+        array $mutators,
+        array $scopes,
+        array $relations,
+        array $statuses,
     ): ModelMetadata {
-        $traits = self::computeTraitFlags($storage, $instance->usesTimestamps());
+        $instance = self::computeSection(
+            $codebase,
+            $modelFqcn,
+            ModelMetadataSection::ModelInstance,
+            $statuses,
+            static fn(): Model => self::instantiateModel($modelFqcn, $reflection),
+            null,
+        );
 
-        // HasUuids / HasUlids override getKeyType(), getIncrementing(), and uniqueIds()
-        // by reading `$this->usesUniqueIds`, which the trait initializer flips to true.
-        // `newInstanceWithoutConstructor()` skips that initializer; flip the flag here
-        // so every downstream Laravel getter (primary key, casts, etc.) sees the same
-        // state the runtime would. See #591 review notes.
-        if ($traits->hasUuids || $traits->hasUlids) {
-            self::flipUsesUniqueIds($instance);
+        if (!$instance instanceof Model) {
+            $instanceStatus = $statuses[ModelMetadataSection::ModelInstance->value];
+            $statuses[ModelMetadataSection::RuntimeConfiguration->value] = ModelMetadataSectionStatus::unavailableBecause(
+                ModelMetadataSection::ModelInstance,
+                $instanceStatus,
+            );
         }
 
-        // Apply the class-level PHP-attribute config (#[Hidden]/#[Visible]/#[Appends]/#[Fillable]/
-        // #[Guarded]/#[Connection]/#[Table]) that Model::__construct() would set via initializeTraits() /
-        // initializeModelAttributes() — both skipped by newInstanceWithoutConstructor(). Mutating the
-        // instance here (like flipUsesUniqueIds above) lets the getters below AND computeSchema()'s
-        // getTable() see the runtime state.
-        self::applyClassAttributeConfig($codebase, $reflection, $instance);
+        $runtime = $instance instanceof Model
+            ? self::computeSection(
+                $codebase,
+                $modelFqcn,
+                ModelMetadataSection::RuntimeConfiguration,
+                $statuses,
+                static fn(): array => self::computeRuntimeConfiguration(
+                    $modelFqcn,
+                    $storage,
+                    $reflection,
+                    $instance,
+                ),
+                self::runtimeFallback($storage, $instance),
+            )
+            : self::runtimeFallback($storage);
 
-        $tableSchema = self::computeSchema($instance);
+        if (!$instance instanceof Model) {
+            self::markInstanceDependantsUnavailable($statuses);
+            $tableSchema = new TableSchema([]);
+            $casts = [];
+            $primaryKey = self::defaultPrimaryKey();
+        } else {
+            $runtimeStatus = $statuses[ModelMetadataSection::RuntimeConfiguration->value];
+            if ($runtimeStatus->isComplete()) {
+                $tableSchema = self::computeSection(
+                    $codebase,
+                    $modelFqcn,
+                    ModelMetadataSection::Schema,
+                    $statuses,
+                    static fn(): TableSchema => self::computeSchema($instance),
+                    new TableSchema([]),
+                );
+            } else {
+                $statuses[ModelMetadataSection::Schema->value] = ModelMetadataSectionStatus::unavailableBecause(
+                    ModelMetadataSection::RuntimeConfiguration,
+                    $runtimeStatus,
+                );
+                $tableSchema = new TableSchema([]);
+            }
 
-        // Method-derived metadata is STORAGE-based (no instance needed), so it is computed the same
-        // way for concrete and abstract models — see computeForAbstract.
-        [$accessors, $mutators, $scopes] = self::computeMethodMetadata($storage, $codebase->classlike_storage_provider);
-
-        // Relations need the Codebase (the AST parser reads parsed file statements), unlike the
-        // storage-only method metadata above — so they are computed separately, not in the walk.
-        $relations = self::computeRelations($codebase, $modelFqcn, $storage);
-
-        // Casts and appends are each needed twice — as their own field AND as a knownProperties()
-        // source — so compute each once into a local rather than re-deriving for the second use.
-        $casts = self::computeCasts($codebase, $modelFqcn, $instance, $traits, $tableSchema);
-        $appends = self::filterStringList($instance->getAppends());
+            $casts = self::computeSection(
+                $codebase,
+                $modelFqcn,
+                ModelMetadataSection::Casts,
+                $statuses,
+                static fn(): array => self::computeCasts(
+                    $codebase,
+                    $modelFqcn,
+                    $instance,
+                    $runtime['traits'],
+                    $tableSchema,
+                    $statuses[ModelMetadataSection::Schema->value]->isComplete(),
+                ),
+                [],
+            );
+            $primaryKey = self::computeSection(
+                $codebase,
+                $modelFqcn,
+                ModelMetadataSection::PrimaryKey,
+                $statuses,
+                static fn(): PrimaryKeyInfo => self::computePrimaryKey($instance, $runtime['traits']),
+                self::defaultPrimaryKey(),
+            );
+        }
 
         return new ModelMetadata(
             fqcn: $modelFqcn,
-            primaryKey: self::computePrimaryKey($instance, $traits),
-            traits: $traits,
+            primaryKey: $primaryKey,
+            traits: $runtime['traits'],
             // PHP-attribute config (#[Fillable]/#[Guarded]/#[Connection]/#[Table]/#[Appends]/#[Hidden]/
             // #[Visible]) was merged onto $instance by applyClassAttributeConfig() above, so these getters
             // now see it. Case is preserved — Laravel's isFillable / isGuarded / getHidden / getVisible do
             // exact-string comparisons, so lowercasing would diverge from runtime semantics.
-            fillable: self::filterStringList($instance->getFillable()),
+            fillable: $runtime['fillable'],
             // asArray() guards Laravel's `$guarded = false` ("guard nothing") idiom — getGuarded()
             // then returns a bool, not an array, and would TypeError filterStringList()'s array param,
             // crashing warm-up for the whole model (e.g. laravel/passport's models). #591.
-            guarded: self::filterStringList(self::asArray($instance->getGuarded())),
-            appends: $appends,
-            with: self::readStringList($instance, 'with'),
-            withCount: self::readStringList($instance, 'withCount'),
-            hidden: self::filterStringList($instance->getHidden()),
+            guarded: $runtime['guarded'],
+            appends: $runtime['appends'],
+            with: $runtime['with'],
+            withCount: $runtime['withCount'],
+            hidden: $runtime['hidden'],
             // getVisible() always returns an array (no `$visible = false` idiom, unlike $guarded), so
             // it needs no asArray() guard. Non-empty $visible is Eloquent's serialization allow-list.
-            visible: self::filterStringList($instance->getVisible()),
-            connection: $instance->getConnectionName(),
-            morphAlias: self::computeMorphAlias($modelFqcn),
+            visible: $runtime['visible'],
+            connection: $runtime['connection'],
+            morphAlias: $runtime['morphAlias'],
             customBuilder: $customBuilder,
             customCollection: $customCollection,
             schemaData: $tableSchema,
@@ -312,7 +407,8 @@ final class ModelMetadataRegistryBuilder
             mutatorsData: $mutators,
             scopesData: $scopes,
             relationsData: $relations,
-            knownPropertiesData: self::computeKnownProperties($tableSchema, $casts, $accessors, $mutators, $relations, $appends),
+            knownPropertiesData: self::computeKnownProperties($tableSchema, $casts, $accessors, $mutators, $relations, $runtime['appends']),
+            completenessData: ModelMetadataCompleteness::fromStatuses($statuses),
         );
     }
 
@@ -328,6 +424,11 @@ final class ModelMetadataRegistryBuilder
      * @param \ReflectionClass<Model>               $reflection
      * @param class-string<\Illuminate\Database\Eloquent\Builder>|null    $customBuilder
      * @param class-string<\Illuminate\Database\Eloquent\Collection>|null $customCollection
+     * @param array<non-empty-lowercase-string, AccessorInfo> $accessors
+     * @param array<non-empty-lowercase-string, MutatorInfo> $mutators
+     * @param array<non-empty-lowercase-string, ScopeInfo> $scopes
+     * @param array<non-empty-lowercase-string, RelationInfo> $relations
+     * @param array<non-empty-string, ModelMetadataSectionStatus> $statuses
      * @return ModelMetadata<Model>
      */
     private static function computeForAbstract(
@@ -337,43 +438,61 @@ final class ModelMetadataRegistryBuilder
         \ReflectionClass $reflection,
         ?string $customBuilder,
         ?string $customCollection,
-        ClassLikeStorageProvider $provider,
+        array $accessors,
+        array $mutators,
+        array $scopes,
+        array $relations,
+        array $statuses,
     ): ModelMetadata {
-        /** @var array<string, mixed> $defaults */
-        $defaults = $reflection->getDefaultProperties();
-
-        // Method-derived metadata is storage-based, so an abstract base populates accessors/mutators/
-        // scopes identically to a concrete model (no instantiation). This is what lets the migrated
-        // handlers resolve an inherited accessor/scope on an abstract-typed receiver (#901).
-        [$accessors, $mutators, $scopes] = self::computeMethodMetadata($storage, $provider);
-
-        // Concrete relation methods declared in the abstract base's own body parse the same way as on
-        // a concrete model (AST + storage, no instantiation).
-        $relations = self::computeRelations($codebase, $modelFqcn, $storage);
+        $runtime = self::computeSection(
+            $codebase,
+            $modelFqcn,
+            ModelMetadataSection::RuntimeConfiguration,
+            $statuses,
+            static fn(): array => self::computeAbstractRuntimeConfiguration($modelFqcn, $storage, $reflection),
+            self::abstractRuntimeFallback($storage),
+        );
+        $defaults = $runtime['defaults'];
+        $statuses[ModelMetadataSection::ModelInstance->value] = ModelMetadataSectionStatus::unavailable(
+            'abstract models cannot be instantiated',
+        );
 
         // Schema and casts are instance-derived — empty for an abstract base (no instance, no table).
         // Hoist the empty schema + the declared $appends so both the fields AND knownProperties()
         // read the same values (knownProperties is still meaningful here: accessors/relations/appends
         // declared on the abstract base populate it).
         $schema = new TableSchema([]);
-        $appends = self::stringListDefault($defaults, 'appends');
+        $statuses[ModelMetadataSection::Schema->value] = ModelMetadataSectionStatus::unavailable(
+            'abstract models have no runtime table instance',
+        );
+        $statuses[ModelMetadataSection::Casts->value] = ModelMetadataSectionStatus::unavailable(
+            'abstract models have no runtime cast instance',
+        );
+        $primaryKey = self::computeSection(
+            $codebase,
+            $modelFqcn,
+            ModelMetadataSection::PrimaryKey,
+            $statuses,
+            static fn(): PrimaryKeyInfo => self::computePrimaryKeyFromDefaults($defaults),
+            self::defaultPrimaryKey(),
+        );
 
         return new ModelMetadata(
             fqcn: $modelFqcn,
-            primaryKey: self::computePrimaryKeyFromDefaults($defaults),
-            traits: self::computeTraitFlags($storage, self::asBool($defaults['timestamps'] ?? null, true)),
-            fillable: self::stringListDefault($defaults, 'fillable'),
+            primaryKey: $primaryKey,
+            traits: $runtime['traits'],
+            fillable: $runtime['fillable'],
             // Laravel's base Model defaults $guarded to ['*'] (guard-all); the default-property
             // read returns exactly that, so no special-casing is needed here.
-            guarded: self::stringListDefault($defaults, 'guarded'),
-            appends: $appends,
-            with: self::stringListDefault($defaults, 'with'),
-            withCount: self::stringListDefault($defaults, 'withCount'),
-            hidden: self::stringListDefault($defaults, 'hidden'),
-            visible: self::stringListDefault($defaults, 'visible'),
+            guarded: $runtime['guarded'],
+            appends: $runtime['appends'],
+            with: $runtime['with'],
+            withCount: $runtime['withCount'],
+            hidden: $runtime['hidden'],
+            visible: $runtime['visible'],
             // Instance-derived — empty for an abstract base (no instance, no table).
             connection: null,
-            morphAlias: self::computeMorphAlias($modelFqcn),
+            morphAlias: $runtime['morphAlias'],
             customBuilder: $customBuilder,
             customCollection: $customCollection,
             schemaData: $schema,
@@ -382,8 +501,283 @@ final class ModelMetadataRegistryBuilder
             mutatorsData: $mutators,
             scopesData: $scopes,
             relationsData: $relations,
-            knownPropertiesData: self::computeKnownProperties($schema, [], $accessors, $mutators, $relations, $appends),
+            knownPropertiesData: self::computeKnownProperties($schema, [], $accessors, $mutators, $relations, $runtime['appends']),
+            completenessData: ModelMetadataCompleteness::fromStatuses($statuses),
         );
+    }
+
+    /**
+     * Preserve storage/AST metadata even in the exceptional case where PHP reflection failed after
+     * the class had already passed the Model and Psalm-storage guards.
+     *
+     * @param class-string<Model> $modelFqcn
+     * @param array<non-empty-lowercase-string, AccessorInfo> $accessors
+     * @param array<non-empty-lowercase-string, MutatorInfo> $mutators
+     * @param array<non-empty-lowercase-string, ScopeInfo> $scopes
+     * @param array<non-empty-lowercase-string, RelationInfo> $relations
+     * @param array<non-empty-string, ModelMetadataSectionStatus> $statuses
+     * @return ModelMetadata<Model>
+     */
+    private static function computeWithoutReflection(
+        string $modelFqcn,
+        ClassLikeStorage $storage,
+        array $accessors,
+        array $mutators,
+        array $scopes,
+        array $relations,
+        array $statuses,
+    ): ModelMetadata {
+        $reflectionStatus = $statuses[ModelMetadataSection::Reflection->value];
+        $statuses[ModelMetadataSection::ModelInstance->value] = ModelMetadataSectionStatus::unavailableBecause(
+            ModelMetadataSection::Reflection,
+            $reflectionStatus,
+        );
+        $statuses[ModelMetadataSection::CustomTypes->value] = ModelMetadataSectionStatus::unavailableBecause(
+            ModelMetadataSection::Reflection,
+            $reflectionStatus,
+        );
+        $statuses[ModelMetadataSection::RuntimeConfiguration->value] = ModelMetadataSectionStatus::unavailableBecause(
+            ModelMetadataSection::Reflection,
+            $reflectionStatus,
+        );
+        self::markRuntimeDependantsUnavailable($statuses);
+
+        $traits = self::computeTraitFlags($storage, true);
+        $schema = new TableSchema([]);
+
+        return new ModelMetadata(
+            fqcn: $modelFqcn,
+            primaryKey: self::defaultPrimaryKey(),
+            traits: $traits,
+            fillable: [],
+            guarded: [],
+            appends: [],
+            with: [],
+            withCount: [],
+            hidden: [],
+            visible: [],
+            connection: null,
+            morphAlias: null,
+            customBuilder: null,
+            customCollection: null,
+            schemaData: $schema,
+            castsData: [],
+            accessorsData: $accessors,
+            mutatorsData: $mutators,
+            scopesData: $scopes,
+            relationsData: $relations,
+            knownPropertiesData: self::computeKnownProperties($schema, [], $accessors, $mutators, $relations, []),
+            completenessData: ModelMetadataCompleteness::fromStatuses($statuses),
+        );
+    }
+
+    /**
+     * @param class-string<Model> $modelFqcn
+     * @param \ReflectionClass<Model> $reflection
+     * @return array{instance: Model, traits: TraitFlags, fillable: list<non-empty-string>, guarded: list<non-empty-string>, appends: list<non-empty-string>, with: list<string>, withCount: list<string>, hidden: list<non-empty-string>, visible: list<non-empty-string>, connection: ?string, morphAlias: ?string}
+     */
+    private static function computeRuntimeConfiguration(
+        string $modelFqcn,
+        ClassLikeStorage $storage,
+        \ReflectionClass $reflection,
+        Model $instance,
+    ): array {
+        $traits = self::computeTraitFlags($storage, $instance->usesTimestamps());
+
+        // newInstanceWithoutConstructor() skips the HasUuids/HasUlids initializer.
+        if ($traits->hasUuids || $traits->hasUlids) {
+            self::flipUsesUniqueIds($instance);
+        }
+
+        self::applyClassAttributeConfig($reflection, $instance);
+
+        return [
+            'instance' => $instance,
+            'traits' => $traits,
+            'fillable' => self::filterStringList($instance->getFillable()),
+            'guarded' => self::filterStringList(self::asArray($instance->getGuarded())),
+            'appends' => self::filterStringList($instance->getAppends()),
+            'with' => self::readStringList($instance, 'with'),
+            'withCount' => self::readStringList($instance, 'withCount'),
+            'hidden' => self::filterStringList($instance->getHidden()),
+            'visible' => self::filterStringList($instance->getVisible()),
+            'connection' => $instance->getConnectionName(),
+            'morphAlias' => self::computeMorphAlias($modelFqcn),
+        ];
+    }
+
+    /**
+     * @return array{instance: Model|null, traits: TraitFlags, fillable: list<non-empty-string>, guarded: list<non-empty-string>, appends: list<non-empty-string>, with: list<string>, withCount: list<string>, hidden: list<non-empty-string>, visible: list<non-empty-string>, connection: null, morphAlias: null}
+     * @psalm-mutation-free
+     */
+    private static function runtimeFallback(ClassLikeStorage $storage, ?Model $instance = null): array
+    {
+        return [
+            'instance' => $instance,
+            'traits' => self::computeTraitFlags($storage, true),
+            'fillable' => [],
+            'guarded' => [],
+            'appends' => [],
+            'with' => [],
+            'withCount' => [],
+            'hidden' => [],
+            'visible' => [],
+            'connection' => null,
+            'morphAlias' => null,
+        ];
+    }
+
+    /**
+     * @param class-string<Model> $modelFqcn
+     * @param \ReflectionClass<Model> $reflection
+     * @return array{defaults: array<string, mixed>, traits: TraitFlags, fillable: list<non-empty-string>, guarded: list<non-empty-string>, appends: list<non-empty-string>, with: list<non-empty-string>, withCount: list<non-empty-string>, hidden: list<non-empty-string>, visible: list<non-empty-string>, morphAlias: ?string}
+     */
+    private static function computeAbstractRuntimeConfiguration(
+        string $modelFqcn,
+        ClassLikeStorage $storage,
+        \ReflectionClass $reflection,
+    ): array {
+        /** @var array<string, mixed> $defaults */
+        $defaults = $reflection->getDefaultProperties();
+
+        return [
+            'defaults' => $defaults,
+            'traits' => self::computeTraitFlags($storage, self::asBool($defaults['timestamps'] ?? null, true)),
+            'fillable' => self::stringListDefault($defaults, 'fillable'),
+            'guarded' => self::stringListDefault($defaults, 'guarded'),
+            'appends' => self::stringListDefault($defaults, 'appends'),
+            'with' => self::stringListDefault($defaults, 'with'),
+            'withCount' => self::stringListDefault($defaults, 'withCount'),
+            'hidden' => self::stringListDefault($defaults, 'hidden'),
+            'visible' => self::stringListDefault($defaults, 'visible'),
+            'morphAlias' => self::computeMorphAlias($modelFqcn),
+        ];
+    }
+
+    /**
+     * @return array{defaults: array<string, mixed>, traits: TraitFlags, fillable: list<non-empty-string>, guarded: list<non-empty-string>, appends: list<non-empty-string>, with: list<non-empty-string>, withCount: list<non-empty-string>, hidden: list<non-empty-string>, visible: list<non-empty-string>, morphAlias: null}
+     * @psalm-mutation-free
+     */
+    private static function abstractRuntimeFallback(ClassLikeStorage $storage): array
+    {
+        return [
+            'defaults' => [],
+            'traits' => self::computeTraitFlags($storage, true),
+            'fillable' => [],
+            'guarded' => [],
+            'appends' => [],
+            'with' => [],
+            'withCount' => [],
+            'hidden' => [],
+            'visible' => [],
+            'morphAlias' => null,
+        ];
+    }
+
+    /** @psalm-pure */
+    private static function defaultPrimaryKey(): PrimaryKeyInfo
+    {
+        return new PrimaryKeyInfo('id', PrimaryKeyType::Integer, incrementing: true, uuidColumns: []);
+    }
+
+    /**
+     * @param class-string<Model> $modelFqcn
+     * @param \ReflectionClass<Model> $reflection
+     */
+    private static function instantiateModel(string $modelFqcn, \ReflectionClass $reflection): Model
+    {
+        $instance = $reflection->newInstanceWithoutConstructor();
+        if (!$instance instanceof Model) {
+            throw new \UnexpectedValueException("Reflection did not create an Eloquent model for {$modelFqcn}");
+        }
+
+        return $instance;
+    }
+
+    /**
+     * @param array<non-empty-string, ModelMetadataSectionStatus> $statuses
+     * @param-out array<non-empty-string, ModelMetadataSectionStatus> $statuses
+     */
+    private static function markRuntimeDependantsUnavailable(array &$statuses): void
+    {
+        $runtimeStatus = $statuses[ModelMetadataSection::RuntimeConfiguration->value];
+        foreach ([ModelMetadataSection::Schema, ModelMetadataSection::Casts, ModelMetadataSection::PrimaryKey] as $section) {
+            $statuses[$section->value] = ModelMetadataSectionStatus::unavailableBecause(
+                ModelMetadataSection::RuntimeConfiguration,
+                $runtimeStatus,
+            );
+        }
+    }
+
+    /**
+     * @param array<non-empty-string, ModelMetadataSectionStatus> $statuses
+     * @param-out array<non-empty-string, ModelMetadataSectionStatus> $statuses
+     */
+    private static function markInstanceDependantsUnavailable(array &$statuses): void
+    {
+        $instanceStatus = $statuses[ModelMetadataSection::ModelInstance->value];
+        foreach (
+            [
+                ModelMetadataSection::Schema,
+                ModelMetadataSection::Casts,
+                ModelMetadataSection::PrimaryKey,
+            ] as $section
+        ) {
+            $statuses[$section->value] = ModelMetadataSectionStatus::unavailableBecause(
+                ModelMetadataSection::ModelInstance,
+                $instanceStatus,
+            );
+        }
+    }
+
+    /**
+     * @template T
+     * @param class-string<Model> $modelFqcn
+     * @param array<non-empty-string, ModelMetadataSectionStatus> $statuses
+     * @param-out array<non-empty-string, ModelMetadataSectionStatus> $statuses
+     * @param \Closure(): T $compute
+     * @param T $fallback
+     * @return T
+     */
+    private static function computeSection(
+        Codebase $codebase,
+        string $modelFqcn,
+        ModelMetadataSection $section,
+        array &$statuses,
+        \Closure $compute,
+        mixed $fallback,
+    ): mixed {
+        try {
+            $result = $compute();
+            $statuses[$section->value] = ModelMetadataSectionStatus::complete();
+
+            return $result;
+        } catch (MetadataSectionUnavailable $unavailable) {
+            $statuses[$section->value] = ModelMetadataSectionStatus::unavailable($unavailable->getMessage());
+
+            return $fallback;
+        } catch (\Throwable $throwable) {
+            $statuses[$section->value] = ModelMetadataSectionStatus::failed($throwable);
+            self::warnSectionFailure($codebase, $modelFqcn, $section, $throwable);
+
+            return $fallback;
+        }
+    }
+
+    /** @param class-string<Model> $modelFqcn */
+    private static function warnSectionFailure(
+        Codebase $codebase,
+        string $modelFqcn,
+        ModelMetadataSection $section,
+        \Throwable $throwable,
+    ): void {
+        $message = "Laravel plugin: ModelMetadataRegistry {$section->value} failed for '{$modelFqcn}': "
+            . "{$throwable->getMessage()} at {$throwable->getFile()}:{$throwable->getLine()}";
+
+        $codebase->progress->warning($message);
+        if ($codebase->progress instanceof VoidProgress) {
+            \fwrite(\STDERR, 'Warning: ' . $message . \PHP_EOL);
+        }
     }
 
     /**
@@ -743,7 +1137,12 @@ final class ModelMetadataRegistryBuilder
                 continue;
             }
 
-            $parsed = RelationMethodParser::parse($codebase, $modelFqcn, $casedName);
+            $parsed = RelationMethodParser::parse(
+                $codebase,
+                $modelFqcn,
+                $casedName,
+                failOnInfrastructureError: true,
+            );
             if ($parsed === null) {
                 continue;
             }
@@ -971,12 +1370,12 @@ final class ModelMetadataRegistryBuilder
     {
         $schema = SchemaStateProvider::getSchema();
         if (!$schema instanceof \Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaAggregator) {
-            return new TableSchema([]);
+            throw new MetadataSectionUnavailable('migration schema provider is unavailable');
         }
 
         $tableName = $instance->getTable();
         if (!isset($schema->tables[$tableName])) {
-            return new TableSchema([]);
+            throw new MetadataSectionUnavailable("migration schema has no resolved table '{$tableName}'");
         }
 
         $columns = [];
@@ -1020,6 +1419,7 @@ final class ModelMetadataRegistryBuilder
         Model $instance,
         TraitFlags $traits,
         TableSchema $schema,
+        bool $schemaComplete,
     ): array {
         $merged = [];
 
@@ -1045,8 +1445,12 @@ final class ModelMetadataRegistryBuilder
         //    newInstanceWithoutConstructor() (unit-test fixtures) leaves it
         //    uninitialized; skip the AST walk there. Production Codebases always
         //    have $methods wired, so the check result is stable per process and cached.
-        if (self::codebaseMethodsInitialized($codebase)) {
-            $merged = \array_merge($merged, CastsMethodParser::parse($codebase, $modelFqcn));
+        if (
+            self::codebaseMethodsInitialized($codebase)
+            && $codebase->classlike_storage_provider->has($modelFqcn)
+            && isset($codebase->classlike_storage_provider->get($modelFqcn)->methods['casts'])
+        ) {
+            $merged = \array_merge($merged, CastsMethodParser::parse($codebase, $modelFqcn, failOnInfrastructureError: true));
         }
 
         $result = [];
@@ -1058,12 +1462,16 @@ final class ModelMetadataRegistryBuilder
             // Bake column nullability into CastInfo::$psalmType at build time so consumers
             // can read it directly without re-running CastResolver (see design §5.4).
             $column = $schema->column($columnName);
-            $nullable = $column instanceof ColumnInfo && $column->nullable;
+            // When schema input is unavailable/failed, absence from the fallback empty schema says
+            // nothing about DB nullability. Preserve the independently complete cast inventory but
+            // make its positive type conservative. Explicit context is required here: an actually
+            // parsed, complete-empty table must remain authoritative rather than looking unavailable.
+            $nullable = !$schemaComplete || ($column instanceof ColumnInfo && $column->nullable);
             // CastsInboundAttributes casts read back as a passthrough of the column's intrinsic
             // type, so CastResolver needs that base type as `$originalType`. The mapping lives on
             // ColumnTypeMapper (Schema namespace) so the builder reads it directly instead of
             // reaching back into the property handler; null when no migration column backs the cast.
-            $originalType = $column instanceof ColumnInfo
+            $originalType = $schemaComplete && $column instanceof ColumnInfo
                 ? ColumnTypeMapper::mapBaseType($column)
                 : null;
             // Preserve original-case column keys to match Eloquent's case-sensitive
@@ -1270,12 +1678,7 @@ final class ModelMetadataRegistryBuilder
      */
     private static function flipUsesUniqueIds(Model $instance): void
     {
-        try {
-            $property = new \ReflectionProperty($instance, 'usesUniqueIds');
-        } catch (\ReflectionException) {
-            return;
-        }
-
+        $property = new \ReflectionProperty($instance, 'usesUniqueIds');
         $property->setValue($instance, true);
     }
 
@@ -1301,35 +1704,35 @@ final class ModelMetadataRegistryBuilder
      *
      * @param \ReflectionClass<Model> $reflection
      */
-    private static function applyClassAttributeConfig(Codebase $codebase, \ReflectionClass $reflection, Model $instance): void
+    private static function applyClassAttributeConfig(\ReflectionClass $reflection, Model $instance): void
     {
         // Union-merge, mirroring mergeHidden() / mergeVisible() / mergeAppends() / mergeFillable().
         // These four configuration attributes only exist from Laravel 13. On Laravel 12.14–12.24,
         // mergeHidden() / mergeVisible() / mergeAppends() are unavailable (mergeFillable() exists), so
         // calling the absent helpers with empty fallbacks crashes warm-up. An absent attribute has nothing to replay.
-        $hidden = self::classAttribute($codebase, $reflection, Hidden::class);
+        $hidden = self::classAttribute($reflection, Hidden::class);
         if ($hidden !== null) {
             $instance->mergeHidden($hidden->columns);
         }
 
-        $visible = self::classAttribute($codebase, $reflection, Visible::class);
+        $visible = self::classAttribute($reflection, Visible::class);
         if ($visible !== null) {
             $instance->mergeVisible($visible->columns);
         }
 
-        $appends = self::classAttribute($codebase, $reflection, Appends::class);
+        $appends = self::classAttribute($reflection, Appends::class);
         if ($appends !== null) {
             $instance->mergeAppends($appends->columns);
         }
 
-        $fillable = self::classAttribute($codebase, $reflection, Fillable::class);
+        $fillable = self::classAttribute($reflection, Fillable::class);
         if ($fillable !== null) {
             $instance->mergeFillable($fillable->columns);
         }
 
-        self::applyGuardedAttribute($codebase, $reflection, $instance);
-        self::applyConnectionAttribute($codebase, $reflection, $instance);
-        self::applyTableAttribute($codebase, $reflection, $instance);
+        self::applyGuardedAttribute($reflection, $instance);
+        self::applyConnectionAttribute($reflection, $instance);
+        self::applyTableAttribute($reflection, $instance);
     }
 
     /**
@@ -1340,13 +1743,13 @@ final class ModelMetadataRegistryBuilder
      *
      * @param \ReflectionClass<Model> $reflection
      */
-    private static function applyGuardedAttribute(Codebase $codebase, \ReflectionClass $reflection, Model $instance): void
+    private static function applyGuardedAttribute(\ReflectionClass $reflection, Model $instance): void
     {
         if ($instance->getGuarded() !== ['*']) {
             return;
         }
 
-        if (self::classAttribute($codebase, $reflection, Unguarded::class) !== null) {
+        if (self::classAttribute($reflection, Unguarded::class) !== null) {
             $instance->guard([]);
 
             return;
@@ -1354,7 +1757,7 @@ final class ModelMetadataRegistryBuilder
 
         // Presence (not non-empty) gates the replace: a present `#[Guarded()]` with no columns sets [],
         // matching Laravel's `columns ?? ['*']` where an empty array is non-null. Absent → keep `['*']`.
-        $guarded = self::classAttribute($codebase, $reflection, Guarded::class);
+        $guarded = self::classAttribute($reflection, Guarded::class);
         if ($guarded !== null) {
             $instance->guard($guarded->columns);
         }
@@ -1370,13 +1773,13 @@ final class ModelMetadataRegistryBuilder
      *
      * @param \ReflectionClass<Model> $reflection
      */
-    private static function applyConnectionAttribute(Codebase $codebase, \ReflectionClass $reflection, Model $instance): void
+    private static function applyConnectionAttribute(\ReflectionClass $reflection, Model $instance): void
     {
         if ($instance->getConnectionName() !== null) {
             return;
         }
 
-        $name = self::classAttribute($codebase, $reflection, Connection::class)?->name;
+        $name = self::classAttribute($reflection, Connection::class)?->name;
         if ($name === null) {
             return;
         }
@@ -1402,9 +1805,9 @@ final class ModelMetadataRegistryBuilder
      *
      * @param \ReflectionClass<Model> $reflection
      */
-    private static function applyTableAttribute(Codebase $codebase, \ReflectionClass $reflection, Model $instance): void
+    private static function applyTableAttribute(\ReflectionClass $reflection, Model $instance): void
     {
-        $name = self::classAttribute($codebase, $reflection, Table::class)?->name;
+        $name = self::classAttribute($reflection, Table::class)?->name;
         if ($name === null) {
             return;
         }
@@ -1458,18 +1861,16 @@ final class ModelMetadataRegistryBuilder
     /**
      * Resolve a class-level attribute the way {@see Model}::resolveClassAttribute() does: walk the class
      * up its parents, return the first ancestor's first instance of `$attributeClass` (no cross-ancestor
-     * merge), or null. A throwing `newInstance()` (malformed attribute args) is swallowed to a null so a
-     * single bad attribute degrades that one field rather than aborting the whole model's warm-up; this
-     * is deliberately broader than Laravel's own `catch (Exception)`, since a static-analysis pass must
-     * never crash where the runtime constructor would. The swallow leaves a debug breadcrumb, like the
-     * file's other reflection catches ({@see compute()}, {@see warmUp()}).
+     * merge), or null. A throwing `newInstance()` is allowed to reach the runtime-configuration section
+     * boundary. That boundary records a failed (not complete) section, emits one warning, and preserves
+     * unrelated storage/AST metadata.
      *
      * @template T of object
      * @param \ReflectionClass<object> $reflection
      * @param class-string<T>          $attributeClass
      * @return T|null
      */
-    private static function classAttribute(Codebase $codebase, \ReflectionClass $reflection, string $attributeClass): ?object
+    private static function classAttribute(\ReflectionClass $reflection, string $attributeClass): ?object
     {
         for ($current = $reflection; $current !== false; $current = $current->getParentClass()) {
             $attributes = $current->getAttributes($attributeClass);
@@ -1477,15 +1878,7 @@ final class ModelMetadataRegistryBuilder
                 continue;
             }
 
-            try {
-                return $attributes[0]->newInstance();
-            } catch (\Throwable $throwable) {
-                $codebase->progress->debug(
-                    "Laravel plugin: ModelMetadataRegistry could not instantiate {$attributeClass} on '{$current->getName()}': {$throwable->getMessage()}\n",
-                );
-
-                return null;
-            }
+            return $attributes[0]->newInstance();
         }
 
         return null;

--- a/src/Handlers/Eloquent/Metadata/ModelMetadataSection.php
+++ b/src/Handlers/Eloquent/Metadata/ModelMetadataSection.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Eloquent\Metadata;
+
+/**
+ * Independently-computed parts of a model metadata snapshot.
+ *
+ * Kept free of Psalm-version-specific types so the registry isolation design can be
+ * backported to the Psalm 6-based 3.x plugin line.
+ *
+ * @internal
+ */
+enum ModelMetadataSection: string
+{
+    case StorageMethods = 'storage-methods';
+    case Relations = 'relations';
+    case Reflection = 'reflection';
+    case ModelInstance = 'model-instance';
+    case RuntimeConfiguration = 'runtime-configuration';
+    case Schema = 'schema';
+    case Casts = 'casts';
+    case PrimaryKey = 'primary-key';
+    case CustomTypes = 'custom-types';
+}

--- a/src/Handlers/Eloquent/Metadata/ModelMetadataSectionStatus.php
+++ b/src/Handlers/Eloquent/Metadata/ModelMetadataSectionStatus.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Eloquent\Metadata;
+
+/**
+ * Status of one independently-computed metadata section.
+ *
+ * @psalm-immutable
+ * @internal
+ */
+final readonly class ModelMetadataSectionStatus
+{
+    private function __construct(
+        public MetadataSectionState $state,
+        public ?string $reason,
+    ) {}
+
+    /** @psalm-pure */
+    public static function complete(): self
+    {
+        return new self(MetadataSectionState::Complete, null);
+    }
+
+    /** @psalm-pure */
+    public static function unavailable(string $reason): self
+    {
+        return new self(MetadataSectionState::Unavailable, $reason);
+    }
+
+    public static function failed(\Throwable $throwable): self
+    {
+        return new self(
+            MetadataSectionState::Failed,
+            "{$throwable->getMessage()} at {$throwable->getFile()}:{$throwable->getLine()}",
+        );
+    }
+
+    /** @psalm-pure */
+    public static function unavailableBecause(ModelMetadataSection $dependency, self $status): self
+    {
+        $reason = "depends on {$dependency->value}, which is {$status->state->value}";
+        if ($status->reason !== null) {
+            $reason .= ': ' . $status->reason;
+        }
+
+        return self::unavailable($reason);
+    }
+
+    /** @psalm-mutation-free */
+    public function isComplete(): bool
+    {
+        return $this->state === MetadataSectionState::Complete;
+    }
+}

--- a/src/Handlers/Eloquent/RelationMethodParser.php
+++ b/src/Handlers/Eloquent/RelationMethodParser.php
@@ -131,15 +131,19 @@ final class RelationMethodParser
      *         an explicit `->using(Pivot::class)` / `->as('alias')` chain mutation was
      *         detected with a statically resolvable argument.
      */
-    public static function parse(Codebase $codebase, string $className, string $methodName): ?array
-    {
-        $cacheKey = $className . '::' . $methodName;
+    public static function parse(
+        Codebase $codebase,
+        string $className,
+        string $methodName,
+        bool $failOnInfrastructureError = false,
+    ): ?array {
+        $cacheKey = $className . '::' . $methodName . ($failOnInfrastructureError ? '|strict' : '');
 
         if (\array_key_exists($cacheKey, self::$cache)) {
             return self::$cache[$cacheKey];
         }
 
-        $result = self::doParse($codebase, $className, $methodName);
+        $result = self::doParse($codebase, $className, $methodName, $failOnInfrastructureError);
         self::$cache[$cacheKey] = $result;
 
         return $result;
@@ -148,9 +152,13 @@ final class RelationMethodParser
     /**
      * @return ?array{relationClass: class-string<Relation>, relatedModel: ?string, intermediateModel: ?string, pivotModel: ?string, accessor: ?string}
      */
-    private static function doParse(Codebase $codebase, string $className, string $methodName): ?array
-    {
-        $context = self::findClassMethodWithStatements($codebase, $className, $methodName);
+    private static function doParse(
+        Codebase $codebase,
+        string $className,
+        string $methodName,
+        bool $failOnInfrastructureError,
+    ): ?array {
+        $context = self::findClassMethodWithStatements($codebase, $className, $methodName, $failOnInfrastructureError);
         if ($context === null) {
             return null;
         }
@@ -165,7 +173,7 @@ final class RelationMethodParser
         // searches the file by `$className`, so a successful lookup means the method body
         // lives in `$className` itself — `self::class` and (conservatively) `static::class`
         // both resolve to `$className`. See {@see resolveClassConstFetch} for the trade-off.
-        $parentClass = self::resolveParentClass($codebase, $className);
+        $parentClass = self::resolveParentClass($codebase, $className, $failOnInfrastructureError);
 
         return self::parseMethodBody($classMethod->stmts, $className, $parentClass);
     }
@@ -177,11 +185,18 @@ final class RelationMethodParser
      * fail-soft style — a missing parent yields null and the handler defers, rather than
      * crashing the analysis run.
      */
-    private static function resolveParentClass(Codebase $codebase, string $className): ?string
-    {
+    private static function resolveParentClass(
+        Codebase $codebase,
+        string $className,
+        bool $failOnInfrastructureError,
+    ): ?string {
         try {
             $storage = $codebase->classlike_storage_provider->get($className);
         } catch (\InvalidArgumentException $invalidArgumentException) {
+            if ($failOnInfrastructureError) {
+                throw $invalidArgumentException;
+            }
+
             $codebase->progress->debug(
                 "Laravel plugin: could not resolve parent class for {$className}: {$invalidArgumentException->getMessage()}\n",
             );
@@ -438,7 +453,7 @@ final class RelationMethodParser
      */
     public static function extractDocblockRelatedModelType(Codebase $codebase, string $className, string $methodName): ?Union
     {
-        $context = self::findClassMethodWithStatements($codebase, $className, $methodName);
+        $context = self::findClassMethodWithStatements($codebase, $className, $methodName, false);
         if ($context === null) {
             return null;
         }
@@ -469,8 +484,12 @@ final class RelationMethodParser
      *
      * @return ?array{classMethod: PhpParser\Node\Stmt\ClassMethod, fileStmts: list<PhpParser\Node\Stmt>}
      */
-    private static function findClassMethodWithStatements(Codebase $codebase, string $className, string $methodName): ?array
-    {
+    private static function findClassMethodWithStatements(
+        Codebase $codebase,
+        string $className,
+        string $methodName,
+        bool $failOnInfrastructureError,
+    ): ?array {
         $methodId = $className . '::' . $methodName;
         $methodIdentifier = MethodIdentifier::wrap($methodId);
 
@@ -481,12 +500,20 @@ final class RelationMethodParser
         // Falling through to getStorage() and catching the resulting UnexpectedValueException
         // for each cold miss adds a real cost per (class, method) pair on first analysis.
         if (!$codebase->methods->hasStorage($methodIdentifier)) {
+            if ($failOnInfrastructureError) {
+                throw new \UnexpectedValueException("Psalm has no method storage for {$methodId}");
+            }
+
             return null;
         }
 
         try {
             $methodStorage = $codebase->methods->getStorage($methodIdentifier);
         } catch (\InvalidArgumentException|\UnexpectedValueException $e) {
+            if ($failOnInfrastructureError) {
+                throw $e;
+            }
+
             $codebase->progress->debug(
                 "Laravel plugin: could not get method storage for {$methodId}: {$e->getMessage()}\n",
             );
@@ -495,12 +522,20 @@ final class RelationMethodParser
 
         $location = $methodStorage->location;
         if (!$location instanceof \Psalm\CodeLocation) {
+            if ($failOnInfrastructureError) {
+                throw new \UnexpectedValueException("Psalm has no source location for {$methodId}");
+            }
+
             return null;
         }
 
         try {
             $stmts = $codebase->getStatementsForFile($location->file_path);
         } catch (\InvalidArgumentException|\UnexpectedValueException $e) {
+            if ($failOnInfrastructureError) {
+                throw $e;
+            }
+
             $codebase->progress->debug(
                 "Laravel plugin: could not get statements for {$location->file_path}: {$e->getMessage()}\n",
             );
@@ -509,6 +544,10 @@ final class RelationMethodParser
 
         $classMethod = self::findMethod($stmts, $className, $methodName);
         if (!$classMethod instanceof PhpParser\Node\Stmt\ClassMethod) {
+            if ($failOnInfrastructureError) {
+                throw new \UnexpectedValueException("Psalm's source AST has no method node for {$methodId}");
+            }
+
             return null;
         }
 

--- a/src/Handlers/Eloquent/Schema/CastsMethodParser.php
+++ b/src/Handlers/Eloquent/Schema/CastsMethodParser.php
@@ -28,7 +28,7 @@ final class CastsMethodParser
      *
      * @return array<string, string> Map of property name → cast string
      */
-    public static function parse(Codebase $codebase, string $modelClass): array
+    public static function parse(Codebase $codebase, string $modelClass, bool $failOnInfrastructureError = false): array
     {
         $methodId = $modelClass . '::casts';
 
@@ -38,7 +38,11 @@ final class CastsMethodParser
 
         try {
             $methodStorage = $codebase->methods->getStorage(MethodIdentifier::wrap($methodId));
-        } catch (\InvalidArgumentException|\UnexpectedValueException) {
+        } catch (\InvalidArgumentException|\UnexpectedValueException $exception) {
+            if ($failOnInfrastructureError) {
+                throw $exception;
+            }
+
             return [];
         }
 
@@ -51,7 +55,11 @@ final class CastsMethodParser
 
         try {
             $stmts = $codebase->getStatementsForFile($filePath);
-        } catch (\InvalidArgumentException|\UnexpectedValueException) {
+        } catch (\InvalidArgumentException|\UnexpectedValueException $exception) {
+            if ($failOnInfrastructureError) {
+                throw $exception;
+            }
+
             return [];
         }
 

--- a/src/Handlers/Rules/UnknownModelAttributeHandler.php
+++ b/src/Handlers/Rules/UnknownModelAttributeHandler.php
@@ -18,6 +18,7 @@ use Psalm\Exception\UnpopulatedClasslikeException;
 use Psalm\IssueBuffer;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadata;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadataRegistry;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadataSection;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Support\EloquentModelMethods;
 use Psalm\LaravelPlugin\Issues\UnknownModelAttribute;
 use Psalm\Plugin\EventHandler\AfterExpressionAnalysisInterface;
@@ -112,10 +113,10 @@ final class UnknownModelAttributeHandler implements AfterExpressionAnalysisInter
             return null;
         }
 
-        // Completeness gate: the unknown-key verdict is only sound when the model's columns are
-        // known. With migrations disabled (or the table unparsed) schema() is empty, so the known
-        // set lacks its column origins and every real column would look unknown — skip the model.
-        if ($metadata->schema()->all() === []) {
+        // A negative verdict is sound only when every registry source that can establish an
+        // attribute name was evaluated completely. Complete-empty schema is authoritative; an
+        // unavailable provider/table or a failed section is not.
+        if (!self::canEvaluate($metadata)) {
             return null;
         }
 
@@ -163,6 +164,23 @@ final class UnknownModelAttributeHandler implements AfterExpressionAnalysisInter
         }
 
         return null;
+    }
+
+    /**
+     * Whether every registry source that could make an attribute known is authoritative.
+     *
+     * @internal public for focused consumer-policy tests
+     * @psalm-mutation-free
+     */
+    public static function canEvaluate(ModelMetadata $metadata): bool
+    {
+        return $metadata->isComplete(
+            ModelMetadataSection::Schema,
+            ModelMetadataSection::RuntimeConfiguration,
+            ModelMetadataSection::Casts,
+            ModelMetadataSection::StorageMethods,
+            ModelMetadataSection::Relations,
+        );
     }
 
     /**

--- a/src/Handlers/Rules/UnresolvableAppendedModelAttributeHandler.php
+++ b/src/Handlers/Rules/UnresolvableAppendedModelAttributeHandler.php
@@ -10,6 +10,7 @@ use Psalm\IssueBuffer;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\CastInfo;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadata;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadataRegistry;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadataSection;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Support\EloquentModelMethods;
 use Psalm\LaravelPlugin\Issues\UnresolvableAppendedModelAttribute;
 use Psalm\Plugin\EventHandler\AfterCodebasePopulatedInterface;
@@ -56,7 +57,9 @@ final class UnresolvableAppendedModelAttributeHandler implements AfterCodebasePo
         $provider = $event->getCodebase()->classlike_storage_provider;
 
         foreach (ModelMetadataRegistry::all() as $fqcn => $metadata) {
-            if ($metadata->appends === [] || !$provider->has($fqcn)) {
+            // This is a negative verdict: a missing backing accessor/cast is conclusive only when
+            // the appends/visibility configuration and both backing sources are complete.
+            if (!self::canEvaluate($metadata) || $metadata->appends === [] || !$provider->has($fqcn)) {
                 continue;
             }
 
@@ -90,6 +93,21 @@ final class UnresolvableAppendedModelAttributeHandler implements AfterCodebasePo
                 );
             }
         }
+    }
+
+    /**
+     * Whether appends/visibility and every possible backing source are authoritative.
+     *
+     * @internal public for focused consumer-policy tests
+     * @psalm-mutation-free
+     */
+    public static function canEvaluate(ModelMetadata $metadata): bool
+    {
+        return $metadata->isComplete(
+            ModelMetadataSection::RuntimeConfiguration,
+            ModelMetadataSection::Casts,
+            ModelMetadataSection::StorageMethods,
+        );
     }
 
     /**

--- a/tests/Unit/Fixtures/Models/CompleteEmptySchemaModel.php
+++ b/tests/Unit/Fixtures/Models/CompleteEmptySchemaModel.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Casts\InboundOnlyCast;
+
+final class CompleteEmptySchemaModel extends Model
+{
+    protected $table = 'complete_empty_schema_models';
+
+    protected $casts = [
+        'flag' => 'boolean',
+        'code' => InboundOnlyCast::class,
+    ];
+}

--- a/tests/Unit/Fixtures/Models/ThrowingCastsModel.php
+++ b/tests/Unit/Fixtures/Models/ThrowingCastsModel.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+final class ThrowingCastsModel extends Model
+{
+    protected $table = 'throwing_casts_models';
+
+    public function getCasts(): array
+    {
+        throw new \RuntimeException('deliberate casts failure');
+    }
+}

--- a/tests/Unit/Fixtures/Models/ThrowingCustomTypesModel.php
+++ b/tests/Unit/Fixtures/Models/ThrowingCustomTypesModel.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+final class ThrowingCustomTypesModel extends Model
+{
+    protected $table = 'throwing_custom_types_models';
+
+    protected $casts = ['flag' => 'boolean'];
+
+    /** Deliberately uninitialized so strict custom-type reflection fails. */
+    protected static string $builder;
+}

--- a/tests/Unit/Fixtures/Models/ThrowingPrimaryKeyModel.php
+++ b/tests/Unit/Fixtures/Models/ThrowingPrimaryKeyModel.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+
+final class ThrowingPrimaryKeyModel extends Model
+{
+    use HasUuids;
+
+    protected $table = 'throwing_primary_key_models';
+
+    protected $casts = ['flag' => 'boolean'];
+
+    public function getCasts(): array
+    {
+        return ['flag' => 'boolean'];
+    }
+
+    public function uniqueIds(): array
+    {
+        throw new \RuntimeException('deliberate primary-key failure');
+    }
+}

--- a/tests/Unit/Fixtures/Models/ThrowingRuntimeConfigurationModel.php
+++ b/tests/Unit/Fixtures/Models/ThrowingRuntimeConfigurationModel.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+final class ThrowingRuntimeConfigurationModel extends Model
+{
+    protected $table = 'throwing_runtime_configuration_models';
+
+    protected $casts = ['flag' => 'boolean'];
+
+    public function getHidden(): array
+    {
+        throw new \RuntimeException('deliberate runtime-configuration failure');
+    }
+}

--- a/tests/Unit/Fixtures/Models/ThrowingSchemaModel.php
+++ b/tests/Unit/Fixtures/Models/ThrowingSchemaModel.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Casts\InboundOnlyCast;
+
+final class ThrowingSchemaModel extends Model
+{
+    protected $casts = [
+        'flag' => 'boolean',
+        'code' => InboundOnlyCast::class,
+    ];
+
+    public function getTable(): string
+    {
+        throw new \RuntimeException('deliberate schema failure');
+    }
+}

--- a/tests/Unit/Handlers/Fixtures/UnknownModelAttribute/app/Models/WarmUpCrashModel.php
+++ b/tests/Unit/Handlers/Fixtures/UnknownModelAttribute/app/Models/WarmUpCrashModel.php
@@ -7,10 +7,9 @@ namespace KnownAttributeFixture\Models;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Deliberately crashes {@see \Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadataRegistryBuilder::compute()}
- * (via `computeSchema()`'s `getTable()` call) to exercise `warmUp()`'s outer safety-net catch, for
- * {@see \Tests\Psalm\LaravelPlugin\Unit\Handlers\WarmUpFailureVisibilityTest}. Warm-up failing for
- * this model must never affect {@see KnownThing}'s own warm-up in the same run (per-model try/catch).
+ * Deliberately fails the registry's schema section (via `computeSchema()`'s `getTable()` call) for
+ * {@see \Tests\Psalm\LaravelPlugin\Unit\Handlers\WarmUpFailureVisibilityTest}. The section warning
+ * must stay visible while the model retains all unrelated metadata.
  */
 class WarmUpCrashModel extends Model
 {

--- a/tests/Unit/Handlers/WarmUpFailureVisibilityTest.php
+++ b/tests/Unit/Handlers/WarmUpFailureVisibilityTest.php
@@ -56,7 +56,7 @@ final class WarmUpFailureVisibilityTest extends TestCase
         $stderr = $process->getErrorOutput();
 
         $this->assertStringContainsString(
-            "Laravel plugin: ModelMetadataRegistry warm-up failed for 'KnownAttributeFixture\\Models\\WarmUpCrashModel'",
+            "Laravel plugin: ModelMetadataRegistry schema failed for 'KnownAttributeFixture\\Models\\WarmUpCrashModel'",
             $stderr,
             "The warm-up failure warning must reach stderr even under --no-progress.\nFull stderr:\n{$stderr}",
         );

--- a/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
+++ b/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
@@ -34,8 +34,11 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psalm\Codebase;
 use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
+use Psalm\Internal\Codebase\ClassLikes;
+use Psalm\Internal\Codebase\Methods;
 use Psalm\Internal\MethodIdentifier;
 use Psalm\Internal\Provider\ClassLikeStorageProvider;
+use Psalm\Internal\Provider\FileReferenceProvider;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\AttributeAccessorInfo;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\AttributeMutatorInfo;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\AttributeScopeInfo;
@@ -44,19 +47,27 @@ use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ColumnInfo;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\LegacyAccessorInfo;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\LegacyMutatorInfo;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\LegacyScopeInfo;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\MetadataSectionState;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadata;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadataCompleteness;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadataRegistry;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadataRegistryBuilder;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadataSection;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadataSectionStatus;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\PrimaryKeyInfo;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\PrimaryKeyType;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\PropertyOrigin;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\RelationInfo;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\TableSchema;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\TraitFlags;
+use Psalm\LaravelPlugin\Handlers\Eloquent\RelationMethodParser;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaAggregator;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaColumn;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaStateProvider;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaTable;
+use Psalm\LaravelPlugin\Handlers\Rules\UnknownModelAttributeHandler;
+use Psalm\LaravelPlugin\Handlers\Rules\UnresolvableAppendedModelAttributeHandler;
+use Psalm\Progress\Progress;
 use Psalm\Progress\VoidProgress;
 use Psalm\Storage\AttributeStorage;
 use Psalm\Storage\ClassLikeStorage;
@@ -70,10 +81,16 @@ use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\AttributeConfiguredChild;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\AttributeConfiguredModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\AttributeOverriddenByPropertyModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\CollectionCastVariantsModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\CompleteEmptySchemaModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\CustomDeletedAtModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\EnumConnectionModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\InboundCastModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\ScalarFieldsModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\ThrowingCastsModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\ThrowingCustomTypesModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\ThrowingPrimaryKeyModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\ThrowingRuntimeConfigurationModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\ThrowingSchemaModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\UnguardedAttributeModel;
 
 #[CoversClass(ModelMetadataRegistry::class)]
@@ -87,6 +104,7 @@ final class ModelMetadataRegistryTest extends TestCase
     protected function setUp(): void
     {
         ModelMetadataRegistryBuilder::reset();
+        RelationMethodParser::reset();
         SchemaStateProvider::setSchema(new SchemaAggregator());
         $this->classLikeStorageProvider = new ClassLikeStorageProvider();
     }
@@ -95,6 +113,7 @@ final class ModelMetadataRegistryTest extends TestCase
     protected function tearDown(): void
     {
         ModelMetadataRegistryBuilder::reset();
+        RelationMethodParser::reset();
     }
 
     // ---------------------------------------------------------------------
@@ -173,6 +192,237 @@ final class ModelMetadataRegistryTest extends TestCase
         $this->assertInstanceOf(ModelMetadata::class, $metadata, 'warm-up must not fail on $guarded = false');
         // `$guarded = false` means guard nothing → empty list (not the base default ['*']).
         $this->assertSame([], $metadata->guarded);
+    }
+
+    #[Test]
+    public function schema_status_distinguishes_complete_empty_unavailable_and_failed(): void
+    {
+        $codebase = $this->makeCodebase();
+        $this->registerStorage(CompleteEmptySchemaModel::class);
+        $this->seedSchema('complete_empty_schema_models', []);
+
+        ModelMetadataRegistryBuilder::warmUp($codebase, CompleteEmptySchemaModel::class);
+        $completeEmpty = $this->metadataFor(CompleteEmptySchemaModel::class);
+        $this->assertSame([], $completeEmpty->schema()->all());
+        $this->assertSame(
+            MetadataSectionState::Complete,
+            $completeEmpty->sectionStatus(ModelMetadataSection::Schema)->state,
+        );
+        $this->assertFalse(
+            $completeEmpty->casts()['flag']->psalmType->isNullable(),
+            'A parsed complete-empty schema remains authoritative rather than conservatively nullable',
+        );
+
+        ModelMetadataRegistryBuilder::reset();
+        SchemaStateProvider::setSchema(new SchemaAggregator());
+        $codebase = $this->makeCodebase();
+        $this->registerStorage(CompleteEmptySchemaModel::class);
+
+        ModelMetadataRegistryBuilder::warmUp($codebase, CompleteEmptySchemaModel::class);
+        $unavailable = $this->metadataFor(CompleteEmptySchemaModel::class);
+        $this->assertSame([], $unavailable->schema()->all());
+        $this->assertSame(
+            MetadataSectionState::Unavailable,
+            $unavailable->sectionStatus(ModelMetadataSection::Schema)->state,
+        );
+        $this->assertArrayHasKey('flag', $unavailable->casts(), 'Cast inventory survives unavailable schema');
+        $this->assertTrue(
+            $unavailable->casts()['flag']->psalmType->isNullable(),
+            'Unknown schema nullability must conservatively include null',
+        );
+        $this->assertTrue(
+            $unavailable->casts()['code']->psalmType->hasMixed(),
+            'Inbound cast without an authoritative column type must remain mixed',
+        );
+        $this->assertTrue($unavailable->casts()['code']->psalmType->isNullable());
+
+        ModelMetadataRegistryBuilder::reset();
+        $codebase = $this->makeCodebase();
+        $this->registerStorage(ThrowingSchemaModel::class);
+
+        ModelMetadataRegistryBuilder::warmUp($codebase, ThrowingSchemaModel::class);
+        $failed = $this->metadataFor(ThrowingSchemaModel::class);
+        $this->assertSame([], $failed->schema()->all());
+        $this->assertSame(
+            MetadataSectionState::Failed,
+            $failed->sectionStatus(ModelMetadataSection::Schema)->state,
+        );
+        $this->assertArrayHasKey('flag', $failed->casts(), 'Cast inventory survives failed schema');
+        $this->assertTrue(
+            $failed->casts()['flag']->psalmType->isNullable(),
+            'Failed schema lookup must conservatively include null',
+        );
+        $this->assertTrue(
+            $failed->casts()['code']->psalmType->hasMixed(),
+            'Inbound cast after schema failure must not invent an original column type',
+        );
+        $this->assertTrue($failed->casts()['code']->psalmType->isNullable());
+    }
+
+    #[Test]
+    public function runtime_configuration_failure_preserves_static_cast_and_primary_key_sections(): void
+    {
+        $codebase = $this->makeCodebase(withMethodServices: true);
+        $this->registerStaticSignals(ThrowingRuntimeConfigurationModel::class);
+
+        ModelMetadataRegistryBuilder::warmUp($codebase, ThrowingRuntimeConfigurationModel::class);
+        $metadata = $this->metadataFor(ThrowingRuntimeConfigurationModel::class);
+
+        $this->assertStaticSignals($metadata);
+        $this->assertSame(MetadataSectionState::Failed, $metadata->sectionStatus(ModelMetadataSection::RuntimeConfiguration)->state);
+        $this->assertSame(MetadataSectionState::Unavailable, $metadata->sectionStatus(ModelMetadataSection::Schema)->state);
+        $this->assertSame(MetadataSectionState::Complete, $metadata->sectionStatus(ModelMetadataSection::Casts)->state);
+        $this->assertSame(MetadataSectionState::Complete, $metadata->sectionStatus(ModelMetadataSection::PrimaryKey)->state);
+        $this->assertArrayHasKey('flag', $metadata->casts());
+    }
+
+    #[Test]
+    public function schema_failure_preserves_runtime_static_cast_and_primary_key_sections(): void
+    {
+        $codebase = $this->makeCodebase(withMethodServices: true);
+        $this->registerStaticSignals(ThrowingSchemaModel::class);
+
+        ModelMetadataRegistryBuilder::warmUp($codebase, ThrowingSchemaModel::class);
+        $metadata = $this->metadataFor(ThrowingSchemaModel::class);
+
+        $this->assertStaticSignals($metadata);
+        $this->assertSame(MetadataSectionState::Complete, $metadata->sectionStatus(ModelMetadataSection::RuntimeConfiguration)->state);
+        $this->assertSame(MetadataSectionState::Failed, $metadata->sectionStatus(ModelMetadataSection::Schema)->state);
+        $this->assertSame(MetadataSectionState::Complete, $metadata->sectionStatus(ModelMetadataSection::Casts)->state);
+        $this->assertSame(MetadataSectionState::Complete, $metadata->sectionStatus(ModelMetadataSection::PrimaryKey)->state);
+    }
+
+    #[Test]
+    public function casts_failure_preserves_runtime_static_schema_and_primary_key_sections(): void
+    {
+        $this->seedSchema('throwing_casts_models', [new SchemaColumn('flag', SchemaColumn::TYPE_BOOL)]);
+        $codebase = $this->makeCodebase(withMethodServices: true);
+        $this->registerStaticSignals(ThrowingCastsModel::class);
+
+        ModelMetadataRegistryBuilder::warmUp($codebase, ThrowingCastsModel::class);
+        $metadata = $this->metadataFor(ThrowingCastsModel::class);
+
+        $this->assertStaticSignals($metadata);
+        $this->assertSame(MetadataSectionState::Complete, $metadata->sectionStatus(ModelMetadataSection::RuntimeConfiguration)->state);
+        $this->assertSame(MetadataSectionState::Complete, $metadata->sectionStatus(ModelMetadataSection::Schema)->state);
+        $this->assertSame(MetadataSectionState::Failed, $metadata->sectionStatus(ModelMetadataSection::Casts)->state);
+        $this->assertSame(MetadataSectionState::Complete, $metadata->sectionStatus(ModelMetadataSection::PrimaryKey)->state);
+        $this->assertTrue($metadata->schema()->has('flag'));
+    }
+
+    #[Test]
+    public function primary_key_failure_preserves_every_other_section(): void
+    {
+        $this->seedSchema('throwing_primary_key_models', [new SchemaColumn('flag', SchemaColumn::TYPE_BOOL)]);
+        $codebase = $this->makeCodebase(withMethodServices: true);
+        $this->registerStaticSignals(ThrowingPrimaryKeyModel::class, [HasUuids::class]);
+
+        ModelMetadataRegistryBuilder::warmUp($codebase, ThrowingPrimaryKeyModel::class);
+        $metadata = $this->metadataFor(ThrowingPrimaryKeyModel::class);
+
+        $this->assertStaticSignals($metadata);
+        $this->assertSame(MetadataSectionState::Complete, $metadata->sectionStatus(ModelMetadataSection::RuntimeConfiguration)->state);
+        $this->assertSame(MetadataSectionState::Complete, $metadata->sectionStatus(ModelMetadataSection::Schema)->state);
+        $this->assertSame(MetadataSectionState::Complete, $metadata->sectionStatus(ModelMetadataSection::Casts)->state);
+        $this->assertSame(MetadataSectionState::Failed, $metadata->sectionStatus(ModelMetadataSection::PrimaryKey)->state);
+    }
+
+    #[Test]
+    public function custom_type_failure_preserves_all_non_custom_sections(): void
+    {
+        $this->seedSchema('throwing_custom_types_models', [new SchemaColumn('flag', SchemaColumn::TYPE_BOOL)]);
+        $codebase = $this->makeCodebase(withMethodServices: true);
+        $this->registerStaticSignals(ThrowingCustomTypesModel::class);
+
+        ModelMetadataRegistryBuilder::warmUp($codebase, ThrowingCustomTypesModel::class);
+        $metadata = $this->metadataFor(ThrowingCustomTypesModel::class);
+
+        $this->assertStaticSignals($metadata);
+        $this->assertSame(MetadataSectionState::Failed, $metadata->sectionStatus(ModelMetadataSection::CustomTypes)->state);
+        $this->assertSame(MetadataSectionState::Complete, $metadata->sectionStatus(ModelMetadataSection::RuntimeConfiguration)->state);
+        $this->assertSame(MetadataSectionState::Complete, $metadata->sectionStatus(ModelMetadataSection::Schema)->state);
+        $this->assertSame(MetadataSectionState::Complete, $metadata->sectionStatus(ModelMetadataSection::Casts)->state);
+        $this->assertSame(MetadataSectionState::Complete, $metadata->sectionStatus(ModelMetadataSection::PrimaryKey)->state);
+    }
+
+    #[Test]
+    public function relation_infrastructure_failure_preserves_storage_and_runtime_sections(): void
+    {
+        $codebase = $this->makeCodebase(withMethodServices: true);
+        $storage = $this->registerStorage(CompleteEmptySchemaModel::class);
+        $this->defineAppearingMethod($storage, 'getStaticLabelAttribute', Type::getString());
+        $this->defineAppearingMethod(
+            $storage,
+            'scopePublished',
+            Type::getMixed(),
+            params: [$this->queryParam()],
+        );
+        // No parser cache/source location is supplied for this declared Relation method. Strict
+        // relation parsing must fail this section rather than silently claim a complete-empty map.
+        $this->defineAppearingMethod($storage, 'orders', new Union([new TNamedObject(HasMany::class)]));
+
+        ModelMetadataRegistryBuilder::warmUp($codebase, CompleteEmptySchemaModel::class);
+        $metadata = $this->metadataFor(CompleteEmptySchemaModel::class);
+
+        $this->assertSame(MetadataSectionState::Failed, $metadata->sectionStatus(ModelMetadataSection::Relations)->state);
+        $this->assertSame([], $metadata->relations());
+        $this->assertArrayHasKey('staticlabel', $metadata->accessors());
+        $this->assertArrayHasKey('published', $metadata->scopes());
+        $this->assertSame(MetadataSectionState::Complete, $metadata->sectionStatus(ModelMetadataSection::StorageMethods)->state);
+        $this->assertSame(MetadataSectionState::Complete, $metadata->sectionStatus(ModelMetadataSection::RuntimeConfiguration)->state);
+        $this->assertSame(MetadataSectionState::Complete, $metadata->sectionStatus(ModelMetadataSection::Casts)->state);
+    }
+
+    #[Test]
+    public function negative_consumers_require_only_their_relevant_sections(): void
+    {
+        $healthy = $this->makeStubMetadata(WorkOrder::class);
+        $this->assertTrue(UnknownModelAttributeHandler::canEvaluate($healthy));
+        $this->assertTrue(UnresolvableAppendedModelAttributeHandler::canEvaluate($healthy));
+
+        $schemaUnavailable = ModelMetadataCompleteness::allComplete()->withStatus(
+            ModelMetadataSection::Schema,
+            ModelMetadataSectionStatus::unavailable('no parsed table'),
+        );
+        $schemaIncomplete = $this->makeStubMetadata(WorkOrder::class, completeness: $schemaUnavailable);
+        $this->assertFalse(UnknownModelAttributeHandler::canEvaluate($schemaIncomplete));
+        $this->assertTrue(UnresolvableAppendedModelAttributeHandler::canEvaluate($schemaIncomplete));
+
+        $relationsUnavailable = ModelMetadataCompleteness::allComplete()->withStatus(
+            ModelMetadataSection::Relations,
+            ModelMetadataSectionStatus::unavailable('AST unavailable'),
+        );
+        $relationsIncomplete = $this->makeStubMetadata(WorkOrder::class, completeness: $relationsUnavailable);
+        $this->assertFalse(UnknownModelAttributeHandler::canEvaluate($relationsIncomplete));
+        $this->assertTrue(UnresolvableAppendedModelAttributeHandler::canEvaluate($relationsIncomplete));
+
+        foreach ([ModelMetadataSection::RuntimeConfiguration, ModelMetadataSection::Casts, ModelMetadataSection::StorageMethods] as $section) {
+            $incomplete = $this->makeStubMetadata(
+                WorkOrder::class,
+                completeness: ModelMetadataCompleteness::allComplete()->withStatus(
+                    $section,
+                    ModelMetadataSectionStatus::unavailable('injected consumer-gate failure'),
+                ),
+            );
+            $this->assertFalse(UnknownModelAttributeHandler::canEvaluate($incomplete));
+            $this->assertFalse(UnresolvableAppendedModelAttributeHandler::canEvaluate($incomplete));
+        }
+    }
+
+    #[Test]
+    public function a_failed_section_warns_once_and_repeated_warm_up_is_silent(): void
+    {
+        $progress = $this->createMock(Progress::class);
+        $progress->expects($this->once())
+            ->method('warning')
+            ->with($this->stringContains("ModelMetadataRegistry schema failed for '" . ThrowingSchemaModel::class . "'"));
+        $codebase = $this->makeCodebase(progress: $progress);
+        $this->registerStorage(ThrowingSchemaModel::class);
+
+        ModelMetadataRegistryBuilder::warmUp($codebase, ThrowingSchemaModel::class);
+        ModelMetadataRegistryBuilder::warmUp($codebase, ThrowingSchemaModel::class);
+
+        $this->assertInstanceOf(ModelMetadata::class, ModelMetadataRegistry::for(ThrowingSchemaModel::class));
     }
 
     #[Test]
@@ -1244,16 +1494,72 @@ final class ModelMetadataRegistryTest extends TestCase
     // Helpers
     // ---------------------------------------------------------------------
 
-    private function makeCodebase(): Codebase
+    private function makeCodebase(bool $withMethodServices = false, ?Progress $progress = null): Codebase
     {
         $codebase = (new \ReflectionClass(Codebase::class))->newInstanceWithoutConstructor();
         $codebase->classlike_storage_provider = $this->classLikeStorageProvider;
 
+        if ($withMethodServices) {
+            $classLikes = (new \ReflectionClass(ClassLikes::class))->newInstanceWithoutConstructor();
+            (new \ReflectionProperty(ClassLikes::class, 'classlike_storage_provider'))
+                ->setValue($classLikes, $this->classLikeStorageProvider);
+            $fileReferenceProvider = (new \ReflectionClass(FileReferenceProvider::class))->newInstanceWithoutConstructor();
+            $codebase->methods = new Methods($this->classLikeStorageProvider, $fileReferenceProvider, $classLikes);
+        }
+
         // $progress is declared protected(set) readonly in Psalm 7 — bypass via reflection.
         $progressProperty = new \ReflectionProperty(Codebase::class, 'progress');
-        $progressProperty->setValue($codebase, new VoidProgress());
+        $progressProperty->setValue($codebase, $progress ?? $this->createStub(Progress::class));
 
         return $codebase;
+    }
+
+    /**
+     * Give a model one storage accessor, scope, and cached AST relation so isolation tests prove all
+     * three positive-inference sources survive failures in unrelated sections.
+     *
+     * @param class-string<Model> $fqcn
+     * @param list<class-string> $traits
+     */
+    private function registerStaticSignals(string $fqcn, array $traits = []): void
+    {
+        $storage = $this->registerStorage($fqcn, $traits);
+        $this->defineAppearingMethod($storage, 'getStaticLabelAttribute', Type::getString());
+        $this->defineAppearingMethod(
+            $storage,
+            'scopePublished',
+            Type::getMixed(),
+            params: [$this->queryParam()],
+        );
+        $this->defineAppearingMethod($storage, 'orders', new Union([new TNamedObject(HasMany::class)]));
+
+        $cacheProperty = new \ReflectionProperty(RelationMethodParser::class, 'cache');
+        /** @var array<string, mixed> $cache */
+        $cache = $cacheProperty->getValue();
+        $cache[$fqcn . '::orders|strict'] = [
+            'relationClass' => HasMany::class,
+            'relatedModel' => WorkOrder::class,
+            'intermediateModel' => null,
+            'pivotModel' => null,
+            'accessor' => null,
+        ];
+        $cacheProperty->setValue(null, $cache);
+    }
+
+    /** @param ModelMetadata<Model> $metadata */
+    private function assertStaticSignals(ModelMetadata $metadata): void
+    {
+        $this->assertArrayHasKey('staticlabel', $metadata->accessors());
+        $this->assertArrayHasKey('published', $metadata->scopes());
+        $this->assertArrayHasKey('orders', $metadata->relations());
+        $this->assertSame(
+            MetadataSectionState::Complete,
+            $metadata->sectionStatus(ModelMetadataSection::StorageMethods)->state,
+        );
+        $this->assertSame(
+            MetadataSectionState::Complete,
+            $metadata->sectionStatus(ModelMetadataSection::Relations)->state,
+        );
     }
 
     /**
@@ -1378,8 +1684,11 @@ final class ModelMetadataRegistryTest extends TestCase
      * @param array<non-empty-lowercase-string, RelationInfo> $relations
      * @return ModelMetadata<Model>
      */
-    private function makeStubMetadata(string $fqcn, array $relations = []): ModelMetadata
-    {
+    private function makeStubMetadata(
+        string $fqcn,
+        array $relations = [],
+        ?ModelMetadataCompleteness $completeness = null,
+    ): ModelMetadata {
         return new ModelMetadata(
             fqcn: $fqcn,
             primaryKey: new PrimaryKeyInfo('id', PrimaryKeyType::Integer, incrementing: true, uuidColumns: []),
@@ -1411,6 +1720,7 @@ final class ModelMetadataRegistryTest extends TestCase
             scopesData: [],
             relationsData: $relations,
             knownPropertiesData: [],
+            completenessData: $completeness,
         );
     }
 }


### PR DESCRIPTION
## Summary

- construct model metadata in independently isolated sections
- record explicit complete, unavailable, and failed state for each section
- preserve storage and AST metadata when runtime enrichment fails
- gate negative diagnostics on the completeness of their relevant inputs
- keep schema-less cast types conservative while preserving the complete cast inventory
- keep section failure warnings visible under `--no-progress` without warning once per consumer

## Why

Registry warm-up previously treated model metadata construction as all-or-nothing. A throwable from model instantiation, attribute replay, schema lookup, casts, primary-key getters, or another runtime probe discarded the model's entire entry, including independent accessor, mutator, scope, and relation metadata.

The new completeness representation distinguishes authoritative empty data from unavailable or failed analysis, allowing positive consumers to use successful sections while negative diagnostics defer unless all relevant inputs are complete. The representation is independent of Psalm 7-only APIs so the design can be backported to the Psalm 6-based 3.x line.

## Validation

- Laravel 13 unit suite: 1,033 tests, 2,654 assertions
- exact Laravel 12.14 / PHP 8.2 unit suite: 1,032 tests, 2,613 assertions
- Psalm: no errors, 100% inferred
- Rector dry run
- PHP-CS-Fixer dry run
- PHP 8.2 changed-file lint
- `git diff --check`

Closes #1255

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786522337&installation_id=141955579&pr_number=1258&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1258&signature=d2ca3a772b275e5b2a157b30b65ef51d0e406308115af2c16f533509d8e28c83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->