### PR TITLE
Make model metadata warm-up section-isolated

### DIFF
--- a/src/Handlers/Eloquent/Metadata/ModelMetadata.php
+++ b/src/Handlers/Eloquent/Metadata/ModelMetadata.php
@@ -91,7 +91,7 @@ final readonly class ModelMetadata
         private array $scopesData,
         private array $relationsData,
         private array $knownPropertiesData,
-        private int $completeSections = self::ALL_SECTIONS,
+        private int $completeSections,
     ) {}
 
     /**
@@ -201,8 +201,9 @@ final readonly class ModelMetadata
      * `$fillable` / `$guarded` are deliberately NOT sources — they are a guard-list over columns, not an
      * independent supply of attribute names — and docblock `@property` names are not parsed yet.
      *
-     * The set is not exhaustive in two known ways, so a consumer must not treat a single model's set as
-     * complete: (1) with migrations disabled
+     * The set is not exhaustive when one of its source sections could not be built, so consumers that
+     * need a definitive answer must first check the relevant completeness bits. Two other known gaps
+     * remain: (1) with migrations disabled
      * ({@see \Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaStateProvider::getSchema()} is null) the schema-column
      * origins are absent, so an unknown-key check must not treat the column set as authoritative in that
      * mode (it would flag valid column keys as unknown); (2) the `relations` source is OWN-CLASS only

--- a/src/Handlers/Eloquent/Metadata/ModelMetadata.php
+++ b/src/Handlers/Eloquent/Metadata/ModelMetadata.php
@@ -27,6 +27,25 @@ use Psalm\LaravelPlugin\Handlers\Eloquent\Support\EloquentModelMethods;
  */
 final readonly class ModelMetadata
 {
+    public const SECTION_METHODS = 1 << 0;
+
+    public const SECTION_RELATIONS = 1 << 1;
+
+    public const SECTION_RUNTIME_CONFIGURATION = 1 << 2;
+
+    public const SECTION_SCHEMA = 1 << 3;
+
+    public const SECTION_CASTS = 1 << 4;
+
+    public const SECTION_PRIMARY_KEY = 1 << 5;
+
+    public const ALL_SECTIONS = self::SECTION_METHODS
+        | self::SECTION_RELATIONS
+        | self::SECTION_RUNTIME_CONFIGURATION
+        | self::SECTION_SCHEMA
+        | self::SECTION_CASTS
+        | self::SECTION_PRIMARY_KEY;
+
     /**
      * Attribute-name fields (`fillable` / `guarded` / `appends` / `hidden` / `visible`) preserve the
      * exact case the user declared — Eloquent's `isFillable` / `isGuarded` / `getHidden` / `getVisible`
@@ -72,7 +91,17 @@ final readonly class ModelMetadata
         private array $scopesData,
         private array $relationsData,
         private array $knownPropertiesData,
+        private int $completeSections = self::ALL_SECTIONS,
     ) {}
+
+    /**
+     * A set bit means the section is authoritative, including when its value is empty. An absent bit
+     * means unavailable or failed; build-time failures are reported once by the registry builder.
+     */
+    public function isComplete(int $requiredSections): bool
+    {
+        return ($this->completeSections & $requiredSections) === $requiredSections;
+    }
 
     public function schema(): TableSchema
     {

--- a/src/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php
+++ b/src/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php
@@ -172,6 +172,32 @@ final class ModelMetadataRegistryBuilder
 
         $storage = $storageProvider->get($modelFqcn);
 
+        /** @var array<string, \Throwable> $failures */
+        $failures = [];
+        $completeSections = 0;
+
+        // Static metadata must survive every instance-backed failure, so build it first.
+        $methodMetadata = self::computeSection(
+            ModelMetadata::SECTION_METHODS,
+            'methods',
+            $completeSections,
+            $failures,
+            static fn(): array => self::computeMethodMetadata($storage, $storageProvider),
+            [[], [], []],
+        );
+        [$accessors, $mutators, $scopes] = $methodMetadata;
+
+        $relations = self::codebaseMethodsInitialized($codebase)
+            ? self::computeSection(
+                ModelMetadata::SECTION_RELATIONS,
+                'relations',
+                $completeSections,
+                $failures,
+                static fn(): array => self::computeRelations($codebase, $modelFqcn, $storage),
+                [],
+            )
+            : [];
+
         try {
             $reflection = new \ReflectionClass($modelFqcn);
         } catch (\ReflectionException $reflectionException) {
@@ -195,40 +221,69 @@ final class ModelMetadataRegistryBuilder
         // throws \Error, not \ReflectionException). Its instance-derived fields (schema, casts,
         // table, connection) stay empty; the rest come from storage + declared property defaults.
         if ($reflection->isAbstract()) {
-            return self::computeForAbstract(
-                $codebase,
+            $metadata = self::computeForAbstract(
                 $modelFqcn,
                 $storage,
                 $reflection,
                 $customBuilder,
                 $customCollection,
-                $storageProvider,
+                $accessors,
+                $mutators,
+                $scopes,
+                $relations,
+                $completeSections,
+                $failures,
             );
-        }
+        } else {
+            $instance = self::computeSection(
+                0,
+                'model instance',
+                $completeSections,
+                $failures,
+                static function () use ($reflection): Model {
+                    $instance = $reflection->newInstanceWithoutConstructor();
+                    if (!$instance instanceof Model) {
+                        throw new \UnexpectedValueException('Reflection did not create an Eloquent model');
+                    }
 
-        try {
-            $instance = $reflection->newInstanceWithoutConstructor();
-        } catch (\ReflectionException $reflectionException) {
-            $codebase->progress->debug(
-                "Laravel plugin: ModelMetadataRegistry could not instantiate '{$modelFqcn}': {$reflectionException->getMessage()}\n",
+                    return $instance;
+                },
+                null,
             );
 
-            return null;
+            $metadata = $instance instanceof Model
+                ? self::computeForInstance(
+                    $codebase,
+                    $modelFqcn,
+                    $storage,
+                    $instance,
+                    $reflection,
+                    $customBuilder,
+                    $customCollection,
+                    $accessors,
+                    $mutators,
+                    $scopes,
+                    $relations,
+                    $completeSections,
+                    $failures,
+                )
+                : self::computeWithoutInstance(
+                    $modelFqcn,
+                    $storage,
+                    $reflection,
+                    $customBuilder,
+                    $customCollection,
+                    $accessors,
+                    $mutators,
+                    $scopes,
+                    $relations,
+                    $completeSections,
+                );
         }
 
-        if (!$instance instanceof Model) {
-            return null;
-        }
+        self::warnFailures($codebase, $modelFqcn, $failures);
 
-        return self::computeForInstance(
-            $codebase,
-            $modelFqcn,
-            $storage,
-            $instance,
-            $reflection,
-            $customBuilder,
-            $customCollection,
-        );
+        return $metadata;
     }
 
     /**
@@ -238,6 +293,11 @@ final class ModelMetadataRegistryBuilder
      * @param \ReflectionClass<Model>               $reflection
      * @param class-string<\Illuminate\Database\Eloquent\Builder>|null    $customBuilder
      * @param class-string<\Illuminate\Database\Eloquent\Collection>|null $customCollection
+     * @param array<non-empty-lowercase-string, AccessorInfo> $accessors
+     * @param array<non-empty-lowercase-string, MutatorInfo>  $mutators
+     * @param array<non-empty-lowercase-string, ScopeInfo>    $scopes
+     * @param array<non-empty-lowercase-string, RelationInfo> $relations
+     * @param array<string, \Throwable> $failures
      * @return ModelMetadata<Model>
      */
     private static function computeForInstance(
@@ -248,62 +308,116 @@ final class ModelMetadataRegistryBuilder
         \ReflectionClass $reflection,
         ?string $customBuilder,
         ?string $customCollection,
+        array $accessors,
+        array $mutators,
+        array $scopes,
+        array $relations,
+        int &$completeSections,
+        array &$failures,
     ): ModelMetadata {
-        $traits = self::computeTraitFlags($storage, $instance->usesTimestamps());
+        $baseTraits = self::computeTraitFlags($storage, true);
+        $uniqueIdsReady = true;
+        if ($baseTraits->hasUuids || $baseTraits->hasUlids) {
+            $uniqueIdsReady = self::computeSection(
+                0,
+                'unique-id initialization',
+                $completeSections,
+                $failures,
+                static function () use ($instance): bool {
+                    self::flipUsesUniqueIds($instance);
 
-        // HasUuids / HasUlids override getKeyType(), getIncrementing(), and uniqueIds()
-        // by reading `$this->usesUniqueIds`, which the trait initializer flips to true.
-        // `newInstanceWithoutConstructor()` skips that initializer; flip the flag here
-        // so every downstream Laravel getter (primary key, casts, etc.) sees the same
-        // state the runtime would. See #591 review notes.
-        if ($traits->hasUuids || $traits->hasUlids) {
-            self::flipUsesUniqueIds($instance);
+                    return true;
+                },
+                false,
+            );
         }
 
-        // Apply the class-level PHP-attribute config (#[Hidden]/#[Visible]/#[Appends]/#[Fillable]/
-        // #[Guarded]/#[Connection]/#[Table]) that Model::__construct() would set via initializeTraits() /
-        // initializeModelAttributes() — both skipped by newInstanceWithoutConstructor(). Mutating the
-        // instance here (like flipUsesUniqueIds above) lets the getters below AND computeSchema()'s
-        // getTable() see the runtime state.
-        self::applyClassAttributeConfig($codebase, $reflection, $instance);
+        $attributesApplied = self::computeSection(
+            0,
+            'class attributes',
+            $completeSections,
+            $failures,
+            static function () use ($reflection, $instance): bool {
+                self::applyClassAttributeConfig($reflection, $instance);
 
-        $tableSchema = self::computeSchema($instance);
+                return true;
+            },
+            false,
+        );
 
-        // Method-derived metadata is STORAGE-based (no instance needed), so it is computed the same
-        // way for concrete and abstract models — see computeForAbstract.
-        [$accessors, $mutators, $scopes] = self::computeMethodMetadata($storage, $codebase->classlike_storage_provider);
+        $runtimeRead = false;
+        $runtime = self::computeSection(
+            0,
+            'runtime configuration',
+            $completeSections,
+            $failures,
+            static function () use ($modelFqcn, $storage, $instance, &$runtimeRead): array {
+                $runtime = self::readRuntimeConfiguration($modelFqcn, $storage, $instance);
+                $runtimeRead = true;
 
-        // Relations need the Codebase (the AST parser reads parsed file statements), unlike the
-        // storage-only method metadata above — so they are computed separately, not in the walk.
-        $relations = self::computeRelations($codebase, $modelFqcn, $storage);
+                return $runtime;
+            },
+            self::runtimeConfigurationFallback($baseTraits),
+        );
+        if ($attributesApplied && $runtimeRead) {
+            $completeSections |= ModelMetadata::SECTION_RUNTIME_CONFIGURATION;
+        }
 
-        // Casts and appends are each needed twice — as their own field AND as a knownProperties()
-        // source — so compute each once into a local rather than re-deriving for the second use.
-        $casts = self::computeCasts($codebase, $modelFqcn, $instance, $traits, $tableSchema);
-        $appends = self::filterStringList($instance->getAppends());
+        $tableSchema = new TableSchema([]);
+        if ($attributesApplied) {
+            try {
+                $resolvedSchema = self::computeSchema($instance);
+                if ($resolvedSchema instanceof TableSchema) {
+                    $tableSchema = $resolvedSchema;
+                    $completeSections |= ModelMetadata::SECTION_SCHEMA;
+                }
+            } catch (\Throwable $throwable) {
+                $failures['schema'] = $throwable;
+            }
+        }
+
+        $schemaComplete = ($completeSections & ModelMetadata::SECTION_SCHEMA) !== 0;
+        $casts = $uniqueIdsReady
+            ? self::computeSection(
+                ModelMetadata::SECTION_CASTS,
+                'casts',
+                $completeSections,
+                $failures,
+                static fn(): array => self::computeCasts(
+                    $codebase,
+                    $modelFqcn,
+                    $instance,
+                    $runtime['traits'],
+                    $tableSchema,
+                    $schemaComplete,
+                ),
+                [],
+            )
+            : [];
+        $primaryKey = $uniqueIdsReady
+            ? self::computeSection(
+                ModelMetadata::SECTION_PRIMARY_KEY,
+                'primary key',
+                $completeSections,
+                $failures,
+                static fn(): PrimaryKeyInfo => self::computePrimaryKey($instance, $runtime['traits']),
+                self::defaultPrimaryKey(),
+            )
+            : self::defaultPrimaryKey();
 
         return new ModelMetadata(
             fqcn: $modelFqcn,
-            primaryKey: self::computePrimaryKey($instance, $traits),
-            traits: $traits,
-            // PHP-attribute config (#[Fillable]/#[Guarded]/#[Connection]/#[Table]/#[Appends]/#[Hidden]/
-            // #[Visible]) was merged onto $instance by applyClassAttributeConfig() above, so these getters
-            // now see it. Case is preserved — Laravel's isFillable / isGuarded / getHidden / getVisible do
-            // exact-string comparisons, so lowercasing would diverge from runtime semantics.
-            fillable: self::filterStringList($instance->getFillable()),
-            // asArray() guards Laravel's `$guarded = false` ("guard nothing") idiom — getGuarded()
-            // then returns a bool, not an array, and would TypeError filterStringList()'s array param,
-            // crashing warm-up for the whole model (e.g. laravel/passport's models). #591.
-            guarded: self::filterStringList(self::asArray($instance->getGuarded())),
-            appends: $appends,
-            with: self::readStringList($instance, 'with'),
-            withCount: self::readStringList($instance, 'withCount'),
-            hidden: self::filterStringList($instance->getHidden()),
-            // getVisible() always returns an array (no `$visible = false` idiom, unlike $guarded), so
-            // it needs no asArray() guard. Non-empty $visible is Eloquent's serialization allow-list.
-            visible: self::filterStringList($instance->getVisible()),
-            connection: $instance->getConnectionName(),
-            morphAlias: self::computeMorphAlias($modelFqcn),
+            primaryKey: $primaryKey,
+            traits: $runtime['traits'],
+            fillable: $runtime['fillable'],
+            guarded: $runtime['guarded'],
+            appends: $runtime['appends'],
+            with: $runtime['with'],
+            withCount: $runtime['withCount'],
+            hidden: $runtime['hidden'],
+            visible: $runtime['visible'],
+            connection: $runtime['connection'],
+            morphAlias: $runtime['morphAlias'],
             customBuilder: $customBuilder,
             customCollection: $customCollection,
             schemaData: $tableSchema,
@@ -312,7 +426,8 @@ final class ModelMetadataRegistryBuilder
             mutatorsData: $mutators,
             scopesData: $scopes,
             relationsData: $relations,
-            knownPropertiesData: self::computeKnownProperties($tableSchema, $casts, $accessors, $mutators, $relations, $appends),
+            knownPropertiesData: self::computeKnownProperties($tableSchema, $casts, $accessors, $mutators, $relations, $runtime['appends']),
+            completeSections: $completeSections,
         );
     }
 
@@ -328,28 +443,34 @@ final class ModelMetadataRegistryBuilder
      * @param \ReflectionClass<Model>               $reflection
      * @param class-string<\Illuminate\Database\Eloquent\Builder>|null    $customBuilder
      * @param class-string<\Illuminate\Database\Eloquent\Collection>|null $customCollection
+     * @param array<non-empty-lowercase-string, AccessorInfo> $accessors
+     * @param array<non-empty-lowercase-string, MutatorInfo>  $mutators
+     * @param array<non-empty-lowercase-string, ScopeInfo>    $scopes
+     * @param array<non-empty-lowercase-string, RelationInfo> $relations
+     * @param array<string, \Throwable> $failures
      * @return ModelMetadata<Model>
      */
     private static function computeForAbstract(
-        Codebase $codebase,
         string $modelFqcn,
         ClassLikeStorage $storage,
         \ReflectionClass $reflection,
         ?string $customBuilder,
         ?string $customCollection,
-        ClassLikeStorageProvider $provider,
+        array $accessors,
+        array $mutators,
+        array $scopes,
+        array $relations,
+        int &$completeSections,
+        array &$failures,
     ): ModelMetadata {
-        /** @var array<string, mixed> $defaults */
-        $defaults = $reflection->getDefaultProperties();
-
-        // Method-derived metadata is storage-based, so an abstract base populates accessors/mutators/
-        // scopes identically to a concrete model (no instantiation). This is what lets the migrated
-        // handlers resolve an inherited accessor/scope on an abstract-typed receiver (#901).
-        [$accessors, $mutators, $scopes] = self::computeMethodMetadata($storage, $provider);
-
-        // Concrete relation methods declared in the abstract base's own body parse the same way as on
-        // a concrete model (AST + storage, no instantiation).
-        $relations = self::computeRelations($codebase, $modelFqcn, $storage);
+        $defaults = self::computeSection(
+            ModelMetadata::SECTION_RUNTIME_CONFIGURATION,
+            'runtime configuration',
+            $completeSections,
+            $failures,
+            static fn(): array => $reflection->getDefaultProperties(),
+            [],
+        );
 
         // Schema and casts are instance-derived — empty for an abstract base (no instance, no table).
         // Hoist the empty schema + the declared $appends so both the fields AND knownProperties()
@@ -357,10 +478,18 @@ final class ModelMetadataRegistryBuilder
         // declared on the abstract base populate it).
         $schema = new TableSchema([]);
         $appends = self::stringListDefault($defaults, 'appends');
+        $primaryKey = self::computeSection(
+            ModelMetadata::SECTION_PRIMARY_KEY,
+            'primary key',
+            $completeSections,
+            $failures,
+            static fn(): PrimaryKeyInfo => self::computePrimaryKeyFromDefaults($defaults),
+            self::defaultPrimaryKey(),
+        );
 
         return new ModelMetadata(
             fqcn: $modelFqcn,
-            primaryKey: self::computePrimaryKeyFromDefaults($defaults),
+            primaryKey: $primaryKey,
             traits: self::computeTraitFlags($storage, self::asBool($defaults['timestamps'] ?? null, true)),
             fillable: self::stringListDefault($defaults, 'fillable'),
             // Laravel's base Model defaults $guarded to ['*'] (guard-all); the default-property
@@ -383,7 +512,187 @@ final class ModelMetadataRegistryBuilder
             scopesData: $scopes,
             relationsData: $relations,
             knownPropertiesData: self::computeKnownProperties($schema, [], $accessors, $mutators, $relations, $appends),
+            completeSections: $completeSections,
         );
+    }
+
+    /**
+     * Preserve static metadata when a concrete model cannot be instantiated.
+     *
+     * @param class-string<Model> $modelFqcn
+     * @param \ReflectionClass<Model> $reflection
+     * @param class-string<\Illuminate\Database\Eloquent\Builder>|null $customBuilder
+     * @param class-string<\Illuminate\Database\Eloquent\Collection>|null $customCollection
+     * @param array<non-empty-lowercase-string, AccessorInfo> $accessors
+     * @param array<non-empty-lowercase-string, MutatorInfo>  $mutators
+     * @param array<non-empty-lowercase-string, ScopeInfo>    $scopes
+     * @param array<non-empty-lowercase-string, RelationInfo> $relations
+     * @return ModelMetadata<Model>
+     */
+    private static function computeWithoutInstance(
+        string $modelFqcn,
+        ClassLikeStorage $storage,
+        \ReflectionClass $reflection,
+        ?string $customBuilder,
+        ?string $customCollection,
+        array $accessors,
+        array $mutators,
+        array $scopes,
+        array $relations,
+        int $completeSections,
+    ): ModelMetadata {
+        $defaults = $reflection->getDefaultProperties();
+        $schema = new TableSchema([]);
+        $appends = self::stringListDefault($defaults, 'appends');
+
+        return new ModelMetadata(
+            fqcn: $modelFqcn,
+            primaryKey: self::defaultPrimaryKey(),
+            traits: self::computeTraitFlags($storage, self::asBool($defaults['timestamps'] ?? null, true)),
+            fillable: self::stringListDefault($defaults, 'fillable'),
+            guarded: self::stringListDefault($defaults, 'guarded'),
+            appends: $appends,
+            with: self::stringListDefault($defaults, 'with'),
+            withCount: self::stringListDefault($defaults, 'withCount'),
+            hidden: self::stringListDefault($defaults, 'hidden'),
+            visible: self::stringListDefault($defaults, 'visible'),
+            connection: null,
+            morphAlias: null,
+            customBuilder: $customBuilder,
+            customCollection: $customCollection,
+            schemaData: $schema,
+            castsData: [],
+            accessorsData: $accessors,
+            mutatorsData: $mutators,
+            scopesData: $scopes,
+            relationsData: $relations,
+            knownPropertiesData: self::computeKnownProperties($schema, [], $accessors, $mutators, $relations, $appends),
+            completeSections: $completeSections,
+        );
+    }
+
+    /**
+     * @return array{
+     *     traits: TraitFlags,
+     *     fillable: list<non-empty-string>,
+     *     guarded: list<non-empty-string>,
+     *     appends: list<non-empty-string>,
+     *     with: list<string>,
+     *     withCount: list<string>,
+     *     hidden: list<non-empty-string>,
+     *     visible: list<non-empty-string>,
+     *     connection: string|null,
+     *     morphAlias: string|null
+     * }
+     * @param class-string<Model> $modelFqcn
+     */
+    private static function readRuntimeConfiguration(
+        string $modelFqcn,
+        ClassLikeStorage $storage,
+        Model $instance,
+    ): array {
+        $traits = self::computeTraitFlags($storage, $instance->usesTimestamps());
+
+        return [
+            'traits' => $traits,
+            'fillable' => self::filterStringList($instance->getFillable()),
+            'guarded' => self::filterStringList(self::asArray($instance->getGuarded())),
+            'appends' => self::filterStringList($instance->getAppends()),
+            'with' => self::readStringList($instance, 'with'),
+            'withCount' => self::readStringList($instance, 'withCount'),
+            'hidden' => self::filterStringList($instance->getHidden()),
+            'visible' => self::filterStringList($instance->getVisible()),
+            'connection' => $instance->getConnectionName(),
+            'morphAlias' => self::computeMorphAlias($modelFqcn),
+        ];
+    }
+
+    /**
+     * @return array{
+     *     traits: TraitFlags,
+     *     fillable: list<non-empty-string>,
+     *     guarded: list<non-empty-string>,
+     *     appends: list<non-empty-string>,
+     *     with: list<string>,
+     *     withCount: list<string>,
+     *     hidden: list<non-empty-string>,
+     *     visible: list<non-empty-string>,
+     *     connection: null,
+     *     morphAlias: null
+     * }
+     * @psalm-pure
+     */
+    private static function runtimeConfigurationFallback(TraitFlags $traits): array
+    {
+        return [
+            'traits' => $traits,
+            'fillable' => [],
+            'guarded' => [],
+            'appends' => [],
+            'with' => [],
+            'withCount' => [],
+            'hidden' => [],
+            'visible' => [],
+            'connection' => null,
+            'morphAlias' => null,
+        ];
+    }
+
+    /** @psalm-pure */
+    private static function defaultPrimaryKey(): PrimaryKeyInfo
+    {
+        return new PrimaryKeyInfo('id', PrimaryKeyType::Integer, incrementing: true, uuidColumns: []);
+    }
+
+    /**
+     * @template T
+     * @param array<string, \Throwable> $failures
+     * @param \Closure(): T $compute
+     * @param T $fallback
+     * @return T
+     */
+    private static function computeSection(
+        int $section,
+        string $name,
+        int &$completeSections,
+        array &$failures,
+        \Closure $compute,
+        mixed $fallback,
+    ): mixed {
+        try {
+            $value = $compute();
+            $completeSections |= $section;
+
+            return $value;
+        } catch (\Throwable $throwable) {
+            $failures[$name] = $throwable;
+
+            return $fallback;
+        }
+    }
+
+    /**
+     * @param class-string<Model> $modelFqcn
+     * @param array<string, \Throwable> $failures
+     */
+    private static function warnFailures(Codebase $codebase, string $modelFqcn, array $failures): void
+    {
+        if ($failures === []) {
+            return;
+        }
+
+        $details = [];
+        foreach ($failures as $section => $throwable) {
+            $details[] = "{$section}: {$throwable->getMessage()} at {$throwable->getFile()}:{$throwable->getLine()}";
+        }
+
+        $message = "Laravel plugin: ModelMetadataRegistry warm-up failed for '{$modelFqcn}' "
+            . '(partial metadata stored): ' . \implode('; ', $details);
+        $codebase->progress->warning($message);
+
+        if ($codebase->progress instanceof VoidProgress) {
+            \fwrite(\STDERR, 'Warning: ' . $message . \PHP_EOL);
+        }
     }
 
     /**
@@ -966,16 +1275,16 @@ final class ModelMetadataRegistryBuilder
         return \is_string($value) && $value !== '' ? $value : null;
     }
 
-    private static function computeSchema(Model $instance): TableSchema
+    private static function computeSchema(Model $instance): ?TableSchema
     {
         $schema = SchemaStateProvider::getSchema();
         if (!$schema instanceof \Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaAggregator) {
-            return new TableSchema([]);
+            return null;
         }
 
         $tableName = $instance->getTable();
         if (!isset($schema->tables[$tableName])) {
-            return new TableSchema([]);
+            return null;
         }
 
         $columns = [];
@@ -1019,6 +1328,7 @@ final class ModelMetadataRegistryBuilder
         Model $instance,
         TraitFlags $traits,
         TableSchema $schema,
+        bool $schemaComplete,
     ): array {
         $merged = [];
 
@@ -1072,12 +1382,14 @@ final class ModelMetadataRegistryBuilder
             // Bake column nullability into CastInfo::$psalmType at build time so consumers
             // can read it directly without re-running CastResolver (see design §5.4).
             $column = $schema->column($columnName);
-            $nullable = $column instanceof ColumnInfo && $column->nullable;
+            // Without authoritative schema, neither absent nullability nor an absent source type
+            // is evidence. Preserve the cast inventory, but keep its inferred type conservative.
+            $nullable = !$schemaComplete || ($column instanceof ColumnInfo && $column->nullable);
             // CastsInboundAttributes casts read back as a passthrough of the column's intrinsic
             // type, so CastResolver needs that base type as `$originalType`. The mapping lives on
             // ColumnTypeMapper (Schema namespace) so the builder reads it directly instead of
             // reaching back into the property handler; null when no migration column backs the cast.
-            $originalType = $column instanceof ColumnInfo
+            $originalType = $schemaComplete && $column instanceof ColumnInfo
                 ? ColumnTypeMapper::mapBaseType($column)
                 : null;
             // Preserve original-case column keys to match Eloquent's case-sensitive
@@ -1284,12 +1596,7 @@ final class ModelMetadataRegistryBuilder
      */
     private static function flipUsesUniqueIds(Model $instance): void
     {
-        try {
-            $property = new \ReflectionProperty($instance, 'usesUniqueIds');
-        } catch (\ReflectionException) {
-            return;
-        }
-
+        $property = new \ReflectionProperty($instance, 'usesUniqueIds');
         $property->setValue($instance, true);
     }
 
@@ -1315,35 +1622,35 @@ final class ModelMetadataRegistryBuilder
      *
      * @param \ReflectionClass<Model> $reflection
      */
-    private static function applyClassAttributeConfig(Codebase $codebase, \ReflectionClass $reflection, Model $instance): void
+    private static function applyClassAttributeConfig(\ReflectionClass $reflection, Model $instance): void
     {
         // Union-merge, mirroring mergeHidden() / mergeVisible() / mergeAppends() / mergeFillable().
         // These four configuration attributes only exist from Laravel 13. On Laravel 12.14–12.24,
         // mergeHidden() / mergeVisible() / mergeAppends() are unavailable (mergeFillable() exists), so
         // calling the absent helpers with empty fallbacks crashes warm-up. An absent attribute has nothing to replay.
-        $hidden = self::classAttribute($codebase, $reflection, Hidden::class);
+        $hidden = self::classAttribute($reflection, Hidden::class);
         if ($hidden !== null) {
             $instance->mergeHidden($hidden->columns);
         }
 
-        $visible = self::classAttribute($codebase, $reflection, Visible::class);
+        $visible = self::classAttribute($reflection, Visible::class);
         if ($visible !== null) {
             $instance->mergeVisible($visible->columns);
         }
 
-        $appends = self::classAttribute($codebase, $reflection, Appends::class);
+        $appends = self::classAttribute($reflection, Appends::class);
         if ($appends !== null) {
             $instance->mergeAppends($appends->columns);
         }
 
-        $fillable = self::classAttribute($codebase, $reflection, Fillable::class);
+        $fillable = self::classAttribute($reflection, Fillable::class);
         if ($fillable !== null) {
             $instance->mergeFillable($fillable->columns);
         }
 
-        self::applyGuardedAttribute($codebase, $reflection, $instance);
-        self::applyConnectionAttribute($codebase, $reflection, $instance);
-        self::applyTableAttribute($codebase, $reflection, $instance);
+        self::applyGuardedAttribute($reflection, $instance);
+        self::applyConnectionAttribute($reflection, $instance);
+        self::applyTableAttribute($reflection, $instance);
     }
 
     /**
@@ -1354,13 +1661,13 @@ final class ModelMetadataRegistryBuilder
      *
      * @param \ReflectionClass<Model> $reflection
      */
-    private static function applyGuardedAttribute(Codebase $codebase, \ReflectionClass $reflection, Model $instance): void
+    private static function applyGuardedAttribute(\ReflectionClass $reflection, Model $instance): void
     {
         if ($instance->getGuarded() !== ['*']) {
             return;
         }
 
-        if (self::classAttribute($codebase, $reflection, Unguarded::class) !== null) {
+        if (self::classAttribute($reflection, Unguarded::class) !== null) {
             $instance->guard([]);
 
             return;
@@ -1368,7 +1675,7 @@ final class ModelMetadataRegistryBuilder
 
         // Presence (not non-empty) gates the replace: a present `#[Guarded()]` with no columns sets [],
         // matching Laravel's `columns ?? ['*']` where an empty array is non-null. Absent → keep `['*']`.
-        $guarded = self::classAttribute($codebase, $reflection, Guarded::class);
+        $guarded = self::classAttribute($reflection, Guarded::class);
         if ($guarded !== null) {
             $instance->guard($guarded->columns);
         }
@@ -1384,13 +1691,13 @@ final class ModelMetadataRegistryBuilder
      *
      * @param \ReflectionClass<Model> $reflection
      */
-    private static function applyConnectionAttribute(Codebase $codebase, \ReflectionClass $reflection, Model $instance): void
+    private static function applyConnectionAttribute(\ReflectionClass $reflection, Model $instance): void
     {
         if ($instance->getConnectionName() !== null) {
             return;
         }
 
-        $name = self::classAttribute($codebase, $reflection, Connection::class)?->name;
+        $name = self::classAttribute($reflection, Connection::class)?->name;
         if ($name === null) {
             return;
         }
@@ -1416,9 +1723,9 @@ final class ModelMetadataRegistryBuilder
      *
      * @param \ReflectionClass<Model> $reflection
      */
-    private static function applyTableAttribute(Codebase $codebase, \ReflectionClass $reflection, Model $instance): void
+    private static function applyTableAttribute(\ReflectionClass $reflection, Model $instance): void
     {
-        $name = self::classAttribute($codebase, $reflection, Table::class)?->name;
+        $name = self::classAttribute($reflection, Table::class)?->name;
         if ($name === null) {
             return;
         }
@@ -1472,18 +1779,15 @@ final class ModelMetadataRegistryBuilder
     /**
      * Resolve a class-level attribute the way {@see Model}::resolveClassAttribute() does: walk the class
      * up its parents, return the first ancestor's first instance of `$attributeClass` (no cross-ancestor
-     * merge), or null. A throwing `newInstance()` (malformed attribute args) is swallowed to a null so a
-     * single bad attribute degrades that one field rather than aborting the whole model's warm-up; this
-     * is deliberately broader than Laravel's own `catch (Exception)`, since a static-analysis pass must
-     * never crash where the runtime constructor would. The swallow leaves a debug breadcrumb, like the
-     * file's other reflection catches ({@see compute()}, {@see warmUp()}).
+     * merge), or null. A throwing `newInstance()` reaches the runtime-configuration boundary, which
+     * preserves independent sections and records the failure once for the model.
      *
      * @template T of object
      * @param \ReflectionClass<object> $reflection
      * @param class-string<T>          $attributeClass
      * @return T|null
      */
-    private static function classAttribute(Codebase $codebase, \ReflectionClass $reflection, string $attributeClass): ?object
+    private static function classAttribute(\ReflectionClass $reflection, string $attributeClass): ?object
     {
         for ($current = $reflection; $current !== false; $current = $current->getParentClass()) {
             $attributes = $current->getAttributes($attributeClass);
@@ -1491,15 +1795,7 @@ final class ModelMetadataRegistryBuilder
                 continue;
             }
 
-            try {
-                return $attributes[0]->newInstance();
-            } catch (\Throwable $throwable) {
-                $codebase->progress->debug(
-                    "Laravel plugin: ModelMetadataRegistry could not instantiate {$attributeClass} on '{$current->getName()}': {$throwable->getMessage()}\n",
-                );
-
-                return null;
-            }
+            return $attributes[0]->newInstance();
         }
 
         return null;

--- a/src/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php
+++ b/src/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php
@@ -76,8 +76,8 @@ final class ModelMetadataRegistryBuilder
      * Pre-compute metadata for a single model. Idempotent — re-computation
      * on a cached FQCN is a no-op.
      *
-     * Never throws: on any failure the method logs a warning through the
-     * codebase's progress handle and returns without storing an entry.
+     * Never throws: isolated section failures are reported while the partial entry is stored;
+     * an unexpected outer failure is reported and leaves the model unstored.
      *
      * Accepts any `class-string` (not narrowed to `class-string<Model>`): the
      * runtime guard in `compute()` early-returns for non-Model classes, and
@@ -596,6 +596,9 @@ final class ModelMetadataRegistryBuilder
         return [
             'traits' => $traits,
             'fillable' => self::filterStringList($instance->getFillable()),
+            // asArray() guards Laravel's `$guarded = false` ("guard nothing") idiom — getGuarded()
+            // then returns a bool, not an array, and would TypeError filterStringList()'s array param,
+            // crashing warm-up for the whole model (e.g. laravel/passport's models). #591.
             'guarded' => self::filterStringList(self::asArray($instance->getGuarded())),
             'appends' => self::filterStringList($instance->getAppends()),
             'with' => self::readStringList($instance, 'with'),
@@ -1191,7 +1194,7 @@ final class ModelMetadataRegistryBuilder
      * Compute primary-key info from a model instance.
      *
      * HasUuids / HasUlids override `getKeyType()` / `getIncrementing()` / `uniqueIds()`
-     * by reading `$this->usesUniqueIds`. The caller in `computeForInstance()` has already flipped
+     * by reading `$this->usesUniqueIds`. The earlier unique-id initialization section has flipped
      * that flag for UUID/ULID models, so the instance getters return the runtime-correct
      * values here (including any user override of `uniqueIds()` returning multiple cols).
      */
@@ -1547,8 +1550,8 @@ final class ModelMetadataRegistryBuilder
      * default values are initialized even by `newInstanceWithoutConstructor()`.
      *
      * Only catches ReflectionException (property genuinely missing on a subclass that
-     * shadowed it). Any other Error surfaces via warmUp()'s outer catch as a warning,
-     * which is the right behavior when something unexpected breaks.
+     * shadowed it). Any other throwable is handled by the runtime-configuration section,
+     * which reports the failure and leaves that section incomplete.
      *
      * @return list<string>
      */

--- a/src/Handlers/Eloquent/ModelPropertyHandler.php
+++ b/src/Handlers/Eloquent/ModelPropertyHandler.php
@@ -174,6 +174,11 @@ final class ModelPropertyHandler
             return null;
         }
 
+        // An incomplete cast inventory cannot prove that a schema column is uncast.
+        if (!$metadata->isComplete(ModelMetadata::SECTION_CASTS)) {
+            return null;
+        }
+
         // Exact-case lookup matches Eloquent's case-sensitive attribute semantics.
         $column = $metadata->schema()->column($columnName);
         if (!$column instanceof ColumnInfo) {

--- a/src/Handlers/Eloquent/ModelSerializationShapeBuilder.php
+++ b/src/Handlers/Eloquent/ModelSerializationShapeBuilder.php
@@ -59,6 +59,14 @@ final class ModelSerializationShapeBuilder
      */
     public static function build(Codebase $codebase, string $modelClass, ModelMetadata $metadata): ?Union
     {
+        if (!$metadata->isComplete(
+            ModelMetadata::SECTION_METHODS
+            | ModelMetadata::SECTION_RUNTIME_CONFIGURATION
+            | ModelMetadata::SECTION_CASTS,
+        )) {
+            return null;
+        }
+
         $columns = $metadata->schema()->all();
         $visible = $metadata->visible;
         $hidden = $metadata->hidden;

--- a/src/Handlers/Rules/UnknownModelAttributeHandler.php
+++ b/src/Handlers/Rules/UnknownModelAttributeHandler.php
@@ -120,13 +120,19 @@ final class UnknownModelAttributeHandler implements AfterExpressionAnalysisInter
             return null;
         }
 
-        if (!$metadata->isComplete(
-            ModelMetadata::SECTION_METHODS
-            | ModelMetadata::SECTION_RELATIONS
-            | ModelMetadata::SECTION_RUNTIME_CONFIGURATION
-            | ModelMetadata::SECTION_SCHEMA
-            | ModelMetadata::SECTION_CASTS,
-        )) {
+        if (
+            !$metadata->isComplete(
+                ModelMetadata::SECTION_METHODS
+                | ModelMetadata::SECTION_RELATIONS
+                | ModelMetadata::SECTION_RUNTIME_CONFIGURATION
+                | ModelMetadata::SECTION_SCHEMA
+                | ModelMetadata::SECTION_CASTS,
+            )
+            // A registered table can still have no statically parsed columns (for example when a
+            // migration uses dynamic names or Blueprint macros). In that case an unknown-key verdict
+            // would treat every real column as a typo, so preserve the rule's conservative bail-out.
+            || $metadata->schema()->all() === []
+        ) {
             return null;
         }
 

--- a/src/Handlers/Rules/UnknownModelAttributeHandler.php
+++ b/src/Handlers/Rules/UnknownModelAttributeHandler.php
@@ -120,10 +120,13 @@ final class UnknownModelAttributeHandler implements AfterExpressionAnalysisInter
             return null;
         }
 
-        // Completeness gate: the unknown-key verdict is only sound when the model's columns are
-        // known. With migrations disabled (or the table unparsed) schema() is empty, so the known
-        // set lacks its column origins and every real column would look unknown — skip the model.
-        if ($metadata->schema()->all() === []) {
+        if (!$metadata->isComplete(
+            ModelMetadata::SECTION_METHODS
+            | ModelMetadata::SECTION_RELATIONS
+            | ModelMetadata::SECTION_RUNTIME_CONFIGURATION
+            | ModelMetadata::SECTION_SCHEMA
+            | ModelMetadata::SECTION_CASTS,
+        )) {
             return null;
         }
 

--- a/src/Handlers/Rules/UnresolvableAppendedModelAttributeHandler.php
+++ b/src/Handlers/Rules/UnresolvableAppendedModelAttributeHandler.php
@@ -56,7 +56,15 @@ final class UnresolvableAppendedModelAttributeHandler implements AfterCodebasePo
         $provider = $event->getCodebase()->classlike_storage_provider;
 
         foreach (ModelMetadataRegistry::all() as $fqcn => $metadata) {
-            if ($metadata->appends === [] || !$provider->has($fqcn)) {
+            if (
+                $metadata->appends === []
+                || !$metadata->isComplete(
+                    ModelMetadata::SECTION_METHODS
+                    | ModelMetadata::SECTION_RUNTIME_CONFIGURATION
+                    | ModelMetadata::SECTION_CASTS,
+                )
+                || !$provider->has($fqcn)
+            ) {
                 continue;
             }
 

--- a/tests/Unit/Fixtures/Models/SectionFailureModel.php
+++ b/tests/Unit/Fixtures/Models/SectionFailureModel.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Casts\InboundOnlyCast;
+
+/** @internal fixture used by ModelMetadataRegistryTest */
+final class SectionFailureModel extends Model
+{
+    use HasUuids {
+        getKeyType as private getKeyTypeFromTrait;
+    }
+
+    /** @var array<string, true> */
+    public static array $failures = [];
+
+    protected $table = 'section_failure_models';
+
+    /** @var array<string, string> */
+    protected $casts = [
+        'flag' => 'boolean',
+        'code' => InboundOnlyCast::class,
+    ];
+
+    public function usesTimestamps(): bool
+    {
+        $this->fail('runtime configuration');
+
+        return parent::usesTimestamps();
+    }
+
+    public function getTable(): string
+    {
+        $this->fail('schema');
+
+        return parent::getTable();
+    }
+
+    /** @return array<string, string> */
+    public function getCasts(): array
+    {
+        $this->fail('casts');
+
+        return parent::getCasts();
+    }
+
+    public function getKeyType(): string
+    {
+        $this->fail('primary key');
+
+        return $this->getKeyTypeFromTrait();
+    }
+
+    private function fail(string $section): void
+    {
+        if (isset(self::$failures[$section])) {
+            throw new \RuntimeException("deliberate {$section} failure");
+        }
+    }
+}

--- a/tests/Unit/Handlers/Eloquent/ModelSerializationShapeBuilderTest.php
+++ b/tests/Unit/Handlers/Eloquent/ModelSerializationShapeBuilderTest.php
@@ -347,6 +347,32 @@ final class ModelSerializationShapeBuilderTest extends TestCase
         $this->assertNull($this->build());
     }
 
+    #[Test]
+    public function incomplete_runtime_or_cast_metadata_defers_to_the_stub(): void
+    {
+        foreach ([ModelMetadata::SECTION_RUNTIME_CONFIGURATION, ModelMetadata::SECTION_CASTS] as $incomplete) {
+            $this->override(
+                columns: ['id' => $this->col('id', SchemaColumn::TYPE_INT)],
+                completeSections: ModelMetadata::ALL_SECTIONS & ~$incomplete,
+            );
+
+            $this->assertNull($this->build());
+        }
+    }
+
+    #[Test]
+    public function incomplete_schema_still_allows_a_safe_append_only_open_shape(): void
+    {
+        $this->override(
+            columns: [],
+            accessors: ['fullname' => new LegacyAccessorInfo('fullname', Type::getString(), new MethodStorage())],
+            appends: ['full_name'],
+            completeSections: ModelMetadata::ALL_SECTIONS & ~ModelMetadata::SECTION_SCHEMA,
+        );
+
+        $this->assertSame('array{full_name?: string, ...<string, mixed>}', (string) $this->build());
+    }
+
     // ---------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------
@@ -398,6 +424,7 @@ final class ModelSerializationShapeBuilderTest extends TestCase
         array $appends = [],
         array $hidden = [],
         array $visible = [],
+        int $completeSections = ModelMetadata::ALL_SECTIONS,
     ): void {
         $metadata = new ModelMetadata(
             fqcn: WorkOrder::class,
@@ -430,6 +457,7 @@ final class ModelSerializationShapeBuilderTest extends TestCase
             scopesData: [],
             relationsData: [],
             knownPropertiesData: [],
+            completeSections: $completeSections,
         );
 
         ModelMetadataRegistryBuilder::overrideForTesting(WorkOrder::class, $metadata);

--- a/tests/Unit/Handlers/Fixtures/UnknownModelAttribute/app/Models/DynamicSchemaThing.php
+++ b/tests/Unit/Handlers/Fixtures/UnknownModelAttribute/app/Models/DynamicSchemaThing.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KnownAttributeFixture\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/** Fixture whose migration creates a real column through a name the schema parser cannot resolve. */
+class DynamicSchemaThing extends Model
+{
+    /** @var list<string> */
+    protected $guarded = [];
+
+    protected $table = 'dynamic_schema_things';
+
+    public static function createWithDynamicMigrationColumn(): self
+    {
+        return static::create(['real_col' => 'valid at runtime']);
+    }
+}

--- a/tests/Unit/Handlers/Fixtures/UnknownModelAttribute/app/Models/WarmUpCrashModel.php
+++ b/tests/Unit/Handlers/Fixtures/UnknownModelAttribute/app/Models/WarmUpCrashModel.php
@@ -7,10 +7,8 @@ namespace KnownAttributeFixture\Models;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Deliberately crashes {@see \Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadataRegistryBuilder::compute()}
- * (via `computeSchema()`'s `getTable()` call) to exercise `warmUp()`'s outer safety-net catch, for
- * {@see \Tests\Psalm\LaravelPlugin\Unit\Handlers\WarmUpFailureVisibilityTest}. Warm-up failing for
- * this model must never affect {@see KnownThing}'s own warm-up in the same run (per-model try/catch).
+ * Deliberately fails the registry's schema section through `getTable()`. The partial warm-up warning
+ * must remain visible, while unrelated static metadata stays cached for this model.
  */
 class WarmUpCrashModel extends Model
 {

--- a/tests/Unit/Handlers/Fixtures/UnknownModelAttribute/database/migrations/2024_01_01_000000_create_known_things_table.php
+++ b/tests/Unit/Handlers/Fixtures/UnknownModelAttribute/database/migrations/2024_01_01_000000_create_known_things_table.php
@@ -13,10 +13,16 @@ return new class extends Migration {
             $table->string('email');
             $table->timestamps();
         });
+
+        Schema::create('dynamic_schema_things', function (Blueprint $table): void {
+            $column = 'real_col';
+            $table->string($column);
+        });
     }
 
     public function down(): void
     {
+        Schema::dropIfExists('dynamic_schema_things');
         Schema::dropIfExists('known_things');
     }
 };

--- a/tests/Unit/Handlers/UnknownModelAttributeEmissionTest.php
+++ b/tests/Unit/Handlers/UnknownModelAttributeEmissionTest.php
@@ -41,12 +41,14 @@ final class UnknownModelAttributeEmissionTest extends TestCase
 
         // One finding per typo'd key, through each of the three receiver forms exercised by the
         // fixture: static::, self::, and a plain external class reference. The three "clean" call
-        // sites (makeClean, create_clean_from_outside) must stay silent — asserting an exact count
-        // proves both that the rule fires and that it does not over-fire.
+        // sites (makeClean, create_clean_from_outside) and the dynamically declared migration
+        // column must stay silent — asserting an exact count proves both that the rule fires and
+        // that it does not over-fire when a registered table has no statically parsed columns.
         $this->assertCount(3, $findings, "Expected exactly 3 UnknownModelAttribute findings, got:\n{$joined}");
         $this->assertStringContainsString("'nmae'", $joined, 'static::create() with a typo must be flagged.');
         $this->assertStringContainsString("'unknown_col'", $joined, 'self::create() with a typo must be flagged.');
         $this->assertStringContainsString("'bad_key'", $joined, 'A plain external Model::create() with a typo must be flagged.');
+        $this->assertStringNotContainsString("'real_col'", $joined, 'A dynamically declared migration column must not be flagged.');
         $this->assertSame(['info', 'info', 'info'], \array_column($findings, 'severity'));
     }
 

--- a/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
+++ b/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
@@ -54,10 +54,12 @@ use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\PropertyOrigin;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\RelationInfo;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\TableSchema;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\TraitFlags;
+use Psalm\LaravelPlugin\Handlers\Eloquent\ModelPropertyHandler;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaAggregator;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaColumn;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaStateProvider;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaTable;
+use Psalm\Progress\Progress;
 use Psalm\Progress\VoidProgress;
 use Psalm\Storage\AttributeStorage;
 use Psalm\Storage\ClassLikeStorage;
@@ -76,6 +78,7 @@ use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\CustomDeletedAtModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\EnumConnectionModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\InboundCastModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\ScalarFieldsModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\SectionFailureModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\UnguardedAttributeModel;
 
 #[CoversClass(ModelMetadataRegistry::class)]
@@ -90,6 +93,7 @@ final class ModelMetadataRegistryTest extends TestCase
     {
         ModelMetadataRegistryBuilder::reset();
         SchemaStateProvider::setSchema(new SchemaAggregator());
+        SectionFailureModel::$failures = [];
         $this->classLikeStorageProvider = new ClassLikeStorageProvider();
     }
 
@@ -187,7 +191,7 @@ final class ModelMetadataRegistryTest extends TestCase
         $this->assertSame([], $metadata->primaryKey->uuidColumns);
         $casts = $metadata->casts();
         $this->assertArrayHasKey('allowed', $casts);
-        $this->assertSame('bool', $casts['allowed']->psalmType->getId());
+        $this->assertSame('bool|null', $casts['allowed']->psalmType->getId());
         $this->assertArrayNotHasKey('', $casts);
     }
 
@@ -453,6 +457,121 @@ final class ModelMetadataRegistryTest extends TestCase
 
         $this->assertInstanceOf(\Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadata::class, $first);
         $this->assertSame($first, $second);
+    }
+
+    #[Test]
+    public function complete_empty_schema_is_distinct_from_unavailable_schema(): void
+    {
+        $codebase = $this->makeCodebase();
+        $this->registerStorage(SectionFailureModel::class, [HasUuids::class]);
+        $this->seedSchema('section_failure_models', []);
+
+        ModelMetadataRegistryBuilder::warmUp($codebase, SectionFailureModel::class);
+        $completeEmpty = $this->metadataFor(SectionFailureModel::class);
+
+        $this->assertSame([], $completeEmpty->schema()->all());
+        $this->assertTrue($completeEmpty->isComplete(ModelMetadata::SECTION_SCHEMA));
+        $this->assertFalse($completeEmpty->casts()['flag']->psalmType->isNullable());
+
+        ModelMetadataRegistryBuilder::reset();
+        SchemaStateProvider::setSchema(new SchemaAggregator());
+        ModelMetadataRegistryBuilder::warmUp($codebase, SectionFailureModel::class);
+        $unavailable = $this->metadataFor(SectionFailureModel::class);
+
+        $this->assertSame([], $unavailable->schema()->all());
+        $this->assertFalse($unavailable->isComplete(ModelMetadata::SECTION_SCHEMA));
+        $this->assertTrue($unavailable->isComplete(ModelMetadata::SECTION_CASTS));
+        $this->assertTrue($unavailable->casts()['flag']->psalmType->isNullable());
+        $this->assertTrue($unavailable->casts()['code']->psalmType->hasMixed());
+    }
+
+    #[Test]
+    public function a_failed_section_preserves_independent_metadata(): void
+    {
+        $codebase = $this->makeCodebase();
+        $storage = $this->registerStorage(SectionFailureModel::class, [HasUuids::class]);
+        $this->defineAppearingMethod($storage, 'getLabelAttribute', Type::getString());
+
+        $expectations = [
+            'runtime configuration' => [ModelMetadata::SECTION_RUNTIME_CONFIGURATION],
+            'schema' => [ModelMetadata::SECTION_SCHEMA],
+            'casts' => [ModelMetadata::SECTION_CASTS],
+            'primary key' => [ModelMetadata::SECTION_PRIMARY_KEY],
+        ];
+
+        foreach ($expectations as $failure => $incompleteSections) {
+            ModelMetadataRegistryBuilder::reset();
+            $this->seedSchema('section_failure_models', [
+                new SchemaColumn('flag', SchemaColumn::TYPE_BOOL),
+                new SchemaColumn('code', SchemaColumn::TYPE_STRING),
+            ]);
+            SectionFailureModel::$failures = [$failure => true];
+
+            ModelMetadataRegistryBuilder::warmUp($codebase, SectionFailureModel::class);
+            $metadata = $this->metadataFor(SectionFailureModel::class);
+
+            $this->assertArrayHasKey('label', $metadata->accessors());
+            $this->assertTrue($metadata->isComplete(ModelMetadata::SECTION_METHODS));
+            foreach ($incompleteSections as $section) {
+                $this->assertFalse($metadata->isComplete($section), $failure);
+            }
+
+            if ($failure === 'runtime configuration') {
+                $this->assertTrue($metadata->isComplete(
+                    ModelMetadata::SECTION_SCHEMA
+                    | ModelMetadata::SECTION_CASTS
+                    | ModelMetadata::SECTION_PRIMARY_KEY,
+                ));
+                $this->assertTrue($metadata->schema()->has('flag'));
+                $this->assertSame('bool', $metadata->casts()['flag']->psalmType->getId());
+                $this->assertSame('string', $metadata->casts()['code']->psalmType->getId());
+                $this->assertSame(PrimaryKeyType::String, $metadata->primaryKey->type);
+                $this->assertFalse($metadata->primaryKey->incrementing);
+            }
+
+            if ($failure === 'schema') {
+                $this->assertTrue($metadata->isComplete(ModelMetadata::SECTION_CASTS));
+                $this->assertTrue($metadata->casts()['flag']->psalmType->isNullable());
+                $this->assertTrue($metadata->casts()['code']->psalmType->hasMixed());
+            }
+
+            if ($failure === 'casts') {
+                $this->assertTrue($metadata->schema()->has('flag'));
+                $this->assertNull(ModelPropertyHandler::resolveColumnType(
+                    $codebase,
+                    SectionFailureModel::class,
+                    'flag',
+                ));
+            }
+
+            if ($failure === 'primary key') {
+                $this->assertTrue($metadata->isComplete(ModelMetadata::SECTION_CASTS));
+                $this->assertSame('bool', $metadata->casts()['flag']->psalmType->getId());
+            }
+        }
+    }
+
+    #[Test]
+    public function failures_warn_once_and_cached_partial_metadata_is_silent(): void
+    {
+        $progress = $this->createMock(Progress::class);
+        $progress->expects($this->once())
+            ->method('warning')
+            ->with($this->stringContains("warm-up failed for '" . SectionFailureModel::class . "'"));
+        $codebase = $this->makeCodebase($progress);
+        $this->registerStorage(SectionFailureModel::class, [HasUuids::class]);
+        SectionFailureModel::$failures = ['schema' => true, 'primary key' => true];
+
+        ModelMetadataRegistryBuilder::warmUp($codebase, SectionFailureModel::class);
+        ModelMetadataRegistryBuilder::warmUp($codebase, SectionFailureModel::class);
+
+        $metadata = $this->metadataFor(SectionFailureModel::class);
+        $this->assertFalse($metadata->isComplete(
+            ModelMetadata::SECTION_SCHEMA | ModelMetadata::SECTION_PRIMARY_KEY,
+        ));
+        $this->assertTrue($metadata->isComplete(
+            ModelMetadata::SECTION_METHODS | ModelMetadata::SECTION_CASTS,
+        ));
     }
 
     // ---------------------------------------------------------------------
@@ -1278,14 +1397,14 @@ final class ModelMetadataRegistryTest extends TestCase
     // Helpers
     // ---------------------------------------------------------------------
 
-    private function makeCodebase(): Codebase
+    private function makeCodebase(?Progress $progress = null): Codebase
     {
         $codebase = (new \ReflectionClass(Codebase::class))->newInstanceWithoutConstructor();
         $codebase->classlike_storage_provider = $this->classLikeStorageProvider;
 
         // $progress is declared protected(set) readonly in Psalm 7 — bypass via reflection.
         $progressProperty = new \ReflectionProperty(Codebase::class, 'progress');
-        $progressProperty->setValue($codebase, new VoidProgress());
+        $progressProperty->setValue($codebase, $progress ?? new VoidProgress());
 
         return $codebase;
     }

--- a/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
+++ b/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
@@ -1564,6 +1564,7 @@ final class ModelMetadataRegistryTest extends TestCase
             scopesData: [],
             relationsData: $relations,
             knownPropertiesData: [],
+            completeSections: ModelMetadata::ALL_SECTIONS,
         );
     }
 }


### PR DESCRIPTION
## Summary

Make model metadata warm-up section-isolated so a failure in one runtime-derived section no longer discards independently available metadata for the whole model.

This is the 4.x / Psalm 7 implementation for #1255. The 3.x / Psalm 6 backport remains separate.

## Root cause

`ModelMetadataRegistryBuilder` previously built a model entry as one all-or-nothing operation. An exception while reading runtime configuration, schema, casts, or primary-key information removed the entire entry, including accessors, mutators, scopes, and relations already recovered from storage and reflection.

That made consumers unable to distinguish a genuinely empty section from metadata that was never completed, and could turn an isolated Laravel compatibility failure into lost inference across every affected model.

## What changed

- Track authoritative metadata sections with a compact positive completeness mask on the existing `ModelMetadata` object.
- Isolate runtime configuration, schema, casts, and primary-key enrichment while preserving successful static and reflection-derived metadata.
- Keep successful sections usable when an unrelated section fails.
- Require negative diagnostics to have every relevant section complete before emitting a definitive issue.
- Continue positive inference from sections that are known to be complete.
- Emit one warm-up warning per partially built model and cache the partial entry so consumers do not repeat it.
- Preserve UUID/ULID initialization dependencies when deciding whether casts and primary-key metadata are authoritative.

A set completeness bit means the section is authoritative even when its data is empty. A missing bit means consumers must treat the section as unavailable; runtime failures are reported by the warm-up warning rather than persisted as a second status/reason model.

No new production service, handler, or metadata entity is introduced.

## Validation

- Focused regression suite: 99 tests, 335 assertions
- Full unit suite: 1,040 tests, 2,633 assertions, 1 skipped
- `composer psalm`: no errors, 100% inferred types
- `composer cs:check`: clean
- `composer rector:dry`: clean
- `git diff --check`: clean
- PHP syntax checks for every changed PHP file: clean

Addresses #1255.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786706331&installation_id=141955579&pr_number=1268&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1268&signature=d7d0bbca550b332d79ad81b65b7f079f056da8abd55e51e0021bf361e13df7e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->