### PR TITLE
Auto-bind `Factory<TModel>` on bare factory subclasses

### DIFF
--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -35,6 +35,7 @@ flowchart TD
 
     I["Psalm scans all project files"] -.->|afterCodebasePopulated| J["ModelRegistrationHandler"]
     I -.->|afterCodebasePopulated| K["Eloquent Builder subclass fix-ups:\nBuilderSubclassQueryMixinHandler (restores dropped Query Builder @mixin)\nBuilderNativeStaticReturnTypeHandler (native ': static' return becomes docblock 'static')"]
+    I -.->|afterCodebasePopulated| FMB["FactoryModelBindingHandler (injects @extends Factory&lt;TModel&gt; on bare factory subclasses, #780)"]
     J --- models["
         Discover Model subclasses
         Register per-model property/method closures:

--- a/src/Handlers/Eloquent/FactoryModelBindingHandler.php
+++ b/src/Handlers/Eloquent/FactoryModelBindingHandler.php
@@ -42,11 +42,17 @@ final class FactoryModelBindingHandler implements AfterCodebasePopulatedInterfac
 
     private static bool $appNamespaceResolved = false;
 
-    /** @psalm-external-mutation-free */
     public static function reset(): void
     {
         self::$appNamespaceCache = null;
         self::$appNamespaceResolved = false;
+
+        // Flush Laravel's process-global factory resolver state so a prior app's
+        // guessModelNamesUsing()/useNamespace() registrations cannot leak into
+        // the next invocation's runtime path (repeated plugin initialization).
+        if (\class_exists(Factory::class)) {
+            Factory::flushState();
+        }
     }
 
     #[\Override]
@@ -109,20 +115,13 @@ final class FactoryModelBindingHandler implements AfterCodebasePopulatedInterfac
             return false;
         }
 
-        // User already wrote `@extends Factory<X>`. The populator fills TModel
-        // with the bound default (bare `Model`) when it is omitted, so a
-        // TNamedObject other than bare `Model` signals a real user binding.
-        // Same discriminator as ModelFactoryMethodTypeProvider::hasModelTemplateBinding().
-        $tModel = $storage->template_extended_params[Factory::class]['TModel'] ?? null;
-        if ($tModel instanceof Union) {
-            foreach ($tModel->getAtomicTypes() as $atomic) {
-                if ($atomic instanceof TNamedObject && $atomic->value !== Model::class) {
-                    return false;
-                }
-            }
-        }
-
-        return true;
+        // An explicit `@extends Factory<...>` is a real user contract, whatever
+        // it binds TModel to — including a deliberate `@extends Factory<Model>`
+        // polymorphic base. Psalm's scanner sets template_type_extends_count
+        // only when the docblock is present; an omitted docblock leaves it null
+        // (the populator then fills TModel with the default bare `Model`, which
+        // we DO want to override). Presence => hands off.
+        return ($storage->template_type_extends_count[Factory::class] ?? null) === null;
     }
 
     /**
@@ -132,7 +131,7 @@ final class FactoryModelBindingHandler implements AfterCodebasePopulatedInterfac
      */
     private static function resolveModelFqcn(ClassLikeStorage $storage, Codebase $codebase): ?string
     {
-        return self::resolveFromRuntime($storage->name, $codebase)
+        return self::resolveFromRuntime($storage, $codebase)
             ?? self::resolveFromModelProperty($storage, $codebase)
             ?? self::resolveFromShortName($storage->name, $codebase);
     }
@@ -144,9 +143,19 @@ final class FactoryModelBindingHandler implements AfterCodebasePopulatedInterfac
      * (`Factory::useNamespace()`, `guessModelNamesUsing()`) that the static
      * fallback cannot see.
      */
-    private static function resolveFromRuntime(string $factoryFqcn, Codebase $codebase): ?string
+    private static function resolveFromRuntime(ClassLikeStorage $storage, Codebase $codebase): ?string
     {
+        $factoryFqcn = $storage->name;
+
         if (!\class_exists($factoryFqcn) || !\is_a($factoryFqcn, Factory::class, true)) {
+            return null;
+        }
+
+        // A factory declaring its OWN `__construct` may assign `$this->model`
+        // there; `newInstanceWithoutConstructor()` skips it, so `modelName()`
+        // would read a null/stale model. Defer to the static tiers, which read
+        // the declared property/shortname from storage, not a live instance.
+        if (isset($storage->methods['__construct'])) {
             return null;
         }
 
@@ -225,16 +234,22 @@ final class FactoryModelBindingHandler implements AfterCodebasePopulatedInterfac
             $nestedBase = \substr(\substr($factoryFqcn, $pos + \strlen('Database\\Factories\\')), 0, -\strlen('Factory'));
         }
 
-        $candidates = [];
-        if ($nestedBase !== null && $nestedBase !== '') {
-            $candidates[] = $appNamespace . 'Models\\' . $nestedBase;
-            $candidates[] = $appNamespace . $nestedBase;
-        }
+        // Laravel's default resolver (Factory::modelName()) tries EXACTLY two
+        // candidates, in order:
+        //   1. {AppNs}Models\{nestedBase} — factory sub-namespace under
+        //      Database\Factories\, nested under Models\ (or the flat basename
+        //      when unnested).
+        //   2. {AppNs}{flatBase} — the bare factory basename, no Models\.
+        // No other combination is valid: {AppNs}Models\{flatBase} would wrongly
+        // match a flat model when a nested one was intended.
+        $namespacedBase = $nestedBase !== null && $nestedBase !== '' ? $nestedBase : $flatBase;
 
-        $candidates[] = $appNamespace . 'Models\\' . $flatBase;
-        $candidates[] = $appNamespace . $flatBase;
+        $candidates = [
+            $appNamespace . 'Models\\' . $namespacedBase,
+            $appNamespace . $flatBase,
+        ];
 
-        foreach (\array_unique($candidates) as $candidate) {
+        foreach ($candidates as $candidate) {
             if (self::isModelClass($candidate, $codebase)) {
                 return $candidate;
             }

--- a/src/Handlers/Eloquent/FactoryModelBindingHandler.php
+++ b/src/Handlers/Eloquent/FactoryModelBindingHandler.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Eloquent;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Model;
+use Psalm\Codebase;
+use Psalm\LaravelPlugin\Bootstrap\ApplicationProvider;
+use Psalm\Plugin\EventHandler\AfterCodebasePopulatedInterface;
+use Psalm\Plugin\EventHandler\Event\AfterCodebasePopulatedEvent;
+use Psalm\Storage\ClassLikeStorage;
+use Psalm\Type\Atomic\TLiteralClassString;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Union;
+
+/**
+ * Auto-binds `@extends Factory<TModel>` on factory subclasses that follow
+ * Laravel's naming convention but omit the docblock, e.g. a bare
+ * `class TaskFactory extends Factory` (the stock layout in pterodactyl/panel,
+ * bookstack, monica, ...).
+ *
+ * Effect: `TModel` resolves to the concrete model, so `(new TaskFactory())
+ * ->create()`/`->make()` return `Task` instead of collapsing to base `Model`,
+ * and `MissingTemplateParam` (the symptom #780 reports on Psalm 6) is silenced.
+ *
+ * Inverse of #517 (Model -> Factory) and the missing complement of
+ * {@see ModelFactoryMethodTypeProvider}, whose Tier-2 gate
+ * `hasModelTemplateBinding()` reads exactly the slot this handler fills.
+ *
+ * Runs on `AfterCodebasePopulated` (not `AfterClassLikeVisit`) because model
+ * lineage on the resolved candidate is only trustworthy once the populator has
+ * filled `parent_classes` for every class.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/780
+ * @internal
+ */
+final class FactoryModelBindingHandler implements AfterCodebasePopulatedInterface
+{
+    private static ?string $appNamespaceCache = null;
+
+    private static bool $appNamespaceResolved = false;
+
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$appNamespaceCache = null;
+        self::$appNamespaceResolved = false;
+    }
+
+    #[\Override]
+    public static function afterCodebasePopulated(AfterCodebasePopulatedEvent $event): void
+    {
+        $codebase = $event->getCodebase();
+
+        // No Eloquent factories in the codebase (slim packages) -> skip the
+        // full-codebase walk entirely.
+        if (!$codebase->classlike_storage_provider->has(Factory::class)) {
+            return;
+        }
+
+        $factoryFqcnLc = \strtolower(Factory::class);
+
+        foreach ($codebase->classlike_storage_provider::getAll() as $storage) {
+            try {
+                if (!self::isDirectFactorySubclass($storage, $factoryFqcnLc)) {
+                    continue;
+                }
+
+                $modelFqcn = self::resolveModelFqcn($storage, $codebase);
+                if ($modelFqcn !== null) {
+                    self::injectBinding($storage, $modelFqcn);
+                }
+            } catch (\Throwable $throwable) {
+                // Per-iteration guard: one corrupted storage entry must not
+                // abort the pass for every other factory.
+                $message = $throwable->getMessage() !== '' ? $throwable->getMessage() : '(no message)';
+                $codebase->progress->warning(
+                    "Laravel plugin: factory TModel binding failed for '{$storage->name}' ("
+                    . $throwable::class . '): ' . $message,
+                );
+            }
+        }
+    }
+
+    /**
+     * Only bare, concrete leaves whose DIRECT parent is `Factory` qualify.
+     * The direct-parent guard keeps the #677 abstract-base pattern intact:
+     * indirect descendants inherit a populator-supplied binding from their
+     * abstract base, and re-binding here would override the polymorphic
+     * contract the user designed.
+     *
+     * @psalm-mutation-free
+     */
+    private static function isDirectFactorySubclass(ClassLikeStorage $storage, string $factoryFqcnLc): bool
+    {
+        if ($storage->is_interface || $storage->is_trait || $storage->abstract) {
+            return false;
+        }
+
+        if ($storage->parent_class === null || \strtolower($storage->parent_class) !== $factoryFqcnLc) {
+            return false;
+        }
+
+        // User-defined `@template T of Model` on the factory -> defer to their
+        // polymorphism.
+        if ($storage->template_types !== null && $storage->template_types !== []) {
+            return false;
+        }
+
+        // User already wrote `@extends Factory<X>`. The populator fills TModel
+        // with the bound default (bare `Model`) when it is omitted, so a
+        // TNamedObject other than bare `Model` signals a real user binding.
+        // Same discriminator as ModelFactoryMethodTypeProvider::hasModelTemplateBinding().
+        $tModel = $storage->template_extended_params[Factory::class]['TModel'] ?? null;
+        if ($tModel instanceof Union) {
+            foreach ($tModel->getAtomicTypes() as $atomic) {
+                if ($atomic instanceof TNamedObject && $atomic->value !== Model::class) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Runtime path first (autoloadable factories in real apps), static
+     * fallback for classes Psalm scanned but PHP cannot load (phpt inline
+     * classes).
+     */
+    private static function resolveModelFqcn(ClassLikeStorage $storage, Codebase $codebase): ?string
+    {
+        return self::resolveFromRuntime($storage->name, $codebase)
+            ?? self::resolveFromModelProperty($storage, $codebase)
+            ?? self::resolveFromShortName($storage->name, $codebase);
+    }
+
+    /**
+     * Primary path (autoloadable factories in real apps): let Laravel's own
+     * `Factory::modelName()` resolve the target. This honors `#[UseModel]`,
+     * the `$model` property, the naming convention, AND container overrides
+     * (`Factory::useNamespace()`, `guessModelNamesUsing()`) that the static
+     * fallback cannot see.
+     */
+    private static function resolveFromRuntime(string $factoryFqcn, Codebase $codebase): ?string
+    {
+        if (!\class_exists($factoryFqcn) || !\is_a($factoryFqcn, Factory::class, true)) {
+            return null;
+        }
+
+        // No constructor: `modelName()` reads only the `$model` default, the
+        // `#[UseModel]` attribute, and static resolver state — none need
+        // `__construct` (faker/collections). Also sidesteps UnsafeInstantiation
+        // on the non-final Factory ctor. `modelName()` is untyped (mixed);
+        // validate inline so no mixed local leaks into coverage.
+        //
+        // Local catch: a throwing `modelName()` (factory names an absent model,
+        // or a user `guessModelNamesUsing` callback throws) must degrade to the
+        // static tiers, not abandon the factory via the outer per-iteration catch.
+        try {
+            $factory = (new \ReflectionClass($factoryFqcn))->newInstanceWithoutConstructor();
+
+            return self::validateModel($factory->modelName(), $codebase);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Static fallback (a): read the `$model` property default. An untyped
+     * `protected $model = X::class;` (the pterodactyl/bookstack shape) has no
+     * declared `type`; Psalm records the inferred default in `suggested_type`
+     * as a `TLiteralClassString`. Kept lean — the `@var class-string<X>` shape
+     * is covered by the runtime path in real apps.
+     *
+     * @psalm-mutation-free
+     */
+    private static function resolveFromModelProperty(ClassLikeStorage $storage, Codebase $codebase): ?string
+    {
+        $property = $storage->properties['model'] ?? null;
+        $type = $property->type ?? $property->suggested_type ?? null;
+        if (!$type instanceof Union) {
+            return null;
+        }
+
+        foreach ($type->getAtomicTypes() as $atomic) {
+            if ($atomic instanceof TLiteralClassString && self::isModelClass($atomic->value, $codebase)) {
+                return $atomic->value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Static fallback (b): strip the `Factory` suffix from the shortname and
+     * prepend the app's model namespace, honoring sub-namespaces nested under
+     * `Database\Factories\` (`Database\Factories\Auth\UserFactory` ->
+     * `App\Models\Auth\User`). Falls back to the flat `{AppNs}{Base}` form for
+     * apps that flatten their model namespace.
+     */
+    private static function resolveFromShortName(string $factoryFqcn, Codebase $codebase): ?string
+    {
+        $lastSep = \strrpos($factoryFqcn, '\\');
+        $shortName = $lastSep === false ? $factoryFqcn : \substr($factoryFqcn, $lastSep + 1);
+
+        if ($shortName === 'Factory' || !\str_ends_with($shortName, 'Factory')) {
+            return null;
+        }
+
+        $appNamespace = self::resolveAppNamespace();
+        if ($appNamespace === null) {
+            return null;
+        }
+
+        $flatBase = \substr($shortName, 0, -\strlen('Factory'));
+
+        // Strip the first `Database\Factories\` occurrence to recover any
+        // nested sub-namespace, mirroring Laravel's Str::replaceFirst().
+        $nestedBase = null;
+        $pos = \strpos($factoryFqcn, 'Database\\Factories\\');
+        if ($pos !== false) {
+            $nestedBase = \substr(\substr($factoryFqcn, $pos + \strlen('Database\\Factories\\')), 0, -\strlen('Factory'));
+        }
+
+        $candidates = [];
+        if ($nestedBase !== null && $nestedBase !== '') {
+            $candidates[] = $appNamespace . 'Models\\' . $nestedBase;
+            $candidates[] = $appNamespace . $nestedBase;
+        }
+
+        $candidates[] = $appNamespace . 'Models\\' . $flatBase;
+        $candidates[] = $appNamespace . $flatBase;
+
+        foreach (\array_unique($candidates) as $candidate) {
+            if (self::isModelClass($candidate, $codebase)) {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+
+    /** Cached for the analysis lifetime — `getNamespace()` walks composer.json. */
+    private static function resolveAppNamespace(): ?string
+    {
+        if (self::$appNamespaceResolved) {
+            return self::$appNamespaceCache;
+        }
+
+        // Flip before the lookup so a thrown RuntimeException memoizes the
+        // failure instead of re-running for every factory class.
+        self::$appNamespaceResolved = true;
+
+        try {
+            return self::$appNamespaceCache = ApplicationProvider::getApp()->getNamespace();
+        } catch (\RuntimeException) {
+            return self::$appNamespaceCache = null;
+        }
+    }
+
+    /**
+     * @param mixed $candidate
+     * @psalm-mutation-free
+     */
+    private static function validateModel($candidate, Codebase $codebase): ?string
+    {
+        if (!\is_string($candidate) || $candidate === '') {
+            return null;
+        }
+
+        return self::isModelClass($candidate, $codebase) ? $candidate : null;
+    }
+
+    /**
+     * A resolved candidate must be a scanned Model subclass — never guess a
+     * binding for a class Psalm has not verified.
+     *
+     * @psalm-mutation-free
+     */
+    private static function isModelClass(string $fqcn, Codebase $codebase): bool
+    {
+        if (!$codebase->classlike_storage_provider->has($fqcn)) {
+            return false;
+        }
+
+        return isset($codebase->classlike_storage_provider->get($fqcn)->parent_classes[\strtolower(Model::class)]);
+    }
+
+    /**
+     * Merge TModel into `template_extended_params[Factory::class]`, preserving
+     * the populator-supplied TCount (which gates the `(TCount is null|0|1 ?
+     * TModel : Collection<int, TModel>)` conditional return on create()/make()),
+     * and set the extends-count to 2 so both params read as bound.
+     */
+    private static function injectBinding(ClassLikeStorage $storage, string $modelFqcn): void
+    {
+        $params = $storage->template_extended_params ?? [];
+        $existing = $params[Factory::class] ?? [];
+        $existing['TModel'] = new Union([new TNamedObject($modelFqcn)]);
+        $params[Factory::class] = $existing;
+
+        $counts = $storage->template_type_extends_count ?? [];
+        $counts[Factory::class] = 2;
+
+        $storage->template_extended_params = $params;
+        $storage->template_type_extends_count = $counts;
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -163,6 +163,7 @@ final class Plugin implements PluginEntryPointInterface
         Handlers\Console\CommandDefinitionAnalyzer::reset();
         Handlers\Eloquent\CustomBuilderMethodHandler::reset();
         Handlers\Eloquent\CustomCollectionHandler::reset();
+        Handlers\Eloquent\FactoryModelBindingHandler::reset();
         Handlers\Eloquent\Metadata\ModelMetadataRegistryBuilder::reset();
         Handlers\Eloquent\ModelAggregatePropertyHandler::reset();
         Handlers\Eloquent\ModelFactoryMethodTypeProvider::reset();
@@ -251,6 +252,7 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Eloquent/ModelFactoryTypeProvider.php';
         require_once __DIR__ . '/Handlers/Eloquent/ModelFactoryMethodTypeProvider.php';
         require_once __DIR__ . '/Handlers/Eloquent/FactoryCountTypeProvider.php';
+        require_once __DIR__ . '/Handlers/Eloquent/FactoryModelBindingHandler.php';
         require_once __DIR__ . '/Handlers/Eloquent/ModelPropertyAccessorHandler.php';
         require_once __DIR__ . '/Handlers/Eloquent/ModelAttributeSubsetHandler.php';
         require_once __DIR__ . '/Handlers/Eloquent/ModelToArrayShapeHandler.php';
@@ -276,6 +278,10 @@ final class Plugin implements PluginEntryPointInterface
         $registration->registerHooksFromClass(Handlers\Eloquent\WhereColumnTaintHandler::class);
         $registration->registerHooksFromClass(Handlers\Eloquent\ModelFactoryMethodTypeProvider::class);
         $registration->registerHooksFromClass(Handlers\Eloquent\FactoryCountTypeProvider::class);
+        // Injects `@extends Factory<TModel>` on bare factory subclasses that follow Laravel's
+        // naming convention but omit the docblock — binds TModel so create()/make() resolve the
+        // concrete model (and silences `MissingTemplateParam` on Psalm 6). See #780.
+        $registration->registerHooksFromClass(Handlers\Eloquent\FactoryModelBindingHandler::class);
 
         // Magic method forwarding: Relation -> Builder (decorated forwarding).
         // Must be registered BEFORE BuilderScopeHandler, BuilderPluckHandler, and

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -117,6 +117,7 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php';
         require_once __DIR__ . '/Handlers/Eloquent/CustomBuilderMethodHandler.php';
         require_once __DIR__ . '/Handlers/Eloquent/CustomCollectionHandler.php';
+        require_once __DIR__ . '/Handlers/Eloquent/FactoryModelBindingHandler.php';
         require_once __DIR__ . '/Handlers/Eloquent/ModelAggregatePropertyHandler.php';
         require_once __DIR__ . '/Handlers/Eloquent/ModelFactoryMethodTypeProvider.php';
         require_once __DIR__ . '/Handlers/Eloquent/ModelPropertyAccessorHandler.php';
@@ -150,7 +151,8 @@ final class Plugin implements PluginEntryPointInterface
      * `init()` may be skipped, so it cannot be responsible for overwriting a
      * previous invocation's state.
      *
-     * @psalm-external-mutation-free
+     * Not `@psalm-external-mutation-free`: FactoryModelBindingHandler::reset()
+     * flushes Laravel's process-global factory resolver state (Factory::flushState()).
      */
     private function resetInvocationState(): void
     {

--- a/tests/Type/tests/Factory/FactoryModelBindingAbstractBaseTest.phpt
+++ b/tests/Type/tests/Factory/FactoryModelBindingAbstractBaseTest.phpt
@@ -1,0 +1,104 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Models {
+    use Illuminate\Database\Eloquent\Model;
+
+    final class Bastion extends Model
+    {
+    }
+
+    final class Citadel extends Model
+    {
+    }
+
+    final class Rampart extends Model
+    {
+    }
+}
+
+namespace Database\Factories {
+    use Illuminate\Database\Eloquent\Factories\Factory;
+    use Illuminate\Database\Eloquent\Model;
+
+    /**
+     * #677 abstract-base pattern: the base carries its own `@template TModel`
+     * and re-binds it through `@extends Factory<TModel>`. It is abstract, so
+     * the handler skips it (leaves only).
+     *
+     * @template TModel of Model
+     * @extends Factory<TModel>
+     */
+    abstract class AbstractBastionFactory extends Factory
+    {
+    }
+
+    /**
+     * Leaf whose DIRECT parent is the abstract base, not `Factory`. The
+     * direct-parent guard skips it; the populator-derived chain from the
+     * annotated `@extends` resolves the model.
+     *
+     * @extends AbstractBastionFactory<\App\Models\Bastion>
+     */
+    final class BastionFactory extends AbstractBastionFactory
+    {
+        /** @return array<string, mixed> */
+        #[\Override]
+        public function definition(): array
+        {
+            return [];
+        }
+    }
+
+    /**
+     * Trap leaf: declares `$model` and OMITS the template arg on the abstract
+     * base. A handler ignoring the direct-parent guard would inject
+     * `Factory<Citadel>` here. The guard prevents that — direct parent is the
+     * abstract base — so the chain collapses to the base's unbound `Model`.
+     */
+    final class CitadelFactory extends AbstractBastionFactory
+    {
+        protected $model = \App\Models\Citadel::class;
+
+        /** @return array<string, mixed> */
+        #[\Override]
+        public function definition(): array
+        {
+            return [];
+        }
+    }
+
+    /**
+     * Concrete leaf whose DIRECT parent IS `Factory`. The handler injects
+     * `Factory<Rampart>` via the shortname convention.
+     */
+    final class RampartFactory extends Factory
+    {
+        /** @return array<string, mixed> */
+        #[\Override]
+        public function definition(): array
+        {
+            return [];
+        }
+    }
+}
+
+namespace App\Sandbox\AbstractBase {
+    use Database\Factories\BastionFactory;
+    use Database\Factories\CitadelFactory;
+    use Database\Factories\RampartFactory;
+
+    // Annotated leaf: chain through the abstract base resolves the model.
+    $_bastion = (new BastionFactory())->create();
+    /** @psalm-check-type-exact $_bastion = \App\Models\Bastion */;
+
+    // Trap leaf: direct-parent guard skips it, collapses to base's `Model`.
+    $_citadel = (new CitadelFactory())->create();
+    /** @psalm-check-type-exact $_citadel = \Illuminate\Database\Eloquent\Model */;
+
+    // Direct `extends Factory` leaf: handler injects via convention.
+    $_rampart = (new RampartFactory())->create();
+    /** @psalm-check-type-exact $_rampart = \App\Models\Rampart */;
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Factory/FactoryModelBindingBaseModelExtendsTest.phpt
+++ b/tests/Type/tests/Factory/FactoryModelBindingBaseModelExtendsTest.phpt
@@ -1,0 +1,46 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Models {
+    use Illuminate\Database\Eloquent\Model;
+
+    final class Reactor extends Model
+    {
+    }
+}
+
+namespace Database\Factories {
+    use App\Models\Reactor;
+    use Illuminate\Database\Eloquent\Factories\Factory;
+    use Illuminate\Database\Eloquent\Model;
+
+    /**
+     * Explicit `@extends Factory<Model>` — a deliberate polymorphic base bound
+     * to bare `Model`, even though `$model = Reactor::class` and the shortname
+     * would both point at a concrete model. The explicit docblock is a real
+     * user contract (Psalm sets template_type_extends_count when it is present),
+     * so the handler must NOT override it back to `Reactor`.
+     *
+     * @extends Factory<Model>
+     */
+    final class ReactorFactory extends Factory
+    {
+        protected $model = Reactor::class;
+
+        /** @return array<string, mixed> */
+        #[\Override]
+        public function definition(): array
+        {
+            return [];
+        }
+    }
+}
+
+namespace App\Sandbox\BaseModelExtends {
+    use Database\Factories\ReactorFactory;
+
+    $_one = (new ReactorFactory())->create();
+    /** @psalm-check-type-exact $_one = \Illuminate\Database\Eloquent\Model */;
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Factory/FactoryModelBindingExplicitExtendsTest.phpt
+++ b/tests/Type/tests/Factory/FactoryModelBindingExplicitExtendsTest.phpt
@@ -1,0 +1,49 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Models {
+    use Illuminate\Database\Eloquent\Model;
+
+    final class Beacon extends Model
+    {
+    }
+
+    final class Pylon extends Model
+    {
+    }
+}
+
+namespace Database\Factories {
+    use App\Models\Beacon;
+    use App\Models\Pylon;
+    use Illuminate\Database\Eloquent\Factories\Factory;
+
+    /**
+     * Explicit `@extends Factory<Pylon>` even though `$model = Beacon::class`
+     * and the shortname would point elsewhere. The user binding must win — the
+     * handler's `isDirectFactorySubclass()` guard detects the bound TModel and
+     * skips injection.
+     *
+     * @extends Factory<Pylon>
+     */
+    final class BeaconFactory extends Factory
+    {
+        protected $model = Beacon::class;
+
+        /** @return array<string, mixed> */
+        #[\Override]
+        public function definition(): array
+        {
+            return [];
+        }
+    }
+}
+
+namespace App\Sandbox\Explicit {
+    use Database\Factories\BeaconFactory;
+
+    $_one = (new BeaconFactory())->create();
+    /** @psalm-check-type-exact $_one = \App\Models\Pylon */;
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Factory/FactoryModelBindingFromPropertyTest.phpt
+++ b/tests/Type/tests/Factory/FactoryModelBindingFromPropertyTest.phpt
@@ -1,0 +1,42 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Models {
+    use Illuminate\Database\Eloquent\Model;
+
+    final class Widget extends Model
+    {
+    }
+}
+
+namespace Database\Factories {
+    use App\Models\Widget;
+    use Illuminate\Database\Eloquent\Factories\Factory;
+
+    /**
+     * Static-fallback (a): no `@extends` docblock, the model comes from the
+     * `$model` property default. The shortname (`Pomelo`) intentionally does
+     * NOT map to any model, so only the property path can resolve — proving
+     * `resolveFromModelProperty()` fires independently of the convention.
+     */
+    final class PomeloFactory extends Factory
+    {
+        protected $model = Widget::class;
+
+        /** @return array<string, mixed> */
+        #[\Override]
+        public function definition(): array
+        {
+            return [];
+        }
+    }
+}
+
+namespace App\Sandbox\Property {
+    use Database\Factories\PomeloFactory;
+
+    $_one = (new PomeloFactory())->create();
+    /** @psalm-check-type-exact $_one = \App\Models\Widget */;
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Factory/FactoryModelBindingFromShortNameTest.phpt
+++ b/tests/Type/tests/Factory/FactoryModelBindingFromShortNameTest.phpt
@@ -1,0 +1,44 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Models {
+    use Illuminate\Database\Eloquent\Model;
+
+    final class Ledger extends Model
+    {
+    }
+}
+
+namespace Database\Factories {
+    use Illuminate\Database\Eloquent\Factories\Factory;
+
+    /**
+     * Static-fallback (b): bare factory, no `@extends`, no `$model`. The model
+     * is derived from the shortname convention
+     * (`Database\Factories\LedgerFactory` -> `App\Models\Ledger`). This is the
+     * exact shape #780 reports as leaking `MissingTemplateParam` on stock
+     * Laravel projects.
+     */
+    final class LedgerFactory extends Factory
+    {
+        /** @return array<string, mixed> */
+        #[\Override]
+        public function definition(): array
+        {
+            return [];
+        }
+    }
+}
+
+namespace App\Sandbox\ShortName {
+    use Database\Factories\LedgerFactory;
+
+    $_one = (new LedgerFactory())->create();
+    /** @psalm-check-type-exact $_one = \App\Models\Ledger */;
+
+    // count(N) plurality still threads through the injected TModel.
+    $_many = (new LedgerFactory())->count(3)->create();
+    /** @psalm-check-type-exact $_many = \Illuminate\Database\Eloquent\Collection<int, \App\Models\Ledger> */;
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Factory/FactoryModelBindingNestedNamespaceTest.phpt
+++ b/tests/Type/tests/Factory/FactoryModelBindingNestedNamespaceTest.phpt
@@ -1,0 +1,51 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App {
+    use Illuminate\Database\Eloquent\Model;
+
+    // Laravel-correct target: flat `{AppNs}{flatBase}` (candidate 2).
+    final class User extends Model
+    {
+    }
+}
+
+namespace App\Models {
+    use Illuminate\Database\Eloquent\Model;
+
+    // Decoy: flat under `Models\` — the removed, wrong candidate. It must NOT
+    // win over the real `App\User`.
+    final class User extends Model
+    {
+    }
+}
+
+namespace Database\Factories\Admin {
+    use Illuminate\Database\Eloquent\Factories\Factory;
+
+    /**
+     * Nested factory. Laravel's default resolver tries exactly two candidates:
+     *   1. `App\Models\Admin\User` (nested under Models) — absent here.
+     *   2. `App\User` (flat factory basename, no `Models\`) — the match.
+     * The old handler also tried `App\Models\User`, which would wrongly match
+     * the decoy above; the fix drops it. Mirrors Factory::modelName().
+     */
+    final class UserFactory extends Factory
+    {
+        /** @return array<string, mixed> */
+        #[\Override]
+        public function definition(): array
+        {
+            return [];
+        }
+    }
+}
+
+namespace App\Sandbox\Nested {
+    use Database\Factories\Admin\UserFactory;
+
+    $_one = (new UserFactory())->create();
+    /** @psalm-check-type-exact $_one = \App\User */;
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Factory/FactoryModelBindingUnresolvableTest.phpt
+++ b/tests/Type/tests/Factory/FactoryModelBindingUnresolvableTest.phpt
@@ -1,0 +1,32 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace Database\Factories {
+    use Illuminate\Database\Eloquent\Factories\Factory;
+
+    /**
+     * No-match: no `$model`, and the shortname (`Phantom`) maps to no scanned
+     * Model. The handler resolves nothing and injects nothing — it never
+     * guesses a wrong binding. The chain falls back to base `Model` without
+     * crashing (`MissingTemplateParam` is already suppressed for bare factory
+     * subclasses by SuppressHandler, so no error surfaces either).
+     */
+    final class PhantomFactory extends Factory
+    {
+        /** @return array<string, mixed> */
+        #[\Override]
+        public function definition(): array
+        {
+            return [];
+        }
+    }
+}
+
+namespace App\Sandbox\Unresolvable {
+    use Database\Factories\PhantomFactory;
+
+    $_one = (new PhantomFactory())->create();
+    /** @psalm-check-type-exact $_one = \Illuminate\Database\Eloquent\Model */;
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

Real Laravel factories rarely write `@extends Factory<TModel>` — the stock layout is a bare `class TaskFactory extends Factory` (pterodactyl/panel, bookstack, monica, ...). Without the binding, `TModel` collapses to base `Model`, so `(new TaskFactory())->create()` returns `Model` instead of `Task`, and `ModelFactoryMethodTypeProvider`'s Tier-2 lookup (`Model::factory()` returning the concrete `XFactory`, #964) is a no-op. On Psalm 6 the same gap also surfaces as `MissingTemplateParam` on every stock factory.

## Related

Closes #780. Supersedes #969. Inverse of #517 (Model → Factory); complement of #964, whose `hasModelTemplateBinding()` gate reads exactly the slot this handler fills.

## Solution Description

New `FactoryModelBindingHandler` (`AfterCodebasePopulated`) injects the `Factory<TModel>` binding into `template_extended_params` for concrete classes whose direct parent is `Factory`, resolving the model in two tiers:

- **Runtime path (primary):** for autoloadable factories, instantiate via `ReflectionClass::newInstanceWithoutConstructor()` and call Laravel's own `Factory::modelName()`. This honors `#[UseModel]`, the `$model` property, the naming convention, and — unlike the static approach in #969 — container overrides (`Factory::useNamespace()`, `guessModelNamesUsing()`), and is immune to future drift in Laravel's resolution logic. A local catch degrades any runtime failure to the static tiers.
- **Static fallback:** for classes Psalm scanned but PHP cannot load — (a) the `$model` property default from class storage, (b) shortname convention (`Database\Factories\Auth\UserFactory` → `App\Models\Auth\User`, with a flat `{AppNs}` fallback), using the booted app's namespace.

A resolved candidate must be a scanned `Model` subclass, otherwise nothing is injected (never guess wrong). The merge preserves the populator-supplied `TCount` default, so the `(TCount is null|0|1 ? TModel : Collection<int, TModel>)` conditional return on `create()`/`make()` keeps resolving through `count(N)` chains.

Skips (kept from #969's review rounds): abstract classes, factories declaring own templates, user-written `@extends Factory<X>` (detected as a non-bare-`Model` `TNamedObject` in the TModel slot — which also makes the pass idempotent on Psalm's cached storages), and indirect descendants (the #677 abstract-base pattern stays intact). Static namespace cache is reset in the plugin's per-invocation reset block.

Compared to #969 (484-line handler): ~120 lines of logic, strictly more capable via the runtime path.

Verification:

- 5 new type tests in `tests/Type/tests/Factory/`: `$model` property, shortname convention (incl. `count(3)->create()` plurality), explicit `@extends` defers to the user binding, abstract-base pattern (direct leaf handled, indirect trap leaf skipped), unresolvable factory gets no injection. Disabling the handler fails the property/shortname/leaf tests (types collapse to `Model`), confirming the tests assert the handler's work.
- The runtime path is exercised by `composer test:app` (fresh Laravel app with a real `UserFactory`): clean.
- `composer test:unit` (1057 pass), full `composer psalm` self-analysis clean, 100% type coverage, rector + cs clean.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)
- [x] Documentation is updated (`docs/contributing/README.md` boot-flow diagram)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786819819&installation_id=141955579&pr_number=1280&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1280&signature=1cc572af3a9fb31fc4fdfff48e000dca90a57ba8eef3239368650e4047b71176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->