### PR TITLE
Exclude migration files from `UnknownModelAttribute`

### DIFF
--- a/docs/issues/UnknownModelAttribute.md
+++ b/docs/issues/UnknownModelAttribute.md
@@ -52,6 +52,7 @@ Because the rule is registered by default, it errs toward silence whenever it ca
 - **No column schema.** When migrations are disabled, or a model's table is not parsed, the column set is unknown, so the rule skips that model entirely rather than flag valid columns. With the default `columnFallback="migrations"` the columns come from your migration files.
 - **Non-literal arrays.** A variable array, a spread (`[...$attributes]`), or a dynamic key carries no statically known key names, so it is never inspected.
 - **Ambiguous receivers.** A static call on a non-model class, or an instance call whose receiver is not exactly one Eloquent model (for example a `Builder` or `Relation`, which is how a mass `update()` on a query is typed), is skipped.
+- **Migration files.** A mass-assignment call inside a migration file is skipped (a file counts as a migration when its name carries the migrator's `YYYY_MM_DD_HHMMSS_` prefix or it sits in a `migrations` directory). The plugin replays every migration into one final schema, so a column a later migration drops is absent from it, and a migration that legitimately wrote that column when it ran would be wrongly flagged against the final state.
 
 ## Known limitation
 

--- a/src/Handlers/Rules/UnknownModelAttributeHandler.php
+++ b/src/Handlers/Rules/UnknownModelAttributeHandler.php
@@ -96,6 +96,14 @@ final class UnknownModelAttributeHandler implements AfterExpressionAnalysisInter
             return null;
         }
 
+        // A migration is point-in-time code: it can mass-assign a column a LATER migration drops, which
+        // the final replayed schema no longer knows about, so the rule would false-positive on code that
+        // was correct when it ran (#1251). Skip a file we recognise as a migration, before the costlier
+        // receiver/registry work.
+        if (self::isMigrationFile($event->getStatementsSource()->getFilePath())) {
+            return null;
+        }
+
         $codebase = $event->getCodebase();
 
         $modelClass = $expr instanceof StaticCall
@@ -163,6 +171,21 @@ final class UnknownModelAttributeHandler implements AfterExpressionAnalysisInter
         }
 
         return null;
+    }
+
+    /**
+     * Best-effort guess: is this file a Laravel migration? Recognised by either universal signal,
+     * without resolving the app's exact migration paths: the migrator's `YYYY_MM_DD_HHMMSS_` filename
+     * prefix (every `php artisan make:migration`), or a `migrations` directory in the path. Either is a
+     * near-certain migration; a stray match only over-suppresses this always-on rule — the safe
+     * direction for a false-positive guard. See {@see UnknownModelAttribute} docs.
+     *
+     * @psalm-pure
+     */
+    public static function isMigrationFile(string $filePath): bool
+    {
+        return \preg_match('#^\d{4}_\d{2}_\d{2}_\d{6}_#', \basename($filePath)) === 1
+            || \str_contains(\str_replace('\\', '/', $filePath), '/migrations/');
     }
 
     /**

--- a/tests/Unit/Handlers/Rules/UnknownModelAttributeHandlerTest.php
+++ b/tests/Unit/Handlers/Rules/UnknownModelAttributeHandlerTest.php
@@ -139,6 +139,52 @@ final class UnknownModelAttributeHandlerTest extends TestCase
         $this->assertNull(UnknownModelAttributeHandler::afterExpressionAnalysis($this->event($call)));
     }
 
+    #[Test]
+    public function skips_a_mass_assignment_inside_a_migration_file(): void
+    {
+        // A create() located in a migration file is left alone: migrations are point-in-time and may
+        // reference since-dropped columns (#1251). The array content is irrelevant — the guard fires
+        // after the literal-array check but before receiver resolution, so the uninitialised Codebase is
+        // never touched (proving the guard is load-bearing, like the sibling early-return tests).
+        $call = $this->positioned(new StaticCall(
+            $this->resolvedModelName(),
+            new Identifier('create'),
+            [new Arg(new Array_([]))],
+        ));
+
+        $this->assertNull(UnknownModelAttributeHandler::afterExpressionAnalysis(
+            $this->event($call, '/project/database/migrations/2024_01_01_000000_create_users_table.php'),
+        ));
+    }
+
+    #[Test]
+    #[DataProvider('migrationFilePaths')]
+    public function is_migration_file_guesses_by_filename_or_directory(string $filePath, bool $expected): void
+    {
+        $this->assertSame($expected, UnknownModelAttributeHandler::isMigrationFile($filePath));
+    }
+
+    /**
+     * @return iterable<string, array{string, bool}>
+     */
+    public static function migrationFilePaths(): iterable
+    {
+        // Both signals present — the common case.
+        yield 'timestamped file in a migrations dir' => ['/app/database/migrations/2024_10_16_120026_move_redis.php', true];
+        // Filename signal alone: a migration in a non-standard directory.
+        yield 'timestamped filename outside a migrations dir' => ['/app/custom/2014_10_12_000000_create_users_table.php', true];
+        // Directory signal alone: a migration whose name lacks the timestamp prefix.
+        yield 'non-timestamped file in a migrations dir' => ['/pkg/database/migrations/create_things.php', true];
+        // Windows separators still match the directory signal after normalization.
+        yield 'windows path in a migrations dir' => ['C:\\proj\\database\\migrations\\2024_01_01_000000_x.php', true];
+        // Neither signal: ordinary application code.
+        yield 'a model' => ['/app/Models/User.php', false];
+        // "Migration" in a filename is not the `migrations` directory, and there is no timestamp prefix.
+        yield 'a class merely named Migration' => ['/app/Support/MigrationHelper.php', false];
+        // A leading-year filename that is not the full YYYY_MM_DD_HHMMSS_ shape.
+        yield 'a partial-timestamp filename' => ['/app/2024_report.php', false];
+    }
+
     /**
      * @param array<non-empty-lowercase-string, true> $allowed
      * @param list<string>                            $rawKeys
@@ -194,7 +240,7 @@ final class UnknownModelAttributeHandlerTest extends TestCase
         return $name;
     }
 
-    private function event(\PhpParser\Node\Expr $expr): AfterExpressionAnalysisEvent
+    private function event(\PhpParser\Node\Expr $expr, string $filePath = '/project/app/Models/User.php'): AfterExpressionAnalysisEvent
     {
         // Default the receiver type to null so an instance call resolves to no model; static-call
         // tests never consult the node type provider.
@@ -202,7 +248,7 @@ final class UnknownModelAttributeHandlerTest extends TestCase
         $nodeTypeProvider->method('getType')->willReturn(null);
 
         $source = $this->createStub(StatementsSource::class);
-        $source->method('getFilePath')->willReturn('/project/app/Models/User.php');
+        $source->method('getFilePath')->willReturn($filePath);
         $source->method('getFileName')->willReturn('User.php');
         $source->method('getSuppressedIssues')->willReturn([]);
         $source->method('getNodeTypeProvider')->willReturn($nodeTypeProvider);


### PR DESCRIPTION
## Issue to Solve

`UnknownModelAttribute` false-positives on migration files. The schema aggregator replays every migration in filename order into one final table state (later `dropColumn` calls remove columns), so a migration that mass-assigns a column a *later* migration drops is checked against the post-drop final schema and flagged, even though the code was correct for the schema at the time it ran.

This is a common Laravel pattern (add FK columns, migrate to polymorphic or rename, drop the old columns), so any app with that migration history hits false positives on its old data-migration files. See the coolify repro in the issue.

## Related

Fixes #1251

## Solution Description

Migrations are inherently point-in-time, so checking them against the final schema is the wrong model. `UnknownModelAttributeHandler` now skips a call when the file under analysis looks like a migration, guessed from the two universal Laravel signals (no app-path resolution needed): the migrator's `YYYY_MM_DD_HHMMSS_` filename prefix (every `php artisan make:migration`), or a `migrations` directory in the path. The check sits after the cheap AST rejects and before the receiver/registry resolution.

Either signal is a near-certain migration, and a stray match only over-suppresses this always-on rule, which is the safe direction for a false-positive guard. The only case it misses is a migration in a custom directory that is neither named `migrations` nor timestamp-named (essentially nonexistent), which keeps the pre-existing behavior.

Verified with unit tests for the guess (`isMigrationFile`: timestamped name, `migrations` directory, a Windows path, and negatives) and a handler test proving the guard fires before receiver resolution. Also verified end-to-end locally against a fixture reproducing the add, use, then drop migration history: the since-dropped column's `create()` inside a migration stays silent while the same typo in application code still fires.

## Checklist
- [x] Tests cover the change (unit test in `tests/Unit/`)
- [x] Documentation is updated (`docs/issues/UnknownModelAttribute.md`)
