### PR TITLE
Fix `UnresolvableAppendedModelAttribute` false positive for casts merged in trait initializers

### DIFF
--- a/src/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php
+++ b/src/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Attributes\Connection;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Guarded;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
+use Illuminate\Database\Eloquent\Attributes\Initialize;
 use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Attributes\Unguarded;
 use Illuminate\Database\Eloquent\Attributes\Visible;
@@ -345,6 +346,26 @@ final class ModelMetadataRegistryBuilder
             false,
         );
 
+        // Replay the model's own trait initializers (→ mergeCasts() / mergeFillable() / ...) the
+        // constructor-less instance skipped, so the readers below see them. No placement is exactly
+        // runtime-faithful — applyClassAttributeConfig() bundles a pre-user-init phase (#[Guarded] via the
+        // concern initializers) and a post one (initializeModelAttributes) — but after it is fine: the
+        // union merges (appends / fillable / hidden / visible) commute as sets; only #[Connection] /
+        // #[Table] fill-null colliding with a user initializer on that same field is order-sensitive (an
+        // exotic case, left as-is). The helper owns the framework-initializer exclusion.
+        $traitsInitialized = self::computeSection(
+            0,
+            'trait initializers',
+            $completeSections,
+            $failures,
+            static function () use ($reflection, $instance): bool {
+                self::replayTraitInitializers($reflection, $instance);
+
+                return true;
+            },
+            false,
+        );
+
         $runtimeRead = false;
         $runtime = self::computeSection(
             0,
@@ -359,12 +380,18 @@ final class ModelMetadataRegistryBuilder
             },
             self::runtimeConfigurationFallback($baseTraits),
         );
-        if ($attributesApplied && $runtimeRead) {
+        // A partial replay ($traitsInitialized false) leaves every instance-derived section below
+        // untrustworthy — a half-run initializer may have mutated some fields and not others — so all
+        // four gate on it (mirroring how $attributesApplied gates them). Here: $appends / $fillable /
+        // $hidden / $visible a trait initializer may have merged.
+        if ($attributesApplied && $runtimeRead && $traitsInitialized) {
             $completeSections |= ModelMetadata::SECTION_RUNTIME_CONFIGURATION;
         }
 
         $tableSchema = new TableSchema([]);
-        if ($attributesApplied) {
+        // Gated on $traitsInitialized too (see above): an initializer can set $table / $connection, and
+        // UnknownModelAttributeHandler trusts SECTION_SCHEMA.
+        if ($attributesApplied && $traitsInitialized) {
             try {
                 $resolvedSchema = self::computeSchema($instance);
                 if ($resolvedSchema instanceof TableSchema) {
@@ -377,7 +404,8 @@ final class ModelMetadataRegistryBuilder
         }
 
         $schemaComplete = ($completeSections & ModelMetadata::SECTION_SCHEMA) !== 0;
-        $casts = $uniqueIdsReady
+        // Gated on $traitsInitialized too (see above): an initializer can mergeCasts().
+        $casts = ($uniqueIdsReady && $traitsInitialized)
             ? self::computeSection(
                 ModelMetadata::SECTION_CASTS,
                 'casts',
@@ -394,7 +422,9 @@ final class ModelMetadataRegistryBuilder
                 [],
             )
             : [];
-        $primaryKey = $uniqueIdsReady
+        // Gated on $traitsInitialized too (see above): an initializer can set $primaryKey / $keyType /
+        // $incrementing.
+        $primaryKey = ($uniqueIdsReady && $traitsInitialized)
             ? self::computeSection(
                 ModelMetadata::SECTION_PRIMARY_KEY,
                 'primary key',
@@ -1604,10 +1634,88 @@ final class ModelMetadataRegistryBuilder
     }
 
     /**
+     * Replay the model's own trait initializers on the constructor-less instance — the runtime work
+     * {@see Model}::initializeTraits() does (each initializer → `mergeCasts()` / `mergeFillable()` /
+     * `mergeAppends()` / ...) that `newInstanceWithoutConstructor()` skips. Without it a cast a user trait
+     * merges is invisible to {@see computeCasts()}, so an `$appends` entry that cast backs looks unbacked
+     * and false-positives {@see \Psalm\LaravelPlugin\Handlers\Rules\UnresolvableAppendedModelAttributeHandler}.
+     *
+     * Discovery mirrors {@see Model}::bootTraits()'s two branches: an initializer is any method whose name
+     * is the conventional `initialize` . class_basename of a used trait (every version), OR that carries
+     * `#[Initialize]` — that attribute and the bootTraits branch reading it land in Laravel 12.22, so the
+     * branch is gated on `class_exists(Initialize::class)`: load-bearing, not just defensive, since below
+     * 12.22 the framework ignores the attribute and the guard keeps us convention-only, at parity. Neither
+     * branch filters `isStatic` — bootTraits' initializer branch, unlike its boot branch, does not. We
+     * re-derive the list here instead of calling `initializeTraits()`, which reads
+     * `static::$traitInitializers` — populated only by `bootTraits()` during boot, and booting registers
+     * global scopes (a known Psalm hang), so it no-ops on this unbooted class.
+     *
+     * Framework (`Illuminate\`) concern initializers are excluded — their effects are already mirrored by
+     * {@see applyClassAttributeConfig()} (`#[...]` config attributes), {@see flipUsesUniqueIds()}
+     * (HasUniqueStringIds), and {@see computeCasts()} (`casts()` + SoftDeletes), so replaying would
+     * double-apply — keyed on the method's SOURCE FILE, not its declaring class: a concern trait `use`d
+     * directly on the model (e.g. `use HasUuids`) flattens its initializer to report the user model as
+     * declarer, yet the method's file stays under `vendor/laravel/framework` (or `vendor/illuminate`).
+     * Only user / third-party run.
+     *
+     * @param \ReflectionClass<Model> $reflection
+     */
+    private static function replayTraitInitializers(\ReflectionClass $reflection, Model $instance): void
+    {
+        // Conventional initialize<Basename> names for every used trait, mirroring bootTraits().
+        // filterStringList() also fixes the value type: outside the plugin's own stubs (self-analysis does
+        // not load them) class_uses_recursive() is typed `array`, so its values would be mixed.
+        $conventional = [];
+        foreach (self::filterStringList(\class_uses_recursive($instance)) as $trait) {
+            $conventional['initialize' . \class_basename($trait)] = true;
+        }
+
+        // Gate the #[Initialize] branch on the attribute class existing — it and the bootTraits branch
+        // reading it arrive in Laravel 12.22, so below that this is a load-bearing no-op that keeps us
+        // convention-only, at parity with the framework (which ignores the attribute there). Computed once.
+        $honorInitializeAttribute = \class_exists(Initialize::class);
+
+        $invoked = [];
+        foreach ($reflection->getMethods() as $method) {
+            $name = $method->getName();
+            // Discover initializers as bootTraits() does — conventional name OR #[Initialize], deduped by
+            // name; getAttributes() is reached only for non-conventional methods (short-circuit).
+            $isInitializer = isset($conventional[$name])
+                || ($honorInitializeAttribute && $method->getAttributes(Initialize::class) !== []);
+            if (isset($invoked[$name]) || !$isInitializer) {
+                continue;
+            }
+
+            // Skip framework concern initializers (some conventionally named, some #[Initialize]-tagged):
+            // hand-mirrored elsewhere, so replaying double-applies. The method's source file is the reliable
+            // discriminator (its declaring class is NOT — a directly-`use`d concern reports the user model).
+            // Anchored to `/vendor/...` so a user repo checked out at e.g. ~/code/laravel/framework/ is not
+            // self-skipped; `/vendor/illuminate/` also covers standalone illuminate/database installs. A
+            // framework symlinked OUTSIDE vendor slips through, but replaying its initializers is idempotent
+            // (they merge exactly what applyClassAttributeConfig()/flipUsesUniqueIds()/computeCasts() apply).
+            $file = \str_replace('\\', '/', (string) $method->getFileName());
+            if (\str_contains($file, '/vendor/laravel/framework/') || \str_contains($file, '/vendor/illuminate/')) {
+                continue;
+            }
+
+            $invoked[$name] = true;
+            // Invoke by reflection, NOT $instance->{$name}(): a protected/private initializer (Laravel's
+            // own initializeHasAttributes() is protected) called from outside the model would route to
+            // Model::__call() query-builder forwarding instead of running. Since PHP 8.1 reflection invokes
+            // non-public methods without setAccessible(). The mixed return is a bare statement — it never
+            // binds to a local, so the file stays at 100% type coverage. Runs user init code, which the
+            // caller wraps in a computeSection() guard so a throw degrades to partial metadata, not a crash.
+            $method->invoke($instance);
+        }
+    }
+
+    /**
      * Apply the class-level PHP-attribute config that {@see Model}::__construct() sets via
      * `initializeTraits()` / `initializeModelAttributes()` — both skipped by
      * `newInstanceWithoutConstructor()`. Mutates `$instance` (like {@see flipUsesUniqueIds()}) so every
-     * downstream getter, and {@see computeSchema()}'s `getTable()`, sees the runtime state.
+     * downstream getter, and {@see computeSchema()}'s `getTable()`, sees the runtime state. Mirrors only
+     * the framework's own config handling; user / third-party trait initializers are replayed separately
+     * by {@see replayTraitInitializers()}.
      *
      * Per-attribute semantics mirror Laravel exactly: `#[Hidden]`/`#[Visible]`/`#[Appends]`/`#[Fillable]`
      * union-merge into the property list; `#[Guarded]`/`#[Unguarded]` only replace the default `['*']`;

--- a/src/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php
+++ b/src/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php
@@ -318,58 +318,27 @@ final class ModelMetadataRegistryBuilder
     ): ModelMetadata {
         $baseTraits = self::computeTraitFlags($storage, true);
 
-        // Replay the model's own trait initializers FIRST — before the framework-mirror steps below
-        // (flipUsesUniqueIds + applyClassAttributeConfig) — matching Laravel 12.22+/13, whose bootTraits()
-        // iterates ReflectionClass::getMethods() and ranks a concrete class's own (flattened) initializers
-        // AHEAD of Model's inherited concern initializers (verified from the tag sources + empirically), with
-        // initializeModelAttributes last. So a user setAppends() lands BEFORE the framework
-        // mergeAppends(#[Appends]); the old order (mirrors first) let it REPLACE the merge, dropping the
-        // #[Appends] entries runtime keeps.
+        // Replay the model's initializers in the exact ReflectionClass::getMethods() order Laravel's
+        // bootTraits()/initializeTraits() uses (12.22+), interleaving the framework-concern MIRRORS
+        // (flipUsesUniqueIds + the #[...] appliers) at their real positions among the user initializers —
+        // because getMethods() ranks trait-flattened vs inherited methods DIFFERENTLY across PHP versions
+        // (8.5 puts a concrete class's own trait inits first; 8.4 puts Model's inherited concern inits first),
+        // and Laravel follows whatever the running PHP yields. Executing in that same walk makes the result
+        // match runtime under either order: e.g. a user setAppends() lands before mergeAppends(#[Appends]) on
+        // 8.5 (both survive) and after it on 8.4 (the replace wins), exactly as getAppends() does. The
+        // initializeModelAttributes phase (#[Connection]/#[Table]) runs last, after the walk.
         //
-        // Laravel 12.14–12.21 bootTraits() instead walks class_uses_recursive() PARENTS-FIRST, so framework
-        // concern inits run BEFORE user ones — replay-first is NOT runtime-faithful there. But every
-        // config-attribute merge (#[Appends]/#[Fillable]/#[Hidden]/#[Visible]/#[Guarded]) is Laravel-13-only,
-        // so nothing collides pre-13; the sole pre-12.22 divergence is casts()-vs-user-mergeCasts() of the
-        // SAME key (documented at computeCasts — pre-existing, since computeCasts always lets casts() win
-        // regardless of this reorder). The other residual is exotic: a user init that READS state a
-        // same-concrete-class framework init writes (a directly-`use`d HasUuids's usesUniqueIds). The helper
-        // owns the framework-initializer exclusion.
-        $traitsInitialized = self::computeSection(
+        // One folded section: a mid-walk throw leaves the instance half-prepared, so all four instance-derived
+        // sections below degrade together (the degradation test still maps 'trait initializers' → those four).
+        // Pre-12.22 (class_uses_recursive parents-first) walk order is immaterial — the config attributes are
+        // all Laravel-13-only; the sole pre-12.22 divergence is casts()-vs-user-mergeCasts() (see computeCasts).
+        $instancePrepared = self::computeSection(
             0,
             'trait initializers',
             $completeSections,
             $failures,
             static function () use ($reflection, $instance): bool {
-                self::replayTraitInitializers($reflection, $instance);
-
-                return true;
-            },
-            false,
-        );
-
-        $uniqueIdsReady = true;
-        if ($baseTraits->hasUuids || $baseTraits->hasUlids) {
-            $uniqueIdsReady = self::computeSection(
-                0,
-                'unique-id initialization',
-                $completeSections,
-                $failures,
-                static function () use ($instance): bool {
-                    self::flipUsesUniqueIds($instance);
-
-                    return true;
-                },
-                false,
-            );
-        }
-
-        $attributesApplied = self::computeSection(
-            0,
-            'class attributes',
-            $completeSections,
-            $failures,
-            static function () use ($reflection, $instance): bool {
-                self::applyClassAttributeConfig($reflection, $instance);
+                self::replayInitializers($reflection, $instance);
 
                 return true;
             },
@@ -390,18 +359,15 @@ final class ModelMetadataRegistryBuilder
             },
             self::runtimeConfigurationFallback($baseTraits),
         );
-        // A partial replay ($traitsInitialized false) leaves every instance-derived section below
-        // untrustworthy — a half-run initializer may have mutated some fields and not others — so all
-        // four gate on it (mirroring how $attributesApplied gates them). Here: $appends / $fillable /
-        // $hidden / $visible a trait initializer may have merged.
-        if ($attributesApplied && $runtimeRead && $traitsInitialized) {
+        // $instancePrepared gates every instance-derived section: a partial walk (some initializers/mirrors
+        // ran, then one threw) leaves the instance's runtime config, schema, casts and key all untrustworthy.
+        if ($instancePrepared && $runtimeRead) {
             $completeSections |= ModelMetadata::SECTION_RUNTIME_CONFIGURATION;
         }
 
         $tableSchema = new TableSchema([]);
-        // Gated on $traitsInitialized too (see above): an initializer can set $table / $connection, and
-        // UnknownModelAttributeHandler trusts SECTION_SCHEMA.
-        if ($attributesApplied && $traitsInitialized) {
+        // UnknownModelAttributeHandler trusts SECTION_SCHEMA, so withhold it on a partial prepare.
+        if ($instancePrepared) {
             try {
                 $resolvedSchema = self::computeSchema($instance);
                 if ($resolvedSchema instanceof TableSchema) {
@@ -414,8 +380,7 @@ final class ModelMetadataRegistryBuilder
         }
 
         $schemaComplete = ($completeSections & ModelMetadata::SECTION_SCHEMA) !== 0;
-        // Gated on $traitsInitialized too (see above): an initializer can mergeCasts().
-        $casts = ($uniqueIdsReady && $traitsInitialized)
+        $casts = $instancePrepared
             ? self::computeSection(
                 ModelMetadata::SECTION_CASTS,
                 'casts',
@@ -432,9 +397,7 @@ final class ModelMetadataRegistryBuilder
                 [],
             )
             : [];
-        // Gated on $traitsInitialized too (see above): an initializer can set $primaryKey / $keyType /
-        // $incrementing.
-        $primaryKey = ($uniqueIdsReady && $traitsInitialized)
+        $primaryKey = $instancePrepared
             ? self::computeSection(
                 ModelMetadata::SECTION_PRIMARY_KEY,
                 'primary key',
@@ -1421,8 +1384,8 @@ final class ModelMetadataRegistryBuilder
         // parents-first) then the user init, so the USER value wins; from 12.22+ the order flips and casts()
         // wins — which is what merging casts() last reproduces on every version. Making it version-aware needs
         // a pre-replay casts snapshot diffed here to re-apply user-merged keys after casts(); deferred as a
-        // documented divergence — a rare same-key collision, on a superseded patch range, costing one cast
-        // type. See replayTraitInitializers() for the reorder that motivates this.
+        // documented divergence — a rare same-key collision, on older supported releases, costing one cast
+        // type. See replayInitializers() for the getMethods()-order walk that motivates this.
 
         $result = [];
         foreach ($merged as $columnName => $castString) {
@@ -1652,38 +1615,38 @@ final class ModelMetadataRegistryBuilder
     }
 
     /**
-     * Replay the model's own trait initializers on the constructor-less instance — the runtime work
-     * {@see Model}::initializeTraits() does (each initializer → `mergeCasts()` / `mergeFillable()` /
-     * `mergeAppends()` / ...) that `newInstanceWithoutConstructor()` skips. Without it a cast a user trait
-     * merges is invisible to {@see computeCasts()}, so an `$appends` entry that cast backs looks unbacked
-     * and false-positives {@see \Psalm\LaravelPlugin\Handlers\Rules\UnresolvableAppendedModelAttributeHandler}.
+     * Replay the model's initializers on the constructor-less instance in {@see Model}::initializeTraits()
+     * order, so the section readers observe the runtime state `newInstanceWithoutConstructor()` skipped
+     * (merged casts / appends / fillable / hidden, flipped uniqueIds, resolved connection/table). Without it a
+     * cast a user trait merges is invisible to {@see computeCasts()}, so an `$appends` entry it backs looks
+     * unbacked and false-positives {@see \Psalm\LaravelPlugin\Handlers\Rules\UnresolvableAppendedModelAttributeHandler}.
      *
-     * Discovery mirrors {@see Model}::bootTraits()'s two branches: an initializer is any method whose name
-     * is the conventional `initialize` . class_basename of a used trait (every version), OR that carries
-     * `#[Initialize]` — that attribute and the bootTraits branch reading it land in Laravel 12.22, so the
-     * branch is gated on `class_exists(Initialize::class)`: load-bearing, not just defensive, since below
-     * 12.22 the framework ignores the attribute and the guard keeps us convention-only, at parity. Neither
-     * branch filters `isStatic` — bootTraits' initializer branch, unlike its boot branch, does not. We
-     * re-derive the list here instead of calling `initializeTraits()`, which reads
-     * `static::$traitInitializers` — populated only by `bootTraits()` during boot, and booting registers
-     * global scopes (a known Psalm hang), so it no-ops on this unbooted class.
+     * ONE walk over `ReflectionClass::getMethods()`, in that exact order — it is the order Laravel runs
+     * initializers (12.22+) AND it is PHP-version-dependent (8.4 ranks Model's inherited concern inits first,
+     * 8.5 the concrete class's own trait inits first), so we must execute in it to match runtime under either
+     * PHP. For each discovered initializer (conventional `initialize`.class_basename of a used trait, OR
+     * `#[Initialize]`-tagged — the attribute branch gated on `class_exists(Initialize::class)`, load-bearing
+     * below 12.22 where the framework ignores it; neither branch filters `isStatic`, matching bootTraits):
+     *  - a user / third-party initializer (source file NOT under the Illuminate\Database root) is invoked;
+     *  - a framework concern initializer runs its registry MIRROR at that position (or no-ops), so its ordering
+     *    against user initializers is automatically correct under either PHP order — a user setAppends() lands
+     *    before mergeAppends(#[Appends]) on 8.5 and after it on 8.4, exactly as getAppends() does.
+     * Concern initializers are discriminated by SOURCE FILE, not declaring class — a directly-`use`d concern
+     * (e.g. `use HasUuids`) flattens its initializer to report the user model as declarer, yet its file stays
+     * under the Illuminate\Database root (derived from Model's own file — install-independent; the trailing '/'
+     * stops a sibling like Illuminate\DatabaseExtra matching). `#[Connection]`/`#[Table]`
+     * (initializeModelAttributes) run last, after the walk, as at runtime.
      *
-     * Framework (`Illuminate\`) concern initializers are excluded — their effects are already mirrored by
-     * {@see applyClassAttributeConfig()} (`#[...]` config attributes), {@see flipUsesUniqueIds()}
-     * (HasUniqueStringIds), and {@see computeCasts()} (`casts()` + SoftDeletes), so replaying would
-     * double-apply — keyed on the method's SOURCE FILE, not its declaring class: a concern trait `use`d
-     * directly on the model (e.g. `use HasUuids`) flattens its initializer to report the user model as
-     * declarer, yet the method's file stays under the `Illuminate\Database` root (derived from Model's own
-     * file — install-layout-independent). Only user / third-party run.
-     *
-     * Only the initialize hooks run — never `boot{Trait}()`: booting registers global scopes (the Psalm
-     * hang). An initializer that depends on boot-prepared state therefore throws here even though runtime
-     * construction succeeds, and the model degrades to four incomplete sections — a warned coverage loss
-     * that prevents potentially-incorrect diagnostics, accepted as the conservative trade.
+     * We re-derive the list here instead of calling `initializeTraits()` (reads `static::$traitInitializers`,
+     * populated only by `bootTraits()` during boot — booting registers global scopes, a Psalm hang, so it
+     * no-ops unbooted). `boot{Trait}()` hooks are never replayed for the same reason: an initializer that
+     * depends on boot-prepared state throws here even though runtime construction succeeds, degrading the model
+     * to partial metadata — a warned coverage loss that prevents potentially-incorrect diagnostics, the
+     * conservative trade.
      *
      * @param \ReflectionClass<Model> $reflection
      */
-    private static function replayTraitInitializers(\ReflectionClass $reflection, Model $instance): void
+    private static function replayInitializers(\ReflectionClass $reflection, Model $instance): void
     {
         // Conventional initialize<Basename> names for every used trait, mirroring bootTraits().
         // filterStringList() also fixes the value type: outside the plugin's own stubs (self-analysis does
@@ -1693,79 +1656,89 @@ final class ModelMetadataRegistryBuilder
             $conventional['initialize' . \class_basename($trait)] = true;
         }
 
-        // Gate the #[Initialize] branch on the attribute class existing — it and the bootTraits branch
-        // reading it arrive in Laravel 12.22, so below that this is a load-bearing no-op that keeps us
-        // convention-only, at parity with the framework (which ignores the attribute there). Computed once.
         $honorInitializeAttribute = \class_exists(Initialize::class);
-
-        // Framework concern initializers (HasAttributes / GuardsAttributes / HidesAttributes / HasTimestamps
-        // / HasRelationships / HasUniqueStringIds / SoftDeletes) all live under Illuminate\Database. Derive
-        // that root from Model's OWN file (dirname .../Illuminate/Database/Eloquent/Model.php, 2) so the skip
-        // is install-layout-independent — custom vendor dirs, composer path-repo symlinks, and split
-        // illuminate/* packages resolve consistently, unlike a hardcoded `/vendor/…` substring.
+        // Framework concern initializers all live under Illuminate\Database; derive that root from Model's OWN
+        // file so the skip is install-layout-independent (custom vendor dirs, path-repo symlinks, split
+        // illuminate/* packages resolve consistently, unlike a hardcoded `/vendor/…` substring).
         $eloquentRoot = \str_replace('\\', '/', \dirname((string) (new \ReflectionClass(Model::class))->getFileName(), 2));
 
         $invoked = [];
         foreach ($reflection->getMethods() as $method) {
             $name = $method->getName();
-            // Discover initializers as bootTraits() does — conventional name OR #[Initialize], deduped by
-            // name; getAttributes() is reached only for non-conventional methods (short-circuit).
+            // Discover as bootTraits() does — conventional name OR #[Initialize] — deduped by name;
+            // getAttributes() is reached only for non-conventional methods (short-circuit).
             $isInitializer = isset($conventional[$name])
                 || ($honorInitializeAttribute && $method->getAttributes(Initialize::class) !== []);
             if (isset($invoked[$name]) || !$isInitializer) {
                 continue;
             }
 
-            // Skip framework concern initializers (some conventionally named, some #[Initialize]-tagged):
-            // hand-mirrored by applyClassAttributeConfig()/flipUsesUniqueIds()/computeCasts(), so replaying
-            // double-applies. The method's source file under the Illuminate\Database root is the reliable
-            // discriminator — its declaring class is NOT (a directly-`use`d concern reports the user model).
-            // The trailing '/' on the root stops a sibling dir like Illuminate/DatabaseExtra from matching.
-            if (\str_starts_with(\str_replace('\\', '/', (string) $method->getFileName()), $eloquentRoot . '/')) {
-                continue;
-            }
-
             $invoked[$name] = true;
-            // Invoke by reflection, NOT $instance->{$name}(): a protected/private initializer (Laravel's
-            // own initializeHasAttributes() is protected) called from outside the model would route to
-            // Model::__call() query-builder forwarding instead of running. Since PHP 8.1 reflection invokes
-            // non-public methods without setAccessible(). The mixed return is a bare statement — it never
-            // binds to a local, so the file stays at 100% type coverage. Runs user init code, which the
-            // caller wraps in a computeSection() guard so a throw degrades to partial metadata, not a crash.
-            $method->invoke($instance);
+            if (\str_starts_with(\str_replace('\\', '/', (string) $method->getFileName()), $eloquentRoot . '/')) {
+                // Framework concern initializer: run its hand-written registry mirror at this position (the
+                // real one would double-apply what computeCasts()/the section readers already derive).
+                self::applyConcernMirror($name, $reflection, $instance);
+            } else {
+                // User / third-party initializer: invoke by reflection, NOT $instance->{$name}() — a
+                // protected/private initializer called from outside would route to Model::__call() query-builder
+                // forwarding instead of running (PHP 8.1 reflection invokes non-public methods, no setAccessible).
+                // Mixed return is a bare statement, so the file stays at 100% coverage.
+                $method->invoke($instance);
+            }
+        }
+
+        // initializeModelAttributes phase — always after initializeTraits at runtime.
+        self::applyConnectionAttribute($reflection, $instance);
+        self::applyTableAttribute($reflection, $instance);
+    }
+
+    /**
+     * Run the registry mirror for a framework concern initializer at its position in the
+     * {@see replayInitializers()} walk (verified 1:1 against vendor Eloquent\Concerns): HasAttributes →
+     * `mergeAppends(#[Appends])` (its `casts()` merge is {@see computeCasts()}'s job, `dateFormat` isn't
+     * stored); HidesAttributes → `mergeHidden`/`mergeVisible`; GuardsAttributes → `mergeFillable(#[Fillable])`
+     * + `#[Guarded]`/`#[Unguarded]`; HasUniqueStringIds → `usesUniqueIds = true`. HasTimestamps /
+     * HasRelationships / SoftDeletes have no registry-observable effect (timestamps/touches aren't stored;
+     * SoftDeletes' `deleted_at` cast is added by {@see computeCasts()}), so they no-op here.
+     *
+     * @param \ReflectionClass<Model> $reflection
+     */
+    private static function applyConcernMirror(string $name, \ReflectionClass $reflection, Model $instance): void
+    {
+        if ($name === 'initializeHasUniqueStringIds') {
+            self::flipUsesUniqueIds($instance);
+        } elseif ($name === 'initializeHasAttributes') {
+            self::applyAppendsAttribute($reflection, $instance);
+        } elseif ($name === 'initializeHidesAttributes') {
+            self::applyHiddenVisibleAttributes($reflection, $instance);
+        } elseif ($name === 'initializeGuardsAttributes') {
+            self::applyFillableGuardedAttributes($reflection, $instance);
         }
     }
 
     /**
-     * Apply the class-level PHP-attribute config that {@see Model}::__construct() sets via
-     * `initializeTraits()` / `initializeModelAttributes()` — both skipped by
-     * `newInstanceWithoutConstructor()`. Mutates `$instance` (like {@see flipUsesUniqueIds()}) so every
-     * downstream getter, and {@see computeSchema()}'s `getTable()`, sees the runtime state. Mirrors only
-     * the framework's own config handling; user / third-party trait initializers are replayed separately
-     * by {@see replayTraitInitializers()}.
-     *
-     * Per-attribute semantics mirror Laravel exactly: `#[Hidden]`/`#[Visible]`/`#[Appends]`/`#[Fillable]`
-     * union-merge into the property list; `#[Guarded]`/`#[Unguarded]` only replace the default `['*']`;
-     * `#[Connection]`/`#[Table]` fill a null.
-     *
-     * Known gap (NOT applied): `#[Table]`'s `key` / `keyType` / `incrementing` sub-overrides and
-     * `#[WithoutIncrementing]`. Laravel's `initializeModelAttributes()` feeds these into the primary key
-     * (`primaryKey ← $table->key` when still `'id'`, etc.), but {@see computePrimaryKey()} reads only the
-     * raw `getKeyName()`/`getKeyType()`/`getIncrementing()` defaults and never consults `#[Table]`, so an
-     * attribute-declared PK is not picked up. Deferred as a separate PK-path change; the table NAME (the
-     * serialization-relevant part) IS applied. (Timestamps are moot — the registry stores no such field.)
-     *
-     * The attribute classes exist from Laravel 13.0; on older lines `getAttributes()` matches nothing and
-     * every branch no-ops (so the plugin stays correct across the 12.4+ support range).
+     * Mirror of `initializeHasAttributes`' `mergeAppends(#[Appends])` (union-merge). The `#[Appends]` attribute
+     * exists from Laravel 13.0; below it `classAttribute()` matches nothing and this no-ops — so `mergeAppends()`,
+     * unavailable on 12.14–12.24, is never called with an empty fallback and cannot crash warm-up.
      *
      * @param \ReflectionClass<Model> $reflection
      */
-    private static function applyClassAttributeConfig(\ReflectionClass $reflection, Model $instance): void
+    private static function applyAppendsAttribute(\ReflectionClass $reflection, Model $instance): void
     {
-        // Union-merge, mirroring mergeHidden() / mergeVisible() / mergeAppends() / mergeFillable().
-        // These four configuration attributes only exist from Laravel 13. On Laravel 12.14–12.24,
-        // mergeHidden() / mergeVisible() / mergeAppends() are unavailable (mergeFillable() exists), so
-        // calling the absent helpers with empty fallbacks crashes warm-up. An absent attribute has nothing to replay.
+        $appends = self::classAttribute($reflection, Appends::class);
+        if ($appends !== null) {
+            $instance->mergeAppends($appends->columns);
+        }
+    }
+
+    /**
+     * Mirror of `initializeHidesAttributes`' `mergeHidden(#[Hidden])` + `mergeVisible(#[Visible])` (union-merge).
+     * Both attributes and helpers are Laravel-13.0; an absent attribute no-ops (see {@see applyAppendsAttribute()}).
+     *
+     * @param \ReflectionClass<Model> $reflection
+     */
+    private static function applyHiddenVisibleAttributes(\ReflectionClass $reflection, Model $instance): void
+    {
         $hidden = self::classAttribute($reflection, Hidden::class);
         if ($hidden !== null) {
             $instance->mergeHidden($hidden->columns);
@@ -1775,20 +1748,28 @@ final class ModelMetadataRegistryBuilder
         if ($visible !== null) {
             $instance->mergeVisible($visible->columns);
         }
+    }
 
-        $appends = self::classAttribute($reflection, Appends::class);
-        if ($appends !== null) {
-            $instance->mergeAppends($appends->columns);
-        }
-
+    /**
+     * Mirror of `initializeGuardsAttributes`: `mergeFillable(#[Fillable])` then the `#[Guarded]`/`#[Unguarded]`
+     * replace-if-default. `mergeFillable()` exists on 12.14+, but an absent `#[Fillable]` still no-ops
+     * (see {@see applyAppendsAttribute()}).
+     *
+     * Known gap (NOT applied by any mirror): `#[Table]`'s `key` / `keyType` / `incrementing` sub-overrides and
+     * `#[WithoutIncrementing]`, which `initializeModelAttributes()` feeds into the primary key. {@see computePrimaryKey()}
+     * reads only the raw `getKeyName()`/`getKeyType()`/`getIncrementing()` defaults; the table NAME (the
+     * serialization-relevant part) IS applied by {@see applyTableAttribute()}.
+     *
+     * @param \ReflectionClass<Model> $reflection
+     */
+    private static function applyFillableGuardedAttributes(\ReflectionClass $reflection, Model $instance): void
+    {
         $fillable = self::classAttribute($reflection, Fillable::class);
         if ($fillable !== null) {
             $instance->mergeFillable($fillable->columns);
         }
 
         self::applyGuardedAttribute($reflection, $instance);
-        self::applyConnectionAttribute($reflection, $instance);
-        self::applyTableAttribute($reflection, $instance);
     }
 
     /**
@@ -1797,9 +1778,10 @@ final class ModelMetadataRegistryBuilder
      * `#[Unguarded]` guards nothing; else the `#[Guarded]` columns (`columns ?? ['*']`, so a present-but-
      * empty `#[Guarded]` also guards nothing); absent → keep `['*']`.
      *
-     * The `getGuarded() !== ['*']` early-return matches runtime precisely because the trait-initializer
-     * replay runs BEFORE this: a user initializer that already set `$guarded` (via `guard()`) makes runtime's
-     * initializeGuardsAttributes skip `#[Guarded]` — and so do we.
+     * The `getGuarded() !== ['*']` early-return matches runtime precisely because this mirror runs at
+     * initializeGuardsAttributes' position in the getMethods() walk: a user initializer that ran earlier
+     * (per that PHP's order) and set `$guarded` via `guard()` makes runtime's initializeGuardsAttributes skip
+     * `#[Guarded]` — and so do we.
      *
      * @param \ReflectionClass<Model> $reflection
      */
@@ -1861,7 +1843,7 @@ final class ModelMetadataRegistryBuilder
      * Known-gap: a `key`/`keyType`-only `#[Table]` (null name) does NOT clear an inherited `$table`
      * default the way Laravel's force-branch does (`$this->table = $table->name ?? null`). That sits
      * inside the same exotic, deferred scenario as the `key`/`keyType`/`incrementing` PK sub-overrides
-     * (see {@see applyClassAttributeConfig()}), so it is left untouched rather than half-applied.
+     * (see {@see applyFillableGuardedAttributes()}), so it is left untouched rather than half-applied.
      *
      * @param \ReflectionClass<Model> $reflection
      */

--- a/src/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php
+++ b/src/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php
@@ -317,6 +317,36 @@ final class ModelMetadataRegistryBuilder
         array &$failures,
     ): ModelMetadata {
         $baseTraits = self::computeTraitFlags($storage, true);
+
+        // Replay the model's own trait initializers FIRST — before the framework-mirror steps below
+        // (flipUsesUniqueIds + applyClassAttributeConfig) — matching Laravel 12.22+/13, whose bootTraits()
+        // iterates ReflectionClass::getMethods() and ranks a concrete class's own (flattened) initializers
+        // AHEAD of Model's inherited concern initializers (verified from the tag sources + empirically), with
+        // initializeModelAttributes last. So a user setAppends() lands BEFORE the framework
+        // mergeAppends(#[Appends]); the old order (mirrors first) let it REPLACE the merge, dropping the
+        // #[Appends] entries runtime keeps.
+        //
+        // Laravel 12.14–12.21 bootTraits() instead walks class_uses_recursive() PARENTS-FIRST, so framework
+        // concern inits run BEFORE user ones — replay-first is NOT runtime-faithful there. But every
+        // config-attribute merge (#[Appends]/#[Fillable]/#[Hidden]/#[Visible]/#[Guarded]) is Laravel-13-only,
+        // so nothing collides pre-13; the sole pre-12.22 divergence is casts()-vs-user-mergeCasts() of the
+        // SAME key (documented at computeCasts — pre-existing, since computeCasts always lets casts() win
+        // regardless of this reorder). The other residual is exotic: a user init that READS state a
+        // same-concrete-class framework init writes (a directly-`use`d HasUuids's usesUniqueIds). The helper
+        // owns the framework-initializer exclusion.
+        $traitsInitialized = self::computeSection(
+            0,
+            'trait initializers',
+            $completeSections,
+            $failures,
+            static function () use ($reflection, $instance): bool {
+                self::replayTraitInitializers($reflection, $instance);
+
+                return true;
+            },
+            false,
+        );
+
         $uniqueIdsReady = true;
         if ($baseTraits->hasUuids || $baseTraits->hasUlids) {
             $uniqueIdsReady = self::computeSection(
@@ -340,26 +370,6 @@ final class ModelMetadataRegistryBuilder
             $failures,
             static function () use ($reflection, $instance): bool {
                 self::applyClassAttributeConfig($reflection, $instance);
-
-                return true;
-            },
-            false,
-        );
-
-        // Replay the model's own trait initializers (→ mergeCasts() / mergeFillable() / ...) the
-        // constructor-less instance skipped, so the readers below see them. No placement is exactly
-        // runtime-faithful — applyClassAttributeConfig() bundles a pre-user-init phase (#[Guarded] via the
-        // concern initializers) and a post one (initializeModelAttributes) — but after it is fine: the
-        // union merges (appends / fillable / hidden / visible) commute as sets; only #[Connection] /
-        // #[Table] fill-null colliding with a user initializer on that same field is order-sensitive (an
-        // exotic case, left as-is). The helper owns the framework-initializer exclusion.
-        $traitsInitialized = self::computeSection(
-            0,
-            'trait initializers',
-            $completeSections,
-            $failures,
-            static function () use ($reflection, $instance): bool {
-                self::replayTraitInitializers($reflection, $instance);
 
                 return true;
             },
@@ -1406,6 +1416,14 @@ final class ModelMetadataRegistryBuilder
             $merged = \array_merge($merged, CastsMethodParser::parse($codebase, $modelFqcn));
         }
 
+        // KNOWN DIVERGENCE (Laravel 12.14–12.21 only): when a user trait initializer mergeCasts() a key that
+        // casts() ALSO declares, runtime there runs casts() first (bootTraits walks class_uses_recursive
+        // parents-first) then the user init, so the USER value wins; from 12.22+ the order flips and casts()
+        // wins — which is what merging casts() last reproduces on every version. Making it version-aware needs
+        // a pre-replay casts snapshot diffed here to re-apply user-merged keys after casts(); deferred as a
+        // documented divergence — a rare same-key collision, on a superseded patch range, costing one cast
+        // type. See replayTraitInitializers() for the reorder that motivates this.
+
         $result = [];
         foreach ($merged as $columnName => $castString) {
             if ($columnName === '' || $castString === '') {
@@ -1655,8 +1673,13 @@ final class ModelMetadataRegistryBuilder
      * (HasUniqueStringIds), and {@see computeCasts()} (`casts()` + SoftDeletes), so replaying would
      * double-apply — keyed on the method's SOURCE FILE, not its declaring class: a concern trait `use`d
      * directly on the model (e.g. `use HasUuids`) flattens its initializer to report the user model as
-     * declarer, yet the method's file stays under `vendor/laravel/framework` (or `vendor/illuminate`).
-     * Only user / third-party run.
+     * declarer, yet the method's file stays under the `Illuminate\Database` root (derived from Model's own
+     * file — install-layout-independent). Only user / third-party run.
+     *
+     * Only the initialize hooks run — never `boot{Trait}()`: booting registers global scopes (the Psalm
+     * hang). An initializer that depends on boot-prepared state therefore throws here even though runtime
+     * construction succeeds, and the model degrades to four incomplete sections — a warned coverage loss
+     * that prevents potentially-incorrect diagnostics, accepted as the conservative trade.
      *
      * @param \ReflectionClass<Model> $reflection
      */
@@ -1675,6 +1698,13 @@ final class ModelMetadataRegistryBuilder
         // convention-only, at parity with the framework (which ignores the attribute there). Computed once.
         $honorInitializeAttribute = \class_exists(Initialize::class);
 
+        // Framework concern initializers (HasAttributes / GuardsAttributes / HidesAttributes / HasTimestamps
+        // / HasRelationships / HasUniqueStringIds / SoftDeletes) all live under Illuminate\Database. Derive
+        // that root from Model's OWN file (dirname .../Illuminate/Database/Eloquent/Model.php, 2) so the skip
+        // is install-layout-independent — custom vendor dirs, composer path-repo symlinks, and split
+        // illuminate/* packages resolve consistently, unlike a hardcoded `/vendor/…` substring.
+        $eloquentRoot = \str_replace('\\', '/', \dirname((string) (new \ReflectionClass(Model::class))->getFileName(), 2));
+
         $invoked = [];
         foreach ($reflection->getMethods() as $method) {
             $name = $method->getName();
@@ -1687,14 +1717,11 @@ final class ModelMetadataRegistryBuilder
             }
 
             // Skip framework concern initializers (some conventionally named, some #[Initialize]-tagged):
-            // hand-mirrored elsewhere, so replaying double-applies. The method's source file is the reliable
-            // discriminator (its declaring class is NOT — a directly-`use`d concern reports the user model).
-            // Anchored to `/vendor/...` so a user repo checked out at e.g. ~/code/laravel/framework/ is not
-            // self-skipped; `/vendor/illuminate/` also covers standalone illuminate/database installs. A
-            // framework symlinked OUTSIDE vendor slips through, but replaying its initializers is idempotent
-            // (they merge exactly what applyClassAttributeConfig()/flipUsesUniqueIds()/computeCasts() apply).
-            $file = \str_replace('\\', '/', (string) $method->getFileName());
-            if (\str_contains($file, '/vendor/laravel/framework/') || \str_contains($file, '/vendor/illuminate/')) {
+            // hand-mirrored by applyClassAttributeConfig()/flipUsesUniqueIds()/computeCasts(), so replaying
+            // double-applies. The method's source file under the Illuminate\Database root is the reliable
+            // discriminator — its declaring class is NOT (a directly-`use`d concern reports the user model).
+            // The trailing '/' on the root stops a sibling dir like Illuminate/DatabaseExtra from matching.
+            if (\str_starts_with(\str_replace('\\', '/', (string) $method->getFileName()), $eloquentRoot . '/')) {
                 continue;
             }
 
@@ -1769,6 +1796,10 @@ final class ModelMetadataRegistryBuilder
      * {@see \Illuminate\Database\Eloquent\Concerns\GuardsAttributes::initializeGuardsAttributes()}:
      * `#[Unguarded]` guards nothing; else the `#[Guarded]` columns (`columns ?? ['*']`, so a present-but-
      * empty `#[Guarded]` also guards nothing); absent → keep `['*']`.
+     *
+     * The `getGuarded() !== ['*']` early-return matches runtime precisely because the trait-initializer
+     * replay runs BEFORE this: a user initializer that already set `$guarded` (via `guard()`) makes runtime's
+     * initializeGuardsAttributes skip `#[Guarded]` — and so do we.
      *
      * @param \ReflectionClass<Model> $reflection
      */

--- a/tests/Application/app/Models/AttributeSerializableModel.php
+++ b/tests/Application/app/Models/AttributeSerializableModel.php
@@ -13,7 +13,7 @@ use Illuminate\Database\Eloquent\Model;
  * Serialization archetype driven by Laravel 13.0+ PHP class attributes (`#[Appends]` / `#[Hidden]`)
  * instead of `$properties`. The harness runs no migrations, so the shape comes entirely from the
  * appended, accessor-backed attributes — letting AttributeConfigShapeTest.phpt assert end-to-end that
- * `applyClassAttributeConfig()` feeds the serialized shape (and that `#[Hidden]` drops an appended key).
+ * `replayInitializers()` feeds the serialized shape (and that `#[Hidden]` drops an appended key).
  *
  * Modern protected `Attribute` accessors keep the legacy public-accessor lint (`PublicModelAccessor`)
  * quiet. The `#[*]` classes only exist from Laravel 13.0, so the phpt is SKIPIF-gated below that line.

--- a/tests/Type/tests/Model/AttributeConfigShapeTest.phpt
+++ b/tests/Type/tests/Model/AttributeConfigShapeTest.phpt
@@ -17,7 +17,7 @@ use App\Models\AttributeSerializableModel;
  * #[Appends]/#[Hidden] PHP-attribute config feeds the serialized shape end-to-end.
  *
  * newInstanceWithoutConstructor() skips Laravel's initializers, so the registry replays the attribute
- * config at warm-up (applyClassAttributeConfig). The harness runs no migrations, so the shape comes
+ * config at warm-up (replayInitializers). The harness runs no migrations, so the shape comes
  * entirely from #[Appends]: `full_name` (accessor-backed) is present, while `secret_token` is appended
  * but dropped by #[Hidden]. Without the fix getAppends() would miss #[Appends] and the shape would
  * collapse to the loose array<string, mixed> stub.

--- a/tests/Unit/Fixtures/Concerns/FailsTraitInitializer.php
+++ b/tests/Unit/Fixtures/Concerns/FailsTraitInitializer.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Concerns;
+
+/**
+ * Trait initializer that throws on demand via the composing model's `fail()` switch, so the warm-up
+ * trait-initializer replay fails and the four instance-derived sections degrade to incomplete. Used only
+ * by {@see \Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\SectionFailureModel} (whose private `fail()`
+ * this method reaches once the trait is flattened in).
+ *
+ * @psalm-require-extends \Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\SectionFailureModel
+ */
+trait FailsTraitInitializer
+{
+    public function initializeFailsTraitInitializer(): void
+    {
+        $this->fail('trait initializers');
+    }
+}

--- a/tests/Unit/Fixtures/Concerns/MergesTraitConfig.php
+++ b/tests/Unit/Fixtures/Concerns/MergesTraitConfig.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Concerns;
+
+use Illuminate\Database\Eloquent\Casts\AsArrayObject;
+
+/**
+ * Merges a class cast AND a fillable entry through Laravel's `initialize<Trait>()` construction hook.
+ * Declared `protected` deliberately: the warm-up replay must invoke it by reflection (as Laravel does),
+ * never `$instance->{$method}()` — an external dynamic call on a protected method routes to
+ * Model::__call() query-builder forwarding instead of running the initializer.
+ *
+ * @psalm-require-extends \Illuminate\Database\Eloquent\Model
+ */
+trait MergesTraitConfig
+{
+    protected function initializeMergesTraitConfig(): void
+    {
+        $this->mergeCasts(['meta' => AsArrayObject::class]);
+        $this->mergeFillable(['trait_fillable']);
+    }
+}

--- a/tests/Unit/Fixtures/Concerns/SeedsCastViaAttribute.php
+++ b/tests/Unit/Fixtures/Concerns/SeedsCastViaAttribute.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Concerns;
+
+use Illuminate\Database\Eloquent\Attributes\Initialize;
+use Illuminate\Database\Eloquent\Casts\AsCollection;
+
+/**
+ * Merges a class cast from a `#[Initialize]`-tagged, NON-conventionally-named initializer (`seedViaAttribute`,
+ * not `initializeSeedsCastViaAttribute`), so only the attribute-discovery branch of the warm-up replay
+ * reaches it — a convention-only replay would miss it. `protected` to also exercise the reflection
+ * (visibility-bypassing) invoke.
+ *
+ * @psalm-require-extends \Illuminate\Database\Eloquent\Model
+ */
+trait SeedsCastViaAttribute
+{
+    #[Initialize]
+    protected function seedViaAttribute(): void
+    {
+        $this->mergeCasts(['via_attr' => AsCollection::class]);
+    }
+}

--- a/tests/Unit/Fixtures/Concerns/SetsAppendInInitializer.php
+++ b/tests/Unit/Fixtures/Concerns/SetsAppendInInitializer.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Concerns;
+
+/**
+ * User trait initializer that `setAppends()` (the REPLACE form). At runtime, `bootTraits()` ranks this
+ * concrete-class initializer ahead of Model's inherited `initializeHasAttributes`, so it runs BEFORE the
+ * `#[Appends]` `mergeAppends()` and both entries survive. Guards that the warm-up replay runs before
+ * `applyClassAttributeConfig()` (a replace after the merge would drop the attribute entry).
+ *
+ * @psalm-require-extends \Illuminate\Database\Eloquent\Model
+ */
+trait SetsAppendInInitializer
+{
+    public function initializeSetsAppendInInitializer(): void
+    {
+        $this->setAppends(['trait_only']);
+    }
+}

--- a/tests/Unit/Fixtures/Concerns/SetsAppendInInitializer.php
+++ b/tests/Unit/Fixtures/Concerns/SetsAppendInInitializer.php
@@ -8,7 +8,7 @@ namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Concerns;
  * User trait initializer that `setAppends()` (the REPLACE form). At runtime, `bootTraits()` ranks this
  * concrete-class initializer ahead of Model's inherited `initializeHasAttributes`, so it runs BEFORE the
  * `#[Appends]` `mergeAppends()` and both entries survive. Guards that the warm-up replay runs before
- * `applyClassAttributeConfig()` (a replace after the merge would drop the attribute entry).
+ * the attribute mirror (a replace after the merge would drop the attribute entry).
  *
  * @psalm-require-extends \Illuminate\Database\Eloquent\Model
  */

--- a/tests/Unit/Fixtures/Models/AppendsOrderModel.php
+++ b/tests/Unit/Fixtures/Models/AppendsOrderModel.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Appends;
+use Illuminate\Database\Eloquent\Model;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Concerns\SetsAppendInInitializer;
+
+/**
+ * `#[Appends('attribute_append')]` plus a trait `setAppends(['trait_only'])`. Runtime `getAppends()` returns
+ * BOTH, because the user initializer runs before `initializeHasAttributes`' `mergeAppends()`. The registry
+ * must reproduce that exactly — replaying the initializer before `applyClassAttributeConfig()`.
+ *
+ * The `#[Appends]` attribute exists from Laravel 13.0, so the consuming test is gated on `class_exists()`.
+ *
+ * @internal fixture used by ModelMetadataRegistryTest
+ */
+#[Appends('attribute_append')]
+final class AppendsOrderModel extends Model
+{
+    use SetsAppendInInitializer;
+}

--- a/tests/Unit/Fixtures/Models/AppendsOrderModel.php
+++ b/tests/Unit/Fixtures/Models/AppendsOrderModel.php
@@ -11,7 +11,7 @@ use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Concerns\SetsAppendInInitializer;
 /**
  * `#[Appends('attribute_append')]` plus a trait `setAppends(['trait_only'])`. Runtime `getAppends()` returns
  * BOTH, because the user initializer runs before `initializeHasAttributes`' `mergeAppends()`. The registry
- * must reproduce that exactly — replaying the initializer before `applyClassAttributeConfig()`.
+ * must reproduce that exactly — running the initializer and the attribute mirror in the same reflection order Laravel observes.
  *
  * The `#[Appends]` attribute exists from Laravel 13.0, so the consuming test is gated on `class_exists()`.
  *

--- a/tests/Unit/Fixtures/Models/AttributeConfiguredModel.php
+++ b/tests/Unit/Fixtures/Models/AttributeConfiguredModel.php
@@ -16,7 +16,7 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Twin of {@see ScalarFieldsModel} that drives the same lists through Laravel 13.0+ PHP class
  * attributes instead of `$properties`, exercising
- * {@see \Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadataRegistryBuilder}::applyClassAttributeConfig().
+ * {@see \Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadataRegistryBuilder}::replayInitializers().
  *
  * The baseline `$property` declarations on the union lists (`$hidden` / `$visible` / `$appends` /
  * `$fillable`) prove the attribute columns are MERGED in, not replaced; `$guarded` is left at the base

--- a/tests/Unit/Fixtures/Models/SectionFailureModel.php
+++ b/tests/Unit/Fixtures/Models/SectionFailureModel.php
@@ -7,10 +7,12 @@ namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Casts\InboundOnlyCast;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Concerns\FailsTraitInitializer;
 
 /** @internal fixture used by ModelMetadataRegistryTest */
 final class SectionFailureModel extends Model
 {
+    use FailsTraitInitializer;
     use HasUuids {
         getKeyType as private getKeyTypeFromTrait;
     }

--- a/tests/Unit/Fixtures/Models/TraitInitializedConfigModel.php
+++ b/tests/Unit/Fixtures/Models/TraitInitializedConfigModel.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Concerns\MergesTraitConfig;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Concerns\SeedsCastViaAttribute;
+
+/**
+ * Drives {@see \Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadataRegistryBuilder}'s
+ * trait-initializer replay across BOTH discovery branches: MergesTraitConfig merges the `meta` class cast
+ * and `trait_fillable` via a conventionally-named initializer, while SeedsCastViaAttribute merges the
+ * `via_attr` class cast via a `#[Initialize]`-tagged, non-conventionally-named one. A constructor-less
+ * warm-up skips both unless replayed. The class-level `$fillable` proves the trait merge unions, not clobbers.
+ *
+ * @internal fixture used by ModelMetadataRegistryTest
+ */
+final class TraitInitializedConfigModel extends Model
+{
+    use MergesTraitConfig;
+    use SeedsCastViaAttribute;
+
+    /** @var list<string> */
+    protected $appends = ['meta'];
+
+    /** @var list<string> */
+    protected $fillable = ['class_fillable'];
+}

--- a/tests/Unit/Handlers/Fixtures/UnresolvableAppendedModelAttribute/app/Concerns/HasMeta.php
+++ b/tests/Unit/Handlers/Fixtures/UnresolvableAppendedModelAttribute/app/Concerns/HasMeta.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppendsFixture\Concerns;
+
+use Illuminate\Database\Eloquent\Casts\AsArrayObject;
+
+/**
+ * Merges a class cast through Laravel's `initialize<Trait>()` construction hook — the runtime path a
+ * constructor-less warm-up instance skips. Backs the `meta` append on
+ * {@see \AppendsFixture\Models\TraitCastBackedModel}.
+ *
+ * @psalm-require-extends \Illuminate\Database\Eloquent\Model
+ */
+trait HasMeta
+{
+    public function initializeHasMeta(): void
+    {
+        $this->mergeCasts(['meta' => AsArrayObject::class]);
+    }
+}

--- a/tests/Unit/Handlers/Fixtures/UnresolvableAppendedModelAttribute/app/Models/TraitCastBackedModel.php
+++ b/tests/Unit/Handlers/Fixtures/UnresolvableAppendedModelAttribute/app/Models/TraitCastBackedModel.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppendsFixture\Models;
+
+use AppendsFixture\Concerns\HasMeta;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Clean: `meta` is backed by a class cast (`AsArrayObject`) that the `HasMeta` trait merges via its
+ * `initializeHasMeta()` construction hook, not a `$casts` property. Warm-up replays trait initializers,
+ * so the cast is present and the append must NOT be reported. End-to-end guard for the
+ * trait-initializer class-cast false positive.
+ */
+class TraitCastBackedModel extends Model
+{
+    use HasMeta;
+
+    /** @var list<string> */
+    protected $appends = ['meta'];
+}

--- a/tests/Unit/Handlers/UnresolvableAppendedModelAttributeEmissionTest.php
+++ b/tests/Unit/Handlers/UnresolvableAppendedModelAttributeEmissionTest.php
@@ -19,11 +19,15 @@ use Symfony\Component\Process\Process;
  * subprocess at a self-contained fixture project whose models ARE autoloadable, so the registry warms
  * them and the handler fires for real.
  *
- * The fixture hosts one unbacked append (must be reported) and three controls that must NOT be:
+ * The fixture hosts one unbacked append (must be reported) and four controls that must NOT be:
  * accessor-backed, cast-backed (a first-party Castable the registry shapes as Primitive, the exact
- * false positive the any-cast-backs design fixes), and an unbacked-but-hidden append (dropped before
- * the throwing loop). Asserting exactly one finding proves the rule both fires on the real bug and
- * stays silent on all three — and would fail loudly if a future change silently no-op'd it.
+ * false positive the any-cast-backs design fixes), trait-cast-backed (a class cast a trait initializer
+ * merges at construction — invisible to a constructor-less warm-up until the initializer replay), and an
+ * unbacked-but-hidden append (dropped before the throwing loop). Asserting exactly one finding proves the
+ * rule both fires on the real bug and stays silent on all four — and would fail loudly if a future change
+ * silently no-op'd it. (The `#[Initialize]`-tagged attribute-discovery path is version-gated to Laravel
+ * 12.22+, so a skip-guarded unit test locks it — not this version-agnostic fork, which the 12.14 floor
+ * job also runs, where that append would be genuinely unbacked.)
  *
  * Like {@see SuppressScopeUnusedCodeTest}, this forks a real `vendor/bin/psalm` (it boots Laravel via
  * the plugin, ~6s) because the emission cannot be observed in-process. It lives in tests/Unit for
@@ -43,9 +47,9 @@ final class UnresolvableAppendedModelAttributeEmissionTest extends TestCase
         );
         $joined = \implode("\n", $messages);
 
-        // Exactly one finding: the unbacked append fires, and the accessor-, cast-, and hidden-backed
-        // controls stay silent. assertCount(1) is the regression guard — a change that broke emission,
-        // or that flagged a backed/hidden entry, fails here.
+        // Exactly one finding: the unbacked append fires, and the accessor-, cast-, trait-cast-, and
+        // hidden-backed controls stay silent. assertCount(1) is the regression guard — a change that broke
+        // emission, or that flagged a backed/hidden entry, fails here.
         $this->assertCount(1, $findings, "Expected exactly one UnresolvableAppendedModelAttribute finding, got:\n{$joined}");
         $this->assertStringContainsString('UnbackedAppendModel', $messages[0]);
         $this->assertStringContainsString("'avatar_url'", $messages[0]);
@@ -53,7 +57,7 @@ final class UnresolvableAppendedModelAttributeEmissionTest extends TestCase
 
         // The controls must never appear (assertCount(1) already implies this; spelled out for a clear
         // failure message if one regresses).
-        foreach (['AccessorBackedAppendModel', 'CastBackedAppendModel', 'HiddenAppendModel'] as $clean) {
+        foreach (['AccessorBackedAppendModel', 'CastBackedAppendModel', 'TraitCastBackedModel', 'HiddenAppendModel'] as $clean) {
             $this->assertStringNotContainsString($clean, $joined, "{$clean} has a backed/hidden append and must not be reported.");
         }
     }

--- a/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
+++ b/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
@@ -239,7 +239,7 @@ final class ModelMetadataRegistryTest extends TestCase
     public function class_attributes_are_merged_at_warm_up(): void
     {
         // newInstanceWithoutConstructor() skips initializeTraits()/initializeModelAttributes(), so the
-        // PHP-attribute config is missed unless applyClassAttributeConfig() replays it. The #[*] classes
+        // PHP-attribute config is missed unless replayInitializers() mirrors it. The #[*] classes
         // only exist from Laravel 13.0, below which this fixture is never loaded.
         if (!class_exists(Hidden::class)) {
             self::markTestSkipped('Eloquent PHP class attributes require Laravel >= 13.0.');
@@ -1017,13 +1017,11 @@ final class ModelMetadataRegistryTest extends TestCase
 
         $metadata = $this->metadataFor(AppendsOrderModel::class);
 
-        // Runtime construction is the oracle: the user setAppends(['trait_only']) runs before
-        // initializeHasAttributes' mergeAppends(#[Appends]) (bootTraits ranks the concrete trait initializer
-        // first), so BOTH survive. The registry must reproduce that byte-for-byte — which only holds if the
-        // replay runs BEFORE applyClassAttributeConfig (the old order let the replace drop 'attribute_append').
-        $runtimeAppends = (new AppendsOrderModel())->getAppends();
-        $this->assertSame(['trait_only', 'attribute_append'], $runtimeAppends);
-        $this->assertSame($runtimeAppends, $metadata->appends);
+        // Runtime construction is the ONLY oracle — never a hardcoded literal: getMethods() ranks the user
+        // setAppends(['trait_only']) vs the framework mergeAppends(#[Appends]) differently across PHP versions
+        // (both survive on 8.5, the replace wins on 8.4), so runtime getAppends() differs by PHP. The registry
+        // must reproduce whatever the running PHP yields, which the getMethods()-order interleave guarantees.
+        $this->assertSame((new AppendsOrderModel())->getAppends(), $metadata->appends);
     }
 
     #[Test]

--- a/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
+++ b/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
@@ -71,6 +71,7 @@ use Psalm\Type\Atomic\TGenericObject;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Union;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\AbstractKeylessModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\AppendsOrderModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\AttributeConfiguredChild;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\AttributeConfiguredModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\AttributeOverriddenByPropertyModel;
@@ -998,6 +999,31 @@ final class ModelMetadataRegistryTest extends TestCase
         // existing class entry first, then the trait-merged one.
         $this->assertTrue($metadata->isComplete(ModelMetadata::SECTION_RUNTIME_CONFIGURATION));
         $this->assertSame(['class_fillable', 'trait_fillable'], $metadata->fillable);
+    }
+
+    #[Test]
+    public function trait_initializer_setAppends_precedes_attribute_merge(): void
+    {
+        // #[Appends] exists from Laravel 13.0; below that the attribute is inert and there is nothing to
+        // order against.
+        if (!\class_exists(\Illuminate\Database\Eloquent\Attributes\Appends::class)) {
+            self::markTestSkipped('The #[Appends] attribute requires Laravel >= 13.0.');
+        }
+
+        $codebase = $this->makeCodebase();
+        $this->registerStorage(AppendsOrderModel::class);
+
+        ModelMetadataRegistryBuilder::warmUp($codebase, AppendsOrderModel::class);
+
+        $metadata = $this->metadataFor(AppendsOrderModel::class);
+
+        // Runtime construction is the oracle: the user setAppends(['trait_only']) runs before
+        // initializeHasAttributes' mergeAppends(#[Appends]) (bootTraits ranks the concrete trait initializer
+        // first), so BOTH survive. The registry must reproduce that byte-for-byte — which only holds if the
+        // replay runs BEFORE applyClassAttributeConfig (the old order let the replace drop 'attribute_append').
+        $runtimeAppends = (new AppendsOrderModel())->getAppends();
+        $this->assertSame(['trait_only', 'attribute_append'], $runtimeAppends);
+        $this->assertSame($runtimeAppends, $metadata->appends);
     }
 
     #[Test]

--- a/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
+++ b/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
@@ -21,6 +21,7 @@ use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
@@ -79,6 +80,7 @@ use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\EnumConnectionModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\InboundCastModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\ScalarFieldsModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\SectionFailureModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\TraitInitializedConfigModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\UnguardedAttributeModel;
 
 #[CoversClass(ModelMetadataRegistry::class)]
@@ -497,6 +499,15 @@ final class ModelMetadataRegistryTest extends TestCase
             'schema' => [ModelMetadata::SECTION_SCHEMA],
             'casts' => [ModelMetadata::SECTION_CASTS],
             'primary key' => [ModelMetadata::SECTION_PRIMARY_KEY],
+            // A trait-initializer replay failure withholds every instance-derived section (a half-run
+            // initializer may have mutated any of $table / $connection / casts / $appends / the key), so
+            // all four gate on it — while the static method metadata (SECTION_METHODS) survives.
+            'trait initializers' => [
+                ModelMetadata::SECTION_RUNTIME_CONFIGURATION,
+                ModelMetadata::SECTION_SCHEMA,
+                ModelMetadata::SECTION_CASTS,
+                ModelMetadata::SECTION_PRIMARY_KEY,
+            ],
         ];
 
         foreach ($expectations as $failure => $incompleteSections) {
@@ -921,6 +932,72 @@ final class ModelMetadataRegistryTest extends TestCase
         $this->assertTrue($metadata->traits->hasSoftDeletes);
         $this->assertArrayHasKey('deleted_at', $metadata->casts());
         $this->assertSame(CastShape::DateTime, $metadata->casts()['deleted_at']->shape);
+    }
+
+    #[Test]
+    public function trait_initializer_merged_class_cast_appears_in_casts(): void
+    {
+        // classifyCast() checks class_exists(..., autoload: false), so force AsArrayObject into memory
+        // first, as a real app boot would (mirrors as_collection_class_cast_classifies_as_class_castable).
+        \class_exists(AsArrayObject::class);
+
+        $codebase = $this->makeCodebase();
+        $this->registerStorage(TraitInitializedConfigModel::class);
+
+        ModelMetadataRegistryBuilder::warmUp($codebase, TraitInitializedConfigModel::class);
+
+        $metadata = $this->metadataFor(TraitInitializedConfigModel::class);
+
+        // The `meta` cast is merged only by MergesTraitConfig::initializeMergesTraitConfig() — a protected
+        // hook the constructor-less warm-up instance skips unless the trait initializer is replayed. Its
+        // presence as a class cast is exactly what backs the `meta` append and clears the false positive.
+        $this->assertTrue($metadata->isComplete(ModelMetadata::SECTION_CASTS));
+        $this->assertArrayHasKey('meta', $metadata->casts());
+        $this->assertTrue($metadata->casts()['meta']->shape->isClassCastable());
+    }
+
+    #[Test]
+    public function attribute_tagged_trait_initializer_merged_class_cast_appears_in_casts(): void
+    {
+        // The #[Initialize] attribute and the bootTraits branch reading it arrive in Laravel 12.22; below
+        // that the framework ignores the tag, so the replay stays convention-only and `via_attr` is absent
+        // (the plugin is correct there — the CI 12.14 floor exercises exactly this).
+        if (!\class_exists(\Illuminate\Database\Eloquent\Attributes\Initialize::class)) {
+            self::markTestSkipped('The #[Initialize] attribute discovery branch requires Laravel >= 12.22.');
+        }
+
+        \class_exists(AsCollection::class);
+
+        $codebase = $this->makeCodebase();
+        $this->registerStorage(TraitInitializedConfigModel::class);
+
+        ModelMetadataRegistryBuilder::warmUp($codebase, TraitInitializedConfigModel::class);
+
+        $metadata = $this->metadataFor(TraitInitializedConfigModel::class);
+
+        // `via_attr` is merged only by SeedsCastViaAttribute::seedViaAttribute() — a `#[Initialize]`-tagged,
+        // NON-conventionally-named initializer. It is reachable only through the replay's attribute-discovery
+        // branch (bootTraits' second branch); a convention-only replay would miss it and the false positive
+        // would return for this shape.
+        $this->assertArrayHasKey('via_attr', $metadata->casts());
+        $this->assertTrue($metadata->casts()['via_attr']->shape->isClassCastable());
+    }
+
+    #[Test]
+    public function trait_initializer_merged_fillable_unions_with_class_fillable(): void
+    {
+        $codebase = $this->makeCodebase();
+        $this->registerStorage(TraitInitializedConfigModel::class);
+
+        ModelMetadataRegistryBuilder::warmUp($codebase, TraitInitializedConfigModel::class);
+
+        $metadata = $this->metadataFor(TraitInitializedConfigModel::class);
+
+        // Replaying the initializer must MERGE the trait's mergeFillable() onto the class-level $fillable,
+        // never replace or drop it (over-restriction). Order mirrors Laravel's mergeFillable(): the
+        // existing class entry first, then the trait-merged one.
+        $this->assertTrue($metadata->isComplete(ModelMetadata::SECTION_RUNTIME_CONFIGURATION));
+        $this->assertSame(['class_fillable', 'trait_fillable'], $metadata->fillable);
     }
 
     #[Test]


### PR DESCRIPTION
## Issue to Solve

`UnresolvableAppendedModelAttribute` ships always-on at `error` and false-positives on valid code when an `$appends` entry is backed by a **class cast merged in a trait initializer** (Laravel's documented `initialize{Trait}()` hook calling `mergeCasts()`):

```php
trait HasMeta
{
    public function initializeHasMeta(): void
    {
        $this->mergeCasts(['meta' => AsArrayObject::class]);
    }
}

class Product extends Model
{
    use HasMeta;

    /** @var list<string> */
    protected $appends = ['meta']; // valid at runtime; plugin errored
}
```

At runtime `(new Product())->toArray()` returns the cast value with no exception, but the plugin reported the append as unbacked. Root cause: warm-up instantiates models via `ReflectionClass::newInstanceWithoutConstructor()`, which skips `initializeTraits()`, so trait-merged casts never entered `ModelMetadataRegistry` — `computeCasts()` read `getCasts()` off an instance whose initializers never ran.

## Related

Follow-up to #694 (the rule's origin). A green build turned red on plugin upgrade with zero app-code changes for projects using this (documented) Laravel pattern.

## Solution Description

Replay the model's trait initializers on the throwaway warm-up instance during instance preparation, before any section reader consumes instance state.

- **Discovery mirrors `Model::bootTraits()` exactly**: a method qualifies by the conventional `initialize<TraitBasename>` name **or** by carrying `#[Initialize]` (the attribute and its `bootTraits()` branch land in Laravel 12.22; a `class_exists` guard keeps discovery convention-only below that, at parity with the framework), deduped by method name like `array_unique()` in `bootTraits()`.
- **Execution interleaves framework mirrors in the same reflection order Laravel observes**: `getMethods()` ranks trait-flattened vs inherited methods differently across PHP versions (8.4 puts inherited concern initializers first, 8.5 the concrete class's), and `bootTraits()` simply follows it — so the walk invokes user initializers directly and, when it reaches a framework concern initializer, runs its registry mirror (`#[Appends]`/`#[Hidden]`/`#[Visible]`/`#[Fillable]`/`#[Guarded]` merges, `usesUniqueIds` flip) at that exact position; the `initializeModelAttributes()` phase (`#[Connection]`/`#[Table]`) stays last, as at runtime. Framework initializers are never invoked directly (their `casts()` merge stays AST-parsed in `computeCasts()`); they are recognized by the method's **source file** living under the Eloquent root derived from `Model::class`'s own file (layout-independent: custom vendor dirs, path-repo symlinks, split `illuminate/*` installs) — the declaring class is unreliable because a concern trait `use`d directly on a model flattens its initializer to report the user model as declarer.
- **Invocation via `ReflectionMethod::invoke()`**, never `$instance->{$method}()`: a protected initializer (Laravel's own are protected) called dynamically from outside the class routes to `Model::__call()` query-builder forwarding instead of running.
- **Failure degrades, never crashes or lies**: the replay runs inside a `computeSection()` guard; a throwing initializer withholds all four instance-derived section bits (runtime configuration, schema, casts, primary key), so registry-gated rules self-silence instead of reporting from a half-mutated instance. The failure surfaces through the existing degraded-warm-up warning path (including the `--no-progress` STDERR fallback).
- Deliberately **not** calling `bootIfNotBooted()` / `initializeTraits()`: booting registers global scopes (a known Psalm hang), and `initializeTraits()` reads `static::$traitInitializers`, which only `bootTraits()` populates during boot.

Verified by:

- New emission fixture `TraitCastBackedModel` (conventional hook, class cast) stays silent end-to-end through a forked real Psalm run, while the unbacked control still emits exactly one finding.
- Registry unit tests: trait-merged class cast appears in metadata casts (protected initializer, exercising the reflection path); trait `mergeFillable()` unions with class-level `$fillable` (exact runtime order); `#[Initialize]`-tagged non-conventionally-named initializer honored (version-gated to >= 12.22, keeping the Laravel 12.14 floor CI job green); throwing initializer degrades all four sections while independent sections survive.
- Full-suite delta over 18 real-world Laravel apps: zero new issues, zero coverage change, no warm-up hangs; filament dropped 2 `Mixed*` issues (trait-merged casts now typed).

## Checklist
- [x] Tests cover the change (unit + forked-psalm emission tests in `tests/Unit/`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786785197&installation_id=141955579&pr_number=1273&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1273&signature=741e69421a4ebbeed117233d7ec0516fc4f9e6d5896135f4d477f70a63054003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
