### PR TITLE
Allow psalm-delta on fork PRs with restore-only cache guard

### DIFF
--- a/.github/workflows/psalm-delta.yml
+++ b/.github/workflows/psalm-delta.yml
@@ -1,31 +1,30 @@
 name: Psalm delta
 
-# Comment-triggered, opt-in PR check: runs the plugin on a curated set of
-# real-world Laravel apps (bin/ci/test-apps.yml) for the PR base AND head, then
-# posts a single sticky comment with the per-app issue delta + which issue types
-# moved. Informational only — it never fails the PR (a delta is often intended:
-# fixing false positives REMOVES issues; new narrowing ADDS some).
+# Comment-triggered, opt-in PR check: runs the plugin on curated real-world
+# Laravel apps (bin/ci/test-apps.yml) for PR base AND head, then posts one sticky
+# comment with per-app issue deltas. Informational only, never fails the PR (a
+# delta is often intended: fixing FPs REMOVES issues, new narrowing ADDS some).
 #
-# Architecture (see .alies/docs/ci-psalm-delta-design.md for the full rationale):
-#   prepare  — resolve refs, fork-PR security guard, emit the app matrix
-#   delta    — ONE job per app (parallel): install app, run base + head, upload
-#              per-app issue/perf JSON. Wall time = slowest single app, not sum.
-#   report   — download all artifacts, run bin/ci/delta-report.php, sticky comment
+# Architecture (.alies/docs/ci-psalm-delta-design.md for full rationale):
+#   prepare — resolve refs, flag fork heads, emit the app matrix
+#   delta   — one job per app (parallel): install, run base + head, upload JSON.
+#             Wall time = slowest app, not sum.
+#   report  — download artifacts, run bin/ci/delta-report.php, sticky comment
+# The runner (delta-app.sh) + comparator (delta-report.php) are the SAME scripts
+# `bash bin/ci/delta.sh <pr-branch>` runs locally, so any row reproduces.
 #
-# The per-app runner (bin/ci/delta-app.sh) and comparator (bin/ci/delta-report.php)
-# are the SAME scripts bin/ci/delta.sh runs locally, so contributors can
-# reproduce any row with `bash bin/ci/delta.sh <pr-branch>`.
-#
-# Security posture: the `delta` job runs the PR's plugin code on the runner
-# (Testbench boots, stubs generate). It is contained by (1) the fork-PR guard in
-# `prepare` that refuses any head from a different repository, (2) the
-# MEMBER/OWNER/COLLABORATOR author check on the trigger, and (3) `contents: read`
-# only + `persist-credentials: false` on that job — no token write scope and no
-# git credentials are exposed to the executed code. The measurement harness
-# (runner, registry, comparator) always comes from the default branch, so
-# base_sha/head_sha are only the two plugin versions measured and the PR cannot
-# alter how it is measured. The privileged `report` job (pull-requests: write)
-# never runs PR code: it runs the default-branch comparator over the JSON.
+# Security posture: `delta` runs the PR's plugin code (Testbench boots, stubs
+# generate), fork PRs INCLUDED. Safe because the job is unprivileged like a
+# native pull_request run: (1) the MEMBER/OWNER/COLLABORATOR author check means a
+# maintainer types `/psalm-delta` after reading the diff, (2) contents:read +
+# persist-credentials:false — no write token, no git creds reach the code. The
+# harness (runner/registry/comparator) is always default-branch, so base/head_sha
+# are only the versions MEASURED, not how. The one cross-run vector — a fork
+# poisoning the shared app cache trusted runs restore — is closed by making the
+# cache restore-only on forks (prepare emits is_fork; delta saves only when
+# is_fork != 'true'). The privileged `report` job never runs PR code, and the
+# fork-controlled JSON reaches the comment only as a file body (-F body=@file),
+# never a `run:` expansion — no injection sink.
 
 on:
   issue_comment:
@@ -51,11 +50,9 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read         # checkout the default branch to read the app registry
-      # The trigger comment lives on a PR, so the reactions API authorises
-      # against pull-requests (not issues); write is required to add the
-      # :rocket:. This job still checks out only the trusted base and never runs
-      # PR code, matching benchmark.yml's pull-requests:write + issues:write.
-      pull-requests: write   # react to the trigger comment + read PR base/head SHAs
+      # Trigger comment lives on a PR, so the reactions API authorises against
+      # pull-requests; write adds the :eyes:. This job never runs PR code.
+      pull-requests: write   # react to comment + read PR base/head SHAs
       issues: write          # reactions API also consults issues scope
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
@@ -64,6 +61,7 @@ jobs:
       base_label: ${{ steps.refs.outputs.base_label }}
       head_label: ${{ steps.refs.outputs.head_label }}
       pr_number: ${{ steps.refs.outputs.pr_number }}
+      is_fork: ${{ steps.refs.outputs.is_fork }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -76,12 +74,11 @@ jobs:
           REPO: ${{ github.repository }}
           COMMENT_ID: ${{ github.event.comment.id }}
         run: |
-          # :eyes: signals "seen, processing". The report job swaps it for
-          # :rocket: once the delta finishes. Cosmetic only; never abort.
+          # :eyes: = seen/processing; report swaps to :rocket:. Cosmetic, never abort.
           gh api "repos/$REPO/issues/comments/$COMMENT_ID/reactions" \
             -f content=eyes --silent || echo "reaction failed (non-fatal)"
 
-      - name: Resolve PR refs (+ fork-PR security guard)
+      - name: Resolve PR refs (+ flag fork head)
         id: refs
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
@@ -91,15 +88,15 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.issue.number,
             });
-            // The delta runs the PR's plugin code on the runner (Testbench boots,
-            // stubs generate). Refuse PRs from a fork so untrusted code cannot
-            // execute with this workflow's token. Same guard as benchmark.yml.
+            // Fork heads are ALLOWED but flagged, not refused: the delta job that
+            // runs this code is unprivileged (contents:read, no creds/secrets,
+            // default-branch harness) = GitHub's pull_request fork model, and the
+            // author gate means a maintainer triggered it. is_fork makes the delta
+            // job's app cache restore-only on forks (poisoning vector, see below).
             const expectedRepo = `${context.repo.owner}/${context.repo.repo}`;
             const headRepo = pr.head.repo ? pr.head.repo.full_name : null;
-            if (headRepo !== expectedRepo) {
-              core.setFailed(`Refusing to run delta on a PR from a different repository (head: ${headRepo}, expected: ${expectedRepo})`);
-              return;
-            }
+            const isFork = headRepo !== expectedRepo;
+            core.setOutput('is_fork', isFork ? 'true' : 'false');
             const baseSha = pr.base.sha;
             const headSha = pr.head.sha;
             core.setOutput('base_sha', baseSha);
@@ -108,12 +105,10 @@ jobs:
             core.setOutput('head_label', `pr-${headSha.substring(0, 8)}`);
             core.setOutput('pr_number', String(pr.number));
 
-      # The HARNESS (registry, runner, comparator) comes from the default branch
-      # — the merged, trusted code — NOT from base_sha/head_sha. base_sha/head_sha
-      # are only the two plugin versions being MEASURED; sourcing the tooling from
-      # them would freeze it at whatever the PR branched off, so fixes to the
-      # harness would never reach an in-flight PR. issue_comment runs from the
-      # default branch, so a ref-less checkout is master HEAD.
+      # HARNESS = default branch (trusted), NOT base/head_sha (only the versions
+      # MEASURED). Sourcing tooling from them would freeze it at the PR's branch
+      # point, so harness fixes never reach in-flight PRs. issue_comment runs from
+      # the default branch, so a ref-less checkout is master HEAD.
       - name: Checkout harness (default branch, for the registry)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -122,10 +117,8 @@ jobs:
       - name: Build app matrix from registry
         id: matrix
         run: |
-          # yq (mikefarah v4, preinstalled on ubuntu-latest) emits the apps list
-          # as a GitHub matrix `include` array straight from the committed YAML
-          # registry. The value is derived only from a repo-tracked file (no
-          # workflow context / PR-author input), so it is not an injection sink.
+          # yq (preinstalled) emits the apps as a matrix `include` array from the
+          # committed registry. Repo-tracked only, no PR-author input: not a sink.
           matrix=$(yq -o=json -I=0 '{"include": .apps}' bin/ci/test-apps.yml)
           printf 'matrix=%s\n' "$matrix" >> "$GITHUB_OUTPUT"
 
@@ -136,7 +129,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 12
     permissions:
-      contents: read  # only checks out source + reads the public app repos; no token write scope
+      contents: read  # checkout source + read public app repos; no write scope
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
@@ -146,10 +139,9 @@ jobs:
         with:
           egress-policy: audit
 
-      # Two plugin checkouts give base and head fully isolated source trees.
-      # delta-app.sh installs each as a symlinked path repo, so the plugin's own
-      # requires resolve into the per-app vendor — these checkouts need no vendor.
-      # persist-credentials: false — the executed PR code never gets git creds.
+      # Base + head as isolated trees. delta-app.sh installs each as a symlinked
+      # path repo (requires resolve into the per-app vendor), so no vendor needed.
+      # persist-credentials:false — executed PR code never gets git creds.
       - name: Checkout base plugin
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -157,9 +149,9 @@ jobs:
           path: plugin-base
           persist-credentials: false
 
-      # Untrusted ref (PR head). Safe only because: same-repo guard passed in
-      # prepare, this job has contents:read and no credentials, and the head
-      # code's only effect is producing issue JSON consumed as data downstream.
+      # Untrusted ref (PR head, fork included). Safe: this job is contents:read
+      # with no creds, and the head code's only effect is issue JSON consumed as
+      # data downstream. See the header security posture.
       - name: Checkout head plugin
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -167,8 +159,8 @@ jobs:
           path: plugin-pr
           persist-credentials: false
 
-      # The measurement harness: default branch (master HEAD), not base/head. The
-      # PR head cannot alter it, and harness fixes reach in-flight PRs immediately.
+      # Measurement harness: default branch, not base/head. PR head can't alter
+      # it; harness fixes reach in-flight PRs immediately.
       - name: Checkout harness (default branch)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -183,34 +175,31 @@ jobs:
           coverage: none
           tools: composer:v2
 
-      # Cache the installed app source (clone + vendor) keyed on the IMMUTABLE
-      # ref, so steady-state runs skip the cold composer install (the dominant
-      # cost). The runner workspace path is stable across runs, so the plugin
-      # path-repo symlink inside vendor stays valid.
+      # Cache installed app source (clone + vendor) keyed on the immutable ref, so
+      # steady-state runs skip the cold composer install (dominant cost). Workspace
+      # path is stable, so the plugin path-repo symlink in vendor stays valid.
       #
       # hashFiles(plugin-base/composer.json) namespaces the key by the measured
-      # plugin's dependency declaration — the superset of delta-app.sh's
-      # plugin_dep_sig (require + autoload), which is what actually determines the
-      # installed vendor. The 3.x and 4.x lines pin the same app refs, so a key
-      # without it lets both lines collide on one entry and poison each other with
-      # an incompatible vendor (e.g. the installed AddTaintsInterface return type
-      # mismatches every handler and fatals at class-load). The hash differs
-      # whenever ANY dependency does — a Psalm major or minor bump, an added
-      # runtime dep — which is exactly when a reinstall is warranted. delta-app.sh
-      # re-validates the same signature on reuse, so an already-poisoned cache
-      # self-heals even when this key happens to hit. Native expression: no
-      # parsing step, no shell, nothing written to an output.
-      - name: Cache app source
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+      # plugin's deps (superset of delta-app.sh's plugin_dep_sig, which determines
+      # the vendor). 3.x and 4.x lines pin the same app refs; without this they
+      # collide on one entry and poison each other with an incompatible vendor
+      # (e.g. AddTaintsInterface return type mismatches every handler, fatals at
+      # class-load). The hash shifts whenever a dep does — exactly when a reinstall
+      # is warranted. delta-app.sh re-validates the sig on reuse, so a poisoned
+      # cache self-heals even on a key hit.
+      #
+      # RESTORE-ONLY; matching save is a separate non-fork-gated step (see below).
+      - name: Restore app source cache
+        id: cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: ~/app-cache/${{ matrix.name }}
           key: psalm-delta-app-${{ matrix.name }}-${{ matrix.ref }}-php${{ matrix.php }}-${{ hashFiles('plugin-base/composer.json') }}-v1
 
       - name: Run delta for ${{ matrix.name }}
-        # All interpolated values go through env (not inline ${{ }} in run) so a
-        # workflow linter can confirm no template-injection sink. Registry values
-        # are trusted (committed, read from the base checkout) but env-izing keeps
-        # the pattern uniform.
+        # Interpolated values go through env, not inline ${{ }}, so a linter can
+        # confirm no template-injection sink. Registry values are trusted but
+        # env-izing keeps the pattern uniform.
         env:
           NAME: ${{ matrix.name }}
           REPO: ${{ matrix.repo }}
@@ -236,15 +225,27 @@ jobs:
           [ -n "$PROJECT_DIR" ] && args+=(--project-dir "$PROJECT_DIR")
           [ -n "$PRIME" ] && args+=(--prime "$PRIME")
           [ -n "$PSALM_ARGS" ] && args+=(--psalm-args "$PSALM_ARGS")
-          # The harness (default branch) owns measurement so the PR cannot alter it.
+          # Harness (default branch) owns measurement; the PR cannot alter it.
           bash "$GITHUB_WORKSPACE/harness/bin/ci/delta-app.sh" "${args[@]}"
+
+      # Save ONLY on a same-repo head. A fork's composer install could write into
+      # ~/app-cache pre-save, and since issue_comment runs on the default ref that
+      # entry lands in the scope TRUSTED runs restore — a backdoored-vendor vector
+      # the plugin_dep_sig self-heal does NOT catch (it only detects a dep-sig
+      # mismatch). So forks read the cache, never write it. cache-hit skips a
+      # redundant same-key save.
+      - name: Save app source cache
+        if: needs.prepare.outputs.is_fork != 'true' && steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: ~/app-cache/${{ matrix.name }}
+          key: ${{ steps.cache.outputs.cache-primary-key }}
 
       - name: Upload per-app JSON
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: delta-${{ matrix.name }}
-          # out/ holds only <app>/<app>-<label>-cache--{issues,perf}.json
-          # (the working copies + cached source live elsewhere).
+          # out/ holds only <app>/<app>-<label>-cache--{issues,perf}.json.
           path: out/
           if-no-files-found: warn
           retention-days: 14
@@ -265,8 +266,8 @@ jobs:
         with:
           egress-policy: audit
 
-      # Harness from the default branch (master HEAD): this job runs only trusted
-      # code (delta-report.php) over the per-app JSON, never the PR's plugin code.
+      # Default-branch harness: this job runs only trusted code (delta-report.php)
+      # over the per-app JSON, never the PR's plugin code.
       - name: Checkout harness (default branch, for the comparator + registry)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -286,9 +287,8 @@ jobs:
           merge-multiple: true  # reconstructs out/<app>/... from every artifact
           path: out
 
-      # Build the markdown to a FILE and post it with `gh api -F body=@file`, so
-      # the (app-derived) report text never transits a shell variable, GITHUB_OUTPUT,
-      # or a heredoc — no command-injection / output-injection surface.
+      # Build markdown to a FILE, post with `gh api -F body=@file`, so app-derived
+      # text never transits a shell var, GITHUB_OUTPUT, or heredoc — no injection.
       - name: Build + post sticky comment
         env:
           GH_TOKEN: ${{ github.token }}
@@ -315,7 +315,7 @@ jobs:
           <sub>Informational only — never fails the PR. Reproduce locally: `bash bin/ci/delta.sh <pr-branch>`.</sub>
           FOOTER
 
-          # Sticky: edit the existing delta comment if present, else create one.
+          # Sticky: edit existing delta comment if present, else create.
           EXISTING=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
             --jq "map(select(.body | startswith(\"$MARKER\"))) | .[0].id // empty")
           if [ -n "$EXISTING" ]; then
@@ -324,9 +324,8 @@ jobs:
             gh api "repos/$REPO/issues/$PR_NUMBER/comments" -F body=@comment.md --silent
           fi
 
-      # Flip the trigger comment from :eyes: (processing, set in prepare) to
-      # :rocket: (done). Runs even if the report failed, so the comment never
-      # stays stuck on :eyes:. Cosmetic only; never abort the job.
+      # Flip :eyes: (set in prepare) to :rocket:. Runs even if report failed, so
+      # the comment never sticks on :eyes:. Cosmetic, never abort.
       - name: React to comment (done)
         if: always()
         env:
@@ -334,11 +333,10 @@ jobs:
           REPO: ${{ github.repository }}
           COMMENT_ID: ${{ github.event.comment.id }}
         run: |
-          # Add :rocket: first so a reaction is always present during the swap.
+          # :rocket: first so a reaction is always present during the swap.
           gh api "repos/$REPO/issues/comments/$COMMENT_ID/reactions" \
             -f content=rocket --silent || echo "rocket reaction failed (non-fatal)"
-          # Remove the :eyes: this workflow's token added in prepare. Match on the
-          # actor login so we never delete a human's :eyes:.
+          # Remove the bot's :eyes: (match on actor login, never a human's).
           EYES_ID=$(gh api "repos/$REPO/issues/comments/$COMMENT_ID/reactions" \
             --jq '.[] | select(.content == "eyes" and .user.login == "github-actions[bot]") | .id' \
             | head -1)


### PR DESCRIPTION
## Issue to Solve

The `psalm-delta` workflow refused every fork PR: the `prepare` job called `core.setFailed` when the head repo differed from the base. That was over-strict. The job that runs PR code (`delta`) is already unprivileged (`contents: read`, `persist-credentials: false`, no secrets, measurement harness always from the default branch), which is exactly GitHub's native `pull_request` fork model. External contributors could never get a delta on their PRs.

## Related

#0

## Solution Description

- **Drop the hard fork guard, flag instead.** `prepare` now emits an `is_fork` output rather than failing. The `MEMBER/OWNER/COLLABORATOR` author-association gate on the trigger stays, so a maintainer still types `/psalm-delta` after reading the diff before any fork code runs.
- **Close the one real cross-run vector.** A fork's `composer install` could write into the shared app-source cache, and because `issue_comment` runs on the default ref that entry lands in the scope trusted runs restore. The `plugin_dep_sig` self-heal catches a dependency-signature mismatch but NOT a backdoored-vendor entry. Fix: split `actions/cache` into `actions/cache/restore` + a `actions/cache/save` step gated on `is_fork != 'true'`, so forks read the warm cache but never write it.
- **No new escalation path.** The privileged `report` job still never runs PR code; fork-controlled JSON reaches the sticky comment only as a file body (`gh api -F body=@file`), never a `run:` expansion.
- **Comments tightened ~2x** and stale references to the removed guard dropped.

Verified: `actionlint` clean; `yq` parses the job/step tree; step order (restore before run, save after) confirmed.

Trust boundary note: this holds only while the `delta` job carries zero secrets. If a secret is ever added there, fork execution becomes a token-theft risk and the guard must return.

## Checklist
- [ ] Tests cover the change (CI workflow; no unit/type test surface)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786714417&installation_id=141955579&pr_number=1269&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1269&signature=fd2c51a8d6e8eb6f4dd77c8ee085b9ddd569d72771dba6201459870eb1d46026"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->