### PR TITLE
Narrow `Model::getKey()` to the model's known primary-key type

### DIFF
--- a/src/Handlers/Eloquent/ModelMethodHandler.php
+++ b/src/Handlers/Eloquent/ModelMethodHandler.php
@@ -706,7 +706,7 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
         }
 
         if ($methodName === 'getkey') {
-            return self::getKeyReturnType($called_fq_classlike_name, $codebase);
+            return self::getKeyReturnType($called_fq_classlike_name);
         }
 
         // Model::query()
@@ -757,12 +757,20 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
      * metadata. Every bail returns null so the stub fallback applies — this only narrows,
      * it never widens or invents a type.
      */
-    private static function getKeyReturnType(string $modelFqcn, Codebase $codebase): ?Union
+    private static function getKeyReturnType(string $modelFqcn): ?Union
     {
         /** @var class-string $modelFqcn */
         $metadata = ModelMetadataRegistry::for($modelFqcn);
 
-        if (!$metadata instanceof ModelMetadata || !$metadata->isComplete(ModelMetadata::SECTION_PRIMARY_KEY)) {
+        // SECTION_CASTS gates two things at once: the cast guard below reads casts(), and —
+        // load-bearing — an abstract receiver's metadata never sets this bit (its primary key
+        // is read from declared-property defaults, so it misses a trait method override like
+        // HasUuids::getKeyType()). AbstractUuidKeyModel's phpt case is the tripwire if that
+        // coupling is ever broken by a future change to abstract warm-up.
+        if (
+            !$metadata instanceof ModelMetadata
+            || !$metadata->isComplete(ModelMetadata::SECTION_PRIMARY_KEY | ModelMetadata::SECTION_CASTS)
+        ) {
             return null;
         }
 
@@ -772,17 +780,10 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
             return null;
         }
 
-        // A getKey() override anywhere below Illuminate (the receiver or an ancestor) wins
-        // over the inferred metadata.
-        $declaringMethodId = $codebase->methods->getDeclaringMethodId(new MethodIdentifier($modelFqcn, 'getkey'));
-
-        if (
-            !$declaringMethodId instanceof MethodIdentifier
-            || !\str_starts_with($declaringMethodId->fq_class_name, 'Illuminate\\')
-        ) {
-            return null;
-        }
-
+        // getMethodReturnType is registered only under Model::class, so a user override of
+        // getKey() (anywhere between the receiver and Model) diverts Psalm's dispatch before
+        // this branch runs at all — no override check needed here. Fragile if getKey() is ever
+        // added to ModelRegistrationHandler's per-model registration.
         $mapped = match ($metadata->primaryKey->type) {
             PrimaryKeyType::Integer => Type::getInt(),
             PrimaryKeyType::String => Type::getString(),

--- a/src/Handlers/Eloquent/ModelMethodHandler.php
+++ b/src/Handlers/Eloquent/ModelMethodHandler.php
@@ -13,6 +13,9 @@ use Psalm\Codebase;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Internal\MethodIdentifier;
 use Psalm\Internal\Type\TypeExpander;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadata;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadataRegistry;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\PrimaryKeyType;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Support\DynamicWhereResolver;
 use Psalm\LaravelPlugin\Internal\ProxyMethodReturnTypeProvider;
 use Psalm\Plugin\EventHandler\Event\MethodExistenceProviderEvent;
@@ -702,6 +705,10 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
             return new Union([self::instanceBuilderType($builderClass, $called_fq_classlike_name, $codebase)]);
         }
 
+        if ($methodName === 'getkey') {
+            return self::getKeyReturnType($called_fq_classlike_name, $codebase);
+        }
+
         // Model::query()
         if ($methodName === 'query') {
             $builderClass = self::getBuilderClassForModel($called_fq_classlike_name);
@@ -743,6 +750,60 @@ final class ModelMethodHandler implements MethodReturnTypeProviderInterface
         }
 
         return null;
+    }
+
+    /**
+     * Narrow Model::getKey()'s stub return (`int|string`) using the registry's primary-key
+     * metadata. Every bail returns null so the stub fallback applies — this only narrows,
+     * it never widens or invents a type.
+     */
+    private static function getKeyReturnType(string $modelFqcn, Codebase $codebase): ?Union
+    {
+        /** @var class-string $modelFqcn */
+        $metadata = ModelMetadataRegistry::for($modelFqcn);
+
+        if (!$metadata instanceof ModelMetadata || !$metadata->isComplete(ModelMetadata::SECTION_PRIMARY_KEY)) {
+            return null;
+        }
+
+        $keyName = $metadata->primaryKey->name;
+
+        if ($keyName === null) {
+            return null;
+        }
+
+        // A getKey() override anywhere below Illuminate (the receiver or an ancestor) wins
+        // over the inferred metadata.
+        $declaringMethodId = $codebase->methods->getDeclaringMethodId(new MethodIdentifier($modelFqcn, 'getkey'));
+
+        if (
+            !$declaringMethodId instanceof MethodIdentifier
+            || !\str_starts_with($declaringMethodId->fq_class_name, 'Illuminate\\')
+        ) {
+            return null;
+        }
+
+        $mapped = match ($metadata->primaryKey->type) {
+            PrimaryKeyType::Integer => Type::getInt(),
+            PrimaryKeyType::String => Type::getString(),
+        };
+
+        // getKey() returns getAttribute($keyName) at runtime, so a cast on the key column
+        // applies too. Eloquent's own getCasts() self-merges [$keyName => $keyType] for
+        // incrementing models, wrapped nullable by the registry's schema-driven resolver —
+        // that nullability isn't a real signal (getKey() itself is never null here per the
+        // stub), so only the non-null shape is compared against the mapped type.
+        $castInfo = $metadata->casts()[$keyName] ?? null;
+        if ($castInfo !== null) {
+            $castTypeBuilder = $castInfo->psalmType->getBuilder();
+            $castTypeBuilder->removeType('null');
+
+            if ($castTypeBuilder->freeze()->getId() !== $mapped->getId()) {
+                return null;
+            }
+        }
+
+        return $mapped;
     }
 
     /**

--- a/tests/Application/app/Models/AbstractUuidKeyModel.php
+++ b/tests/Application/app/Models/AbstractUuidKeyModel.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Abstract base using HasUuids — regression fixture for an abstract-typed receiver. HasUuids
+ * overrides the getKeyType() METHOD and declares no $keyType property, so the abstract warm-up
+ * path (which reads only declared-property defaults) can't see the override.
+ */
+abstract class AbstractUuidKeyModel extends Model
+{
+    use HasUuids;
+}

--- a/tests/Application/app/Models/ConflictingKeyCastModel.php
+++ b/tests/Application/app/Models/ConflictingKeyCastModel.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * A cast on the primary-key column that conflicts with $keyType — getKey() must fall back to
+ * the stub's `int|string` rather than trust a mapped type the cast contradicts.
+ */
+final class ConflictingKeyCastModel extends Model
+{
+    /** @var array<string, string> */
+    protected $casts = [
+        'id' => 'string',
+    ];
+}

--- a/tests/Application/app/Models/GetKeyOverrideModel.php
+++ b/tests/Application/app/Models/GetKeyOverrideModel.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Overrides getKey() so callers must fall back to the stub's `int|string` — the plugin
+ * must not narrow past a user override of the method it is narrowing.
+ */
+final class GetKeyOverrideModel extends Model
+{
+    public function getKey()
+    {
+        return parent::getKey();
+    }
+}

--- a/tests/Application/app/Models/StringKeyModel.php
+++ b/tests/Application/app/Models/StringKeyModel.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Plain `$keyType = 'string'` override — the property-only path to a string primary key,
+ * distinct from the trait-driven UuidModel/UlidModel archetypes.
+ */
+class StringKeyModel extends Model
+{
+    protected $keyType = 'string';
+}

--- a/tests/Type/tests/Model/GetKeyReturnTypeTest.phpt
+++ b/tests/Type/tests/Model/GetKeyReturnTypeTest.phpt
@@ -1,0 +1,79 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\ConflictingKeyCastModel;
+use App\Models\Customer;
+use App\Models\GetKeyOverrideModel;
+use App\Models\UlidModel;
+use App\Models\UuidModel;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Standard auto-incrementing int primary key narrows getKey() from the stub's
+ * `int|string` to `int`.
+ */
+function test_get_key_int(Customer $customer): int
+{
+    $key = $customer->getKey();
+    /** @psalm-check-type-exact $key = int */
+
+    return $key;
+}
+
+/** HasUuids forces the primary key to string, regardless of the base $keyType default. */
+function test_get_key_uuid(UuidModel $model): string
+{
+    $key = $model->getKey();
+    /** @psalm-check-type-exact $key = string */
+
+    return $key;
+}
+
+/** HasUlids forces the primary key to string, same as HasUuids. */
+function test_get_key_ulid(UlidModel $model): string
+{
+    $key = $model->getKey();
+    /** @psalm-check-type-exact $key = string */
+
+    return $key;
+}
+
+/**
+ * A model overriding getKey() must fall back to the stub's `int|string` — the plugin
+ * never narrows past a user override of the method it is narrowing.
+ */
+function test_get_key_override(GetKeyOverrideModel $model): int|string
+{
+    $key = $model->getKey();
+    /** @psalm-check-type-exact $key = int|string */
+
+    return $key;
+}
+
+/**
+ * A cast on the primary-key column that conflicts with the mapped type (here $keyType='int'
+ * by default, but $casts declares 'id' => 'string') must not be trusted — falls back to the
+ * stub's `int|string`.
+ */
+function test_get_key_conflicting_cast(ConflictingKeyCastModel $model): int|string
+{
+    $key = $model->getKey();
+    /** @psalm-check-type-exact $key = int|string */
+
+    return $key;
+}
+
+/**
+ * An anonymous model subclass is never warmed up by the registry (synthetic,
+ * unloadable FQCN), so getKey() falls back to the stub's `int|string`.
+ */
+function test_get_key_unregistered(): int|string
+{
+    $model = new class extends Model {};
+    $key = $model->getKey();
+    /** @psalm-check-type-exact $key = int|string */
+
+    return $key;
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Model/GetKeyReturnTypeTest.phpt
+++ b/tests/Type/tests/Model/GetKeyReturnTypeTest.phpt
@@ -4,6 +4,8 @@
 use App\Models\ConflictingKeyCastModel;
 use App\Models\Customer;
 use App\Models\GetKeyOverrideModel;
+use App\Models\KeylessPermission;
+use App\Models\StringKeyModel;
 use App\Models\UlidModel;
 use App\Models\UuidModel;
 use Illuminate\Database\Eloquent\Model;
@@ -34,6 +36,27 @@ function test_get_key_ulid(UlidModel $model): string
 {
     $key = $model->getKey();
     /** @psalm-check-type-exact $key = string */
+
+    return $key;
+}
+
+/** A plain $keyType='string' property override narrows the same as the trait-driven forms. */
+function test_get_key_string_property(StringKeyModel $model): string
+{
+    $key = $model->getKey();
+    /** @psalm-check-type-exact $key = string */
+
+    return $key;
+}
+
+/**
+ * A keyless model (no single Eloquent primary key) must fall back to the stub's
+ * `int|string` — there is no column name to look up.
+ */
+function test_get_key_keyless(KeylessPermission $model): int|string
+{
+    $key = $model->getKey();
+    /** @psalm-check-type-exact $key = int|string */
 
     return $key;
 }

--- a/tests/Type/tests/Model/GetKeyReturnTypeTest.phpt
+++ b/tests/Type/tests/Model/GetKeyReturnTypeTest.phpt
@@ -1,22 +1,25 @@
 --FILE--
 <?php declare(strict_types=1);
 
+use App\Models\AbstractUuidKeyModel;
 use App\Models\ConflictingKeyCastModel;
-use App\Models\Customer;
 use App\Models\GetKeyOverrideModel;
 use App\Models\KeylessPermission;
 use App\Models\StringKeyModel;
 use App\Models\UlidModel;
 use App\Models\UuidModel;
+use App\Models\Vehicle;
 use Illuminate\Database\Eloquent\Model;
 
 /**
  * Standard auto-incrementing int primary key narrows getKey() from the stub's
- * `int|string` to `int`.
+ * `int|string` to `int`. Uses Vehicle, not Customer — Customer declares
+ * `@property string $id` (see PropertyAnnotationPrecedenceTest.phpt), which would assert a
+ * conflicting type for the same runtime value on the property-read path.
  */
-function test_get_key_int(Customer $customer): int
+function test_get_key_int(Vehicle $vehicle): int
 {
-    $key = $customer->getKey();
+    $key = $vehicle->getKey();
     /** @psalm-check-type-exact $key = int */
 
     return $key;
@@ -54,6 +57,21 @@ function test_get_key_string_property(StringKeyModel $model): string
  * `int|string` — there is no column name to look up.
  */
 function test_get_key_keyless(KeylessPermission $model): int|string
+{
+    $key = $model->getKey();
+    /** @psalm-check-type-exact $key = int|string */
+
+    return $key;
+}
+
+/**
+ * An abstract receiver's metadata is derived from declared-property defaults, not an
+ * instance — HasUuids overrides getKeyType() as a METHOD and never declares its own $keyType
+ * property, so the abstract path can't see the override and must not narrow. This is pinned
+ * via the SECTION_CASTS gate (abstract warm-up never sets it), not a dedicated abstract check
+ * — this test is the tripwire if that coupling ever breaks.
+ */
+function test_get_key_abstract_uuid(AbstractUuidKeyModel $model): int|string
 {
     $key = $model->getKey();
     /** @psalm-check-type-exact $key = int|string */

--- a/tests/Unit/Handlers/Eloquent/ModelMethodHandlerGetKeyReturnTypeTest.php
+++ b/tests/Unit/Handlers/Eloquent/ModelMethodHandlerGetKeyReturnTypeTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Eloquent;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\Codebase;
+use Psalm\Internal\Provider\ClassLikeStorageProvider;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadata;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadataRegistry;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadataRegistryBuilder;
+use Psalm\LaravelPlugin\Handlers\Eloquent\ModelMethodHandler;
+use Psalm\Progress\VoidProgress;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\SectionFailureModel;
+
+/**
+ * getKeyReturnType() is private; the bail branch exercised here (an incomplete
+ * SECTION_PRIMARY_KEY) can't be reached through a normal booted-app phpt fixture, since a
+ * genuinely broken warm-up there would spill into every other phpt sharing the same app boot.
+ */
+#[CoversClass(ModelMethodHandler::class)]
+final class ModelMethodHandlerGetKeyReturnTypeTest extends TestCase
+{
+    private ClassLikeStorageProvider $classLikeStorageProvider;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        ModelMetadataRegistryBuilder::reset();
+        SectionFailureModel::$failures = [];
+        $this->classLikeStorageProvider = new ClassLikeStorageProvider();
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        ModelMetadataRegistryBuilder::reset();
+    }
+
+    /**
+     * Regression guard: a crashed primary-key warm-up must not let getKeyReturnType() fall back
+     * to a guessed type. Asserting isComplete() directly (not just the final null) is
+     * deliberate — every degraded-warm-up path also defaults primaryKey to a guess, so a test
+     * that only checked the return value could pass vacuously against a silently-wrong guard.
+     */
+    #[Test]
+    public function incomplete_primary_key_section_bails_to_stub_fallback(): void
+    {
+        $codebase = $this->makeCodebase();
+        $this->classLikeStorageProvider->create(SectionFailureModel::class);
+        SectionFailureModel::$failures = ['primary key' => true];
+
+        ModelMetadataRegistryBuilder::warmUp($codebase, SectionFailureModel::class);
+
+        $metadata = ModelMetadataRegistry::for(SectionFailureModel::class);
+        $this->assertNotNull($metadata);
+        $this->assertFalse($metadata->isComplete(ModelMetadata::SECTION_PRIMARY_KEY));
+
+        $method = new \ReflectionMethod(ModelMethodHandler::class, 'getKeyReturnType');
+        $result = $method->invoke(null, SectionFailureModel::class, $codebase);
+
+        $this->assertNull($result);
+    }
+
+    private function makeCodebase(): Codebase
+    {
+        $codebase = (new \ReflectionClass(Codebase::class))->newInstanceWithoutConstructor();
+        $codebase->classlike_storage_provider = $this->classLikeStorageProvider;
+
+        // $progress is declared protected(set) readonly in Psalm 7 — bypass via reflection.
+        $progressProperty = new \ReflectionProperty(Codebase::class, 'progress');
+        $progressProperty->setValue($codebase, new VoidProgress());
+
+        return $codebase;
+    }
+}


### PR DESCRIPTION
## Issue to Solve

`$model->getKey()` always infers `int|string`, even when the model's primary-key type is provably `string` (or `int`). The `ModelMetadataRegistry` already knows the precise type; nothing wired it into the `getKey()` return.

Fixes #1270. Supersedes #1271.

## Solution Description

One branch in `ModelMethodHandler::getMethodReturnType()` (already the `Model::class` provider; `getkey` previously fell through to `null`) reads `ModelMetadata::primaryKey` and maps `PrimaryKeyType::Integer` -> `int`, `PrimaryKeyType::String` -> `string`.

Every bail returns `null` so the stub's `int|string` stays the fallback. The branch can only narrow, never widen or invent a type. It bails on:

- a model the registry never warmed up,
- an incomplete `SECTION_PRIMARY_KEY` or `SECTION_CASTS`,
- a keyless model (null key name),
- a cast on the key column that disagrees with the mapped type.

### Why `SECTION_CASTS` is required

Two reasons, and the second is easy to lose:

1. The cast guard reads `casts()`. `getKey()` returns `getAttribute($keyName)` at runtime, so a cast on the key column applies. An incomplete casts section returns the empty fallback, which would silently no-op the guard.
2. It is what excludes abstract receivers. `computeForAbstract()` derives the primary key from declared-property defaults, so a trait method override is invisible to it (`HasUuids::getKeyType()` overrides the method and declares no `$keyType` property). Without the gate, `abstract class Base extends Model { use HasUuids; }` emits `int` where runtime returns a UUID string. `AbstractUuidKeyModel`'s type-test case is the tripwire if that coupling is ever broken by a change to abstract warm-up.

### Why there is no override check

`getMethodReturnType` is registered only under `Model::class`, so a user override of `getKey()` diverts Psalm's dispatch before the branch runs. An explicit declaring-method guard was tried and removed: it could never bail, and it cost a `getDeclaringMethodId()` on every `getKey()` call site.

## Accepted unsoundness

Recorded deliberately, consistent with existing convention:

- **No `|null`.** `getKey()` returns null on an unsaved model at runtime. The stub already returns non-null `int|string`; narrowing inherits that convention rather than changing it here.
- **Non-final receivers.** Narrowing keys on the statically-known class. A subclass re-declaring `$keyType` at runtime is accepted imprecision, matching how `ModelPropertyResolver`'s collection/relation `TKey` narrowing already behaves.
- **Exotic lifecycle overrides.** Custom `boot()`, suppressed `bootTraits()`, stateful initializers: if warm-up succeeded and the sections are complete, the registry is trusted. The section-completeness bits are the authority mechanism; this is a consumer of them.

Two known imprecisions worth naming, neither addressed here:

- A `@property` annotation on the key column is not consulted, though this repo treats `@property` as authoritative for property reads. `Customer` (`@property string $id`) is why the int-PK test case uses `Vehicle`.
- `$keyType` values other than `'string'` map to `Integer` (pre-existing in `ModelMetadataRegistryBuilder`, first consumed here). For a non-incrementing model with an exotic `$keyType`, no self-merged cast exists to trip the guard.

## Why this supersedes #1271

#1271 grew an authority-proof engine (lifecycle helpers, boot-chain provenance, token-level source parsing) across 27 files to establish per-feature what the registry's section-completeness contract already establishes. This is the same feature as a ~60-line consumer of that contract.

## Real-world impact

`psalm-delta` across 18 apps: net +1 issue, type coverage unchanged, no performance change (timing deltas in the first run were a cache-warmth artifact; a warm re-measure lands at base).

The movement is qualitatively a win. Removed, among others:

- `InvalidReturnStatement: The inferred type 'int|null|string' does not match the declared return type 'int|null'` — the exact shape #1270 reports.
- `PossiblyInvalidPropertyAssignmentValue: ... with declared type 'int|null' cannot be assigned possibly string`.

Added are 8 `RedundantCast` / `RedundantCondition` — true positives the narrowing reveals (`(int) $model->getKey()` genuinely is a redundant cast once `getKey()` is `int`). Two `InvalidArgument` "additions" are churn at the same file:line as two removals: only the types quoted inside the message changed.

## Checklist

- [x] Tests cover the change (type tests in `tests/Type/`, unit test in `tests/Unit/`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786819537&installation_id=141955579&pr_number=1279&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1279&signature=9ccf240f10dc97e5dd1e6073809b5c5aa1263ccd46266cce4e7c3c3e6d6a451b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->