### PR TITLE
Fix custom builder method forwarding on relations

### DIFF
--- a/docs/contributing/laravel-magic-call-patterns.md
+++ b/docs/contributing/laravel-magic-call-patterns.md
@@ -127,6 +127,23 @@ $post->comments()->where('approved', true)
 
 **Psalm challenge:** Psalm resolves `where()` via `@mixin Builder` on Relation. The resolved method returns `Builder`, not the Relation. The plugin solves this with `MethodForwardingHandler` using `interceptMixin=true`: the handler registers for Builder (the mixin target), detects when the original caller was a Relation, and returns the concrete Relation type with template params instead. For methods declared in Relation stubs, Psalm finds them in `declaring_method_ids` before reaching the mixin.
 
+Custom builders require one more lookup because Relation's `@mixin Builder` cannot expose
+methods declared on `PostBuilder`. `RelatedBuilderMethodResolver` takes the related model from
+the Relation's first template parameter, resolves that model's effective builder, and reads the
+custom method signature from Psalm storage. Its return union is then decorated branch by branch:
+Builder subtypes become the original Relation while scalar/model/collection/null branches remain
+unchanged. The same signature is handed to the params provider for direct `Relation::__call`
+dispatch. This must remain storage-only—booting builders can execute application code, and a
+synthetic method call recursively clones Psalm node data on this hot path.
+
+Method-level templates are inferred only from information safely available at this provider's
+event point: an existing argument node type, a literal/simple expression, or a variable/property
+in the current context. Psalm has not yet analyzed nested calls or unpacked arguments here. Those
+inputs use the template's declared upper bound (normally `mixed`) rather than duplicating Psalm's
+call and unpack analysis inside a relation-specific handler. Inference is all-or-bound for each
+call: if any template-bearing argument is unavailable, no partial method-template bounds are kept,
+because they could over-constrain another argument that Psalm analyzes later.
+
 
 ### 2. Eloquent Builder → Query Builder
 
@@ -776,7 +793,7 @@ but the handler ensures template params propagate correctly.
 
 | Pattern                    | Psalm mechanism                                              | Known limitations                                                    |
 |----------------------------|--------------------------------------------------------------|----------------------------------------------------------------------|
-| Relation → Builder fluent  | Stub declares methods on Relation + `MethodForwardingHandler` | Methods not in stub fall through to `@mixin` and lose Relation type  |
+| Relation → Builder fluent  | Relation stubs + `MethodForwardingHandler` + related custom-builder storage resolution | Instance-local builder macros that have no static metadata remain unresolved |
 | Builder → Query\Builder    | `@mixin Query\Builder` on Eloquent\Builder                   | Same mixin issue, but less impactful                                 |
 | Facade → Service           | Generated alias stubs                                        | Taint annotations lost through `__callStatic`                        |
 | Model → Builder static     | `ModelMethodHandler`                                         | Scopes need `@mixin` or scope handler                                |

--- a/docs/contributing/laravel-magic-call-patterns.md
+++ b/docs/contributing/laravel-magic-call-patterns.md
@@ -136,13 +136,14 @@ unchanged. The same signature is handed to the params provider for direct `Relat
 dispatch. This must remain storage-only—booting builders can execute application code, and a
 synthetic method call recursively clones Psalm node data on this hot path.
 
-Method-level templates are inferred only from information safely available at this provider's
-event point: an existing argument node type, a literal/simple expression, or a variable/property
-in the current context. Psalm has not yet analyzed nested calls or unpacked arguments here. Those
-inputs use the template's declared upper bound (normally `mixed`) rather than duplicating Psalm's
-call and unpack analysis inside a relation-specific handler. Inference is all-or-bound for each
-call: if any template-bearing argument is unavailable, no partial method-template bounds are kept,
-because they could over-constrain another argument that Psalm analyzes later.
+Method-level templates uniformly degrade to their declared upper bound (normally `mixed`) when
+forwarded this way. This provider fires on the missing-method path before Psalm's normal argument
+analyzer runs, so argument types are not reliably available yet (nested calls and unpacked
+arguments have not been analyzed). Inferring a template from only the arguments that happen to
+already have a type would be unsound, since a later-analyzed sibling argument could validly widen
+the same template. Making that inference safe would mean duplicating Psalm's own call and unpack
+analysis inside a relation-specific handler, which is disproportionate for the rarest case and has
+previously caused catastrophic memory use.
 
 
 ### 2. Eloquent Builder → Query Builder

--- a/src/Handlers/Eloquent/BuilderScopeHandler.php
+++ b/src/Handlers/Eloquent/BuilderScopeHandler.php
@@ -717,6 +717,31 @@ final class BuilderScopeHandler implements MethodReturnTypeProviderInterface, Me
     }
 
     /**
+     * Get a trait-declared fluent builder method's parameters for one concrete model.
+     *
+     * The parameter registry is shared because a trait method has one signature, but the
+     * existence check must stay model-aware: registering SoftDeletes for one model must not
+     * make onlyTrashed() appear on every unrelated model's relation.
+     *
+     * @param class-string<Model> $modelClass
+     * @param lowercase-string $methodName
+     * @return list<FunctionLikeParameter>|null
+     * @internal Used by relation forwarding for base-Builder related models
+     * @psalm-external-mutation-free
+     */
+    public static function getTraitMethodParamsForModel(
+        Codebase $codebase,
+        string $modelClass,
+        string $methodName,
+    ): ?array {
+        if (!self::isTraitBuilderMethod($codebase, $modelClass, $methodName)) {
+            return null;
+        }
+
+        return self::$baseBuilderTraitMethods[$methodName] ?? null;
+    }
+
+    /**
      * Check if the model has a trait-declared builder method for the given name.
      *
      * Looks for @method static annotations on the model (inherited from traits like

--- a/src/Handlers/Eloquent/Support/RelatedBuilderMethodResolver.php
+++ b/src/Handlers/Eloquent/Support/RelatedBuilderMethodResolver.php
@@ -1,0 +1,587 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Eloquent\Support;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use Psalm\Codebase;
+use Psalm\Context;
+use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
+use Psalm\Internal\Analyzer\Statements\Expression\Call\ClassTemplateParamCollector;
+use Psalm\Internal\Analyzer\Statements\Expression\ExpressionIdentifier;
+use Psalm\Internal\Analyzer\Statements\Expression\SimpleTypeInferer;
+use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\Internal\MethodIdentifier;
+use Psalm\Internal\Type\TemplateBound;
+use Psalm\Internal\Type\TemplateInferredTypeReplacer;
+use Psalm\Internal\Type\TemplateResult;
+use Psalm\Internal\Type\TemplateStandinTypeReplacer;
+use Psalm\Internal\Type\TypeExpander;
+use Psalm\LaravelPlugin\Handlers\Eloquent\BuilderScopeHandler;
+use Psalm\LaravelPlugin\Handlers\Eloquent\CustomBuilderMethodHandler;
+use Psalm\LaravelPlugin\Handlers\Eloquent\ModelMethodHandler;
+use Psalm\Storage\ClassLikeStorage;
+use Psalm\Storage\FunctionLikeParameter;
+use Psalm\Storage\MethodStorage;
+use Psalm\Type;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Union;
+
+/**
+ * Resolves methods that Laravel forwards from a Relation to its related model's builder.
+ *
+ * This deliberately works from Psalm storage only. Instantiating a model/builder would boot
+ * application code, while analyzing a synthetic call recursively has previously caused
+ * unbounded memory usage in the relation forwarding provider.
+ *
+ * @internal
+ */
+final class RelatedBuilderMethodResolver
+{
+    /**
+     * Declared-method lookup cache. Signatures are localized per call because cheap method-level
+     * template inference may use types already available for the current arguments.
+     *
+     * @var array<string, array{MethodIdentifier, MethodStorage}|null>
+     */
+    private static array $declaredMethodCache = [];
+
+    /**
+     * Class-level template localization is stable for an effective builder atomic.
+     *
+     * @var array<string, array{
+     *     ClassLikeStorage,
+     *     MethodIdentifier,
+     *     ClassLikeStorage,
+     *     array<string, non-empty-array<string, Union>>|null
+     * }|null>
+     */
+    private static array $specializationContextCache = [];
+
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$declaredMethodCache = [];
+        self::$specializationContextCache = [];
+    }
+
+    /**
+     * Resolve a real public instance method introduced by a custom builder hierarchy.
+     * Methods merely inherited from Eloquent's base Builder are intentionally excluded:
+     * MethodForwardingHandler's existing Builder/Query Builder path owns those methods.
+     *
+     * @param class-string<Model> $modelClass
+     * @param lowercase-string $methodName
+     * @param list<Arg> $arguments
+     */
+    public static function resolveDeclaredMethod(
+        Codebase $codebase,
+        StatementsAnalyzer $source,
+        Context $context,
+        string $modelClass,
+        string $methodName,
+        array $arguments,
+    ): ?ResolvedForwardedMethod {
+        $builderType = ModelMethodHandler::resolvedBuilderTypeFor($modelClass, $codebase);
+        /** @var class-string<Builder> $builderClass */
+        $builderClass = $builderType->value;
+
+        if ($builderClass === Builder::class) {
+            return null;
+        }
+
+        $resolvedStorage = self::declaredMethodStorage($codebase, $builderClass, $methodName);
+        if ($resolvedStorage === null) {
+            return null;
+        }
+
+        [$methodId, $methodStorage] = $resolvedStorage;
+
+        $specializationContext = self::specializationContext(
+            $codebase,
+            $builderClass,
+            $builderType,
+            $methodId,
+            $methodName,
+        );
+        if ($specializationContext === null) {
+            return new ResolvedForwardedMethod(
+                $methodStorage->return_type ?? $methodStorage->signature_return_type ?? Type::getMixed(),
+                DynamicWhereResolver::variadicMixedParams(),
+            );
+        }
+
+        [$builderStorage, $declaringMethodId, $declaringClassStorage, $classTemplateParams]
+            = $specializationContext;
+
+        $templateResult = new TemplateResult([], $classTemplateParams ?? []);
+        if ($methodStorage->template_types !== null) {
+            $templateResult->template_types += $methodStorage->template_types;
+        }
+
+        self::inferMethodTemplates(
+            $codebase,
+            $source,
+            $context,
+            $methodStorage->params,
+            $arguments,
+            $methodStorage->template_types ?? [],
+            $templateResult,
+        );
+        self::fillUnresolvedMethodTemplateBounds($methodStorage, $templateResult);
+
+        $methodReturnSelfClass = $declaringMethodId->fq_class_name;
+
+        try {
+            $returnType = $codebase->methods->getMethodReturnType(
+                $codebase,
+                $methodId,
+                $methodReturnSelfClass,
+                $source,
+                $arguments,
+                $templateResult,
+            );
+        } catch (\InvalidArgumentException|\UnexpectedValueException) {
+            $returnType = null;
+        }
+
+        // The declaration owns `self`; the effective builder atomic passed separately
+        // owns late-static (`static`/`$this`) expansion.
+        $selfClass = $declaringMethodId->fq_class_name;
+
+        $returnType ??= $methodStorage->return_type
+            ?? $methodStorage->signature_return_type
+            ?? Type::getMixed();
+
+        $returnType = self::specializeUnion(
+            $codebase,
+            $returnType,
+            $templateResult,
+            $selfClass,
+            $builderType,
+            $declaringClassStorage->parent_class,
+            $builderStorage->final,
+        );
+
+        $parameters = [];
+        foreach ($methodStorage->params as $parameter) {
+            $parameters[] = self::specializeParameter(
+                $codebase,
+                $parameter,
+                $templateResult,
+                $selfClass,
+                $builderType,
+                $declaringClassStorage->parent_class,
+                $builderStorage->final,
+            );
+        }
+
+        if ($methodStorage->variadic && !self::hasVariadicParameter($parameters)) {
+            $parameters[] = new FunctionLikeParameter(
+                name: 'args',
+                by_ref: false,
+                type: Type::getMixed(),
+                is_variadic: true,
+            );
+        }
+
+        return new ResolvedForwardedMethod($returnType, $parameters);
+    }
+
+    /**
+     * @param class-string<Builder> $builderClass
+     * @param lowercase-string $methodName
+     * @return array{
+     *     ClassLikeStorage,
+     *     MethodIdentifier,
+     *     ClassLikeStorage,
+     *     array<string, non-empty-array<string, Union>>|null
+     * }|null
+     */
+    private static function specializationContext(
+        Codebase $codebase,
+        string $builderClass,
+        TNamedObject $builderType,
+        MethodIdentifier $methodId,
+        string $methodName,
+    ): ?array {
+        $cacheKey = \strtolower($builderType->getId()) . '::' . $methodName;
+        if (\array_key_exists($cacheKey, self::$specializationContextCache)) {
+            return self::$specializationContextCache[$cacheKey];
+        }
+
+        try {
+            $builderStorage = $codebase->classlike_storage_provider->get(\strtolower($builderClass));
+            $methodClassStorage = $codebase->methods->getClassLikeStorageForMethod($methodId);
+            $declaringMethodId = $codebase->methods->getDeclaringMethodId($methodId) ?? $methodId;
+            $declaringClassStorage = $codebase->classlike_storage_provider->get(
+                \strtolower($declaringMethodId->fq_class_name),
+            );
+
+            $classTemplateParams = ClassTemplateParamCollector::collect(
+                $codebase,
+                $methodClassStorage,
+                $builderStorage,
+                $methodName,
+                $builderType,
+            );
+        } catch (\InvalidArgumentException|\UnexpectedValueException|\AssertionError) {
+            return self::$specializationContextCache[$cacheKey] = null;
+        }
+
+        return self::$specializationContextCache[$cacheKey] = [
+            $builderStorage,
+            $declaringMethodId,
+            $declaringClassStorage,
+            $classTemplateParams,
+        ];
+    }
+
+    /**
+     * Resolve builder-returning pseudo-methods contributed by model traits. Registration
+     * already filters this metadata to fluent Builder returns, so no framework method names
+     * are hard-coded here.
+     *
+     * @param class-string<Model> $modelClass
+     * @param lowercase-string $methodName
+     * @psalm-external-mutation-free
+     */
+    public static function resolveTraitMethod(
+        Codebase $codebase,
+        string $modelClass,
+        string $methodName,
+    ): ?ResolvedForwardedMethod {
+        $builderType = ModelMethodHandler::resolvedBuilderTypeFor($modelClass, $codebase);
+
+        if ($builderType->value === Builder::class) {
+            $parameters = BuilderScopeHandler::getTraitMethodParamsForModel($codebase, $modelClass, $methodName);
+        } else {
+            if (!CustomBuilderMethodHandler::hasTraitMethod($modelClass, $methodName)) {
+                return null;
+            }
+
+            $parameters = CustomBuilderMethodHandler::getTraitMethodParams($modelClass, $methodName);
+        }
+
+        if ($parameters === null) {
+            return null;
+        }
+
+        return new ResolvedForwardedMethod(new Union([$builderType]), $parameters);
+    }
+
+    /**
+     * @param class-string<Builder> $builderClass
+     * @param lowercase-string $methodName
+     * @return array{MethodIdentifier, MethodStorage}|null
+     * @psalm-external-mutation-free
+     */
+    private static function declaredMethodStorage(
+        Codebase $codebase,
+        string $builderClass,
+        string $methodName,
+    ): ?array {
+        $cacheKey = \strtolower($builderClass) . '::' . $methodName;
+
+        if (\array_key_exists($cacheKey, self::$declaredMethodCache)) {
+            return self::$declaredMethodCache[$cacheKey];
+        }
+
+        try {
+            $builderStorage = $codebase->classlike_storage_provider->get(\strtolower($builderClass));
+            $baseBuilderStorage = $codebase->classlike_storage_provider->get(\strtolower(Builder::class));
+        } catch (\InvalidArgumentException) {
+            return self::$declaredMethodCache[$cacheKey] = null;
+        }
+
+        $declaringMethodId = $builderStorage->declaring_method_ids[$methodName] ?? null;
+        if ($declaringMethodId === null) {
+            return self::$declaredMethodCache[$cacheKey] = null;
+        }
+
+        // The same declaring id means the custom builder merely inherited Laravel's method.
+        // A different id includes methods on shared application builder bases and trait imports.
+        $baseDeclaringMethodId = $baseBuilderStorage->declaring_method_ids[$methodName] ?? null;
+        if (
+            $baseDeclaringMethodId !== null
+            && \strtolower((string) $baseDeclaringMethodId) === \strtolower((string) $declaringMethodId)
+        ) {
+            return self::$declaredMethodCache[$cacheKey] = null;
+        }
+
+        try {
+            $methodStorage = $codebase->methods->getStorage($declaringMethodId);
+        } catch (\InvalidArgumentException|\UnexpectedValueException) {
+            return self::$declaredMethodCache[$cacheKey] = null;
+        }
+
+        if ($methodStorage->is_static || $methodStorage->visibility !== ClassLikeAnalyzer::VISIBILITY_PUBLIC) {
+            return self::$declaredMethodCache[$cacheKey] = null;
+        }
+
+        return self::$declaredMethodCache[$cacheKey] = [
+            new MethodIdentifier($builderClass, $methodName),
+            $methodStorage,
+        ];
+    }
+
+    /**
+     * Infer method-level template bounds from already-analyzed call arguments.
+     * Psalm will perform the actual argument validation afterwards using the localized
+     * parameters handed to MethodForwardingHandler's params provider.
+     *
+     * @param list<FunctionLikeParameter> $parameters
+     * @param list<Arg> $arguments
+     * @param array<string, non-empty-array<string, Union>> $methodTemplateTypes
+     */
+    private static function inferMethodTemplates(
+        Codebase $codebase,
+        StatementsAnalyzer $source,
+        Context $context,
+        array $parameters,
+        array $arguments,
+        array $methodTemplateTypes,
+        TemplateResult $templateResult,
+    ): void {
+        if ($methodTemplateTypes === []) {
+            return;
+        }
+
+        /** @var list<array{Union, Union, int}> $inferences */
+        $inferences = [];
+
+        foreach ($arguments as $argumentOffset => $argument) {
+            $parameterOffset = self::parameterOffsetForArgument($argument, $argumentOffset, $parameters);
+            $parameter = $parameters[$parameterOffset] ?? null;
+
+            if (
+                !$parameter instanceof FunctionLikeParameter
+                || !$parameter->type instanceof Union
+                || !self::hasMethodTemplate($parameter->type, $methodTemplateTypes)
+            ) {
+                continue;
+            }
+
+            // Do not partially constrain a method template. An unpacked or unavailable sibling
+            // may validly widen the same template once Psalm performs ordinary argument analysis.
+            if ($argument->unpack) {
+                return;
+            }
+
+            $argumentType = self::argumentType($codebase, $source, $context, $argument->value);
+
+            if (!$argumentType instanceof Union) {
+                return;
+            }
+
+            $inferences[] = [$parameter->type, $argumentType, $argumentOffset];
+        }
+
+        foreach ($inferences as [$parameterType, $argumentType, $argumentOffset]) {
+            TemplateStandinTypeReplacer::fillTemplateResult(
+                $parameterType,
+                $templateResult,
+                $codebase,
+                $source,
+                $argumentType,
+                $argumentOffset,
+                $context->self,
+                $context->calling_method_id !== null
+                    ? $context->calling_method_id
+                    : $context->calling_function_id,
+            );
+        }
+    }
+
+    /**
+     * @param array<string, non-empty-array<string, Union>> $methodTemplateTypes
+     * @psalm-mutation-free
+     */
+    private static function hasMethodTemplate(Union $type, array $methodTemplateTypes): bool
+    {
+        foreach ($type->getTemplateTypes() as $templateType) {
+            if (isset($methodTemplateTypes[$templateType->param_name][$templateType->defining_class])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Return-type providers on the missing-method path run before Psalm's normal argument
+     * analyzer. Use only types already present on the AST/context or Psalm's side-effect-free
+     * simple-expression inferer.
+     * Deliberately do not invoke ExpressionAnalyzer/CallAnalyzer: doing so recursively from
+     * this provider can duplicate analysis and previously caused catastrophic memory use.
+     */
+    private static function argumentType(
+        Codebase $codebase,
+        StatementsAnalyzer $source,
+        Context $context,
+        Expr $expression,
+    ): ?Union {
+        $argumentType = $source->getNodeTypeProvider()->getType($expression);
+        if ($argumentType instanceof Union) {
+            return $argumentType;
+        }
+
+        $argumentType = SimpleTypeInferer::infer(
+            $codebase,
+            $source->node_data,
+            $expression,
+            $source->getAliases(),
+            $source,
+        );
+        if ($argumentType instanceof Union) {
+            return $argumentType;
+        }
+
+        $argumentVarId = ExpressionIdentifier::getExtendedVarId(
+            $expression,
+            $context->self,
+            $source,
+        );
+        if ($argumentVarId !== null && isset($context->vars_in_scope[$argumentVarId])) {
+            return $context->vars_in_scope[$argumentVarId];
+        }
+
+        return null;
+    }
+
+    /**
+     * A missing-method provider cannot safely analyze arbitrary nested calls to infer their
+     * result. Replace any still-unbound method template with its declared upper bound so both
+     * return and parameter types degrade predictably (usually to mixed) instead of exposing an
+     * unresolved template that Psalm's later relation params check cannot bind.
+     */
+    private static function fillUnresolvedMethodTemplateBounds(
+        MethodStorage $methodStorage,
+        TemplateResult $templateResult,
+    ): void {
+        foreach ($methodStorage->template_types ?? [] as $templateName => $definingClasses) {
+            foreach ($definingClasses as $definingClass => $bound) {
+                if (isset($templateResult->lower_bounds[$templateName][$definingClass])) {
+                    continue;
+                }
+
+                $templateResult->lower_bounds[$templateName][$definingClass] = [new TemplateBound($bound)];
+            }
+        }
+    }
+
+    /**
+     * @param list<FunctionLikeParameter> $parameters
+     * @psalm-mutation-free
+     */
+    private static function parameterOffsetForArgument(
+        Arg $argument,
+        int $argumentOffset,
+        array $parameters,
+    ): int {
+        if ($argument->name instanceof \PhpParser\Node\Identifier) {
+            $argumentName = $argument->name->toString();
+            foreach ($parameters as $parameterOffset => $parameter) {
+                if ($parameter->name === $argumentName) {
+                    return $parameterOffset;
+                }
+            }
+        }
+
+        if (isset($parameters[$argumentOffset])) {
+            return $argumentOffset;
+        }
+
+        $lastOffset = \array_key_last($parameters);
+
+        return $lastOffset !== null && $parameters[$lastOffset]->is_variadic ? $lastOffset : $argumentOffset;
+    }
+
+    private static function specializeParameter(
+        Codebase $codebase,
+        FunctionLikeParameter $parameter,
+        TemplateResult $templateResult,
+        string $selfClass,
+        TNamedObject $builderType,
+        ?string $parentClass,
+        bool $final,
+    ): FunctionLikeParameter {
+        $parameter = clone $parameter;
+
+        foreach (['type', 'signature_type', 'out_type', 'default_type'] as $property) {
+            $type = $parameter->{$property};
+            if (!$type instanceof Union) {
+                continue;
+            }
+
+            $parameter->{$property} = self::specializeUnion(
+                $codebase,
+                $type,
+                $templateResult,
+                $selfClass,
+                $builderType,
+                $parentClass,
+                $final,
+            );
+        }
+
+        return $parameter;
+    }
+
+    private static function specializeUnion(
+        Codebase $codebase,
+        Union $type,
+        TemplateResult $templateResult,
+        string $selfClass,
+        TNamedObject $builderType,
+        ?string $parentClass,
+        bool $final,
+    ): Union {
+        $type = TypeExpander::expandUnion(
+            $codebase,
+            $type,
+            $selfClass,
+            $builderType,
+            $parentClass,
+            true,
+            false,
+            $final,
+            true,
+        );
+
+        if ($templateResult->lower_bounds !== []) {
+            $type = TemplateInferredTypeReplacer::replace($type, $templateResult, $codebase);
+        }
+
+        return TypeExpander::expandUnion(
+            $codebase,
+            $type,
+            $selfClass,
+            $builderType,
+            $parentClass,
+            true,
+            false,
+            $final,
+            true,
+        );
+    }
+
+    /**
+     * @param list<FunctionLikeParameter> $parameters
+     * @psalm-mutation-free
+     */
+    private static function hasVariadicParameter(array $parameters): bool
+    {
+        foreach ($parameters as $parameter) {
+            if ($parameter->is_variadic) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Handlers/Eloquent/Support/RelatedBuilderMethodResolver.php
+++ b/src/Handlers/Eloquent/Support/RelatedBuilderMethodResolver.php
@@ -7,19 +7,14 @@ namespace Psalm\LaravelPlugin\Handlers\Eloquent\Support;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use PhpParser\Node\Arg;
-use PhpParser\Node\Expr;
 use Psalm\Codebase;
-use Psalm\Context;
 use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\Call\ClassTemplateParamCollector;
-use Psalm\Internal\Analyzer\Statements\Expression\ExpressionIdentifier;
-use Psalm\Internal\Analyzer\Statements\Expression\SimpleTypeInferer;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Internal\MethodIdentifier;
 use Psalm\Internal\Type\TemplateBound;
 use Psalm\Internal\Type\TemplateInferredTypeReplacer;
 use Psalm\Internal\Type\TemplateResult;
-use Psalm\Internal\Type\TemplateStandinTypeReplacer;
 use Psalm\Internal\Type\TypeExpander;
 use Psalm\LaravelPlugin\Handlers\Eloquent\BuilderScopeHandler;
 use Psalm\LaravelPlugin\Handlers\Eloquent\CustomBuilderMethodHandler;
@@ -43,8 +38,8 @@ use Psalm\Type\Union;
 final class RelatedBuilderMethodResolver
 {
     /**
-     * Declared-method lookup cache. Signatures are localized per call because cheap method-level
-     * template inference may use types already available for the current arguments.
+     * Declared-method lookup cache. Signatures no longer depend on per-call argument types;
+     * localization depends only on the effective builder's class templates.
      *
      * @var array<string, array{MethodIdentifier, MethodStorage}|null>
      */
@@ -81,7 +76,6 @@ final class RelatedBuilderMethodResolver
     public static function resolveDeclaredMethod(
         Codebase $codebase,
         StatementsAnalyzer $source,
-        Context $context,
         string $modelClass,
         string $methodName,
         array $arguments,
@@ -123,16 +117,7 @@ final class RelatedBuilderMethodResolver
             $templateResult->template_types += $methodStorage->template_types;
         }
 
-        self::inferMethodTemplates(
-            $codebase,
-            $source,
-            $context,
-            $methodStorage->params,
-            $arguments,
-            $methodStorage->template_types ?? [],
-            $templateResult,
-        );
-        self::fillUnresolvedMethodTemplateBounds($methodStorage, $templateResult);
+        self::boundMethodTemplates($methodStorage, $templateResult);
 
         $methodReturnSelfClass = $declaringMethodId->fq_class_name;
 
@@ -330,175 +315,24 @@ final class RelatedBuilderMethodResolver
     }
 
     /**
-     * Infer method-level template bounds from already-analyzed call arguments.
-     * Psalm will perform the actual argument validation afterwards using the localized
-     * parameters handed to MethodForwardingHandler's params provider.
-     *
-     * @param list<FunctionLikeParameter> $parameters
-     * @param list<Arg> $arguments
-     * @param array<string, non-empty-array<string, Union>> $methodTemplateTypes
+     * This provider fires on the missing-method path before Psalm's normal argument analyzer
+     * runs, so argument types are not reliably available yet (nested calls and unpacked
+     * arguments have not been analyzed). Inferring a template from only the arguments that
+     * happen to already have a type would be unsound, since a later-analyzed sibling argument
+     * could validly widen the same template. Making that inference safe would mean duplicating
+     * Psalm's own call analysis inside a relation-specific handler, which has previously caused
+     * runaway memory use. Every method template therefore degrades unconditionally and
+     * predictably to its declared upper bound (normally `mixed`).
      */
-    private static function inferMethodTemplates(
-        Codebase $codebase,
-        StatementsAnalyzer $source,
-        Context $context,
-        array $parameters,
-        array $arguments,
-        array $methodTemplateTypes,
-        TemplateResult $templateResult,
-    ): void {
-        if ($methodTemplateTypes === []) {
-            return;
-        }
-
-        /** @var list<array{Union, Union, int}> $inferences */
-        $inferences = [];
-
-        foreach ($arguments as $argumentOffset => $argument) {
-            $parameterOffset = self::parameterOffsetForArgument($argument, $argumentOffset, $parameters);
-            $parameter = $parameters[$parameterOffset] ?? null;
-
-            if (
-                !$parameter instanceof FunctionLikeParameter
-                || !$parameter->type instanceof Union
-                || !self::hasMethodTemplate($parameter->type, $methodTemplateTypes)
-            ) {
-                continue;
-            }
-
-            // Do not partially constrain a method template. An unpacked or unavailable sibling
-            // may validly widen the same template once Psalm performs ordinary argument analysis.
-            if ($argument->unpack) {
-                return;
-            }
-
-            $argumentType = self::argumentType($codebase, $source, $context, $argument->value);
-
-            if (!$argumentType instanceof Union) {
-                return;
-            }
-
-            $inferences[] = [$parameter->type, $argumentType, $argumentOffset];
-        }
-
-        foreach ($inferences as [$parameterType, $argumentType, $argumentOffset]) {
-            TemplateStandinTypeReplacer::fillTemplateResult(
-                $parameterType,
-                $templateResult,
-                $codebase,
-                $source,
-                $argumentType,
-                $argumentOffset,
-                $context->self,
-                $context->calling_method_id !== null
-                    ? $context->calling_method_id
-                    : $context->calling_function_id,
-            );
-        }
-    }
-
-    /**
-     * @param array<string, non-empty-array<string, Union>> $methodTemplateTypes
-     * @psalm-mutation-free
-     */
-    private static function hasMethodTemplate(Union $type, array $methodTemplateTypes): bool
-    {
-        foreach ($type->getTemplateTypes() as $templateType) {
-            if (isset($methodTemplateTypes[$templateType->param_name][$templateType->defining_class])) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Return-type providers on the missing-method path run before Psalm's normal argument
-     * analyzer. Use only types already present on the AST/context or Psalm's side-effect-free
-     * simple-expression inferer.
-     * Deliberately do not invoke ExpressionAnalyzer/CallAnalyzer: doing so recursively from
-     * this provider can duplicate analysis and previously caused catastrophic memory use.
-     */
-    private static function argumentType(
-        Codebase $codebase,
-        StatementsAnalyzer $source,
-        Context $context,
-        Expr $expression,
-    ): ?Union {
-        $argumentType = $source->getNodeTypeProvider()->getType($expression);
-        if ($argumentType instanceof Union) {
-            return $argumentType;
-        }
-
-        $argumentType = SimpleTypeInferer::infer(
-            $codebase,
-            $source->node_data,
-            $expression,
-            $source->getAliases(),
-            $source,
-        );
-        if ($argumentType instanceof Union) {
-            return $argumentType;
-        }
-
-        $argumentVarId = ExpressionIdentifier::getExtendedVarId(
-            $expression,
-            $context->self,
-            $source,
-        );
-        if ($argumentVarId !== null && isset($context->vars_in_scope[$argumentVarId])) {
-            return $context->vars_in_scope[$argumentVarId];
-        }
-
-        return null;
-    }
-
-    /**
-     * A missing-method provider cannot safely analyze arbitrary nested calls to infer their
-     * result. Replace any still-unbound method template with its declared upper bound so both
-     * return and parameter types degrade predictably (usually to mixed) instead of exposing an
-     * unresolved template that Psalm's later relation params check cannot bind.
-     */
-    private static function fillUnresolvedMethodTemplateBounds(
+    private static function boundMethodTemplates(
         MethodStorage $methodStorage,
         TemplateResult $templateResult,
     ): void {
         foreach ($methodStorage->template_types ?? [] as $templateName => $definingClasses) {
             foreach ($definingClasses as $definingClass => $bound) {
-                if (isset($templateResult->lower_bounds[$templateName][$definingClass])) {
-                    continue;
-                }
-
                 $templateResult->lower_bounds[$templateName][$definingClass] = [new TemplateBound($bound)];
             }
         }
-    }
-
-    /**
-     * @param list<FunctionLikeParameter> $parameters
-     * @psalm-mutation-free
-     */
-    private static function parameterOffsetForArgument(
-        Arg $argument,
-        int $argumentOffset,
-        array $parameters,
-    ): int {
-        if ($argument->name instanceof \PhpParser\Node\Identifier) {
-            $argumentName = $argument->name->toString();
-            foreach ($parameters as $parameterOffset => $parameter) {
-                if ($parameter->name === $argumentName) {
-                    return $parameterOffset;
-                }
-            }
-        }
-
-        if (isset($parameters[$argumentOffset])) {
-            return $argumentOffset;
-        }
-
-        $lastOffset = \array_key_last($parameters);
-
-        return $lastOffset !== null && $parameters[$lastOffset]->is_variadic ? $lastOffset : $argumentOffset;
     }
 
     private static function specializeParameter(

--- a/src/Handlers/Eloquent/Support/ResolvedForwardedMethod.php
+++ b/src/Handlers/Eloquent/Support/ResolvedForwardedMethod.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Eloquent\Support;
+
+use Psalm\Storage\FunctionLikeParameter;
+use Psalm\Type\Union;
+
+/**
+ * The fully-localized signature of a method forwarded to a related model's builder.
+ *
+ * @internal
+ * @psalm-immutable
+ */
+final class ResolvedForwardedMethod
+{
+    /**
+     * @param list<FunctionLikeParameter> $parameters
+     */
+    public function __construct(
+        public readonly Union $returnType,
+        public readonly array $parameters,
+    ) {}
+}

--- a/src/Handlers/Magic/MethodForwardingHandler.php
+++ b/src/Handlers/Magic/MethodForwardingHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Handlers\Magic;
 
+use Illuminate\Database\Eloquent\Builder;
 use PhpParser\Node\Expr\MethodCall;
 use Psalm\Codebase;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
@@ -11,6 +12,8 @@ use Psalm\LaravelPlugin\Handlers\Eloquent\BuilderScopeHandler;
 use Psalm\LaravelPlugin\Handlers\Eloquent\ModelMethodHandler;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Support\DynamicWhereResolver;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Support\ModelPropertyResolver;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Support\RelatedBuilderMethodResolver;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Support\ResolvedForwardedMethod;
 use Psalm\Plugin\EventHandler\Event\MethodParamsProviderEvent;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\MethodParamsProviderInterface;
@@ -75,6 +78,15 @@ final class MethodForwardingHandler implements MethodReturnTypeProviderInterface
     private static array $scopeParamsCache = [];
 
     /**
+     * Direct Relation::__call signature hand-off. The return-type provider resolves a
+     * custom-builder or trait method immediately before Psalm asks this params provider
+     * to validate the same call. Entries are consumed once to prevent cross-call leakage.
+     *
+     * @var array<string, list<FunctionLikeParameter>>
+     */
+    private static array $pendingBuilderMethodParams = [];
+
+    /**
      * Reset all static state. Called once per Plugin::__construct in production, plus
      * by test fixtures that re-bootstrap the handler. Every cache MUST be cleared so
      * leftover entries from a previous run can't leak across boundaries — in particular
@@ -93,6 +105,8 @@ final class MethodForwardingHandler implements MethodReturnTypeProviderInterface
         self::$sourceClassIndex = [];
         self::$searchClassIndex = [];
         self::$scopeParamsCache = [];
+        self::$pendingBuilderMethodParams = [];
+        RelatedBuilderMethodResolver::reset();
         DynamicWhereResolver::reset();
 
         foreach ($rule->allSourceClasses() as $class) {
@@ -174,10 +188,46 @@ final class MethodForwardingHandler implements MethodReturnTypeProviderInterface
             $fqClassName,
         );
 
+        $relationAtomic = $templateParams !== null
+            ? new TGenericObject($fqClassName, $templateParams)
+            : null;
+
+        // A real method introduced by the related model's custom builder wins over
+        // Builder::__call and Query Builder forwarding, matching PHP dispatch.
+        if ($relationAtomic instanceof TGenericObject) {
+            $customBuilderResult = self::resolveDeclaredBuilderMethodOnRelation(
+                $source,
+                $event,
+                $codebase,
+                $methodName,
+                $relationAtomic,
+                true,
+            );
+
+            if ($customBuilderResult instanceof Union) {
+                return $customBuilderResult;
+            }
+        }
+
         $resolved = ReturnTypeResolver::resolve($fqClassName, $templateParams, $codebase, $methodName);
 
         if ($resolved instanceof \Psalm\Type\Union) {
             return $resolved;
+        }
+
+        // Trait-provided fluent methods are runtime builder macros. Real Builder methods
+        // above retain precedence; scopes remain the next fallback below.
+        if ($relationAtomic instanceof TGenericObject) {
+            $traitBuilderResult = self::resolveTraitBuilderMethodOnRelation(
+                $codebase,
+                $methodName,
+                $relationAtomic,
+                true,
+            );
+
+            if ($traitBuilderResult instanceof Union) {
+                return $traitBuilderResult;
+            }
         }
 
         // Scope method fallback for Path 2: check if the method is a scope on the related model.
@@ -244,6 +294,17 @@ final class MethodForwardingHandler implements MethodReturnTypeProviderInterface
         // Don't override params for methods declared on the source class (stubs)
         if (self::isInDeclaringMethodIds($codebase, $fqClassName, $methodName)) {
             return null;
+        }
+
+        // A direct custom-builder/trait signature resolved by the return provider takes
+        // precedence over base Builder params (important for a custom override of a magic
+        // Query Builder method). Consume once so another call cannot inherit this signature.
+        $builderMethodKey = \strtolower($fqClassName) . '::' . $methodName;
+        if (\array_key_exists($builderMethodKey, self::$pendingBuilderMethodParams)) {
+            $parameters = self::$pendingBuilderMethodParams[$builderMethodKey];
+            unset(self::$pendingBuilderMethodParams[$builderMethodKey]);
+
+            return $parameters;
         }
 
         // Find method on search classes, return its params
@@ -313,6 +374,8 @@ final class MethodForwardingHandler implements MethodReturnTypeProviderInterface
      * where() via @mixin Builder<Phone> and fires the provider for Builder.
      * This method detects the original caller (HasOne) from the node type provider
      * and returns the Relation's generic type instead of Builder's.
+     *
+     * @param lowercase-string $methodName
      */
     private static function handleMixinInterception(
         StatementsAnalyzer $source,
@@ -360,6 +423,22 @@ final class MethodForwardingHandler implements MethodReturnTypeProviderInterface
                 continue;
             }
 
+            // The Relation's @mixin only exposes the base Builder surface. Look through
+            // the related model first so a declared custom-builder override follows PHP's
+            // real method dispatch and so custom-only methods do not collapse to mixed.
+            $customBuilderResult = self::resolveDeclaredBuilderMethodOnRelation(
+                $source,
+                $event,
+                $codebase,
+                $methodName,
+                $atomicType,
+                false,
+            );
+
+            if ($customBuilderResult instanceof Union) {
+                return $customBuilderResult;
+            }
+
             // Try declared fluent-method resolution first (e.g. where(), orderBy()).
             $resolved = ReturnTypeResolver::resolve(
                 $atomicType->value,
@@ -370,6 +449,17 @@ final class MethodForwardingHandler implements MethodReturnTypeProviderInterface
 
             if ($resolved instanceof \Psalm\Type\Union) {
                 return $resolved;
+            }
+
+            $traitBuilderResult = self::resolveTraitBuilderMethodOnRelation(
+                $codebase,
+                $methodName,
+                $atomicType,
+                false,
+            );
+
+            if ($traitBuilderResult instanceof Union) {
+                return $traitBuilderResult;
             }
 
             // Scope method fallback: check if the method is a scope on the related model.
@@ -405,6 +495,129 @@ final class MethodForwardingHandler implements MethodReturnTypeProviderInterface
         }
 
         return null;
+    }
+
+    /**
+     * Resolve a real custom-builder method and apply Relation::forwardDecoratedCallTo
+     * semantics to its localized return type.
+     *
+     * @param lowercase-string $methodName
+     */
+    private static function resolveDeclaredBuilderMethodOnRelation(
+        StatementsAnalyzer $source,
+        MethodReturnTypeProviderEvent $event,
+        Codebase $codebase,
+        string $methodName,
+        TGenericObject $relationAtomic,
+        bool $storeParameters,
+    ): ?Union {
+        $modelClass = ModelPropertyResolver::extractModelFromUnion($relationAtomic->type_params[0] ?? null);
+        if ($modelClass === null) {
+            return null;
+        }
+
+        $resolved = RelatedBuilderMethodResolver::resolveDeclaredMethod(
+            $codebase,
+            $source,
+            $event->getContext(),
+            $modelClass,
+            $methodName,
+            $event->getCallArgs(),
+        );
+
+        if (!$resolved instanceof ResolvedForwardedMethod) {
+            return null;
+        }
+
+        if ($storeParameters) {
+            self::storePendingBuilderMethodParams($relationAtomic->value, $methodName, $resolved->parameters);
+        }
+
+        return self::decorateBuilderReturn($codebase, $resolved->returnType, $relationAtomic);
+    }
+
+    /**
+     * Resolve a model-trait fluent builder pseudo-method on a relation.
+     *
+     * @param lowercase-string $methodName
+     * @psalm-external-mutation-free
+     */
+    private static function resolveTraitBuilderMethodOnRelation(
+        Codebase $codebase,
+        string $methodName,
+        TGenericObject $relationAtomic,
+        bool $storeParameters,
+    ): ?Union {
+        $modelClass = ModelPropertyResolver::extractModelFromUnion($relationAtomic->type_params[0] ?? null);
+        if ($modelClass === null) {
+            return null;
+        }
+
+        $resolved = RelatedBuilderMethodResolver::resolveTraitMethod($codebase, $modelClass, $methodName);
+        if (!$resolved instanceof ResolvedForwardedMethod) {
+            return null;
+        }
+
+        if ($storeParameters) {
+            self::storePendingBuilderMethodParams($relationAtomic->value, $methodName, $resolved->parameters);
+        }
+
+        return self::decorateBuilderReturn($codebase, $resolved->returnType, $relationAtomic);
+    }
+
+    /**
+     * Laravel substitutes the Relation only when the forwarded result is the wrapped
+     * builder instance. Static analysis cannot express object identity, so a Builder
+     * subtype is the established fluent approximation; every non-builder union branch
+     * remains untouched.
+     *
+     * @psalm-external-mutation-free
+     */
+    private static function decorateBuilderReturn(
+        Codebase $codebase,
+        Union $returnType,
+        TGenericObject $relationAtomic,
+    ): Union {
+        $builder = $returnType->getBuilder();
+        $changed = false;
+
+        foreach ($returnType->getAtomicTypes() as $key => $atomicType) {
+            if (!$atomicType instanceof \Psalm\Type\Atomic\TNamedObject) {
+                continue;
+            }
+
+            $isBuilder = \strtolower($atomicType->value) === \strtolower(Builder::class);
+
+            if (!$isBuilder) {
+                try {
+                    $isBuilder = $codebase->classExtendsOrImplements($atomicType->value, Builder::class);
+                } catch (\InvalidArgumentException) {
+                    $isBuilder = false;
+                }
+            }
+
+            if (!$isBuilder) {
+                continue;
+            }
+
+            $builder->removeType($key);
+            $builder->addType($relationAtomic);
+            $changed = true;
+        }
+
+        return $changed ? $builder->freeze() : $returnType;
+    }
+
+    /**
+     * @param list<FunctionLikeParameter> $parameters
+     * @psalm-external-mutation-free
+     */
+    private static function storePendingBuilderMethodParams(
+        string $relationClass,
+        string $methodName,
+        array $parameters,
+    ): void {
+        self::$pendingBuilderMethodParams[\strtolower($relationClass) . '::' . $methodName] = $parameters;
     }
 
     /**

--- a/src/Handlers/Magic/MethodForwardingHandler.php
+++ b/src/Handlers/Magic/MethodForwardingHandler.php
@@ -519,7 +519,6 @@ final class MethodForwardingHandler implements MethodReturnTypeProviderInterface
         $resolved = RelatedBuilderMethodResolver::resolveDeclaredMethod(
             $codebase,
             $source,
-            $event->getContext(),
             $modelClass,
             $methodName,
             $event->getCallArgs(),

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -282,6 +282,8 @@ final class Plugin implements PluginEntryPointInterface
         // CustomCollectionHandler — the handler returns null for non-Relation callers
         // (fast O(1) check), so downstream handlers fire unaffected.
         require_once __DIR__ . '/Handlers/Eloquent/Support/DynamicWhereResolver.php';
+        require_once __DIR__ . '/Handlers/Eloquent/Support/ResolvedForwardedMethod.php';
+        require_once __DIR__ . '/Handlers/Eloquent/Support/RelatedBuilderMethodResolver.php';
         require_once __DIR__ . '/Handlers/Magic/ForwardingRule.php';
         require_once __DIR__ . '/Handlers/Magic/ReturnTypeResolver.php';
         require_once __DIR__ . '/Handlers/Magic/MethodForwardingHandler.php';

--- a/tests/Application/app/Builders/MechanicBuilder.php
+++ b/tests/Application/app/Builders/MechanicBuilder.php
@@ -22,4 +22,14 @@ class MechanicBuilder extends Builder
     {
         return $this->where('certified', true);
     }
+
+    /**
+     * A real custom method with the same name as Query\Builder's magic-forwarded groupBy().
+     * PHP invokes this declaration before Builder::__call, so relation forwarding must use
+     * this terminal signature rather than the Query Builder's fluent one.
+     */
+    public function groupBy(string $group): int
+    {
+        return \strlen($group);
+    }
 }

--- a/tests/Application/app/Builders/VehicleBuilder.php
+++ b/tests/Application/app/Builders/VehicleBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Builders;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -28,4 +29,120 @@ class VehicleBuilder extends Builder
     {
         return $this->where('make', $make);
     }
+
+    /** @psalm-return int<0, max> */
+    public function countByMake(string $make): int
+    {
+        return $this->where('make', $make)->count();
+    }
+
+    /** @psalm-return TModel|null */
+    public function firstByMake(string $make): ?Model
+    {
+        return $this->where('make', $make)->first();
+    }
+
+    /** @return Collection<int, TModel> */
+    public function getByMake(string $make): Collection
+    {
+        return $this->where('make', $make)->get();
+    }
+
+    /** @psalm-return self<TModel>|null */
+    public function maybeWhereElectric(bool $apply): ?self
+    {
+        return $apply ? $this->whereElectric() : null;
+    }
+
+    /**
+     * @psalm-return self<TModel>
+     */
+    public function whereByOptions(string $make, ?int $year = null): self
+    {
+        return $this->where('make', $make)->when(
+            $year !== null,
+            static fn(Builder $query): Builder => $query->where('year', $year),
+        );
+    }
+
+    /** @psalm-return self<TModel> */
+    public function whereByMakes(string &$first, string ...$others): self
+    {
+        return $this->whereIn('make', [$first, ...$others]);
+    }
+
+    /**
+     * @param-out int<0, max> $count
+     * @psalm-return self<TModel>
+     */
+    public function withMatchCount(mixed &$count): self
+    {
+        $count = $this->count();
+
+        return $this;
+    }
+
+    /**
+     * @template TValue
+     * @param TValue $value
+     * @return TValue
+     */
+    public function passthrough(mixed $value): mixed
+    {
+        return $value;
+    }
+
+    /**
+     * @template TValue of Model
+     * @param TValue $value
+     * @return TValue
+     */
+    public function modelPassthrough(Model $value): Model
+    {
+        return $value;
+    }
+
+    /**
+     * @template TValue of Model
+     * @param TValue $first
+     * @param TValue $second
+     * @return TValue
+     */
+    public function chooseModel(Model $first, Model $second): Model
+    {
+        return $first;
+    }
+
+    /**
+     * @template TValue
+     * @param TModel $model
+     * @param TValue $value
+     * @return TValue
+     */
+    public function valueForModel(Model $model, mixed $value): mixed
+    {
+        return $value;
+    }
+
+    /**
+     * @template TValue
+     * @param TValue $value
+     * @return TValue
+     */
+    public function labelledPassthrough(string $label, mixed $value): mixed
+    {
+        return $value;
+    }
+
+    /**
+     * @template TValue
+     * @param TValue ...$values
+     * @return TValue
+     */
+    public function lastValue(mixed ...$values): mixed
+    {
+        return $values[\array_key_last($values)];
+    }
+
+    public function recordQuery(): void {}
 }

--- a/tests/Application/app/Builders/VehicleBuilder.php
+++ b/tests/Application/app/Builders/VehicleBuilder.php
@@ -113,36 +113,5 @@ class VehicleBuilder extends Builder
         return $first;
     }
 
-    /**
-     * @template TValue
-     * @param TModel $model
-     * @param TValue $value
-     * @return TValue
-     */
-    public function valueForModel(Model $model, mixed $value): mixed
-    {
-        return $value;
-    }
-
-    /**
-     * @template TValue
-     * @param TValue $value
-     * @return TValue
-     */
-    public function labelledPassthrough(string $label, mixed $value): mixed
-    {
-        return $value;
-    }
-
-    /**
-     * @template TValue
-     * @param TValue ...$values
-     * @return TValue
-     */
-    public function lastValue(mixed ...$values): mixed
-    {
-        return $values[\array_key_last($values)];
-    }
-
     public function recordQuery(): void {}
 }

--- a/tests/Application/app/Models/Shop.php
+++ b/tests/Application/app/Models/Shop.php
@@ -61,6 +61,12 @@ final class Shop extends Model
         return $this->hasMany(WorkOrder::class);
     }
 
+    /** HasMany whose related model uses a method inherited from an abstract custom builder. */
+    public function artists(): HasMany
+    {
+        return $this->hasMany(Artist::class);
+    }
+
     /** BelongsToMany without generics — Part has PartCollection via newCollection() */
     public function parts(): BelongsToMany
     {

--- a/tests/Type/tests/Relation/CustomBuilderMethodTest.phpt
+++ b/tests/Type/tests/Relation/CustomBuilderMethodTest.phpt
@@ -1,0 +1,199 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Artist;
+use App\Models\Customer;
+use App\Models\Invoice;
+use App\Models\Mechanic;
+use App\Models\Part;
+use App\Models\Shop;
+use App\Models\Vehicle;
+use App\Models\WorkOrder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+function makeVehicleForRelationTemplate(): Vehicle {
+    return new Vehicle();
+}
+
+function makeCustomerForRelationTemplate(): Customer {
+    return new Customer();
+}
+
+final class RelationVehicleFactory {
+    public function make(): Vehicle {
+        return new Vehicle();
+    }
+}
+
+/**
+ * Issue #1262: Relation::__call forwards custom methods to the related model's
+ * effective builder and substitutes the Relation only for builder-returning branches.
+ */
+
+function test_new_eloquent_builder_fluent_method(): void {
+    $_result = (new Customer())->vehicles()->whereElectric()->get();
+    /** @psalm-check-type-exact $_result = Collection<int, Vehicle> */
+}
+
+function test_use_eloquent_builder_attribute_fluent_method(): void {
+    $_result = (new Shop())->workOrders()->whereCompleted();
+    /** @psalm-check-type-exact $_result = HasMany<WorkOrder, Shop> */
+}
+
+function test_static_builder_property_fluent_method(): void {
+    $_result = (new Shop())->mechanics()->whereCertified();
+    /** @psalm-check-type-exact $_result = HasManyThrough<Mechanic, Vehicle, Shop> */
+}
+
+function test_non_templated_custom_builder_fluent_method(): void {
+    // Explicitly reference the related model so psalm-tester scans and registers its
+    // metadata before analyzing the relation-only call in this isolated fixture.
+    static function (Invoice $_invoice): void {};
+    $_result = (new Shop())->latestInvoice()->wherePaid();
+    /** @psalm-check-type-exact $_result = HasOne<Invoice, Shop> */
+}
+
+function test_method_inherited_from_abstract_custom_builder(): void {
+    static function (Artist $_artist): void {};
+    $_result = (new Shop())->artists()->accessible();
+    /** @psalm-check-type-exact $_result = HasMany<Artist, Shop> */
+
+    $_nullable = (new Shop())->artists()->accessibleOrNull();
+    /** @psalm-check-type-exact $_nullable = HasMany<Artist, Shop>|null */
+}
+
+function test_terminal_custom_builder_returns(): void {
+    $relation = (new Customer())->vehicles();
+
+    $_count = $relation->countByMake('Toyota');
+    /** @psalm-check-type-exact $_count = int<0, max> */
+
+    $_first = $relation->firstByMake('Toyota');
+    /** @psalm-check-type-exact $_first = Vehicle|null */
+
+    $_collection = $relation->getByMake('Toyota');
+    /** @psalm-check-type-exact $_collection = Collection<int, Vehicle> */
+
+    $_void = $relation->recordQuery();
+}
+
+function test_builder_union_branch_is_decorated(): void {
+    $_result = (new Customer())->vehicles()->maybeWhereElectric(true);
+    /** @psalm-check-type-exact $_result = HasMany<Vehicle, Customer>|null */
+}
+
+function test_declared_custom_builder_parameters(): void {
+    $relation = (new Customer())->vehicles();
+
+    $_named = $relation->whereByOptions(year: 2024, make: 'Toyota');
+    /** @psalm-check-type-exact $_named = HasMany<Vehicle, Customer> */
+
+    $first = 'Toyota';
+    $_variadic = $relation->whereByMakes($first, 'Honda', 'Volvo');
+    /** @psalm-check-type-exact $_variadic = HasMany<Vehicle, Customer> */
+
+    $count = null;
+    $_out = $relation->withMatchCount($count);
+    /** @psalm-check-type-exact $_out = HasMany<Vehicle, Customer> */
+    /** @psalm-check-type-exact $count = int<0, max> */
+}
+
+function test_method_template_is_inferred_from_available_argument_types(): void {
+    $_result = (new Customer())->vehicles()->passthrough('Toyota');
+    /** @psalm-check-type-exact $_result = 'Toyota' */
+
+    $vehicle = new Vehicle();
+    $_model = (new Customer())->vehicles()->passthrough($vehicle);
+    /** @psalm-check-type-exact $_model = Vehicle */
+
+    $_named = (new Customer())->vehicles()->labelledPassthrough(
+        value: new Vehicle(),
+        label: 'vehicle',
+    );
+    /** @psalm-check-type-exact $_named = Vehicle */
+
+    $_allKnown = (new Customer())->vehicles()->chooseModel(new Vehicle(), new Vehicle());
+    /** @psalm-check-type-exact $_allKnown = Vehicle */
+
+    // An unavailable argument for the builder's class template must not disable inference
+    // for an independent method template whose argument is fully known.
+    $_independent = (new Customer())->vehicles()->valueForModel(
+        makeVehicleForRelationTemplate(),
+        'known',
+    );
+    /** @psalm-check-type-exact $_independent = 'known' */
+}
+
+function test_unavailable_method_template_inputs_fall_back_safely(RelationVehicleFactory $factory): void {
+    // This missing-method provider runs before nested calls and unpacked arguments have their
+    // normal Psalm argument types. Recreating that analysis here would be disproportionate, so
+    // unresolved method templates use their declared upper bounds (normally `mixed`).
+    $_functionCall = (new Customer())->vehicles()->passthrough(makeVehicleForRelationTemplate());
+    /** @psalm-check-type-exact $_functionCall = mixed */
+
+    $_methodCall = (new Customer())->vehicles()->passthrough($factory->make());
+    /** @psalm-check-type-exact $_methodCall = mixed */
+
+    $_bounded = (new Customer())->vehicles()->modelPassthrough(makeVehicleForRelationTemplate());
+    /** @psalm-check-type-exact $_bounded = Illuminate\Database\Eloquent\Model */
+
+    // The first argument is available, but the direct function call is not. Inferring only
+    // Vehicle would reject the valid Customer sibling after Psalm analyzes it, so the whole
+    // method-template inference step falls back to the declared Model bound.
+    $_partiallyAvailable = (new Customer())->vehicles()->chooseModel(
+        new Vehicle(),
+        makeCustomerForRelationTemplate(),
+    );
+    /** @psalm-check-type-exact $_partiallyAvailable = Illuminate\Database\Eloquent\Model */
+
+    /** @var list<Vehicle> $vehicles */
+    $vehicles = [new Vehicle(), new Vehicle()];
+    $_unpacked = (new Customer())->vehicles()->lastValue(...$vehicles);
+    /** @psalm-check-type-exact $_unpacked = mixed */
+}
+
+function test_custom_method_wins_over_query_builder_magic(): void {
+    $_result = (new Shop())->mechanics()->groupBy('certification');
+    /** @psalm-check-type-exact $_result = int */
+}
+
+function test_trait_fluent_methods_are_model_aware(): void {
+    $_base = (new Shop())->owner()->onlyTrashed();
+    /** @psalm-check-type-exact $_base = BelongsTo<Customer, Shop> */
+
+    $_custom = (new Shop())->workOrders()->withTrashed();
+    /** @psalm-check-type-exact $_custom = HasMany<WorkOrder, Shop> */
+
+    $_missing = (new Shop())->parts()->onlyTrashed();
+    /** @psalm-check-type-exact $_missing = mixed */
+}
+
+function test_custom_builder_params_reject_wrong_type(): void {
+    (new Customer())->vehicles()->whereByMake(123);
+}
+
+function test_custom_builder_params_reject_wrong_arity(): void {
+    (new Customer())->vehicles()->whereByMake();
+    (new Customer())->vehicles()->whereByMake('Toyota', 'Honda');
+}
+
+function test_custom_builder_param_handoff_is_consumed_once(): void {
+    // Custom MechanicBuilder::groupBy accepts exactly one string and populates the
+    // HasManyThrough::groupby hand-off, which must be consumed by this call.
+    (new Shop())->mechanics()->groupBy('certification');
+
+    // Same relation class and method, different related model: this resolves through
+    // Query\Builder's variadic groupBy and must not inherit MechanicBuilder's signature.
+    (new Customer())->workOrders()->groupBy('status', 'priority');
+}
+?>
+--EXPECTF--
+AssignmentToVoid on line %d: Cannot assign $_void to type void
+InvalidArgument on line %d: Argument 1 of %s::wherebymake expects string, but 123 provided
+TooFewArguments on line %d: Too few arguments for %s::wherebymake - expecting make to be passed
+TooManyArguments on line %d: Too many arguments for %s::wherebymake - expecting 1 but saw 2

--- a/tests/Type/tests/Relation/CustomBuilderMethodTest.phpt
+++ b/tests/Type/tests/Relation/CustomBuilderMethodTest.phpt
@@ -16,20 +16,6 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 
-function makeVehicleForRelationTemplate(): Vehicle {
-    return new Vehicle();
-}
-
-function makeCustomerForRelationTemplate(): Customer {
-    return new Customer();
-}
-
-final class RelationVehicleFactory {
-    public function make(): Vehicle {
-        return new Vehicle();
-    }
-}
-
 /**
  * Issue #1262: Relation::__call forwards custom methods to the related model's
  * effective builder and substitutes the Relation only for builder-returning branches.
@@ -103,58 +89,18 @@ function test_declared_custom_builder_parameters(): void {
     /** @psalm-check-type-exact $count = int<0, max> */
 }
 
-function test_method_template_is_inferred_from_available_argument_types(): void {
-    $_result = (new Customer())->vehicles()->passthrough('Toyota');
-    /** @psalm-check-type-exact $_result = 'Toyota' */
+function test_method_templates_degrade_to_declared_bounds(): void {
+    // Method-level templates cannot be inferred on the missing-method provider path
+    // (argument types are not reliably analyzed yet at this provider's event point), so they
+    // resolve to their declared upper bound.
+    $_unbounded = (new Customer())->vehicles()->passthrough('Toyota');
+    /** @psalm-check-type-exact $_unbounded = mixed */
 
-    $vehicle = new Vehicle();
-    $_model = (new Customer())->vehicles()->passthrough($vehicle);
-    /** @psalm-check-type-exact $_model = Vehicle */
-
-    $_named = (new Customer())->vehicles()->labelledPassthrough(
-        value: new Vehicle(),
-        label: 'vehicle',
-    );
-    /** @psalm-check-type-exact $_named = Vehicle */
-
-    $_allKnown = (new Customer())->vehicles()->chooseModel(new Vehicle(), new Vehicle());
-    /** @psalm-check-type-exact $_allKnown = Vehicle */
-
-    // An unavailable argument for the builder's class template must not disable inference
-    // for an independent method template whose argument is fully known.
-    $_independent = (new Customer())->vehicles()->valueForModel(
-        makeVehicleForRelationTemplate(),
-        'known',
-    );
-    /** @psalm-check-type-exact $_independent = 'known' */
-}
-
-function test_unavailable_method_template_inputs_fall_back_safely(RelationVehicleFactory $factory): void {
-    // This missing-method provider runs before nested calls and unpacked arguments have their
-    // normal Psalm argument types. Recreating that analysis here would be disproportionate, so
-    // unresolved method templates use their declared upper bounds (normally `mixed`).
-    $_functionCall = (new Customer())->vehicles()->passthrough(makeVehicleForRelationTemplate());
-    /** @psalm-check-type-exact $_functionCall = mixed */
-
-    $_methodCall = (new Customer())->vehicles()->passthrough($factory->make());
-    /** @psalm-check-type-exact $_methodCall = mixed */
-
-    $_bounded = (new Customer())->vehicles()->modelPassthrough(makeVehicleForRelationTemplate());
+    $_bounded = (new Customer())->vehicles()->modelPassthrough(new Vehicle());
     /** @psalm-check-type-exact $_bounded = Illuminate\Database\Eloquent\Model */
 
-    // The first argument is available, but the direct function call is not. Inferring only
-    // Vehicle would reject the valid Customer sibling after Psalm analyzes it, so the whole
-    // method-template inference step falls back to the declared Model bound.
-    $_partiallyAvailable = (new Customer())->vehicles()->chooseModel(
-        new Vehicle(),
-        makeCustomerForRelationTemplate(),
-    );
-    /** @psalm-check-type-exact $_partiallyAvailable = Illuminate\Database\Eloquent\Model */
-
-    /** @var list<Vehicle> $vehicles */
-    $vehicles = [new Vehicle(), new Vehicle()];
-    $_unpacked = (new Customer())->vehicles()->lastValue(...$vehicles);
-    /** @psalm-check-type-exact $_unpacked = mixed */
+    $_twoArgs = (new Customer())->vehicles()->chooseModel(new Vehicle(), new Vehicle());
+    /** @psalm-check-type-exact $_twoArgs = Illuminate\Database\Eloquent\Model */
 }
 
 function test_custom_method_wins_over_query_builder_magic(): void {

--- a/tests/Unit/Handlers/Magic/MethodForwardingHandlerTest.php
+++ b/tests/Unit/Handlers/Magic/MethodForwardingHandlerTest.php
@@ -7,9 +7,11 @@ namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Magic;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Support\RelatedBuilderMethodResolver;
 use Psalm\LaravelPlugin\Handlers\Magic\MethodForwardingHandler;
 
 #[CoversClass(MethodForwardingHandler::class)]
+#[CoversClass(RelatedBuilderMethodResolver::class)]
 final class MethodForwardingHandlerTest extends TestCase
 {
     /**
@@ -22,31 +24,33 @@ final class MethodForwardingHandlerTest extends TestCase
     #[Test]
     public function it_does_not_import_ProxyMethodReturnTypeProvider(): void
     {
-        $reflection = new \ReflectionClass(MethodForwardingHandler::class);
-        $fileName = $reflection->getFileName();
-        $this->assertIsString($fileName);
+        foreach ([MethodForwardingHandler::class, RelatedBuilderMethodResolver::class] as $class) {
+            $reflection = new \ReflectionClass($class);
+            $fileName = $reflection->getFileName();
+            $this->assertIsString($fileName);
 
-        $fileContents = \file_get_contents($fileName);
-        $this->assertIsString($fileContents);
+            $fileContents = \file_get_contents($fileName);
+            $this->assertIsString($fileContents);
 
-        // Strip comments to avoid false positives from explanatory comments
-        $tokens = \token_get_all($fileContents);
-        $codeOnly = '';
+            // Strip comments to avoid false positives from explanatory comments
+            $tokens = \token_get_all($fileContents);
+            $codeOnly = '';
 
-        foreach ($tokens as $token) {
-            if (\is_array($token) && \in_array($token[0], [\T_COMMENT, \T_DOC_COMMENT], true)) {
-                continue;
+            foreach ($tokens as $token) {
+                if (\is_array($token) && \in_array($token[0], [\T_COMMENT, \T_DOC_COMMENT], true)) {
+                    continue;
+                }
+
+                $codeOnly .= \is_array($token) ? $token[1] : $token;
             }
 
-            $codeOnly .= \is_array($token) ? $token[1] : $token;
+            $this->assertStringNotContainsString(
+                'ProxyMethodReturnTypeProvider',
+                $codeOnly,
+                $class . ' must not use ProxyMethodReturnTypeProvider::executeFakeCall() — '
+                . 'it causes 50+ GB memory explosion on large projects. '
+                . 'Use ClassLikeStorage->declaring_method_ids for method lookup instead.',
+            );
         }
-
-        $this->assertStringNotContainsString(
-            'ProxyMethodReturnTypeProvider',
-            $codeOnly,
-            'MethodForwardingHandler must not use ProxyMethodReturnTypeProvider::executeFakeCall() — '
-            . 'it causes 50+ GB memory explosion on large projects. '
-            . 'Use ClassLikeStorage->declaring_method_ids for method lookup instead.',
-        );
     }
 }


### PR DESCRIPTION
## Summary

- resolve custom builder methods forwarded through Eloquent relations from Psalm class and method storage
- preserve Laravel's decorated-call behavior by replacing only Builder return branches with the original Relation type
- support model-aware trait-provided fluent methods such as onlyTrashed() and withTrashed() for base and custom builders
- carry the localized custom method signature into direct Relation::__call parameter validation with a consume-once handoff

## Root cause

Relation mixins expose the base Eloquent Builder surface, but not methods declared on a related model's custom builder. The forwarding handler therefore fell through to mixed for custom-only methods. Returning the relation for every discovered method would also be incorrect because terminal custom methods can return scalars, models, collections, null, or void.

The storage-only resolver finds the related model's effective builder, resolves and specializes public custom-builder method signatures, and leaves framework base methods to the existing forwarding path. No model or builder is instantiated, and no synthetic call analysis is used.

Builder subtypes in the resolved return union are decorated to the original relation type; non-builder branches are preserved. Class-level templates are localized (a `firstByMake(): ?TModel` on `VehicleBuilder` returns `Vehicle|null` through the relation), and exact parameter metadata is handed to the params provider for direct relation calls. Trait fluent metadata is model-aware, so SoftDeletes methods are not exposed on unrelated models.

## Design boundary: method-level templates degrade to their bounds

Method-level `@template` types on custom builder methods are not inferred from call arguments on this path. The missing-method provider event fires before Psalm's argument analyzer, so argument types are not reliably available (nested calls and unpacked arguments have no node types yet), and inferring from only the arguments that happen to have a type is unsound because a later-analyzed sibling could validly widen the same template. Making that safe would mean duplicating Psalm's call and unpack analysis inside a relation-specific handler.

Every method-level template therefore degrades uniformly and predictably to its declared upper bound (normally `mixed`). Class-level template localization is unaffected. This is a plugin-side workaround for a Psalm API gap: unlike PHPStan's `MethodsClassReflectionExtension`, Psalm has no way for a plugin to hand back a full method reflection and let the engine run its own argument and template analysis.

This does not claim to solve instance-local builder macros such as `restore()`; that remains the separate scope of #929.

## Tests

- type suite: 584 passed, 1 skipped
- unit suite: 1,058 passed, 1 skipped
- Psalm self-analysis: clean without `--no-suggestions`, 100% inferred
- code style, Rector dry run, `git diff --check`: clean

Coverage includes all supported custom-builder registration mechanisms, inherited and non-templated builders, fluent and terminal returns, nullable unions, parameter validation (wrong type and wrong arity), method precedence over Query Builder magic, SoftDeletes trait methods, model isolation, method-template bound degradation, and consume-once parameter handoff.

Fixes #1262
