### PR TITLE
Stop `RelationResolver` autoloading related models

### DIFF
--- a/src/Handlers/Eloquent/Support/RelationResolver.php
+++ b/src/Handlers/Eloquent/Support/RelationResolver.php
@@ -7,6 +7,7 @@ namespace Psalm\LaravelPlugin\Handlers\Eloquent\Support;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Psalm\Codebase;
+use Psalm\Exception\UnpopulatedClasslikeException;
 use Psalm\LaravelPlugin\Handlers\Eloquent\RelationMethodParser;
 use Psalm\Type\Atomic\TGenericObject;
 use Psalm\Type\Atomic\TNamedObject;
@@ -129,27 +130,27 @@ final class RelationResolver
             return null;
         }
 
-        return self::extractRelatedFromReturnType($returnType);
+        return self::extractRelatedFromReturnType($codebase, $returnType);
     }
 
     /**
      * Extract the related model FQCN from the first generic parameter of a
      * `Relation<TRelated, ...>` return type.
      *
-     * @psalm-mutation-free
+     * @psalm-external-mutation-free
      */
-    private static function extractRelatedFromReturnType(?Union $returnType): ?string
+    private static function extractRelatedFromReturnType(Codebase $codebase, ?Union $returnType): ?string
     {
         if (!$returnType instanceof Union) {
             return null;
         }
 
         foreach ($returnType->getAtomicTypes() as $atomic) {
-            if (!$atomic instanceof TGenericObject || !\is_a($atomic->value, Relation::class, true)) {
+            if (!$atomic instanceof TGenericObject || !self::isClassOrSubclassOf($codebase, $atomic->value, Relation::class)) {
                 continue;
             }
 
-            return self::singleModel($atomic->type_params[0] ?? null);
+            return self::singleModel($codebase, $atomic->type_params[0] ?? null);
         }
 
         return null;
@@ -163,9 +164,9 @@ final class RelationResolver
      * Psalm collapses morphTo's `<..., $this>` generic before this is reached; this
      * keeps the deferral correct even when it does not.
      *
-     * @psalm-mutation-free
+     * @psalm-external-mutation-free
      */
-    private static function singleModel(?Union $type): ?string
+    private static function singleModel(Codebase $codebase, ?Union $type): ?string
     {
         if (!$type instanceof Union) {
             return null;
@@ -174,7 +175,7 @@ final class RelationResolver
         $model = null;
 
         foreach ($type->getAtomicTypes() as $atomic) {
-            if (!$atomic instanceof TNamedObject || !\is_a($atomic->value, Model::class, true)) {
+            if (!$atomic instanceof TNamedObject || !self::isClassOrSubclassOf($codebase, $atomic->value, Model::class)) {
                 continue;
             }
 
@@ -186,5 +187,33 @@ final class RelationResolver
         }
 
         return $model;
+    }
+
+    /**
+     * $class is $ancestor or a subclass, without autoloading. Unlike `\is_a($class, ..., true)`, which
+     * loads the class file: a related model FQCN taken from a relation's generic return type could emit
+     * a load-time deprecation that Psalm's error handler turns into a thrown exception, crashing the
+     * whole run (the #1253 bug class, which the sibling {@see \Psalm\LaravelPlugin\Handlers\Rules\UndefinedModelRelationHandler}
+     * fixed for its own sites but not for this resolver it delegates to). Mirrors that handler's own
+     * non-autoloading check. classExtends() is non-reflexive → identity is checked first; every ancestor
+     * passed here (Relation, Model) is a class, so classExtends() alone suffices.
+     *
+     * @psalm-external-mutation-free
+     */
+    private static function isClassOrSubclassOf(Codebase $codebase, string $class, string $ancestor): bool
+    {
+        if (\strtolower($class) === \strtolower($ancestor)) {
+            return true;
+        }
+
+        if (!$codebase->classExists($class)) {
+            return false;
+        }
+
+        try {
+            return $codebase->classExtends($class, $ancestor);
+        } catch (\InvalidArgumentException|UnpopulatedClasslikeException) {
+            return false;
+        }
     }
 }

--- a/tests/Unit/Handlers/Fixtures/UndefinedRelationAutoloadCrash/app/DeprecatedTierTwoRelated.php
+++ b/tests/Unit/Handlers/Fixtures/UndefinedRelationAutoloadCrash/app/DeprecatedTierTwoRelated.php
@@ -11,6 +11,4 @@ namespace AutoloadCrashFixture;
 // warm-up, which would crash here first and defeat the isolation of the resolver site under test.
 \trigger_error('deprecated on load', \E_USER_DEPRECATED);
 
-class DeprecatedTierTwoRelated
-{
-}
+class DeprecatedTierTwoRelated {}

--- a/tests/Unit/Handlers/Fixtures/UndefinedRelationAutoloadCrash/app/DeprecatedTierTwoRelated.php
+++ b/tests/Unit/Handlers/Fixtures/UndefinedRelationAutoloadCrash/app/DeprecatedTierTwoRelated.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoloadCrashFixture;
+
+// Tier-2 target: referenced only inside TierTwoModel::deprecatedRel()'s `@return` generic, so Psalm
+// scans it but never loads its file — until RelationResolver's pre-fix `is_a($related, Model::class,
+// true)` autoloads it while walking the `deprecatedRel.child` dot-path. Not a Model subclass, for the
+// same reason as DeprecatedOnLoad: ModelRegistrationHandler autoloads every Model on its own during
+// warm-up, which would crash here first and defeat the isolation of the resolver site under test.
+\trigger_error('deprecated on load', \E_USER_DEPRECATED);
+
+class DeprecatedTierTwoRelated
+{
+}

--- a/tests/Unit/Handlers/Fixtures/UndefinedRelationAutoloadCrash/app/TierTwoModel.php
+++ b/tests/Unit/Handlers/Fixtures/UndefinedRelationAutoloadCrash/app/TierTwoModel.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AutoloadCrashFixture;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+/**
+ * A real Eloquent model (loads without deprecation, so warm-up processes it normally). Its relation's
+ * declared generic points at {@see DeprecatedTierTwoRelated}, and the method body passes hasOne() an
+ * indirect argument so RelationMethodParser (tier 1) cannot extract the related class-string and defers
+ * to the return-type generic (tier 2) in {@see \Psalm\LaravelPlugin\Handlers\Eloquent\Support\RelationResolver}.
+ * Tier 2 is the path with the pre-fix autoloading `is_a(..., true)`.
+ */
+class TierTwoModel extends Model
+{
+    /**
+     * @return HasOne<DeprecatedTierTwoRelated, static>
+     */
+    public function deprecatedRel(): HasOne
+    {
+        // Indirect argument (a method call, not a `::class` literal) → tier-1 parsing yields nothing,
+        // forcing tier-2 resolution off this docblock generic.
+        return $this->hasOne($this->relatedClass());
+    }
+
+    /** @return class-string<DeprecatedTierTwoRelated> */
+    private function relatedClass(): string
+    {
+        return DeprecatedTierTwoRelated::class;
+    }
+}

--- a/tests/Unit/Handlers/Fixtures/UndefinedRelationAutoloadCrash/app/usage.php
+++ b/tests/Unit/Handlers/Fixtures/UndefinedRelationAutoloadCrash/app/usage.php
@@ -13,3 +13,12 @@ function drive_instance_path(DeprecatedOnLoadInstance $x): void
 {
     $x->with('posts');
 }
+
+// Drives RelationResolver's tier-2 dot-walk (relatedModel() -> extractRelatedFromReturnType() ->
+// singleModel()) — the autoload sites #1253 fixed in UndefinedModelRelationHandler but missed in this
+// resolver it delegates to. The dot forces resolving deprecatedRel's target model from its return-type
+// generic, autoloading DeprecatedTierTwoRelated pre-fix.
+function drive_tier_two_dot_path(TierTwoModel $model): void
+{
+    $model->with('deprecatedRel.child');
+}


### PR DESCRIPTION
## Issue to Solve

`RelationResolver` (the dot-notation walker behind the `UndefinedModelRelation` rule) resolved a relation's target model from its generic return type with `is_a($fqcn, Model::class, true)`. The `true` flag autoloads the class file. A related model that emits a load-time deprecation (`E_USER_DEPRECATED`) is turned into a thrown exception by Psalm's error handler, crashing the entire analysis run.

This is the same bug class #1253 fixed, one tier deeper: #1253 removed the autoloading `is_a(..., true)` receiver checks from `UndefinedModelRelationHandler`, but not from the sibling `RelationResolver` it delegates to for dot-path walking (`with('a.b')`, `load()`, `has()`). Reachable only via tier-2 resolution (a relation with a declared generic return type but a body `RelationMethodParser` cannot parse), which is why #1253's own fixture never covered it.

## Related

Follows up #1253 (same autoload-crash class, one tier deeper).

## Solution Description

- Swap both autoloading sites (`RelationResolver.php:148`, `:177`) for a non-autoloading `classExists` + `classExtends` check, mirroring `UndefinedModelRelationHandler::isClassOrSubclassOf()`. Thread `$codebase` through `extractRelatedFromReturnType()` / `singleModel()`, and relax their `@psalm-mutation-free` to `@psalm-external-mutation-free` (the storage reads are internally mutating but externally pure, matching the sibling helper).
- Regression: extend the existing `UndefinedRelationAutoloadCrash` fixture with a tier-2 case (`TierTwoModel`, whose relation body defeats tier-1 parsing and whose generic points at a non-model class that deprecates on load, driven by `with('deprecatedRel.child')`). Proven non-vacuous: reverting the fix makes Psalm emit `Uncaught RuntimeException: PHP Error: deprecated on load`.
- Verified: psalm self-analysis 0 errors, unit 1040, type 582, app clean, `rector` + `cs` no-op.

Scope note (not fixed here): the same `is_a(..., true)` pattern appears in ~10 other sites, but every warm-up site is double-guarded by `warmUp()` + `computeSection()` `catch (\Throwable)`, so it degrades to partial metadata rather than crashing. `RelationResolver` was the only unprotected analysis-time surface. A broader hardening audit can follow up.

## Checklist
- [x] Tests cover the change (unit regression fixture in `tests/Unit/Handlers/Fixtures/UndefinedRelationAutoloadCrash/`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786776321&installation_id=141955579&pr_number=1272&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1272&signature=3f5621b9fcef7672fa42fbbc32502a5e2ea7ae927eb44b94fe9490104960aac7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->