### PR TITLE
Mirror `Model::initializeHasTimestamps` at model warm-up

### DIFF
--- a/src/Handlers/Eloquent/Metadata/ModelInstancePreparer.php
+++ b/src/Handlers/Eloquent/Metadata/ModelInstancePreparer.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Attributes\Initialize;
 use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Attributes\Unguarded;
 use Illuminate\Database\Eloquent\Attributes\Visible;
+use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -93,14 +94,12 @@ final class ModelInstancePreparer
      * Hand-written mirrors of the framework concerns: HasAttributes → `mergeAppends(#[Appends])` (its
      * `casts()` merge is {@see ModelMetadataRegistryBuilder::computeCasts()}'s job, `dateFormat` isn't stored);
      * HidesAttributes → `mergeHidden`/`mergeVisible`; GuardsAttributes → `mergeFillable(#[Fillable])` +
-     * `#[Guarded]`/`#[Unguarded]`; HasUniqueStringIds → `usesUniqueIds = true`. HasRelationships / SoftDeletes
-     * no-op — nothing they set is stored (SoftDeletes' `deleted_at` cast comes from computeCasts()).
+     * `#[Guarded]`/`#[Unguarded]`; HasUniqueStringIds → `usesUniqueIds = true`; HasTimestamps →
+     * `#[WithoutTimestamps]`/`#[Table(timestamps:)]`. HasRelationships / SoftDeletes no-op — nothing they
+     * set is stored (SoftDeletes' `deleted_at` cast comes from computeCasts()).
      *
-     * KNOWN GAP (#1276): HasTimestamps has no mirror, yet `usesTimestamps()` IS stored (via
-     * {@see ModelMetadataRegistryBuilder::computeTraitFlags()}), so a `#[WithoutTimestamps]` or
-     * `#[Table(timestamps:)]` model records `usesTimestamps = true` where runtime says false. The
-     * `$timestamps = false` property idiom is unaffected. Same deferred attribute-config family as the
-     * `#[Table]` PK sub-overrides below.
+     * Audited against every `initialize*` under vendor `Illuminate\Database\` — the walk's skip root, and
+     * wider than `Eloquent\Concerns`, since SoftDeletes and Model itself sit outside it.
      *
      * @param \ReflectionClass<Model> $reflection
      */
@@ -114,6 +113,8 @@ final class ModelInstancePreparer
             self::applyHiddenVisibleAttributes($reflection, $instance);
         } elseif ($name === 'initializeGuardsAttributes') {
             self::applyFillableGuardedAttributes($reflection, $instance);
+        } elseif ($name === 'initializeHasTimestamps') {
+            self::applyTimestampsAttributes($reflection, $instance);
         }
     }
 
@@ -205,6 +206,44 @@ final class ModelInstancePreparer
         $guarded = self::classAttribute($reflection, Guarded::class);
         if ($guarded !== null) {
             $instance->guard($guarded->columns);
+        }
+    }
+
+    /**
+     * Mirror of `initializeHasTimestamps`, precedence included. Feeds `TraitFlags::$usesTimestamps` through
+     * {@see ModelMetadataRegistryBuilder::readRuntimeConfiguration()}'s `usesTimestamps()` read. #1276.
+     *
+     * The `!== true` early-return is Laravel's own `=== true` guard: an attribute only speaks while
+     * `$timestamps` is still `true`. Both ways of closing it are live — a declared `$timestamps = false` is a
+     * property default `newInstanceWithoutConstructor()` applies, and a user initializer that ran earlier in
+     * the walk has already written it (same position-dependence as {@see applyGuardedAttribute()}).
+     *
+     * No `class_exists` gate. `initializeHasTimestamps()` is 13.0+, so the 12.x floor never reaches this.
+     * Above it, `#[WithoutTimestamps]` (13.2) is newer than the initializer that dispatches here, and package
+     * atomicity does NOT close that window — 13.1 ships the initializer without the attribute in one artifact.
+     * Composer's `require` on `illuminate/database: ^12.14 || ^13.3` is what closes it; the
+     * `laravel/framework` entry is dev-only and binds nothing a user installs. Widening that floor is
+     * survivable rather than fatal, but check here first: {@see classAttribute()} name-matches an attribute
+     * whose class is absent and throws on `newInstance()`. Only a model naming a class its own framework
+     * lacks gets there — code Laravel fatals on too, since `Error` escapes its `catch (Exception)`.
+     *
+     * @param \ReflectionClass<Model> $reflection
+     */
+    private static function applyTimestampsAttributes(\ReflectionClass $reflection, Model $instance): void
+    {
+        if ($instance->timestamps !== true) {
+            return;
+        }
+
+        if (self::classAttribute($reflection, WithoutTimestamps::class) !== null) {
+            $instance->timestamps = false;
+
+            return;
+        }
+
+        $table = self::classAttribute($reflection, Table::class);
+        if ($table !== null && $table->timestamps !== null) {
+            $instance->timestamps = $table->timestamps;
         }
     }
 

--- a/tests/Unit/Fixtures/Concerns/EnablesTimestampsInInitializer.php
+++ b/tests/Unit/Fixtures/Concerns/EnablesTimestampsInInitializer.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Concerns;
+
+/**
+ * User trait initializer that re-enables timestamps. Paired with a declared `$timestamps = false` and
+ * `#[WithoutTimestamps]` in {@see \Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\TimestampsInitializerOrderModel},
+ * this makes the outcome depend on WHERE the mirror runs in the walk, which is the only way to observe
+ * that ordering: whether `initializeHasTimestamps()` sees `false` (and returns) or `true` (and applies
+ * `#[WithoutTimestamps]`) is decided by whether this initializer ran first.
+ *
+ * @psalm-require-extends \Illuminate\Database\Eloquent\Model
+ */
+trait EnablesTimestampsInInitializer
+{
+    public function initializeEnablesTimestampsInInitializer(): void
+    {
+        $this->timestamps = true;
+    }
+}

--- a/tests/Unit/Fixtures/Models/AttributeConfiguredModel.php
+++ b/tests/Unit/Fixtures/Models/AttributeConfiguredModel.php
@@ -25,6 +25,10 @@ use Illuminate\Database\Eloquent\Model;
  * The `#[*]` classes only exist from Laravel 13.0, so the consuming test is gated on
  * `class_exists()`; below that floor this file is never loaded.
  *
+ * Do NOT add a `timestamps:` argument to the `#[Table]` below: its absence is the point of the
+ * timestamps case that reuses this model ({@see TableTimestampsEnabledModel} covers the present-argument
+ * side). Adding one fails that case as a Laravel drift, which would misdiagnose it.
+ *
  * @internal fixture used by ModelMetadataRegistryTest
  */
 #[Hidden('attr_hidden')]

--- a/tests/Unit/Fixtures/Models/AttributeOverriddenByPropertyModel.php
+++ b/tests/Unit/Fixtures/Models/AttributeOverriddenByPropertyModel.php
@@ -11,14 +11,16 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * An explicit `$property` declaration wins over the matching `#[Attribute]`, mirroring Laravel's
  * "replace only the default" / `$declaresTable` guards: `#[Guarded]` is ignored because `$guarded` is
- * no longer `['*']`, and `#[Table]` does not override an own `$table` property. Guards the
- * `applyGuardedAttribute()` early-return and `applyTableAttribute()` directness branch. Laravel 13.0+
- * only; the consuming test is gated on `class_exists()`.
+ * no longer `['*']`, `#[Table]` does not override an own `$table` property, and `#[Table(timestamps: true)]`
+ * is ignored because `$timestamps` is no longer `true`. Guards the `applyGuardedAttribute()` early-return,
+ * the `applyTableAttribute()` directness branch and the `applyTimestampsAttributes()` `!== true` return.
+ * Laravel 13.0+ only; both consuming tests are gated on `class_exists()` (the guard/table one on
+ * `#[Hidden]`, the timestamps one on the 13.2 `#[WithoutTimestamps]`).
  *
  * @internal fixture used by ModelMetadataRegistryTest
  */
 #[Guarded('attr_guard')]
-#[Table('attr_table')]
+#[Table('attr_table', timestamps: true)]
 final class AttributeOverriddenByPropertyModel extends Model
 {
     /** @var list<string> */
@@ -26,4 +28,7 @@ final class AttributeOverriddenByPropertyModel extends Model
 
     /** @var string */
     protected $table = 'own_table';
+
+    /** @var bool */
+    public $timestamps = false;
 }

--- a/tests/Unit/Fixtures/Models/TableTimestampsAttributeModel.php
+++ b/tests/Unit/Fixtures/Models/TableTimestampsAttributeModel.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * `#[Table(timestamps: false)]`, the second form `initializeHasTimestamps()` honours. Paired with
+ * {@see AttributeConfiguredModel}, whose `#[Table]` carries no `timestamps:` argument and must stay
+ * timestamped: together they pin that the mirror reads the argument rather than the attribute's presence.
+ *
+ * Uses only `#[Table]` (Laravel 13.0+), but its consuming test shares a 13.2 `#[WithoutTimestamps]`
+ * gate with the rest of the timestamps cases.
+ *
+ * @internal fixture used by ModelMetadataRegistryTest
+ */
+#[Table(name: 'table_timestamps_models', timestamps: false)]
+final class TableTimestampsAttributeModel extends Model {}

--- a/tests/Unit/Fixtures/Models/TableTimestampsEnabledModel.php
+++ b/tests/Unit/Fixtures/Models/TableTimestampsEnabledModel.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * `#[Table(timestamps: true)]` on an otherwise-default model: the only fixture that reaches the mirror's
+ * `$timestamps = $table->timestamps` assignment with `true` on the right-hand side. Every other
+ * `timestamps: true` fixture short-circuits before it — {@see TimestampsAttributePrecedenceModel} on
+ * `#[WithoutTimestamps]`, {@see AttributeOverriddenByPropertyModel} on the `!== true` guard.
+ *
+ * Without this, hard-coding the assignment to `false` passes the whole suite while inverting #1276:
+ * a `timestamps: true` model would record false where runtime says true.
+ *
+ * Laravel 13.0+ only; the consuming test shares the 13.2 `#[WithoutTimestamps]` gate.
+ *
+ * @internal fixture used by ModelMetadataRegistryTest
+ */
+#[Table(name: 'table_timestamps_enabled_models', timestamps: true)]
+final class TableTimestampsEnabledModel extends Model {}

--- a/tests/Unit/Fixtures/Models/TimestampsAttributeInheritedBase.php
+++ b/tests/Unit/Fixtures/Models/TimestampsAttributeInheritedBase.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Abstract base carrying `#[WithoutTimestamps]` so {@see TimestampsAttributeInheritedModel} can prove the
+ * mirror resolves it through `classAttribute()`'s ancestor walk. Kept separate from
+ * {@see AttributeConfiguredBase}, whose consuming test gates on the 13.0 `#[Hidden]`: a 13.2 attribute
+ * there would outrank its gate.
+ *
+ * @internal fixture used by ModelMetadataRegistryTest
+ */
+#[WithoutTimestamps]
+abstract class TimestampsAttributeInheritedBase extends Model {}

--- a/tests/Unit/Fixtures/Models/TimestampsAttributeInheritedModel.php
+++ b/tests/Unit/Fixtures/Models/TimestampsAttributeInheritedModel.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Table;
+
+/**
+ * Inherits `#[WithoutTimestamps]` from {@see TimestampsAttributeInheritedBase} while declaring its own
+ * `#[Table(timestamps: true)]`. Runtime resolves the parent's attribute first and disables timestamps, so
+ * the child's own argument loses.
+ *
+ * Pins two things nothing else does. The mirror must reach `#[WithoutTimestamps]` through the ANCESTOR
+ * walk — a non-recursive `$reflection->getAttributes()` (the idiom `applyTableAttribute()` correctly uses
+ * for its own `$declaresTable` check) would miss it here and fall through to the child's `#[Table]`,
+ * recording true. And precedence is decided ACROSS the hierarchy, not per class, which
+ * {@see TimestampsAttributePrecedenceModel} cannot show with both attributes on one class.
+ *
+ * Laravel 13.2+ (`#[WithoutTimestamps]`); the consuming test is gated on `class_exists()`.
+ *
+ * @internal fixture used by ModelMetadataRegistryTest
+ */
+#[Table(name: 'timestamps_inherited_models', timestamps: true)]
+final class TimestampsAttributeInheritedModel extends TimestampsAttributeInheritedBase {}

--- a/tests/Unit/Fixtures/Models/TimestampsAttributePrecedenceModel.php
+++ b/tests/Unit/Fixtures/Models/TimestampsAttributePrecedenceModel.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Both forms, disagreeing: `#[WithoutTimestamps]` wins over `#[Table(timestamps: true)]` because
+ * `initializeHasTimestamps()` checks it first and returns. Pins the mirror's branch ORDER — swap the two
+ * and this model records true while runtime says false.
+ *
+ * Laravel 13.2+ (`#[WithoutTimestamps]`); the consuming test is gated on `class_exists()`.
+ *
+ * @internal fixture used by ModelMetadataRegistryTest
+ */
+#[WithoutTimestamps]
+#[Table(name: 'timestamps_precedence_models', timestamps: true)]
+final class TimestampsAttributePrecedenceModel extends Model {}

--- a/tests/Unit/Fixtures/Models/TimestampsInitializerOrderModel.php
+++ b/tests/Unit/Fixtures/Models/TimestampsInitializerOrderModel.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;
+use Illuminate\Database\Eloquent\Model;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Concerns\EnablesTimestampsInInitializer;
+
+/**
+ * The only fixture whose answer depends on WHERE the timestamps mirror runs in the walk, rather than on
+ * what it computes. `$timestamps = false` closes the `=== true` guard, the trait initializer reopens it,
+ * and `#[WithoutTimestamps]` is what the guard admits or refuses — so the outcome is decided purely by
+ * whether the initializer ran before the mirror.
+ *
+ * getMethods() ranks the two differently per PHP version (8.4 puts Model's inherited concern initializers
+ * first, 8.5 the concrete class's own), so runtime disagrees with itself across the CI matrix and the
+ * consuming test must use the runtime oracle with NO literal — see {@see AppendsOrderModel}, same shape.
+ *
+ * Guards the mirror's dispatch POSITION: hoisting applyTimestampsAttributes() out of applyConcernMirror()
+ * to the tail of prepare() (next to applyTableAttribute(), which reads the same `#[Table]`) is a plausible
+ * tidy-up that every other timestamps fixture accepts. This one diverges from runtime under PHP 8.4.
+ *
+ * That guard is conditional on the 8.4-vs-8.5 split existing: were a future PHP to settle on one order, the
+ * hoist would stop diverging and this would quietly stop guarding. It degrades to a passing test, never a
+ * spurious failure, and the oracle keeps it honest meanwhile — but do not read a green here as proof the
+ * position is still pinned.
+ *
+ * Laravel 13.2+ (`#[WithoutTimestamps]`); the consuming test is gated on `class_exists()`.
+ *
+ * @internal fixture used by ModelMetadataRegistryTest
+ */
+#[WithoutTimestamps]
+final class TimestampsInitializerOrderModel extends Model
+{
+    use EnablesTimestampsInInitializer;
+
+    /** @var bool */
+    public $timestamps = false;
+}

--- a/tests/Unit/Fixtures/Models/WithoutTimestampsAttributeModel.php
+++ b/tests/Unit/Fixtures/Models/WithoutTimestampsAttributeModel.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * `#[WithoutTimestamps]` alone — runtime `usesTimestamps()` is false. The archetype of #1276: warm-up
+ * used to record true here, because `newInstanceWithoutConstructor()` skips `initializeHasTimestamps()`
+ * and no mirror replaced it.
+ *
+ * `#[WithoutTimestamps]` exists from Laravel 13.2, so the consuming test is gated on `class_exists()`.
+ *
+ * @internal fixture used by ModelMetadataRegistryTest
+ */
+#[WithoutTimestamps]
+final class WithoutTimestampsAttributeModel extends Model {}

--- a/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
+++ b/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
@@ -20,6 +20,7 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
+use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsCollection;
@@ -32,6 +33,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psalm\Codebase;
@@ -81,8 +83,13 @@ use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\EnumConnectionModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\InboundCastModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\ScalarFieldsModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\SectionFailureModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\TableTimestampsAttributeModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\TableTimestampsEnabledModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\TimestampsAttributeInheritedModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\TimestampsAttributePrecedenceModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\TraitInitializedConfigModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\UnguardedAttributeModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\WithoutTimestampsAttributeModel;
 
 #[CoversClass(ModelMetadataRegistry::class)]
 #[CoversClass(ModelMetadataRegistryBuilder::class)]
@@ -336,6 +343,65 @@ final class ModelMetadataRegistryTest extends TestCase
         $this->assertSame(['own_guard'], $metadata->guarded);
         // Own $table wins over #[Table], so the schema resolves under 'own_table'.
         $this->assertTrue($metadata->schema()->has('own_col'), 'own $table must win over #[Table]');
+    }
+
+    /**
+     * Each case pairs a fixture with the `usesTimestamps()` its attributes must produce. #1276.
+     *
+     * @return iterable<string, array{class-string<Model>, bool}>
+     */
+    public static function timestampsAttributeCases(): iterable
+    {
+        yield '#[WithoutTimestamps]' => [WithoutTimestampsAttributeModel::class, false];
+        yield '#[Table(timestamps: false)]' => [TableTimestampsAttributeModel::class, false];
+        yield '#[WithoutTimestamps] outranks #[Table(timestamps: true)]' => [TimestampsAttributePrecedenceModel::class, false];
+        // Inherited #[WithoutTimestamps] outranks the CHILD's own #[Table] — precedence is decided across
+        // the hierarchy, and only the ancestor walk finds the parent's attribute.
+        yield 'inherited #[WithoutTimestamps] outranks the child #[Table]' => [TimestampsAttributeInheritedModel::class, false];
+        yield 'declared $timestamps = false closes the guard' => [AttributeOverriddenByPropertyModel::class, false];
+        // The only case that assigns `true` FROM the attribute rather than leaving the default.
+        yield '#[Table(timestamps: true)]' => [TableTimestampsEnabledModel::class, true];
+        // #[Table] carrying no timestamps: argument must leave them alone — pins that the mirror reads
+        // the argument, not the attribute's presence.
+        yield '#[Table] without a timestamps: argument' => [AttributeConfiguredModel::class, true];
+    }
+
+    /**
+     * @param class-string<Model> $modelFqcn
+     */
+    #[Test]
+    #[DataProvider('timestampsAttributeCases')]
+    public function timestamps_attributes_reach_the_registry(string $modelFqcn, bool $expected): void
+    {
+        // #[WithoutTimestamps] is Laravel 13.2 (#[Table] 13.0). Below that these fixtures' attributes are
+        // either inert (12.x has no initializeHasTimestamps() to mirror, so the premise assertion fails)
+        // or unresolvable (the #[Table] carriers name-match a class absent on 12.x, and applyTableAttribute()
+        // — which runs regardless of the walk — then throws inside classAttribute()'s newInstance()).
+        if (!class_exists(WithoutTimestamps::class)) {
+            self::markTestSkipped('#[WithoutTimestamps] requires Laravel >= 13.2.');
+        }
+
+        $codebase = $this->makeCodebase();
+        $this->registerStorage($modelFqcn);
+
+        ModelMetadataRegistryBuilder::warmUp($codebase, $modelFqcn);
+
+        $metadata = ModelMetadataRegistry::for($modelFqcn);
+        $this->assertInstanceOf(ModelMetadata::class, $metadata);
+
+        // Warm-up must have COMPLETED, not degraded: every failure path falls back to usesTimestamps=true,
+        // which the true-expecting cases below cannot tell from a correct read. Only this section — the
+        // fixtures seed no migrations, so SECTION_SCHEMA is legitimately incomplete.
+        $this->assertTrue($metadata->isComplete(ModelMetadata::SECTION_RUNTIME_CONFIGURATION));
+
+        // A constructed model is the oracle: it runs the real initializeHasTimestamps() that
+        // newInstanceWithoutConstructor() skips, so this stays honest if Laravel changes the rules.
+        $runtime = (new $modelFqcn())->usesTimestamps();
+
+        // Pin the premise first. Without it, a Laravel that stopped applying these attributes would make
+        // both sides agree on true and the oracle below would pass while testing nothing.
+        $this->assertSame($expected, $runtime, 'fixture premise drifted from Laravel behaviour');
+        $this->assertSame($runtime, $metadata->traits->usesTimestamps);
     }
 
     #[Test]

--- a/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
+++ b/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
@@ -87,6 +87,7 @@ use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\TableTimestampsAttributeModel
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\TableTimestampsEnabledModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\TimestampsAttributeInheritedModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\TimestampsAttributePrecedenceModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\TimestampsInitializerOrderModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\TraitInitializedConfigModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\UnguardedAttributeModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\WithoutTimestampsAttributeModel;
@@ -402,6 +403,32 @@ final class ModelMetadataRegistryTest extends TestCase
         // both sides agree on true and the oracle below would pass while testing nothing.
         $this->assertSame($expected, $runtime, 'fixture premise drifted from Laravel behaviour');
         $this->assertSame($runtime, $metadata->traits->usesTimestamps);
+    }
+
+    #[Test]
+    public function trait_initializer_ordering_decides_the_timestamps_mirror(): void
+    {
+        if (!class_exists(WithoutTimestamps::class)) {
+            self::markTestSkipped('#[WithoutTimestamps] requires Laravel >= 13.2.');
+        }
+
+        $codebase = $this->makeCodebase();
+        $this->registerStorage(TimestampsInitializerOrderModel::class);
+
+        ModelMetadataRegistryBuilder::warmUp($codebase, TimestampsInitializerOrderModel::class);
+
+        $metadata = $this->metadataFor(TimestampsInitializerOrderModel::class);
+        $this->assertTrue($metadata->isComplete(ModelMetadata::SECTION_RUNTIME_CONFIGURATION));
+
+        // Runtime construction is the ONLY oracle — never a literal: getMethods() ranks the user
+        // initializer against Model's inherited initializeHasTimestamps() differently per PHP version, so
+        // the correct answer is true on 8.4 and false on 8.5. The mirror is right only if it runs at the
+        // framework initializer's own position; hoisting it out of the walk diverges under 8.4.
+        $this->assertSame(
+            (new TimestampsInitializerOrderModel())->usesTimestamps(),
+            $metadata->traits->usesTimestamps,
+            'the timestamps mirror must run at initializeHasTimestamps() position in the getMethods() walk',
+        );
     }
 
     #[Test]


### PR DESCRIPTION
## Why

Fixes #1276.

`ModelInstancePreparer::prepare()` builds its instance with `newInstanceWithoutConstructor()`, so `initializeHasTimestamps()` never runs, and `applyConcernMirror()` had no branch for it. A model that disables timestamps through `#[WithoutTimestamps]` or `#[Table(timestamps: false)]` therefore recorded `TraitFlags::$usesTimestamps = true` where runtime says `false`:

```php
#[WithoutTimestamps]
final class Post extends Model {}

runtime  (new Post())->usesTimestamps()  => false
warm-up  prepared instance               => true   // wrong
```

The `$timestamps = false` property idiom was unaffected — that is a declared default the constructor-less instance already carries. Only the attribute forms were wrong.

Nothing reads `$usesTimestamps` for a diagnostic today (`grep -rn '\->traits' src/` is empty — the whole `TraitFlags` object is write-only outside the registry that fills it), so there is no user-visible false positive. The value was simply stored wrong, and any future consumer would have inherited it. This replaces the `KNOWN GAP (#1276)` that #1275 documented on `applyConcernMirror()`.

## What

`applyTimestampsAttributes()` mirrors the framework initializer branch-for-branch: `#[WithoutTimestamps]` first, then `#[Table(timestamps:)]`, behind Laravel's `=== true` guard — which keeps a declared `$timestamps = false` and an earlier user initializer authoritative.

With it, `applyConcernMirror()`'s "verified 1:1" claim holds for the first time. The remaining unmirrored initializers are `initializeHasRelationships` (writes `$touches`, which the registry never stores) and `initializeSoftDeletes` (whose `deleted_at` cast `computeCasts()` supplies). The audit note now names the walk's real skip root, `Illuminate\Database\`, rather than `Eloquent\Concerns` — `SoftDeletes` and `Model` itself already sit outside that namespace, so auditing it alone would miss a future addition. That mis-scoping is how this gap survived.

## The version rationale is narrower than it looks

No `class_exists` gate, but **not** for the reason the issue suggests.

| | 12.14–12.x | 13.0–13.1 | 13.2+ |
|---|---|---|---|
| `initializeHasTimestamps()` | absent | present | present |
| `#[Table(timestamps:)]` | absent | present | present |
| `#[WithoutTimestamps]` | absent | **absent** | present |

The issue states both attributes are 13.0. `#[WithoutTimestamps]` is **13.2** — absent at `v13.0.0` and `v13.1.0`.

On the 12.x floor the walk never finds the initializer, so the mirror never runs. The window that matters is 13.0–13.1, where the initializer exists and `#[WithoutTimestamps]` does not.

Package-version atomicity does **not** close it — 13.1 ships the initializer *without* the attribute in a single artifact. What closes it is composer's `require` on `illuminate/database: ^12.14 || ^13.3`; the `laravel/framework` entry is `require-dev` and binds nothing a user installs. The docblock records that, so nobody widens the floor believing atomicity covers them.

Widening it would be survivable rather than fatal, and the docblock is careful to say so: reaching `classAttribute()`'s throwing `newInstance()` needs a model naming an attribute class its own framework lacks — code Laravel fatals on too, since `Error` escapes its `catch (Exception)` — and `warmUp()` catches `Throwable` and degrades the section. The cost is parity with an already-broken runtime, not correctness.

## Tests

A runtime-constructed model is the oracle, so the suite self-adapts if Laravel changes the rules, with a premise pin so it cannot pass vacuously and an `isComplete(SECTION_RUNTIME_CONFIGURATION)` guard so a degraded warm-up cannot masquerade as a correct `true` (every failure path falls back to `usesTimestamps = true`, and a fresh model agrees).

Each fixture kills a distinct mutation — verified by applying each one:

| Mutation | Caught by |
|---|---|
| mirror branch deleted (the bug as filed) | 3 cases |
| branch order swapped | precedence + inherited |
| `!== true` guard dropped | declared-property |
| `#[Table]` presence read as its value | `#[Table]`-without-arg |
| assignment hard-coded to `false` | `#[Table(timestamps: true)]` |
| non-recursive `getAttributes()` | inherited |
| mirror hoisted out of the walk | initializer-order |

The last one only diverges on PHP 8.4, so its test carries no literal: the same fixture is correctly `true` on 8.4 (Model's inherited initializer ranks first, sees the declared `false`, returns) and `false` on 8.5 (the class's own initializer runs first, so the framework one sees `true`). Deterministic per version, never nondeterministic. Follows `AppendsOrderModel`, which exists for the same reason.

Without the `isComplete` guard, a simulated throw inside the mirror left 3 of 7 cases green; with it, all 7 fail.

## Deliberately not here

- **`computeForAbstract()` / `computeWithoutInstance()`** derive `usesTimestamps` from property defaults, so an abstract base carrying `#[WithoutTimestamps]` still records `true`. Those paths ignore every attribute identically (`#[Guarded]`, `#[Fillable]`, `#[Appends]`, …); fixing timestamps alone would make it the lone attribute-aware field on paths that honour none. Pre-existing and uniform across every attribute, so filed as #1278 rather than half-fixed here.
- **An upstream `laravel/framework` bug**, found while verifying this. `Model::resolveClassAttribute()` builds its cache key as `$class.'@'.$attributeClass`, omitting `$property`, so `isIgnoringTouch()`'s 3-arg call shares a slot with the property-less calls. Reproduced both directions on 13.20: a `#[Table(timestamps: false)]` model gets touched anyway, and in the cold-cache order both `#[Table]` arguments are silently ignored. It cannot reach this PR — `usesTimestamps()` reads a different static, and `classAttribute()` is uncached, so it always computes the intended answer. Filed upstream as laravel/framework#60803.

## Verification

`composer test:unit` (1057) on PHP **8.5 and 8.4**, `composer test:type` (582), `composer test:app`, `composer rector`, `composer cs` all green. Raw `composer psalm` (no `--no-suggestions`) reports 0 errors at 100% type coverage. Test isolation checked under `--order-by=reverse` and three random seeds.

No psalm-delta run: nothing consumes `$usesTimestamps`, so no diagnostic can move.
