### PR TITLE
Refactor: extract `ModelInstancePreparer` from the registry builder

### DIFF
--- a/src/Handlers/Eloquent/Metadata/ModelInstancePreparer.php
+++ b/src/Handlers/Eloquent/Metadata/ModelInstancePreparer.php
@@ -1,0 +1,334 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Eloquent\Metadata;
+
+use Illuminate\Database\Eloquent\Attributes\Appends;
+use Illuminate\Database\Eloquent\Attributes\Connection;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Guarded;
+use Illuminate\Database\Eloquent\Attributes\Hidden;
+use Illuminate\Database\Eloquent\Attributes\Initialize;
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Attributes\Unguarded;
+use Illuminate\Database\Eloquent\Attributes\Visible;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Mirrors {@see Model}::__construct()'s initializer lifecycle on a constructor-less instance.
+ *
+ * {@see ModelMetadataRegistryBuilder} reads a model's runtime fields off a `newInstanceWithoutConstructor()`
+ * throwaway, which skips `initializeTraits()` / `initializeModelAttributes()`; unreplayed, everything those
+ * merge stays invisible to it.
+ *
+ * Laravel and reflection only — no Psalm, no sections. Throws propagate: the caller owns failure policy.
+ *
+ * @internal
+ */
+final class ModelInstancePreparer
+{
+    /**
+     * Unreplayed, a cast a user trait merges is invisible to
+     * {@see ModelMetadataRegistryBuilder::computeCasts()}, so an `$appends` entry it backs looks unbacked and
+     * false-positives {@see \Psalm\LaravelPlugin\Handlers\Rules\UnresolvableAppendedModelAttributeHandler}.
+     *
+     * ONE walk over `getMethods()`: that order IS Laravel's initializer order (12.22+) and is PHP-dependent
+     * (8.4 ranks Model's inherited concern inits first, 8.5 the class's own trait inits), so executing in it
+     * matches runtime under either. Discovery mirrors bootTraits(): conventional name or `#[Initialize]`
+     * (gated — the framework ignores the tag below 12.22), neither filtering isStatic.
+     *
+     * Framework concerns run a MIRROR at their position rather than being invoked, discriminated by SOURCE
+     * FILE, not declaring class: a directly-`use`d concern flattens to report the user model as declarer.
+     * `#[Connection]`/`#[Table]` run last, as at runtime.
+     *
+     * Not `initializeTraits()`: it reads `static::$traitInitializers`, populated only by `bootTraits()` — and
+     * booting registers global scopes, a Psalm hang. `boot{Trait}()` is skipped for the same reason, so an
+     * initializer depending on boot-prepared state may fail here even though runtime construction succeeds.
+     * That trade is deliberate: the caller withholds the affected sections rather than risk wrong diagnostics.
+     *
+     * @param \ReflectionClass<Model> $reflection
+     */
+    public static function prepare(\ReflectionClass $reflection, Model $instance): void
+    {
+        // filterStringList() also fixes the value type: self-analysis does not load the plugin's own stubs, so
+        // class_uses_recursive() is typed `array` and its values would be mixed.
+        $conventional = [];
+        foreach (self::filterStringList(\class_uses_recursive($instance)) as $trait) {
+            $conventional['initialize' . \class_basename($trait)] = true;
+        }
+
+        $honorInitializeAttribute = \class_exists(Initialize::class);
+        // Root from Model's OWN file, never a hardcoded `/vendor/…` substring — survives custom vendor dirs,
+        // path-repo symlinks and split illuminate/* packages. Trailing '/' stops `Illuminate\DatabaseExtra`.
+        $eloquentRoot = \str_replace('\\', '/', \dirname((string) (new \ReflectionClass(Model::class))->getFileName(), 2));
+
+        $invoked = [];
+        foreach ($reflection->getMethods() as $method) {
+            $name = $method->getName();
+            // isset() first: getAttributes() is reached only for non-conventional methods.
+            $isInitializer = isset($conventional[$name])
+                || ($honorInitializeAttribute && $method->getAttributes(Initialize::class) !== []);
+            if (isset($invoked[$name]) || !$isInitializer) {
+                continue;
+            }
+
+            $invoked[$name] = true;
+            if (\str_starts_with(\str_replace('\\', '/', (string) $method->getFileName()), $eloquentRoot . '/')) {
+                self::applyConcernMirror($name, $reflection, $instance);
+            } else {
+                // Reflection, NOT $instance->{$name}(): a protected initializer called from outside routes to
+                // Model::__call() query-builder forwarding instead of running. Bare statement keeps the mixed
+                // return off the coverage tally.
+                $method->invoke($instance);
+            }
+        }
+
+        // initializeModelAttributes phase — always after initializeTraits at runtime.
+        self::applyConnectionAttribute($reflection, $instance);
+        self::applyTableAttribute($reflection, $instance);
+    }
+
+    /**
+     * Hand-written mirrors of the framework concerns: HasAttributes → `mergeAppends(#[Appends])` (its
+     * `casts()` merge is {@see ModelMetadataRegistryBuilder::computeCasts()}'s job, `dateFormat` isn't stored);
+     * HidesAttributes → `mergeHidden`/`mergeVisible`; GuardsAttributes → `mergeFillable(#[Fillable])` +
+     * `#[Guarded]`/`#[Unguarded]`; HasUniqueStringIds → `usesUniqueIds = true`. HasRelationships / SoftDeletes
+     * no-op — nothing they set is stored (SoftDeletes' `deleted_at` cast comes from computeCasts()).
+     *
+     * KNOWN GAP (#1276): HasTimestamps has no mirror, yet `usesTimestamps()` IS stored (via
+     * {@see ModelMetadataRegistryBuilder::computeTraitFlags()}), so a `#[WithoutTimestamps]` or
+     * `#[Table(timestamps:)]` model records `usesTimestamps = true` where runtime says false. The
+     * `$timestamps = false` property idiom is unaffected. Same deferred attribute-config family as the
+     * `#[Table]` PK sub-overrides below.
+     *
+     * @param \ReflectionClass<Model> $reflection
+     */
+    private static function applyConcernMirror(string $name, \ReflectionClass $reflection, Model $instance): void
+    {
+        if ($name === 'initializeHasUniqueStringIds') {
+            self::flipUsesUniqueIds($instance);
+        } elseif ($name === 'initializeHasAttributes') {
+            self::applyAppendsAttribute($reflection, $instance);
+        } elseif ($name === 'initializeHidesAttributes') {
+            self::applyHiddenVisibleAttributes($reflection, $instance);
+        } elseif ($name === 'initializeGuardsAttributes') {
+            self::applyFillableGuardedAttributes($reflection, $instance);
+        }
+    }
+
+    /**
+     * What HasUniqueStringIds' initializer does: makes `getKeyType()`/`getIncrementing()` return the
+     * string/non-incrementing values Laravel returns at runtime.
+     */
+    private static function flipUsesUniqueIds(Model $instance): void
+    {
+        $property = new \ReflectionProperty($instance, 'usesUniqueIds');
+        $property->setValue($instance, true);
+    }
+
+    /**
+     * `#[Appends]` is Laravel 13.0+; below it classAttribute() matches nothing and this no-ops — so
+     * `mergeAppends()`, absent on 12.14–12.24, is never called and cannot crash warm-up.
+     *
+     * @param \ReflectionClass<Model> $reflection
+     */
+    private static function applyAppendsAttribute(\ReflectionClass $reflection, Model $instance): void
+    {
+        $appends = self::classAttribute($reflection, Appends::class);
+        if ($appends !== null) {
+            $instance->mergeAppends($appends->columns);
+        }
+    }
+
+    /**
+     * Both attributes and helpers are Laravel-13.0; an absent attribute no-ops
+     * (see {@see self::applyAppendsAttribute()}).
+     *
+     * @param \ReflectionClass<Model> $reflection
+     */
+    private static function applyHiddenVisibleAttributes(\ReflectionClass $reflection, Model $instance): void
+    {
+        $hidden = self::classAttribute($reflection, Hidden::class);
+        if ($hidden !== null) {
+            $instance->mergeHidden($hidden->columns);
+        }
+
+        $visible = self::classAttribute($reflection, Visible::class);
+        if ($visible !== null) {
+            $instance->mergeVisible($visible->columns);
+        }
+    }
+
+    /**
+     * Known gap, applied by no mirror: `#[Table]`'s `key`/`keyType`/`incrementing` sub-overrides and
+     * `#[WithoutIncrementing]`, which `initializeModelAttributes()` feeds into the primary key.
+     * {@see ModelMetadataRegistryBuilder::computePrimaryKey()} reads only the raw getter defaults; the table
+     * NAME (the serialization-relevant part) IS applied by {@see self::applyTableAttribute()}.
+     *
+     * @param \ReflectionClass<Model> $reflection
+     */
+    private static function applyFillableGuardedAttributes(\ReflectionClass $reflection, Model $instance): void
+    {
+        $fillable = self::classAttribute($reflection, Fillable::class);
+        if ($fillable !== null) {
+            $instance->mergeFillable($fillable->columns);
+        }
+
+        self::applyGuardedAttribute($reflection, $instance);
+    }
+
+    /**
+     * `#[Guarded]`/`#[Unguarded]` only replace the default `['*']`, mirroring
+     * {@see \Illuminate\Database\Eloquent\Concerns\GuardsAttributes::initializeGuardsAttributes()}.
+     *
+     * The early-return matches runtime precisely because this mirror runs at initializeGuardsAttributes'
+     * position in the walk: a user initializer that ran earlier (per that PHP's order) and called guard()
+     * makes runtime skip `#[Guarded]` too.
+     *
+     * @param \ReflectionClass<Model> $reflection
+     */
+    private static function applyGuardedAttribute(\ReflectionClass $reflection, Model $instance): void
+    {
+        if ($instance->getGuarded() !== ['*']) {
+            return;
+        }
+
+        if (self::classAttribute($reflection, Unguarded::class) !== null) {
+            $instance->guard([]);
+
+            return;
+        }
+
+        // Presence, not non-emptiness, gates the replace: `#[Guarded()]` with no columns sets [], matching
+        // Laravel's `columns ?? ['*']`.
+        $guarded = self::classAttribute($reflection, Guarded::class);
+        if ($guarded !== null) {
+            $instance->guard($guarded->columns);
+        }
+    }
+
+    /**
+     * `#[Connection(name:)]` fills a null `$connection` (`??=`), normalized to string like
+     * `Model::getConnectionName()`'s `enum_value()`. Deliberately stronger than storing the raw enum: the
+     * registry's `connection` field is `?string`, and an int-backed enum would TypeError under strict_types,
+     * dropping the whole model via warmUp()'s catch.
+     *
+     * @param \ReflectionClass<Model> $reflection
+     */
+    private static function applyConnectionAttribute(\ReflectionClass $reflection, Model $instance): void
+    {
+        if ($instance->getConnectionName() !== null) {
+            return;
+        }
+
+        $name = self::classAttribute($reflection, Connection::class)?->name;
+        if ($name === null) {
+            return;
+        }
+
+        $instance->setConnection(match (true) {
+            \is_string($name) => $name,
+            $name instanceof \BackedEnum => (string) $name->value,
+            default => $name->name,
+        });
+    }
+
+    /**
+     * A `#[Table]` declared DIRECTLY on the concrete class (Laravel's non-recursive check) with no own
+     * `$table` overwrites the table; otherwise the ancestor-walked name only fills a still-null one (`??=`).
+     * Feeds {@see ModelMetadataRegistryBuilder::computeSchema()}'s migration lookup.
+     *
+     * Known gap: a `key`/`keyType`-only `#[Table]` (null name) does NOT clear an inherited `$table` the way
+     * Laravel's force-branch does. Same deferred scenario as {@see self::applyFillableGuardedAttributes()}'s
+     * PK sub-overrides, so left untouched rather than half-applied.
+     *
+     * @param \ReflectionClass<Model> $reflection
+     */
+    private static function applyTableAttribute(\ReflectionClass $reflection, Model $instance): void
+    {
+        $name = self::classAttribute($reflection, Table::class)?->name;
+        if ($name === null) {
+            return;
+        }
+
+        $forceSet = !self::declaresOwnProperty($reflection, 'table') && $reflection->getAttributes(Table::class) !== [];
+        if ($forceSet || self::rawTableIsNull($instance)) {
+            $instance->setTable($name);
+        }
+    }
+
+    /**
+     * Mirrors the `$declaresTable` check in `initializeModelAttributes()`.
+     *
+     * @param \ReflectionClass<Model> $reflection
+     * @psalm-pure
+     */
+    private static function declaresOwnProperty(\ReflectionClass $reflection, string $name): bool
+    {
+        if (!$reflection->hasProperty($name)) {
+            return false;
+        }
+
+        return $reflection->getProperty($name)->getDeclaringClass()->getName() === $reflection->getName();
+    }
+
+    /** Reads the raw property, not `getTable()`, which always derives a non-null name from the class. */
+    private static function rawTableIsNull(Model $instance): bool
+    {
+        try {
+            $property = new \ReflectionProperty($instance, 'table');
+        } catch (\ReflectionException) {
+            // Unreachable while Model declares `protected $table` (it does); defensive only.
+            return true;
+        }
+
+        // A typed-uninitialized `$table` (non-idiomatic) has no value to read; treat it as null and avoid the
+        // \Error getValue() throws on it.
+        if (!$property->isInitialized($instance)) {
+            return true;
+        }
+
+        // Consume the mixed value inline so it never binds to a local — keeps coverage at 100%.
+        return $property->getValue($instance) === null;
+    }
+
+    /**
+     * Mirrors {@see Model}::resolveClassAttribute(): first ancestor's first instance, no cross-ancestor merge.
+     *
+     * @template T of object
+     * @param \ReflectionClass<object> $reflection
+     * @param class-string<T>          $attributeClass
+     * @return T|null
+     */
+    private static function classAttribute(\ReflectionClass $reflection, string $attributeClass): ?object
+    {
+        for ($current = $reflection; $current !== false; $current = $current->getParentClass()) {
+            $attributes = $current->getAttributes($attributeClass);
+            if ($attributes === []) {
+                continue;
+            }
+
+            return $attributes[0]->newInstance();
+        }
+
+        return null;
+    }
+
+    /**
+     * Deliberate copy of {@see ModelMetadataRegistryBuilder}'s: its other sections still need theirs, and
+     * calling across would point this class back at the one that depends on it.
+     *
+     * @param array<array-key, mixed> $values
+     * @return list<non-empty-string>
+     * @psalm-pure
+     */
+    private static function filterStringList(array $values): array
+    {
+        /** @var list<non-empty-string> */
+        return \array_values(\array_filter(
+            $values,
+            static fn(mixed $entry): bool => \is_string($entry) && $entry !== '',
+        ));
+    }
+}

--- a/src/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php
+++ b/src/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php
@@ -4,15 +4,6 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Handlers\Eloquent\Metadata;
 
-use Illuminate\Database\Eloquent\Attributes\Appends;
-use Illuminate\Database\Eloquent\Attributes\Connection;
-use Illuminate\Database\Eloquent\Attributes\Fillable;
-use Illuminate\Database\Eloquent\Attributes\Guarded;
-use Illuminate\Database\Eloquent\Attributes\Hidden;
-use Illuminate\Database\Eloquent\Attributes\Initialize;
-use Illuminate\Database\Eloquent\Attributes\Table;
-use Illuminate\Database\Eloquent\Attributes\Unguarded;
-use Illuminate\Database\Eloquent\Attributes\Visible;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -318,15 +309,9 @@ final class ModelMetadataRegistryBuilder
     ): ModelMetadata {
         $baseTraits = self::computeTraitFlags($storage, true);
 
-        // Replay the model's initializers in the exact ReflectionClass::getMethods() order Laravel's
-        // bootTraits()/initializeTraits() uses (12.22+), interleaving the framework-concern MIRRORS
-        // (flipUsesUniqueIds + the #[...] appliers) at their real positions among the user initializers —
-        // because getMethods() ranks trait-flattened vs inherited methods DIFFERENTLY across PHP versions
-        // (8.5 puts a concrete class's own trait inits first; 8.4 puts Model's inherited concern inits first),
-        // and Laravel follows whatever the running PHP yields. Executing in that same walk makes the result
-        // match runtime under either order: e.g. a user setAppends() lands before mergeAppends(#[Appends]) on
-        // 8.5 (both survive) and after it on 8.4 (the replace wins), exactly as getAppends() does. The
-        // initializeModelAttributes phase (#[Connection]/#[Table]) runs last, after the walk.
+        // prepare() replays Model::__construct()'s initializer lifecycle on the constructor-less instance;
+        // see its docblock for the getMethods()-order walk. Without it the readers below observe unmerged
+        // casts/appends/fillable/hidden, an unflipped uniqueIds and an unresolved connection/table.
         //
         // One folded section: a mid-walk throw leaves the instance half-prepared, so all four instance-derived
         // sections below degrade together (the degradation test still maps 'trait initializers' → those four).
@@ -338,7 +323,7 @@ final class ModelMetadataRegistryBuilder
             $completeSections,
             $failures,
             static function () use ($reflection, $instance): bool {
-                self::replayInitializers($reflection, $instance);
+                ModelInstancePreparer::prepare($reflection, $instance);
 
                 return true;
             },
@@ -1385,7 +1370,7 @@ final class ModelMetadataRegistryBuilder
         // wins — which is what merging casts() last reproduces on every version. Making it version-aware needs
         // a pre-replay casts snapshot diffed here to re-apply user-merged keys after casts(); deferred as a
         // documented divergence — a rare same-key collision, on older supported releases, costing one cast
-        // type. See replayInitializers() for the getMethods()-order walk that motivates this.
+        // type. See ModelInstancePreparer::prepare() for the getMethods()-order walk that motivates this.
 
         $result = [];
         foreach ($merged as $columnName => $castString) {
@@ -1601,328 +1586,6 @@ final class ModelMetadataRegistryBuilder
         }
 
         return 'deleted_at';
-    }
-
-    /**
-     * Flip `$usesUniqueIds = true` on a HasUuids/HasUlids instance so `getKeyType()` and
-     * `getIncrementing()` return the string/non-incrementing values Laravel would return
-     * at runtime — work that the trait initializer normally handles.
-     */
-    private static function flipUsesUniqueIds(Model $instance): void
-    {
-        $property = new \ReflectionProperty($instance, 'usesUniqueIds');
-        $property->setValue($instance, true);
-    }
-
-    /**
-     * Replay the model's initializers on the constructor-less instance in {@see Model}::initializeTraits()
-     * order, so the section readers observe the runtime state `newInstanceWithoutConstructor()` skipped
-     * (merged casts / appends / fillable / hidden, flipped uniqueIds, resolved connection/table). Without it a
-     * cast a user trait merges is invisible to {@see computeCasts()}, so an `$appends` entry it backs looks
-     * unbacked and false-positives {@see \Psalm\LaravelPlugin\Handlers\Rules\UnresolvableAppendedModelAttributeHandler}.
-     *
-     * ONE walk over `ReflectionClass::getMethods()`, in that exact order — it is the order Laravel runs
-     * initializers (12.22+) AND it is PHP-version-dependent (8.4 ranks Model's inherited concern inits first,
-     * 8.5 the concrete class's own trait inits first), so we must execute in it to match runtime under either
-     * PHP. For each discovered initializer (conventional `initialize`.class_basename of a used trait, OR
-     * `#[Initialize]`-tagged — the attribute branch gated on `class_exists(Initialize::class)`, load-bearing
-     * below 12.22 where the framework ignores it; neither branch filters `isStatic`, matching bootTraits):
-     *  - a user / third-party initializer (source file NOT under the Illuminate\Database root) is invoked;
-     *  - a framework concern initializer runs its registry MIRROR at that position (or no-ops), so its ordering
-     *    against user initializers is automatically correct under either PHP order — a user setAppends() lands
-     *    before mergeAppends(#[Appends]) on 8.5 and after it on 8.4, exactly as getAppends() does.
-     * Concern initializers are discriminated by SOURCE FILE, not declaring class — a directly-`use`d concern
-     * (e.g. `use HasUuids`) flattens its initializer to report the user model as declarer, yet its file stays
-     * under the Illuminate\Database root (derived from Model's own file — install-independent; the trailing '/'
-     * stops a sibling like Illuminate\DatabaseExtra matching). `#[Connection]`/`#[Table]`
-     * (initializeModelAttributes) run last, after the walk, as at runtime.
-     *
-     * We re-derive the list here instead of calling `initializeTraits()` (reads `static::$traitInitializers`,
-     * populated only by `bootTraits()` during boot — booting registers global scopes, a Psalm hang, so it
-     * no-ops unbooted). `boot{Trait}()` hooks are never replayed for the same reason: an initializer that
-     * depends on boot-prepared state throws here even though runtime construction succeeds, degrading the model
-     * to partial metadata — a warned coverage loss that prevents potentially-incorrect diagnostics, the
-     * conservative trade.
-     *
-     * @param \ReflectionClass<Model> $reflection
-     */
-    private static function replayInitializers(\ReflectionClass $reflection, Model $instance): void
-    {
-        // Conventional initialize<Basename> names for every used trait, mirroring bootTraits().
-        // filterStringList() also fixes the value type: outside the plugin's own stubs (self-analysis does
-        // not load them) class_uses_recursive() is typed `array`, so its values would be mixed.
-        $conventional = [];
-        foreach (self::filterStringList(\class_uses_recursive($instance)) as $trait) {
-            $conventional['initialize' . \class_basename($trait)] = true;
-        }
-
-        $honorInitializeAttribute = \class_exists(Initialize::class);
-        // Framework concern initializers all live under Illuminate\Database; derive that root from Model's OWN
-        // file so the skip is install-layout-independent (custom vendor dirs, path-repo symlinks, split
-        // illuminate/* packages resolve consistently, unlike a hardcoded `/vendor/…` substring).
-        $eloquentRoot = \str_replace('\\', '/', \dirname((string) (new \ReflectionClass(Model::class))->getFileName(), 2));
-
-        $invoked = [];
-        foreach ($reflection->getMethods() as $method) {
-            $name = $method->getName();
-            // Discover as bootTraits() does — conventional name OR #[Initialize] — deduped by name;
-            // getAttributes() is reached only for non-conventional methods (short-circuit).
-            $isInitializer = isset($conventional[$name])
-                || ($honorInitializeAttribute && $method->getAttributes(Initialize::class) !== []);
-            if (isset($invoked[$name]) || !$isInitializer) {
-                continue;
-            }
-
-            $invoked[$name] = true;
-            if (\str_starts_with(\str_replace('\\', '/', (string) $method->getFileName()), $eloquentRoot . '/')) {
-                // Framework concern initializer: run its hand-written registry mirror at this position (the
-                // real one would double-apply what computeCasts()/the section readers already derive).
-                self::applyConcernMirror($name, $reflection, $instance);
-            } else {
-                // User / third-party initializer: invoke by reflection, NOT $instance->{$name}() — a
-                // protected/private initializer called from outside would route to Model::__call() query-builder
-                // forwarding instead of running (PHP 8.1 reflection invokes non-public methods, no setAccessible).
-                // Mixed return is a bare statement, so the file stays at 100% coverage.
-                $method->invoke($instance);
-            }
-        }
-
-        // initializeModelAttributes phase — always after initializeTraits at runtime.
-        self::applyConnectionAttribute($reflection, $instance);
-        self::applyTableAttribute($reflection, $instance);
-    }
-
-    /**
-     * Run the registry mirror for a framework concern initializer at its position in the
-     * {@see replayInitializers()} walk (verified 1:1 against vendor Eloquent\Concerns): HasAttributes →
-     * `mergeAppends(#[Appends])` (its `casts()` merge is {@see computeCasts()}'s job, `dateFormat` isn't
-     * stored); HidesAttributes → `mergeHidden`/`mergeVisible`; GuardsAttributes → `mergeFillable(#[Fillable])`
-     * + `#[Guarded]`/`#[Unguarded]`; HasUniqueStringIds → `usesUniqueIds = true`. HasTimestamps /
-     * HasRelationships / SoftDeletes have no registry-observable effect (timestamps/touches aren't stored;
-     * SoftDeletes' `deleted_at` cast is added by {@see computeCasts()}), so they no-op here.
-     *
-     * @param \ReflectionClass<Model> $reflection
-     */
-    private static function applyConcernMirror(string $name, \ReflectionClass $reflection, Model $instance): void
-    {
-        if ($name === 'initializeHasUniqueStringIds') {
-            self::flipUsesUniqueIds($instance);
-        } elseif ($name === 'initializeHasAttributes') {
-            self::applyAppendsAttribute($reflection, $instance);
-        } elseif ($name === 'initializeHidesAttributes') {
-            self::applyHiddenVisibleAttributes($reflection, $instance);
-        } elseif ($name === 'initializeGuardsAttributes') {
-            self::applyFillableGuardedAttributes($reflection, $instance);
-        }
-    }
-
-    /**
-     * Mirror of `initializeHasAttributes`' `mergeAppends(#[Appends])` (union-merge). The `#[Appends]` attribute
-     * exists from Laravel 13.0; below it `classAttribute()` matches nothing and this no-ops — so `mergeAppends()`,
-     * unavailable on 12.14–12.24, is never called with an empty fallback and cannot crash warm-up.
-     *
-     * @param \ReflectionClass<Model> $reflection
-     */
-    private static function applyAppendsAttribute(\ReflectionClass $reflection, Model $instance): void
-    {
-        $appends = self::classAttribute($reflection, Appends::class);
-        if ($appends !== null) {
-            $instance->mergeAppends($appends->columns);
-        }
-    }
-
-    /**
-     * Mirror of `initializeHidesAttributes`' `mergeHidden(#[Hidden])` + `mergeVisible(#[Visible])` (union-merge).
-     * Both attributes and helpers are Laravel-13.0; an absent attribute no-ops (see {@see applyAppendsAttribute()}).
-     *
-     * @param \ReflectionClass<Model> $reflection
-     */
-    private static function applyHiddenVisibleAttributes(\ReflectionClass $reflection, Model $instance): void
-    {
-        $hidden = self::classAttribute($reflection, Hidden::class);
-        if ($hidden !== null) {
-            $instance->mergeHidden($hidden->columns);
-        }
-
-        $visible = self::classAttribute($reflection, Visible::class);
-        if ($visible !== null) {
-            $instance->mergeVisible($visible->columns);
-        }
-    }
-
-    /**
-     * Mirror of `initializeGuardsAttributes`: `mergeFillable(#[Fillable])` then the `#[Guarded]`/`#[Unguarded]`
-     * replace-if-default. `mergeFillable()` exists on 12.14+, but an absent `#[Fillable]` still no-ops
-     * (see {@see applyAppendsAttribute()}).
-     *
-     * Known gap (NOT applied by any mirror): `#[Table]`'s `key` / `keyType` / `incrementing` sub-overrides and
-     * `#[WithoutIncrementing]`, which `initializeModelAttributes()` feeds into the primary key. {@see computePrimaryKey()}
-     * reads only the raw `getKeyName()`/`getKeyType()`/`getIncrementing()` defaults; the table NAME (the
-     * serialization-relevant part) IS applied by {@see applyTableAttribute()}.
-     *
-     * @param \ReflectionClass<Model> $reflection
-     */
-    private static function applyFillableGuardedAttributes(\ReflectionClass $reflection, Model $instance): void
-    {
-        $fillable = self::classAttribute($reflection, Fillable::class);
-        if ($fillable !== null) {
-            $instance->mergeFillable($fillable->columns);
-        }
-
-        self::applyGuardedAttribute($reflection, $instance);
-    }
-
-    /**
-     * `#[Guarded]` / `#[Unguarded]` only replace the default `['*']` denylist, mirroring
-     * {@see \Illuminate\Database\Eloquent\Concerns\GuardsAttributes::initializeGuardsAttributes()}:
-     * `#[Unguarded]` guards nothing; else the `#[Guarded]` columns (`columns ?? ['*']`, so a present-but-
-     * empty `#[Guarded]` also guards nothing); absent → keep `['*']`.
-     *
-     * The `getGuarded() !== ['*']` early-return matches runtime precisely because this mirror runs at
-     * initializeGuardsAttributes' position in the getMethods() walk: a user initializer that ran earlier
-     * (per that PHP's order) and set `$guarded` via `guard()` makes runtime's initializeGuardsAttributes skip
-     * `#[Guarded]` — and so do we.
-     *
-     * @param \ReflectionClass<Model> $reflection
-     */
-    private static function applyGuardedAttribute(\ReflectionClass $reflection, Model $instance): void
-    {
-        if ($instance->getGuarded() !== ['*']) {
-            return;
-        }
-
-        if (self::classAttribute($reflection, Unguarded::class) !== null) {
-            $instance->guard([]);
-
-            return;
-        }
-
-        // Presence (not non-empty) gates the replace: a present `#[Guarded()]` with no columns sets [],
-        // matching Laravel's `columns ?? ['*']` where an empty array is non-null. Absent → keep `['*']`.
-        $guarded = self::classAttribute($reflection, Guarded::class);
-        if ($guarded !== null) {
-            $instance->guard($guarded->columns);
-        }
-    }
-
-    /**
-     * `#[Connection(name:)]` fills a null `$connection`, mirroring `initializeModelAttributes()`'s `??=`.
-     * The name is normalized to a string before storing, matching `Model::getConnectionName()`'s
-     * `enum_value()` (BackedEnum → backing value, UnitEnum → case name). This is deliberately stronger
-     * than storing the raw enum: the registry's `connection` field is `?string`, and an int-backed enum
-     * would make `getConnectionName()` return an `int` that TypeErrors the `?string` parameter under
-     * `strict_types`, dropping the whole model via warmUp()'s catch.
-     *
-     * @param \ReflectionClass<Model> $reflection
-     */
-    private static function applyConnectionAttribute(\ReflectionClass $reflection, Model $instance): void
-    {
-        if ($instance->getConnectionName() !== null) {
-            return;
-        }
-
-        $name = self::classAttribute($reflection, Connection::class)?->name;
-        if ($name === null) {
-            return;
-        }
-
-        $instance->setConnection(match (true) {
-            \is_string($name) => $name,
-            $name instanceof \BackedEnum => (string) $name->value,
-            default => $name->name,
-        });
-    }
-
-    /**
-     * `#[Table(name:)]` sets the table, mirroring the `$declaresTable` branch of
-     * `initializeModelAttributes()`: a `#[Table]` declared DIRECTLY on the concrete class (Laravel's
-     * non-recursive `getAttributes()` check) AND no own `$table` property overwrites the table; otherwise
-     * the resolved (ancestor-walked) name only fills a still-null table (`??=`). Feeds
-     * {@see computeSchema()}'s migration lookup.
-     *
-     * Known-gap: a `key`/`keyType`-only `#[Table]` (null name) does NOT clear an inherited `$table`
-     * default the way Laravel's force-branch does (`$this->table = $table->name ?? null`). That sits
-     * inside the same exotic, deferred scenario as the `key`/`keyType`/`incrementing` PK sub-overrides
-     * (see {@see applyFillableGuardedAttributes()}), so it is left untouched rather than half-applied.
-     *
-     * @param \ReflectionClass<Model> $reflection
-     */
-    private static function applyTableAttribute(\ReflectionClass $reflection, Model $instance): void
-    {
-        $name = self::classAttribute($reflection, Table::class)?->name;
-        if ($name === null) {
-            return;
-        }
-
-        // Force-set only on a DIRECT concrete-class attribute (non-recursive, no own $table property);
-        // otherwise `??=` fills a still-null table with the resolved name.
-        $forceSet = !self::declaresOwnProperty($reflection, 'table') && $reflection->getAttributes(Table::class) !== [];
-        if ($forceSet || self::rawTableIsNull($instance)) {
-            $instance->setTable($name);
-        }
-    }
-
-    /**
-     * True when the concrete class itself declares `$name` (not inherited) — mirrors the `$declaresTable`
-     * check in `initializeModelAttributes()`.
-     *
-     * @param \ReflectionClass<Model> $reflection
-     * @psalm-pure
-     */
-    private static function declaresOwnProperty(\ReflectionClass $reflection, string $name): bool
-    {
-        if (!$reflection->hasProperty($name)) {
-            return false;
-        }
-
-        return $reflection->getProperty($name)->getDeclaringClass()->getName() === $reflection->getName();
-    }
-
-    /**
-     * Whether the raw `$table` property is still null (so a `#[Table]` may fill it). Reads the property,
-     * not `getTable()`, which always derives a non-null name from the class.
-     */
-    private static function rawTableIsNull(Model $instance): bool
-    {
-        try {
-            $property = new \ReflectionProperty($instance, 'table');
-        } catch (\ReflectionException) {
-            return true;
-        }
-
-        // A typed-uninitialized `$table` (non-idiomatic) has no value to read; treat it as null so a
-        // `#[Table]` may fill it, and avoid the \Error that getValue() throws on an uninitialized typed prop.
-        if (!$property->isInitialized($instance)) {
-            return true;
-        }
-
-        // Consume the mixed value inline (=== null) so it never binds to a local — keeps coverage at 100%.
-        return $property->getValue($instance) === null;
-    }
-
-    /**
-     * Resolve a class-level attribute the way {@see Model}::resolveClassAttribute() does: walk the class
-     * up its parents, return the first ancestor's first instance of `$attributeClass` (no cross-ancestor
-     * merge), or null. A throwing `newInstance()` reaches the runtime-configuration boundary, which
-     * preserves independent sections and records the failure once for the model.
-     *
-     * @template T of object
-     * @param \ReflectionClass<object> $reflection
-     * @param class-string<T>          $attributeClass
-     * @return T|null
-     */
-    private static function classAttribute(\ReflectionClass $reflection, string $attributeClass): ?object
-    {
-        for ($current = $reflection; $current !== false; $current = $current->getParentClass()) {
-            $attributes = $current->getAttributes($attributeClass);
-            if ($attributes === []) {
-                continue;
-            }
-
-            return $attributes[0]->newInstance();
-        }
-
-        return null;
     }
 
     /**

--- a/tests/Application/app/Models/AttributeSerializableModel.php
+++ b/tests/Application/app/Models/AttributeSerializableModel.php
@@ -13,7 +13,7 @@ use Illuminate\Database\Eloquent\Model;
  * Serialization archetype driven by Laravel 13.0+ PHP class attributes (`#[Appends]` / `#[Hidden]`)
  * instead of `$properties`. The harness runs no migrations, so the shape comes entirely from the
  * appended, accessor-backed attributes — letting AttributeConfigShapeTest.phpt assert end-to-end that
- * `replayInitializers()` feeds the serialized shape (and that `#[Hidden]` drops an appended key).
+ * `ModelInstancePreparer::prepare()` feeds the serialized shape (and that `#[Hidden]` drops an appended key).
  *
  * Modern protected `Attribute` accessors keep the legacy public-accessor lint (`PublicModelAccessor`)
  * quiet. The `#[*]` classes only exist from Laravel 13.0, so the phpt is SKIPIF-gated below that line.

--- a/tests/Type/tests/Model/AttributeConfigShapeTest.phpt
+++ b/tests/Type/tests/Model/AttributeConfigShapeTest.phpt
@@ -17,7 +17,7 @@ use App\Models\AttributeSerializableModel;
  * #[Appends]/#[Hidden] PHP-attribute config feeds the serialized shape end-to-end.
  *
  * newInstanceWithoutConstructor() skips Laravel's initializers, so the registry replays the attribute
- * config at warm-up (replayInitializers). The harness runs no migrations, so the shape comes
+ * config at warm-up (ModelInstancePreparer::prepare()). The harness runs no migrations, so the shape comes
  * entirely from #[Appends]: `full_name` (accessor-backed) is present, while `secret_token` is appended
  * but dropped by #[Hidden]. Without the fix getAppends() would miss #[Appends] and the shape would
  * collapse to the loose array<string, mixed> stub.

--- a/tests/Unit/Fixtures/Models/AppendsOrderModel.php
+++ b/tests/Unit/Fixtures/Models/AppendsOrderModel.php
@@ -15,7 +15,7 @@ use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Concerns\SetsAppendInInitializer;
  *
  * The `#[Appends]` attribute exists from Laravel 13.0, so the consuming test is gated on `class_exists()`.
  *
- * @internal fixture used by ModelMetadataRegistryTest
+ * @internal fixture used by ModelMetadataRegistryTest and ModelInstancePreparerTest
  */
 #[Appends('attribute_append')]
 final class AppendsOrderModel extends Model

--- a/tests/Unit/Fixtures/Models/AttributeConfiguredModel.php
+++ b/tests/Unit/Fixtures/Models/AttributeConfiguredModel.php
@@ -16,7 +16,7 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Twin of {@see ScalarFieldsModel} that drives the same lists through Laravel 13.0+ PHP class
  * attributes instead of `$properties`, exercising
- * {@see \Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadataRegistryBuilder}::replayInitializers().
+ * {@see \Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelInstancePreparer}::prepare().
  *
  * The baseline `$property` declarations on the union lists (`$hidden` / `$visible` / `$appends` /
  * `$fillable`) prove the attribute columns are MERGED in, not replaced; `$guarded` is left at the base

--- a/tests/Unit/Fixtures/Models/CustomDeletedAtModel.php
+++ b/tests/Unit/Fixtures/Models/CustomDeletedAtModel.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * `ModelMetadataRegistryBuilder::resolveDeletedAtColumn()` — the registry must
  * key the auto-added datetime cast off `archived_at`, not the default `deleted_at`.
  *
- * @internal fixture used by ModelMetadataRegistryTest
+ * @internal fixture used by ModelMetadataRegistryTest and ModelInstancePreparerTest
  */
 final class CustomDeletedAtModel extends Model
 {

--- a/tests/Unit/Fixtures/Models/SectionFailureModel.php
+++ b/tests/Unit/Fixtures/Models/SectionFailureModel.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Casts\InboundOnlyCast;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Concerns\FailsTraitInitializer;
 
-/** @internal fixture used by ModelMetadataRegistryTest */
+/** @internal fixture used by ModelMetadataRegistryTest and ModelInstancePreparerTest */
 final class SectionFailureModel extends Model
 {
     use FailsTraitInitializer;

--- a/tests/Unit/Fixtures/Models/TraitInitializedConfigModel.php
+++ b/tests/Unit/Fixtures/Models/TraitInitializedConfigModel.php
@@ -9,13 +9,13 @@ use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Concerns\MergesTraitConfig;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Concerns\SeedsCastViaAttribute;
 
 /**
- * Drives {@see \Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadataRegistryBuilder}'s
+ * Drives {@see \Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelInstancePreparer}'s
  * trait-initializer replay across BOTH discovery branches: MergesTraitConfig merges the `meta` class cast
  * and `trait_fillable` via a conventionally-named initializer, while SeedsCastViaAttribute merges the
  * `via_attr` class cast via a `#[Initialize]`-tagged, non-conventionally-named one. A constructor-less
  * warm-up skips both unless replayed. The class-level `$fillable` proves the trait merge unions, not clobbers.
  *
- * @internal fixture used by ModelMetadataRegistryTest
+ * @internal fixture used by ModelMetadataRegistryTest and ModelInstancePreparerTest
  */
 final class TraitInitializedConfigModel extends Model
 {

--- a/tests/Unit/Providers/ModelMetadata/ModelInstancePreparerTest.php
+++ b/tests/Unit/Providers/ModelMetadata/ModelInstancePreparerTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Providers\ModelMetadata;
+
+use Illuminate\Database\Eloquent\Attributes\Appends;
+use Illuminate\Database\Eloquent\Attributes\Initialize;
+use Illuminate\Database\Eloquent\Casts\AsArrayObject;
+use Illuminate\Database\Eloquent\Casts\AsCollection;
+use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelInstancePreparer;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\AppendsOrderModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\CustomDeletedAtModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\SectionFailureModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\TraitInitializedConfigModel;
+
+/**
+ * Drives the replay directly — no registry, no Codebase — which is what the Psalm-free boundary buys.
+ * {@see ModelMetadataRegistryTest} covers the same behaviour end-to-end through warm-up.
+ *
+ * @internal
+ */
+#[CoversClass(ModelInstancePreparer::class)]
+final class ModelInstancePreparerTest extends TestCase
+{
+    #[\Override]
+    protected function setUp(): void
+    {
+        SectionFailureModel::$failures = [];
+    }
+
+    // Also on the way out: the switch is a public static, so a consumer not defending itself would inherit it.
+    #[\Override]
+    protected function tearDown(): void
+    {
+        SectionFailureModel::$failures = [];
+    }
+
+    #[Test]
+    public function user_trait_initializer_is_invoked_on_the_constructor_less_instance(): void
+    {
+        // initializeMergesTraitConfig() is protected: only the reflection invoke reaches it, since
+        // $instance->{$name}() from outside routes to Model::__call() query-builder forwarding.
+        $instance = $this->prepare(TraitInitializedConfigModel::class);
+
+        // Key, not whole map: getCasts() also merges [getKeyName() => getKeyType()].
+        $this->assertSame(AsArrayObject::class, $instance->getCasts()['meta'] ?? null);
+        // Union-merge, not clobber.
+        $this->assertSame(['class_fillable', 'trait_fillable'], $instance->getFillable());
+    }
+
+    #[Test]
+    public function attribute_tagged_trait_initializer_is_invoked(): void
+    {
+        // #[Initialize] and the bootTraits branch reading it arrive in Laravel 12.22; below that the framework
+        // ignores the tag and the replay stays convention-only, so `via_attr` is legitimately absent.
+        if (!\class_exists(Initialize::class)) {
+            self::markTestSkipped('The #[Initialize] attribute discovery branch requires Laravel >= 12.22.');
+        }
+
+        // seedViaAttribute() is non-conventionally named: only the attribute-discovery branch reaches it.
+        $this->assertSame(
+            AsCollection::class,
+            $this->prepare(TraitInitializedConfigModel::class)->getCasts()['via_attr'] ?? null,
+        );
+    }
+
+    #[Test]
+    public function framework_concern_initializer_runs_its_mirror_at_the_right_position(): void
+    {
+        if (!\class_exists(Appends::class)) {
+            self::markTestSkipped('Eloquent PHP class attributes require Laravel >= 13.0.');
+        }
+
+        // Runtime construction as oracle, never a literal: getMethods() ranks the user setAppends(['trait_only'])
+        // against the framework mergeAppends(#[Appends]) differently per PHP (both survive on 8.5, the replace
+        // wins on 8.4), so a literal would pin one PHP line.
+        $this->assertSame(
+            (new AppendsOrderModel())->getAppends(),
+            $this->prepare(AppendsOrderModel::class)->getAppends(),
+        );
+    }
+
+    #[Test]
+    public function framework_concern_initializer_is_mirrored_not_invoked(): void
+    {
+        // Real initializeSoftDeletes() writes $casts[getDeletedAtColumn()]; the mirror no-ops and leaves that
+        // cast to computeCasts(). So invoking framework initializers instead of mirroring leaves it behind.
+        $casts = new \ReflectionProperty(Model::class, 'casts');
+
+        // Pin that Laravel still writes the cast; otherwise [] would not distinguish mirroring from invoking.
+        $this->assertSame(['archived_at' => 'datetime'], $casts->getValue(new CustomDeletedAtModel()));
+        $this->assertSame([], $casts->getValue($this->prepare(CustomDeletedAtModel::class)));
+    }
+
+    #[Test]
+    public function throwing_initializer_propagates_to_the_caller(): void
+    {
+        // prepare() lets the throw out; the builder's section guard decides what a half-prepared instance backs.
+        SectionFailureModel::$failures['trait initializers'] = true;
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('deliberate trait initializers failure');
+
+        $this->prepare(SectionFailureModel::class);
+    }
+
+    /** @param class-string<Model> $modelFqcn */
+    private function prepare(string $modelFqcn): Model
+    {
+        $reflection = new \ReflectionClass($modelFqcn);
+        $instance = $reflection->newInstanceWithoutConstructor();
+        ModelInstancePreparer::prepare($reflection, $instance);
+
+        return $instance;
+    }
+}

--- a/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
+++ b/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
@@ -239,7 +239,7 @@ final class ModelMetadataRegistryTest extends TestCase
     public function class_attributes_are_merged_at_warm_up(): void
     {
         // newInstanceWithoutConstructor() skips initializeTraits()/initializeModelAttributes(), so the
-        // PHP-attribute config is missed unless replayInitializers() mirrors it. The #[*] classes
+        // PHP-attribute config is missed unless ModelInstancePreparer::prepare() mirrors it. The #[*] classes
         // only exist from Laravel 13.0, below which this fixture is never loaded.
         if (!class_exists(Hidden::class)) {
             self::markTestSkipped('Eloquent PHP class attributes require Laravel >= 13.0.');
@@ -915,7 +915,7 @@ final class ModelMetadataRegistryTest extends TestCase
         $this->assertTrue($metadata->traits->hasUlids);
         $this->assertSame(PrimaryKeyType::String, $metadata->primaryKey->type);
         $this->assertFalse($metadata->primaryKey->incrementing);
-        // Same bogus-cast guard as the HasUuids test: flipUsesUniqueIds keeps
+        // Same bogus-cast guard as the HasUuids test: the preparer's uniqueIds flip keeps
         // getCasts() from injecting [id => 'int'] on ULID models too.
         $this->assertArrayNotHasKey('id', $metadata->casts());
     }


### PR DESCRIPTION
## Why

`ModelMetadataRegistryBuilder` had grown to ~1970 lines holding two unrelated domains:

1. **Instance preparation.** Mirroring Laravel's `Model::__construct` lifecycle on a `newInstanceWithoutConstructor()` throwaway: trait-initializer discovery and replay, framework-concern mirrors, PHP-attribute config. About 320 lines, one entry point, zero Psalm dependencies.
2. **Section computation.** Building `ModelMetadata` sections (methods, relations, schema, casts, primary key) from Psalm storage plus the prepared instance.

Domain 1 is where the fragile knowledge lives (bootTraits discovery branches, the Laravel 12.22 boundary, PHP-8.4-vs-8.5 `getMethods()` ordering, framework-vs-user source-file discrimination) and it is where the recent churn landed: all three review-iteration commits on #1273 confined their changes to it. Extracted, it becomes directly unit-testable without warming a registry (the new test runs in ~0.02s against ~4s through warm-up), and the Psalm-free boundary is now enforced by the class rather than by convention.

Precedent: `CustomTypeDetector` and `CastsMethodParser` already carve specialist logic out of the builder the same way. `ModelInstancePreparer` matches `CustomTypeDetector` exactly: `final`, all-static, `@internal`, same namespace, and plainly autoloaded. It gets no `require_once` in `Plugin.php` because it is neither a handler nor an issue class, and `Plugin.php` never references it; ordinary static calls resolve through Composer's autoloader, which is already load-bearing for 80 files under `src/` (22 in `Metadata/` alone, including the `ModelMetadata` every warm-up constructs).

## What moved

Into `src/Handlers/Eloquent/Metadata/ModelInstancePreparer.php`:

- `replayInitializers()` becomes the sole public entry point, `prepare()`. It already ran the post-walk `#[Connection]`/`#[Table]` phase internally, so the single call site moved intact.
- `applyConcernMirror()`, `applyAppendsAttribute()`, `applyHiddenVisibleAttributes()`, `applyFillableGuardedAttributes()`, `applyGuardedAttribute()`, `applyConnectionAttribute()`, `applyTableAttribute()`, `flipUsesUniqueIds()` (all private).
- `classAttribute()`, `declaresOwnProperty()`, `rawTableIsNull()` (all private, see below).

The `computeSection` guard, `$failures` recording, section-bit gating and the warning path all stay in the builder. The preparer knows nothing about Psalm, sections, or `computeSection`; a throwing initializer propagates and the caller decides what a half-prepared instance still backs.

## Dependency decisions

- **`classAttribute()`** had zero builder call sites outside the moved cluster, so it moves wholesale and stays `private`. No `@internal` public surface was needed.
- **`declaresOwnProperty()` / `rawTableIsNull()`** have exactly one caller each (`applyTableAttribute()`), so they moved with it.
- **`filterStringList()`** stays in the builder, which still needs it in 8 call sites across other sections. The preparer keeps a private copy (8 lines, pure leaf utility) rather than calling across: the builder already depends on the preparer, so a call in the other direction would make the pair mutually dependent and defeat the extraction. The duplication carries a one-line comment.
- **`asNonEmptyString()`** is not used by the moved cluster and was left untouched.

## What deliberately did not change

- **Behaviour.** Every moved method body is token-identical to its original on `master` (verified mechanically by comparing PHP token streams with comments and whitespace stripped). The interleaved walk semantics survive intact: PHP-version-dependent `getMethods()` order, the 12.22 `class_exists(Initialize::class)` gate, source-file framework discrimination with the trailing slash, the dedupe map, and `ReflectionMethod::invoke` never dynamic dispatch.
- **Tests.** No existing test expectation changed. The only edits to existing tests are comment and `{@see}` repointing. The appends-order runtime oracle is untouched.
## Comments were rewritten, not moved

The one thing this PR does change beyond relocation. The moved docblocks were condensed (182 to 134 comment lines in the new class, 31 to 23 in the test), keeping every non-obvious fact and cutting prose, restatement, and illustrative examples. What survives, deliberately: the PHP-8.4-vs-8.5 `getMethods()` ordering, the source-file-not-declaring-class discrimination and its trailing-slash guard, the 12.22 `#[Initialize]` gate, the boot-hang rationale for re-deriving instead of calling `initializeTraits()`, the reflection-not-dynamic-call trap, every KNOWN GAP, and the 100%-coverage shapes.

Condensing the comments meant re-reading each claim, which turned up a false one: `applyConcernMirror()`'s docblock said the mirrors were "verified 1:1" and that HasTimestamps could no-op because "nothing they set is stored". `usesTimestamps()` is in fact stored, via `computeTraitFlags()`, and Laravel's `initializeHasTimestamps()` applies `#[WithoutTimestamps]`/`#[Table(timestamps:)]` — which no mirror reproduces, so such a model records `usesTimestamps = true` where runtime says `false`. That is a pre-existing gap, filed as #1276 and now documented as a KNOWN GAP instead of denied.

Four edits are worth checking individually:

1. `computeForInstance()` carried a nine-line paragraph restating walk mechanics that now live in `prepare()`'s docblock. Replaced by a pointer; the following paragraph (the "one folded section" degradation rationale, genuinely the builder's business) is byte-identical. Restating another file's fragile mechanics is rot waiting to happen.
2. A clause was deleted from `classAttribute()`'s docblock claiming a throwing `newInstance()` "reaches the runtime-configuration boundary". It never did: that failure has only ever landed in the section wrapping the replay, and the class docblock states the contract correctly. Relabelling would have named a caller section inside a class that knows nothing about sections.
3. `rawTableIsNull()`'s `catch (\ReflectionException)` gained a comment. It is unreachable while `Model` declares `protected $table` (it does), and it is now the only catch in a class whose docblock says failure handling belongs to the caller, so an unexplained swallow read like a contradiction.
4. `prepare()`'s docblock no longer says a failing initializer "degrades the model to warned partial metadata". `prepare()` does neither: the builder's guard does. It now states only that preparation may fail where runtime construction would succeed, which is the fact worth keeping.

## Tests

New: `tests/Unit/Providers/ModelMetadata/ModelInstancePreparerTest.php` (5 tests), driving `prepare()` directly with no registry or `Codebase`, which is what the Psalm-free boundary buys: it runs in ~0.02s where the equivalent warm-up path takes ~4s. It reuses existing fixtures only, and covers a conventionally-named user trait initializer running through the reflection path, an `#[Initialize]`-tagged one (gated on Laravel 12.22), a framework concern being mirrored rather than invoked, the mirror landing at the correct position in the walk (runtime-constructed-model oracle), and a throwing initializer propagating to the caller.

Each assertion was mutation-checked: replacing the framework mirror with a real `$method->invoke()`, swapping the reflection invoke for `$instance->{$name}()`, and deleting the post-walk `#[Connection]`/`#[Table]` phase each turn a test red.

The mirrored-not-invoked test leans on SoftDeletes, whose real `initializeSoftDeletes()` writes `$casts[getDeletedAtColumn()]` while our mirror deliberately no-ops and leaves that cast to `computeCasts()`. Since an empty `$casts` is also the untouched default, that assertion is preceded by a premise-pinning check against a runtime-constructed model, so the test fails loudly rather than going quietly green if Laravel ever stops writing the cast.

## Verification

`composer test:unit` (1049 tests), `composer test:type` (582 tests), `composer test:app`, `composer rector`, `composer cs` all green. Raw `composer psalm` reports 0 errors at 100% type coverage (the only info-level issues are two pre-existing `ClassMustBeFinal` in `src/Cli/Diagnose/`, untouched here). The registry and preparer tests were additionally run under both PHP 8.4 (CI's Unit job) and PHP 8.5 (dev), since the walk is reflection-order-sensitive, and the `#[Initialize]` gate was checked by forcing it false to simulate the `laravel_12_14_floor` job.

The pure-move claim is machine-checked rather than asserted: comparing PHP token streams (comments and whitespace stripped) shows all 13 moved bodies identical to `master`, and `computeForInstance()` differing in exactly two token positions (`self` to `ModelInstancePreparer`, `replayInitializers` to `prepare`) at an unchanged token count.

A pure move cannot shift psalm-delta results, so no delta run was performed.

## Follow-up, deliberately not in this PR

`AppendsOrderModel`'s docblock says runtime `getAppends()` returns both entries, which holds on PHP 8.5 but not on 8.4, where the replace wins. Pre-existing on `master` (whose registry test already carries the correcting note), so it is left untouched here rather than folded into a behaviour-preserving move.

Context: #1273 (the churn this separates out). Issue #1274's planned `composeCasts` work is deliberately not included: it is a behaviour change on the Laravel 12.14-12.21 boundary and would cost this PR its zero-test-change property. Its step 1 (snapshotting raw `$casts` before the replay to isolate user-merged keys) does gain a natural home on this seam.
