### PR TITLE
Invoke Laravel's own model initializers at warm-up

### DIFF
--- a/src/Handlers/Eloquent/Metadata/ModelInstancePreparer.php
+++ b/src/Handlers/Eloquent/Metadata/ModelInstancePreparer.php
@@ -5,19 +5,11 @@ declare(strict_types=1);
 namespace Psalm\LaravelPlugin\Handlers\Eloquent\Metadata;
 
 use Illuminate\Database\Eloquent\Attributes\Appends;
-use Illuminate\Database\Eloquent\Attributes\Connection;
-use Illuminate\Database\Eloquent\Attributes\Fillable;
-use Illuminate\Database\Eloquent\Attributes\Guarded;
-use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Attributes\Initialize;
-use Illuminate\Database\Eloquent\Attributes\Table;
-use Illuminate\Database\Eloquent\Attributes\Unguarded;
-use Illuminate\Database\Eloquent\Attributes\Visible;
-use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Mirrors {@see Model}::__construct()'s initializer lifecycle on a constructor-less instance.
+ * Replays {@see Model}::__construct()'s initializer lifecycle on a constructor-less instance.
  *
  * {@see ModelMetadataRegistryBuilder} reads a model's runtime fields off a `newInstanceWithoutConstructor()`
  * throwaway, which skips `initializeTraits()` / `initializeModelAttributes()`; unreplayed, everything those
@@ -39,9 +31,9 @@ final class ModelInstancePreparer
      * matches runtime under either. Discovery mirrors bootTraits(): conventional name or `#[Initialize]`
      * (gated — the framework ignores the tag below 12.22), neither filtering isStatic.
      *
-     * Framework concerns run a MIRROR at their position rather than being invoked, discriminated by SOURCE
-     * FILE, not declaring class: a directly-`use`d concern flattens to report the user model as declarer.
-     * `#[Connection]`/`#[Table]` run last, as at runtime.
+     * Framework and user initializers are INVOKED alike, so each does whatever the INSTALLED Laravel does —
+     * version-correct by construction, with no hand-written mirror to drift when a release moves one. Exactly
+     * one is not invoked: the framework's `initializeHasAttributes` ({@see applyAppendsAttribute()}).
      *
      * Not `initializeTraits()`: it reads `static::$traitInitializers`, populated only by `bootTraits()` — and
      * booting registers global scopes, a Psalm hang. `boot{Trait}()` is skipped for the same reason, so an
@@ -75,8 +67,17 @@ final class ModelInstancePreparer
             }
 
             $invoked[$name] = true;
-            if (\str_starts_with(\str_replace('\\', '/', (string) $method->getFileName()), $eloquentRoot . '/')) {
-                self::applyConcernMirror($name, $reflection, $instance);
+            // Discriminated by SOURCE FILE, not declaring class: a directly-`use`d concern flattens to report
+            // the user model as declarer. So anything declared in the user's own file — their own trait named
+            // `HasAttributes`, or an override on the model — takes the invoke branch, exactly as it would
+            // dispatch at runtime. An override that calls `parent::initializeHasAttributes()` therefore does
+            // reach `casts()`; that is the honest limit of the rule below, and it is not fixable by
+            // discrimination (no reflection can tell an override that calls up from one that does not).
+            $isFrameworkHasAttributes = $name === 'initializeHasAttributes'
+                && \str_starts_with(\str_replace('\\', '/', (string) $method->getFileName()), $eloquentRoot . '/');
+
+            if ($isFrameworkHasAttributes) {
+                self::applyAppendsAttribute($reflection, $instance);
             } else {
                 // Reflection, NOT $instance->{$name}(): a protected initializer called from outside routes to
                 // Model::__call() query-builder forwarding instead of running. Bare statement keeps the mixed
@@ -85,52 +86,39 @@ final class ModelInstancePreparer
             }
         }
 
-        // initializeModelAttributes phase — always after initializeTraits at runtime.
-        self::applyConnectionAttribute($reflection, $instance);
-        self::applyTableAttribute($reflection, $instance);
-    }
-
-    /**
-     * Hand-written mirrors of the framework concerns: HasAttributes → `mergeAppends(#[Appends])` (its
-     * `casts()` merge is {@see ModelMetadataRegistryBuilder::computeCasts()}'s job, `dateFormat` isn't stored);
-     * HidesAttributes → `mergeHidden`/`mergeVisible`; GuardsAttributes → `mergeFillable(#[Fillable])` +
-     * `#[Guarded]`/`#[Unguarded]`; HasUniqueStringIds → `usesUniqueIds = true`; HasTimestamps →
-     * `#[WithoutTimestamps]`/`#[Table(timestamps:)]`. HasRelationships / SoftDeletes no-op — nothing they
-     * set is stored (SoftDeletes' `deleted_at` cast comes from computeCasts()).
-     *
-     * Audited against every `initialize*` under vendor `Illuminate\Database\` — the walk's skip root, and
-     * wider than `Eloquent\Concerns`, since SoftDeletes and Model itself sit outside it.
-     *
-     * @param \ReflectionClass<Model> $reflection
-     */
-    private static function applyConcernMirror(string $name, \ReflectionClass $reflection, Model $instance): void
-    {
-        if ($name === 'initializeHasUniqueStringIds') {
-            self::flipUsesUniqueIds($instance);
-        } elseif ($name === 'initializeHasAttributes') {
-            self::applyAppendsAttribute($reflection, $instance);
-        } elseif ($name === 'initializeHidesAttributes') {
-            self::applyHiddenVisibleAttributes($reflection, $instance);
-        } elseif ($name === 'initializeGuardsAttributes') {
-            self::applyFillableGuardedAttributes($reflection, $instance);
-        } elseif ($name === 'initializeHasTimestamps') {
-            self::applyTimestampsAttributes($reflection, $instance);
+        // The initializeModelAttributes phase — `#[Table]`/`#[Connection]` plus the primary-key sub-overrides
+        // they carry. Runs after initializeTraits at runtime, so last here too. The method is Laravel 13.0;
+        // the 12.x floor has no such phase at all, which is what the guard is for (12.x reaching the call
+        // would route it through Model::__call() to the query builder). Not every attribute it reads is 13.0
+        // — `#[WithoutIncrementing]` is 13.2 — but `^13.3` puts the whole set below the floor.
+        if (\method_exists($instance, 'initializeModelAttributes')) {
+            $instance->initializeModelAttributes();
         }
     }
 
     /**
-     * What HasUniqueStringIds' initializer does: makes `getKeyType()`/`getIncrementing()` return the
-     * string/non-incrementing values Laravel returns at runtime.
-     */
-    private static function flipUsesUniqueIds(Model $instance): void
-    {
-        $property = new \ReflectionProperty($instance, 'usesUniqueIds');
-        $property->setValue($instance, true);
-    }
-
-    /**
+     * The framework's `initializeHasAttributes` is the one initializer stood in for rather than invoked.
+     *
+     * NOT because it runs user code: the walk above invokes user trait initializers deliberately, and doing so
+     * is the only way to observe them at all. Because `casts()` is the one initializer input already available
+     * STATICALLY — {@see \Psalm\LaravelPlugin\Handlers\Eloquent\Schema\CastsMethodParser} AST-parses it and
+     * {@see ModelMetadataRegistryBuilder::computeCasts()} merges that result last. Executing it would buy no
+     * information the registry does not already have, at the cost of evaluating arbitrary user expressions
+     * inside warm-up. A user trait initializer has no such static equivalent, which is what makes the two
+     * different — not who wrote them.
+     *
+     * Standing in for it costs three effects, of which only the third is reproduced:
+     *  - `ensureCastsAreStringValues()`, which also normalizes the DECLARED `$casts`. No `casts()` call is
+     *    involved, so the rule above does NOT excuse skipping it: a `protected $casts = ['x' => [Foo::class,
+     *    'arg']]` stays an array here where a constructed model holds `'Foo:arg'`, and computeCasts() then
+     *    drops that model's whole casts section on the resulting TypeError. Pre-existing, not this rework's
+     *    doing, tracked as #1281 — do not read this mirror as evidence the gap is intended.
+     *  - `$dateFormat`, which nothing stores.
+     *  - `mergeAppends()`, mirrored below.
+     *
      * `#[Appends]` is Laravel 13.0+; below it classAttribute() matches nothing and this no-ops — so
-     * `mergeAppends()`, absent on 12.14–12.24, is never called and cannot crash warm-up.
+     * `mergeAppends()`, absent on 12.14–12.24, is never called and cannot crash warm-up. Identical across the
+     * whole `illuminate/database: ^12.14 || ^13.3` range.
      *
      * @param \ReflectionClass<Model> $reflection
      */
@@ -143,197 +131,12 @@ final class ModelInstancePreparer
     }
 
     /**
-     * Both attributes and helpers are Laravel-13.0; an absent attribute no-ops
-     * (see {@see self::applyAppendsAttribute()}).
-     *
-     * @param \ReflectionClass<Model> $reflection
-     */
-    private static function applyHiddenVisibleAttributes(\ReflectionClass $reflection, Model $instance): void
-    {
-        $hidden = self::classAttribute($reflection, Hidden::class);
-        if ($hidden !== null) {
-            $instance->mergeHidden($hidden->columns);
-        }
-
-        $visible = self::classAttribute($reflection, Visible::class);
-        if ($visible !== null) {
-            $instance->mergeVisible($visible->columns);
-        }
-    }
-
-    /**
-     * Known gap, applied by no mirror: `#[Table]`'s `key`/`keyType`/`incrementing` sub-overrides and
-     * `#[WithoutIncrementing]`, which `initializeModelAttributes()` feeds into the primary key.
-     * {@see ModelMetadataRegistryBuilder::computePrimaryKey()} reads only the raw getter defaults; the table
-     * NAME (the serialization-relevant part) IS applied by {@see self::applyTableAttribute()}.
-     *
-     * @param \ReflectionClass<Model> $reflection
-     */
-    private static function applyFillableGuardedAttributes(\ReflectionClass $reflection, Model $instance): void
-    {
-        $fillable = self::classAttribute($reflection, Fillable::class);
-        if ($fillable !== null) {
-            $instance->mergeFillable($fillable->columns);
-        }
-
-        self::applyGuardedAttribute($reflection, $instance);
-    }
-
-    /**
-     * `#[Guarded]`/`#[Unguarded]` only replace the default `['*']`, mirroring
-     * {@see \Illuminate\Database\Eloquent\Concerns\GuardsAttributes::initializeGuardsAttributes()}.
-     *
-     * The early-return matches runtime precisely because this mirror runs at initializeGuardsAttributes'
-     * position in the walk: a user initializer that ran earlier (per that PHP's order) and called guard()
-     * makes runtime skip `#[Guarded]` too.
-     *
-     * @param \ReflectionClass<Model> $reflection
-     */
-    private static function applyGuardedAttribute(\ReflectionClass $reflection, Model $instance): void
-    {
-        if ($instance->getGuarded() !== ['*']) {
-            return;
-        }
-
-        if (self::classAttribute($reflection, Unguarded::class) !== null) {
-            $instance->guard([]);
-
-            return;
-        }
-
-        // Presence, not non-emptiness, gates the replace: `#[Guarded()]` with no columns sets [], matching
-        // Laravel's `columns ?? ['*']`.
-        $guarded = self::classAttribute($reflection, Guarded::class);
-        if ($guarded !== null) {
-            $instance->guard($guarded->columns);
-        }
-    }
-
-    /**
-     * Mirror of `initializeHasTimestamps`, precedence included. Feeds `TraitFlags::$usesTimestamps` through
-     * {@see ModelMetadataRegistryBuilder::readRuntimeConfiguration()}'s `usesTimestamps()` read. #1276.
-     *
-     * The `!== true` early-return is Laravel's own `=== true` guard: an attribute only speaks while
-     * `$timestamps` is still `true`. Both ways of closing it are live — a declared `$timestamps = false` is a
-     * property default `newInstanceWithoutConstructor()` applies, and a user initializer that ran earlier in
-     * the walk has already written it (same position-dependence as {@see applyGuardedAttribute()}).
-     *
-     * No `class_exists` gate. `initializeHasTimestamps()` is 13.0+, so the 12.x floor never reaches this.
-     * Above it, `#[WithoutTimestamps]` (13.2) is newer than the initializer that dispatches here, and package
-     * atomicity does NOT close that window — 13.1 ships the initializer without the attribute in one artifact.
-     * Composer's `require` on `illuminate/database: ^12.14 || ^13.3` is what closes it; the
-     * `laravel/framework` entry is dev-only and binds nothing a user installs. Widening that floor is
-     * survivable rather than fatal, but check here first: {@see classAttribute()} name-matches an attribute
-     * whose class is absent and throws on `newInstance()`. Only a model naming a class its own framework
-     * lacks gets there — code Laravel fatals on too, since `Error` escapes its `catch (Exception)`.
-     *
-     * @param \ReflectionClass<Model> $reflection
-     */
-    private static function applyTimestampsAttributes(\ReflectionClass $reflection, Model $instance): void
-    {
-        if ($instance->timestamps !== true) {
-            return;
-        }
-
-        if (self::classAttribute($reflection, WithoutTimestamps::class) !== null) {
-            $instance->timestamps = false;
-
-            return;
-        }
-
-        $table = self::classAttribute($reflection, Table::class);
-        if ($table !== null && $table->timestamps !== null) {
-            $instance->timestamps = $table->timestamps;
-        }
-    }
-
-    /**
-     * `#[Connection(name:)]` fills a null `$connection` (`??=`), normalized to string like
-     * `Model::getConnectionName()`'s `enum_value()`. Deliberately stronger than storing the raw enum: the
-     * registry's `connection` field is `?string`, and an int-backed enum would TypeError under strict_types,
-     * dropping the whole model via warmUp()'s catch.
-     *
-     * @param \ReflectionClass<Model> $reflection
-     */
-    private static function applyConnectionAttribute(\ReflectionClass $reflection, Model $instance): void
-    {
-        if ($instance->getConnectionName() !== null) {
-            return;
-        }
-
-        $name = self::classAttribute($reflection, Connection::class)?->name;
-        if ($name === null) {
-            return;
-        }
-
-        $instance->setConnection(match (true) {
-            \is_string($name) => $name,
-            $name instanceof \BackedEnum => (string) $name->value,
-            default => $name->name,
-        });
-    }
-
-    /**
-     * A `#[Table]` declared DIRECTLY on the concrete class (Laravel's non-recursive check) with no own
-     * `$table` overwrites the table; otherwise the ancestor-walked name only fills a still-null one (`??=`).
-     * Feeds {@see ModelMetadataRegistryBuilder::computeSchema()}'s migration lookup.
-     *
-     * Known gap: a `key`/`keyType`-only `#[Table]` (null name) does NOT clear an inherited `$table` the way
-     * Laravel's force-branch does. Same deferred scenario as {@see self::applyFillableGuardedAttributes()}'s
-     * PK sub-overrides, so left untouched rather than half-applied.
-     *
-     * @param \ReflectionClass<Model> $reflection
-     */
-    private static function applyTableAttribute(\ReflectionClass $reflection, Model $instance): void
-    {
-        $name = self::classAttribute($reflection, Table::class)?->name;
-        if ($name === null) {
-            return;
-        }
-
-        $forceSet = !self::declaresOwnProperty($reflection, 'table') && $reflection->getAttributes(Table::class) !== [];
-        if ($forceSet || self::rawTableIsNull($instance)) {
-            $instance->setTable($name);
-        }
-    }
-
-    /**
-     * Mirrors the `$declaresTable` check in `initializeModelAttributes()`.
-     *
-     * @param \ReflectionClass<Model> $reflection
-     * @psalm-pure
-     */
-    private static function declaresOwnProperty(\ReflectionClass $reflection, string $name): bool
-    {
-        if (!$reflection->hasProperty($name)) {
-            return false;
-        }
-
-        return $reflection->getProperty($name)->getDeclaringClass()->getName() === $reflection->getName();
-    }
-
-    /** Reads the raw property, not `getTable()`, which always derives a non-null name from the class. */
-    private static function rawTableIsNull(Model $instance): bool
-    {
-        try {
-            $property = new \ReflectionProperty($instance, 'table');
-        } catch (\ReflectionException) {
-            // Unreachable while Model declares `protected $table` (it does); defensive only.
-            return true;
-        }
-
-        // A typed-uninitialized `$table` (non-idiomatic) has no value to read; treat it as null and avoid the
-        // \Error getValue() throws on it.
-        if (!$property->isInitialized($instance)) {
-            return true;
-        }
-
-        // Consume the mixed value inline so it never binds to a local — keeps coverage at 100%.
-        return $property->getValue($instance) === null;
-    }
-
-    /**
      * Mirrors {@see Model}::resolveClassAttribute(): first ancestor's first instance, no cross-ancestor merge.
+     *
+     * Name-matches an attribute whose class may be absent, and throws on `newInstance()` if so. The
+     * `illuminate/database: ^12.14 || ^13.3` floor is what keeps that unreachable — only a model naming a
+     * class its own framework lacks reaches it, code Laravel fatals on too, since `Error` escapes
+     * resolveClassAttribute()'s `catch (Exception)`. Re-check this if the floor ever widens.
      *
      * @template T of object
      * @param \ReflectionClass<object> $reflection

--- a/src/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php
+++ b/src/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php
@@ -317,6 +317,9 @@ final class ModelMetadataRegistryBuilder
         // sections below degrade together (the degradation test still maps 'trait initializers' → those four).
         // Pre-12.22 (class_uses_recursive parents-first) walk order is immaterial — the config attributes are
         // all Laravel-13-only; the sole pre-12.22 divergence is casts()-vs-user-mergeCasts() (see computeCasts).
+        //
+        // prepare() INVOKES Laravel's own initializers rather than mirroring them, so what the readers below
+        // observe is the installed framework's behaviour, not a copy of it that has to be kept in sync.
         $instancePrepared = self::computeSection(
             0,
             'trait initializers',
@@ -375,7 +378,6 @@ final class ModelMetadataRegistryBuilder
                     $codebase,
                     $modelFqcn,
                     $instance,
-                    $runtime['traits'],
                     $tableSchema,
                     $schemaComplete,
                 ),
@@ -593,9 +595,36 @@ final class ModelMetadataRegistryBuilder
             'withCount' => self::readStringList($instance, 'withCount'),
             'hidden' => self::filterStringList($instance->getHidden()),
             'visible' => self::filterStringList($instance->getVisible()),
-            'connection' => $instance->getConnectionName(),
+            'connection' => self::asConnectionName($instance->getConnectionName()),
             'morphAlias' => self::computeMorphAlias($modelFqcn),
         ];
+    }
+
+    /**
+     * `getConnectionName()` is annotated `@return string|null`, but returns `enum_value($this->connection)` —
+     * and `enum_value()` unwraps a BackedEnum to its raw `->value`, an INT for an int-backed enum. That int
+     * would reach {@see ModelMetadata}'s native `?string $connection` and TypeError under strict_types,
+     * OUTSIDE every computeSection() guard, so warmUp()'s catch would drop the whole model rather than
+     * degrade one section. `#[Connection(Enum::X)]` and a plain `protected $connection = Enum::X;` default
+     * both get there.
+     *
+     * Coerce at the READ site, not on the instance: normalizing the property would still miss a model that
+     * overrides `getConnectionName()` itself, and this is the single expression whose value reaches the field.
+     *
+     * No enum handling here — `enum_value()` has already done it (a UnitEnum yields `->name`, a string-backed
+     * enum a string); only its int case is left to stringify. Anything else is outside Laravel's declared
+     * `\UnitEnum|string|null` contract and has no connection name to give, so null beats a whole-model drop.
+     * The `mixed` parameter is also what keeps Psalm from calling the coercion redundant given that docblock.
+     *
+     * @psalm-pure
+     */
+    private static function asConnectionName(mixed $value): ?string
+    {
+        return match (true) {
+            \is_string($value) => $value,
+            \is_int($value) => (string) $value,
+            default => null,
+        };
     }
 
     /**
@@ -1185,6 +1214,10 @@ final class ModelMetadataRegistryBuilder
      * by reading `$this->usesUniqueIds`. The earlier unique-id initialization section has flipped
      * that flag for UUID/ULID models, so the instance getters return the runtime-correct
      * values here (including any user override of `uniqueIds()` returning multiple cols).
+     *
+     * Reading the getters (never the raw property defaults) is also what makes `#[Table(key:, keyType:,
+     * incrementing:)]` and `#[WithoutIncrementing]` land: `initializeModelAttributes()` writes those during
+     * the replay, so they arrive here already applied.
      */
     private static function computePrimaryKey(Model $instance, TraitFlags $traits): PrimaryKeyInfo
     {
@@ -1317,24 +1350,16 @@ final class ModelMetadataRegistryBuilder
         Codebase $codebase,
         string $modelFqcn,
         Model $instance,
-        TraitFlags $traits,
         TableSchema $schema,
         bool $schemaComplete,
     ): array {
-        $merged = [];
-
-        // 1. SoftDeletes adds its deleted-at column as a `datetime` cast via the trait
-        //    initializer, which `newInstanceWithoutConstructor()` skips. Mirror that
-        //    manually (lowest priority). Honor the `DELETED_AT` class-constant override
-        //    (`const DELETED_AT = 'archived_at';` is the Laravel-documented pattern).
-        if ($traits->hasSoftDeletes) {
-            $merged[self::resolveDeletedAtColumn($instance)] = 'datetime';
-        }
-
-        // 2. Laravel's base getCasts() returns $this->casts, prepending an implicit key cast when
+        // 1. Laravel's base getCasts() returns $this->casts, prepending an implicit key cast when
         //    the model is incrementing. initializeHasAttributes() normally merges casts() during
-        //    construction, but this instance skips the constructor, so step 3 parses casts()
-        //    separately. The caller has already recreated the runtime UUID/ULID trait state.
+        //    construction, but this instance skips the constructor, so step 2 parses casts()
+        //    separately. The caller has already replayed the trait initializers, which puts two
+        //    separate things the read below depends on in place: the UUID/ULID flags that decide the
+        //    implicit key cast, and SoftDeletes' deleted-at datetime cast, which its own initializer
+        //    wrote straight into $casts (hence no step of ours re-adds it).
         //    For a keyless incrementing model, temporarily disable only the implicit key cast;
         //    restore the real value before the primary-key snapshot is computed.
         $incrementing = $instance->getIncrementing();
@@ -1352,9 +1377,9 @@ final class ModelMetadataRegistryBuilder
             }
         }
 
-        $merged = \array_merge($merged, $instanceCasts);
+        $merged = $instanceCasts;
 
-        // 3. casts() method (AST-parsed) overrides #2 when both declare the same key.
+        // 2. casts() method (AST-parsed) overrides #1 when both declare the same key.
         //    CastsMethodParser calls Codebase::methodExists(), which dereferences the
         //    non-nullable Codebase::$methods. A Codebase constructed via
         //    newInstanceWithoutConstructor() (unit-test fixtures) leaves it
@@ -1565,27 +1590,6 @@ final class ModelMetadataRegistryBuilder
         }
 
         return self::filterStringList($value);
-    }
-
-    /**
-     * Resolve SoftDeletes' deleted-at column. Laravel reads `static::DELETED_AT` when
-     * defined (see `SoftDeletes::getDeletedAtColumn()`), otherwise defaults to
-     * `'deleted_at'`. We replicate that without invoking the trait method, since calling
-     * a trait method through a `Model` variable fails Psalm's type check.
-     *
-     * @psalm-pure
-     */
-    private static function resolveDeletedAtColumn(Model $instance): string
-    {
-        $constantName = $instance::class . '::DELETED_AT';
-        if (\defined($constantName)) {
-            // Inline \constant() into the mixed-param helper so the mixed value never binds to a
-            // local — keeps the file at 100% type coverage (a `@psalm-var mixed` local would
-            // still count against the mixed-expression tally).
-            return self::asNonEmptyString(\constant($constantName)) ?? 'deleted_at';
-        }
-
-        return 'deleted_at';
     }
 
     /**

--- a/tests/Unit/Fixtures/Concerns/EnablesTimestampsInInitializer.php
+++ b/tests/Unit/Fixtures/Concerns/EnablesTimestampsInInitializer.php
@@ -7,8 +7,8 @@ namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Concerns;
 /**
  * User trait initializer that re-enables timestamps. Paired with a declared `$timestamps = false` and
  * `#[WithoutTimestamps]` in {@see \Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\TimestampsInitializerOrderModel},
- * this makes the outcome depend on WHERE the mirror runs in the walk, which is the only way to observe
- * that ordering: whether `initializeHasTimestamps()` sees `false` (and returns) or `true` (and applies
+ * this makes the outcome depend on WHERE `initializeHasTimestamps` runs in the walk, which is the only way
+ * to observe that ordering: whether `initializeHasTimestamps()` sees `false` (and returns) or `true` (and applies
  * `#[WithoutTimestamps]`) is decided by whether this initializer ran first.
  *
  * @psalm-require-extends \Illuminate\Database\Eloquent\Model

--- a/tests/Unit/Fixtures/Concerns/ForcesIntKeyType.php
+++ b/tests/Unit/Fixtures/Concerns/ForcesIntKeyType.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Concerns;
+
+/**
+ * Writes `$keyType` from a trait initializer, so the walk and the `initializeModelAttributes()` phase both
+ * touch the same property. That collision is what makes the phase's POSITION observable — see
+ * {@see \Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\KeyTypeInitializerOrderModel}.
+ *
+ * @psalm-require-extends \Illuminate\Database\Eloquent\Model
+ */
+trait ForcesIntKeyType
+{
+    public function initializeForcesIntKeyType(): void
+    {
+        $this->keyType = 'int';
+    }
+}

--- a/tests/Unit/Fixtures/Concerns/SetsAppendInInitializer.php
+++ b/tests/Unit/Fixtures/Concerns/SetsAppendInInitializer.php
@@ -5,10 +5,17 @@ declare(strict_types=1);
 namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Concerns;
 
 /**
- * User trait initializer that `setAppends()` (the REPLACE form). At runtime, `bootTraits()` ranks this
- * concrete-class initializer ahead of Model's inherited `initializeHasAttributes`, so it runs BEFORE the
- * `#[Appends]` `mergeAppends()` and both entries survive. Guards that the warm-up replay runs before
- * the attribute mirror (a replace after the merge would drop the attribute entry).
+ * User trait initializer that `setAppends()` (the REPLACE form), so its result depends entirely on whether it
+ * lands before or after `initializeHasAttributes`' `mergeAppends(#[Appends])`.
+ *
+ * Which one it is, is PHP-version-dependent — `getMethods()` ranks this concrete-class initializer first on
+ * 8.5 (both entries survive) but Model's inherited concern initializer first on 8.4 (the replace lands last
+ * and drops the attribute entry). Runtime disagrees with itself across the CI matrix, so the consuming test
+ * carries no literal and reads a runtime oracle; see
+ * {@see \Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\AppendsOrderModel}.
+ *
+ * What it guards is that the replay ranks the two exactly as `getMethods()` does, whichever PHP is running —
+ * the same invariant {@see EnablesTimestampsInInitializer} pins for the timestamps initializer.
  *
  * @psalm-require-extends \Illuminate\Database\Eloquent\Model
  */

--- a/tests/Unit/Fixtures/Models/AttributeConfiguredBase.php
+++ b/tests/Unit/Fixtures/Models/AttributeConfiguredBase.php
@@ -9,9 +9,10 @@ use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Abstract base carrying `#[Hidden]`/`#[Appends]` so {@see AttributeConfiguredChild} can prove the
- * `classAttribute()` ancestor walk (mirroring `Model::resolveClassAttribute()`) resolves an inherited
- * attribute. Laravel 13.0+ only.
+ * Abstract base carrying `#[Hidden]`/`#[Appends]` so {@see AttributeConfiguredChild} can prove an inherited
+ * attribute is resolved. The two now travel different roads: `#[Hidden]` through Laravel's own
+ * `resolveClassAttribute()` inside the invoked `initializeHidesAttributes()`, `#[Appends]` through the
+ * plugin's `classAttribute()` — the one remaining mirror, and the only caller left. Laravel 13.0+ only.
  *
  * @internal fixture used by ModelMetadataRegistryTest
  */

--- a/tests/Unit/Fixtures/Models/AttributeOverriddenByPropertyModel.php
+++ b/tests/Unit/Fixtures/Models/AttributeOverriddenByPropertyModel.php
@@ -9,11 +9,16 @@ use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * An explicit `$property` declaration wins over the matching `#[Attribute]`, mirroring Laravel's
+ * An explicit `$property` declaration wins over the matching `#[Attribute]` through Laravel's own
  * "replace only the default" / `$declaresTable` guards: `#[Guarded]` is ignored because `$guarded` is
  * no longer `['*']`, `#[Table]` does not override an own `$table` property, and `#[Table(timestamps: true)]`
- * is ignored because `$timestamps` is no longer `true`. Guards the `applyGuardedAttribute()` early-return,
- * the `applyTableAttribute()` directness branch and the `applyTimestampsAttributes()` `!== true` return.
+ * is ignored because `$timestamps` is no longer `true`.
+ *
+ * The replay invokes those initializers rather than reproducing their guards, so what this pins is the
+ * PRECONDITION every one of them reads: `newInstanceWithoutConstructor()` applies declared property
+ * defaults, so the invoked initializers see `$guarded`/`$table`/`$timestamps` exactly as a constructed model
+ * does. Were that not true, all three guards would silently open and the attributes would win.
+ *
  * Laravel 13.0+ only; both consuming tests are gated on `class_exists()` (the guard/table one on
  * `#[Hidden]`, the timestamps one on the 13.2 `#[WithoutTimestamps]`).
  *

--- a/tests/Unit/Fixtures/Models/CastsMethodModel.php
+++ b/tests/Unit/Fixtures/Models/CastsMethodModel.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Declares a `casts()` method, which `HasAttributes::initializeHasAttributes()` EXECUTES at construction.
+ *
+ * That execution is the whole reason the warm-up replay stands in for that one initializer instead of
+ * invoking it (see
+ * {@see \Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelInstancePreparer::applyAppendsAttribute()}) —
+ * not because `casts()` is user code, but because it is the one initializer input the registry ALREADY has
+ * statically: {@see \Psalm\LaravelPlugin\Handlers\Eloquent\Schema\CastsMethodParser} AST-parses it and the
+ * builder merges that result last. The cast is therefore absent from the replayed instance and present on a
+ * constructed one — the contrast the consuming test asserts.
+ *
+ * Not version-gated: the `casts()` merge is in `initializeHasAttributes()` across the whole supported range.
+ *
+ * @internal fixture used by ModelInstancePreparerTest
+ */
+final class CastsMethodModel extends Model
+{
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return ['from_casts_method' => 'array'];
+    }
+}

--- a/tests/Unit/Fixtures/Models/CustomDeletedAtModel.php
+++ b/tests/Unit/Fixtures/Models/CustomDeletedAtModel.php
@@ -8,9 +8,13 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
- * SoftDeletes model that overrides the `DELETED_AT` class constant. Exercises
- * `ModelMetadataRegistryBuilder::resolveDeletedAtColumn()` — the registry must
- * key the auto-added datetime cast off `archived_at`, not the default `deleted_at`.
+ * SoftDeletes model that overrides the `DELETED_AT` class constant, so the auto-added datetime cast must be
+ * keyed off `archived_at` rather than the default `deleted_at`.
+ *
+ * The warm-up replay invokes the real `SoftDeletes::initializeSoftDeletes()`, which reads
+ * `getDeletedAtColumn()` and honours the constant on its own — so this fixture pins that the replay INVOKES
+ * that initializer rather than standing in for it: a mirror would have to re-derive the constant by hand,
+ * which is exactly the copy this class exists to make unnecessary.
  *
  * @internal fixture used by ModelMetadataRegistryTest and ModelInstancePreparerTest
  */

--- a/tests/Unit/Fixtures/Models/EnumConnectionModel.php
+++ b/tests/Unit/Fixtures/Models/EnumConnectionModel.php
@@ -9,9 +9,13 @@ use Illuminate\Database\Eloquent\Model;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Enums\SerializedIntStatus;
 
 /**
- * `#[Connection]` with an int-backed enum: `getConnectionName()` would return the raw `int`, which the
- * registry's `?string $connection` field rejects under `strict_types` — `applyConnectionAttribute()`
- * must normalize it to a string so the whole model entry is not dropped. Laravel 13.0+ only.
+ * `#[Connection]` with an int-backed enum: `getConnectionName()` applies `enum_value()`, which unwraps a
+ * BackedEnum to its raw `->value` — an `int` here, despite the method's `@return string|null`. The registry's
+ * `?string $connection` rejects that under `strict_types`, and the TypeError lands outside every section
+ * guard, so the whole model entry would be dropped.
+ * {@see \Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadataRegistryBuilder::asConnectionName()}
+ * coerces it at the read site — the single expression whose value reaches that field, and therefore the only
+ * place a model that overrides `getConnectionName()` itself can also be caught. Laravel 13.0+ only.
  *
  * @internal fixture used by ModelMetadataRegistryTest
  */

--- a/tests/Unit/Fixtures/Models/InheritedTableBase.php
+++ b/tests/Unit/Fixtures/Models/InheritedTableBase.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Declares `$table` so {@see TableKeyOnlyModel} can INHERIT it — the only shape in which
+ * `initializeModelAttributes()`'s `$declaresTable` branch is observable.
+ *
+ * @internal fixture used by ModelInstancePreparerTest
+ */
+abstract class InheritedTableBase extends Model
+{
+    /** @var string */
+    protected $table = 'inherited_table';
+}

--- a/tests/Unit/Fixtures/Models/KeyTypeInitializerOrderModel.php
+++ b/tests/Unit/Fixtures/Models/KeyTypeInitializerOrderModel.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Concerns\ForcesIntKeyType;
+
+/**
+ * The only fixture that can observe WHERE the `initializeModelAttributes()` phase runs relative to the walk.
+ *
+ * `#[Table(keyType:)]` is applied behind Laravel's `$this->keyType === 'int'` guard, and the trait initializer
+ * writes exactly that value — so the two orders disagree:
+ *  - phase LAST (runtime, and what prepare() does): the initializer sets `int`, the guard then admits the
+ *    attribute, and `getKeyType()` is `string`.
+ *  - phase HOISTED before the walk: the attribute applies to the pristine `int` default, then the initializer
+ *    overwrites it, and `getKeyType()` is `int`.
+ *
+ * Chosen over the `$table` force-branch, which is the other way to catch the hoist but only from 13.6 (13.3
+ * through 13.5 have none). The `keyType` guard has no force branch and no version split — byte-identical from
+ * 13.3 to 13.20 — so this discriminates across the whole `^13.3` range.
+ *
+ * Laravel 13.0+ (`#[Table]`); the consuming test is gated on `class_exists()`.
+ *
+ * @internal fixture used by ModelInstancePreparerTest
+ */
+#[Table(name: 'key_type_order_models', keyType: 'string')]
+final class KeyTypeInitializerOrderModel extends \Illuminate\Database\Eloquent\Model
+{
+    use ForcesIntKeyType;
+}

--- a/tests/Unit/Fixtures/Models/PlainEnumConnectionModel.php
+++ b/tests/Unit/Fixtures/Models/PlainEnumConnectionModel.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Enums\SerializedIntStatus;
+
+/**
+ * An int-backed enum reaching `$connection` as a plain PROPERTY DEFAULT, with no `#[Connection]` involved —
+ * the other half of what {@see EnumConnectionModel} covers, and the half no attribute mirror could ever see.
+ * `newInstanceWithoutConstructor()` applies it before any initializer runs.
+ *
+ * Same failure if unnormalized: `getConnectionName()`'s `enum_value()` yields the raw `int` backing value,
+ * which the registry's `?string $connection` rejects outside every section guard, dropping the whole model.
+ *
+ * Laravel 12.28+, NOT 13.0: `$connection` widened to `\UnitEnum|string|null` and `getConnectionName()` began
+ * applying `enum_value()` in 12.28, well before the 13.0 `#[Connection]` attribute. So this row is live on
+ * most of the 12.x line, and its consuming test gates on the capability (an int back from the getter) rather
+ * than on any attribute's existence. On 12.14–12.27 the getter returns the enum object untouched.
+ *
+ * @internal fixture used by ModelMetadataRegistryTest
+ */
+final class PlainEnumConnectionModel extends Model
+{
+    /** @var \Tests\Psalm\LaravelPlugin\Unit\Fixtures\Enums\SerializedIntStatus */
+    protected $connection = SerializedIntStatus::Published;
+}

--- a/tests/Unit/Fixtures/Models/TableKeyAttributeModel.php
+++ b/tests/Unit/Fixtures/Models/TableKeyAttributeModel.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * `#[Table]`'s primary-key sub-overrides — the half of the attribute that is not the table name.
+ * `initializeModelAttributes()` applies each behind a still-at-its-default guard (`primaryKey === 'id'`,
+ * `keyType === 'int'`), so this fixture leaves all three at their defaults for the attribute to speak.
+ *
+ * Laravel 13.0+ (`#[Table]`); the consuming test is gated on `class_exists()`.
+ *
+ * @internal fixture used by ModelMetadataRegistryTest
+ */
+#[Table(name: 'table_key_attribute_models', key: 'uuid', keyType: 'string', incrementing: false)]
+final class TableKeyAttributeModel extends Model {}

--- a/tests/Unit/Fixtures/Models/TableKeyOnlyModel.php
+++ b/tests/Unit/Fixtures/Models/TableKeyOnlyModel.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Table;
+
+/**
+ * A name-less `#[Table]` on a class that inherits `$table` rather than declaring its own — the shape that
+ * reaches `initializeModelAttributes()`'s `$declaresTable` force-branch.
+ *
+ * The answer is VERSION-SPLIT inside the supported range, which is exactly why the replay must invoke the
+ * real method rather than reproduce it: Laravel 13.3-13.5 have no force-branch and their `$this->table ??=`
+ * keeps the inherited name, while 13.6+ assigns `$table->name ?? null` unconditionally — nulling it, so
+ * `getTable()` re-derives from the class name. The consuming test therefore pins a runtime oracle and never a
+ * literal.
+ *
+ * Laravel 13.0+ (`#[Table]`); the consuming test is gated on `class_exists()`.
+ *
+ * @internal fixture used by ModelInstancePreparerTest
+ */
+#[Table(key: 'uuid')]
+final class TableKeyOnlyModel extends InheritedTableBase {}

--- a/tests/Unit/Fixtures/Models/TableTimestampsAttributeModel.php
+++ b/tests/Unit/Fixtures/Models/TableTimestampsAttributeModel.php
@@ -10,7 +10,8 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * `#[Table(timestamps: false)]`, the second form `initializeHasTimestamps()` honours. Paired with
  * {@see AttributeConfiguredModel}, whose `#[Table]` carries no `timestamps:` argument and must stay
- * timestamped: together they pin that the mirror reads the argument rather than the attribute's presence.
+ * timestamped: together they pin that the ARGUMENT decides, not the attribute's presence — Laravel's rule,
+ * and the registry must record its outcome.
  *
  * Uses only `#[Table]` (Laravel 13.0+), but its consuming test shares a 13.2 `#[WithoutTimestamps]`
  * gate with the rest of the timestamps cases.

--- a/tests/Unit/Fixtures/Models/TableTimestampsEnabledModel.php
+++ b/tests/Unit/Fixtures/Models/TableTimestampsEnabledModel.php
@@ -8,13 +8,15 @@ use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * `#[Table(timestamps: true)]` on an otherwise-default model: the only fixture that reaches the mirror's
- * `$timestamps = $table->timestamps` assignment with `true` on the right-hand side. Every other
+ * `#[Table(timestamps: true)]` on an otherwise-default model: the only fixture that reaches
+ * `initializeHasTimestamps()`'s `$timestamps = $table->timestamps` assignment with `true` on the
+ * right-hand side. Every other
  * `timestamps: true` fixture short-circuits before it — {@see TimestampsAttributePrecedenceModel} on
  * `#[WithoutTimestamps]`, {@see AttributeOverriddenByPropertyModel} on the `!== true` guard.
  *
- * Without this, hard-coding the assignment to `false` passes the whole suite while inverting #1276:
- * a `timestamps: true` model would record false where runtime says true.
+ * Without it, a registry that recorded `false` for every attribute-configured model would pass the rest of
+ * the timestamps cases while inverting #1276: a `timestamps: true` model reporting false where runtime
+ * says true.
  *
  * Laravel 13.0+ only; the consuming test shares the 13.2 `#[WithoutTimestamps]` gate.
  *

--- a/tests/Unit/Fixtures/Models/TimestampsAttributeInheritedBase.php
+++ b/tests/Unit/Fixtures/Models/TimestampsAttributeInheritedBase.php
@@ -8,8 +8,9 @@ use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Abstract base carrying `#[WithoutTimestamps]` so {@see TimestampsAttributeInheritedModel} can prove the
- * mirror resolves it through `classAttribute()`'s ancestor walk. Kept separate from
+ * Abstract base carrying `#[WithoutTimestamps]` so {@see TimestampsAttributeInheritedModel} can prove an
+ * INHERITED attribute is resolved — through Laravel's own `resolveClassAttribute()` ancestor walk, inside
+ * the initializer the replay invokes. Kept separate from
  * {@see AttributeConfiguredBase}, whose consuming test gates on the 13.0 `#[Hidden]`: a 13.2 attribute
  * there would outrank its gate.
  *

--- a/tests/Unit/Fixtures/Models/TimestampsAttributeInheritedModel.php
+++ b/tests/Unit/Fixtures/Models/TimestampsAttributeInheritedModel.php
@@ -11,11 +11,13 @@ use Illuminate\Database\Eloquent\Attributes\Table;
  * `#[Table(timestamps: true)]`. Runtime resolves the parent's attribute first and disables timestamps, so
  * the child's own argument loses.
  *
- * Pins two things nothing else does. The mirror must reach `#[WithoutTimestamps]` through the ANCESTOR
- * walk — a non-recursive `$reflection->getAttributes()` (the idiom `applyTableAttribute()` correctly uses
- * for its own `$declaresTable` check) would miss it here and fall through to the child's `#[Table]`,
- * recording true. And precedence is decided ACROSS the hierarchy, not per class, which
- * {@see TimestampsAttributePrecedenceModel} cannot show with both attributes on one class.
+ * Pins that precedence is decided ACROSS the hierarchy, not per class — which
+ * {@see TimestampsAttributePrecedenceModel} cannot show, carrying both attributes on one class.
+ *
+ * The ancestor walk itself is Laravel's: the replay invokes the real `initializeHasTimestamps()`, whose
+ * `resolveClassAttribute()` climbs the parents. So what is at stake here is the registry's read of the
+ * result, not a hand-written walk — and a replay that resolved `#[WithoutTimestamps]` non-recursively would
+ * still be caught, falling through to the child's `#[Table]` and recording true.
  *
  * Laravel 13.2+ (`#[WithoutTimestamps]`); the consuming test is gated on `class_exists()`.
  *

--- a/tests/Unit/Fixtures/Models/TimestampsAttributePrecedenceModel.php
+++ b/tests/Unit/Fixtures/Models/TimestampsAttributePrecedenceModel.php
@@ -10,8 +10,8 @@ use Illuminate\Database\Eloquent\Model;
 
 /**
  * Both forms, disagreeing: `#[WithoutTimestamps]` wins over `#[Table(timestamps: true)]` because
- * `initializeHasTimestamps()` checks it first and returns. Pins the mirror's branch ORDER — swap the two
- * and this model records true while runtime says false.
+ * `initializeHasTimestamps()` checks it first and returns. The branch order is Laravel's, and the replay
+ * invokes it — so what this pins is the registry's read of a precedence it no longer reproduces itself.
  *
  * Laravel 13.2+ (`#[WithoutTimestamps]`); the consuming test is gated on `class_exists()`.
  *

--- a/tests/Unit/Fixtures/Models/TimestampsInitializerOrderModel.php
+++ b/tests/Unit/Fixtures/Models/TimestampsInitializerOrderModel.php
@@ -9,18 +9,19 @@ use Illuminate\Database\Eloquent\Model;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Concerns\EnablesTimestampsInInitializer;
 
 /**
- * The only fixture whose answer depends on WHERE the timestamps mirror runs in the walk, rather than on
- * what it computes. `$timestamps = false` closes the `=== true` guard, the trait initializer reopens it,
+ * The only fixture whose answer depends on WHERE `initializeHasTimestamps` runs in the walk, rather than on
+ * what it computes. `$timestamps = false` closes its `=== true` guard, the trait initializer reopens it,
  * and `#[WithoutTimestamps]` is what the guard admits or refuses — so the outcome is decided purely by
- * whether the initializer ran before the mirror.
+ * whether the user initializer ran before the framework one.
  *
  * getMethods() ranks the two differently per PHP version (8.4 puts Model's inherited concern initializers
  * first, 8.5 the concrete class's own), so runtime disagrees with itself across the CI matrix and the
  * consuming test must use the runtime oracle with NO literal — see {@see AppendsOrderModel}, same shape.
  *
- * Guards the mirror's dispatch POSITION: hoisting applyTimestampsAttributes() out of applyConcernMirror()
- * to the tail of prepare() (next to applyTableAttribute(), which reads the same `#[Table]`) is a plausible
- * tidy-up that every other timestamps fixture accepts. This one diverges from runtime under PHP 8.4.
+ * Guards the framework initializer's dispatch POSITION: invoking `initializeHasTimestamps` anywhere other
+ * than at its own rank in the walk — hoisting it to the tail beside `initializeModelAttributes()`, which
+ * reads the same `#[Table]`, is the plausible tidy-up — diverges from runtime under PHP 8.4. Every other
+ * timestamps fixture accepts that hoist.
  *
  * That guard is conditional on the 8.4-vs-8.5 split existing: were a future PHP to settle on one order, the
  * hoist would stop diverging and this would quietly stop guarding. It degrades to a passing test, never a

--- a/tests/Unit/Fixtures/Models/UnguardedAttributeModel.php
+++ b/tests/Unit/Fixtures/Models/UnguardedAttributeModel.php
@@ -8,9 +8,10 @@ use Illuminate\Database\Eloquent\Attributes\Unguarded;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * `#[Unguarded]` should empty the default `['*']` denylist (guard nothing), exercising the
- * `applyGuardedAttribute()` Unguarded branch — distinct from the `$guarded = false` idiom that
- * {@see UnguardedModel} covers. Laravel 13.0+ only; the consuming test is gated on `class_exists()`.
+ * `#[Unguarded]` should empty the default `['*']` denylist (guard nothing), exercising the Unguarded branch
+ * of `GuardsAttributes::initializeGuardsAttributes()`, which the warm-up replay invokes — distinct from the
+ * `$guarded = false` idiom that {@see UnguardedModel} covers.
+ * Laravel 13.0+ only; the consuming test is gated on `class_exists()`.
  *
  * @internal fixture used by ModelMetadataRegistryTest
  */

--- a/tests/Unit/Fixtures/Models/WithoutIncrementingAttributeModel.php
+++ b/tests/Unit/Fixtures/Models/WithoutIncrementingAttributeModel.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Attributes\WithoutIncrementing;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * `#[WithoutIncrementing]` — the other, separately-gated way `initializeModelAttributes()` reaches
+ * `$incrementing`. It takes precedence over `#[Table(incrementing:)]` rather than merging with it, and unlike
+ * the `#[Table]` sub-overrides it is not conditioned on the property still holding its default.
+ *
+ * Key name and type stay at their defaults here: this fixture isolates the incrementing flag.
+ *
+ * Laravel 13.2+ — later than the 13.0 `#[Table]` it takes precedence over, so the consuming test gates on
+ * THIS attribute rather than that one. Moot under the `^13.3` floor; the gate is what keeps it moot.
+ *
+ * @internal fixture used by ModelMetadataRegistryTest
+ */
+#[WithoutIncrementing]
+final class WithoutIncrementingAttributeModel extends Model {}

--- a/tests/Unit/Fixtures/Models/WithoutTimestampsAttributeModel.php
+++ b/tests/Unit/Fixtures/Models/WithoutTimestampsAttributeModel.php
@@ -10,7 +10,8 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * `#[WithoutTimestamps]` alone — runtime `usesTimestamps()` is false. The archetype of #1276: warm-up
  * used to record true here, because `newInstanceWithoutConstructor()` skips `initializeHasTimestamps()`
- * and no mirror replaced it.
+ * and nothing replayed it. The replay now invokes that initializer, which is why the gap cannot reopen
+ * one Laravel release at a time.
  *
  * `#[WithoutTimestamps]` exists from Laravel 13.2, so the consuming test is gated on `class_exists()`.
  *

--- a/tests/Unit/Providers/ModelMetadata/ModelInstancePreparerTest.php
+++ b/tests/Unit/Providers/ModelMetadata/ModelInstancePreparerTest.php
@@ -6,6 +6,7 @@ namespace Tests\Psalm\LaravelPlugin\Unit\Providers\ModelMetadata;
 
 use Illuminate\Database\Eloquent\Attributes\Appends;
 use Illuminate\Database\Eloquent\Attributes\Initialize;
+use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Model;
@@ -14,8 +15,11 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelInstancePreparer;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\AppendsOrderModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\CastsMethodModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\CustomDeletedAtModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\KeyTypeInitializerOrderModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\SectionFailureModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\TableKeyOnlyModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\TraitInitializedConfigModel;
 
 /**
@@ -86,15 +90,74 @@ final class ModelInstancePreparerTest extends TestCase
     }
 
     #[Test]
-    public function framework_concern_initializer_is_mirrored_not_invoked(): void
+    public function framework_concern_initializer_is_invoked(): void
     {
-        // Real initializeSoftDeletes() writes $casts[getDeletedAtColumn()]; the mirror no-ops and leaves that
-        // cast to computeCasts(). So invoking framework initializers instead of mirroring leaves it behind.
+        // Framework initializers are invoked, not mirrored: whatever the installed Laravel does IS the
+        // behaviour. initializeSoftDeletes() writing $casts[getDeletedAtColumn()] is the observable proof,
+        // and it lands keyed off the DELETED_AT override without the replay knowing that rule.
         $casts = new \ReflectionProperty(Model::class, 'casts');
 
-        // Pin that Laravel still writes the cast; otherwise [] would not distinguish mirroring from invoking.
+        // Pin what Laravel itself writes; [] on both sides would not distinguish invoking from mirroring.
         $this->assertSame(['archived_at' => 'datetime'], $casts->getValue(new CustomDeletedAtModel()));
-        $this->assertSame([], $casts->getValue($this->prepare(CustomDeletedAtModel::class)));
+        $this->assertSame(
+            $casts->getValue(new CustomDeletedAtModel()),
+            $casts->getValue($this->prepare(CustomDeletedAtModel::class)),
+        );
+    }
+
+    #[Test]
+    public function the_has_attributes_initializer_is_mirrored_not_invoked(): void
+    {
+        // The ONE initializer still mirrored, and this is why: invoking it would execute the user's casts(),
+        // whose result the registry already has statically (CastsMethodParser AST-parses it). Not a
+        // no-user-code rule — the walk invokes user trait initializers deliberately. Delete the mirror and
+        // this fixture's cast appears on the replayed instance.
+        $casts = new \ReflectionProperty(Model::class, 'casts');
+
+        // Pin that Laravel itself runs casts(); an absent key on both sides would prove nothing.
+        $this->assertSame(['from_casts_method' => 'array'], $casts->getValue(new CastsMethodModel()));
+        // The key, not the whole map: a future Laravel initializer writing some OTHER cast is not this
+        // test's business, and asserting [] would turn that into a false alarm.
+        $this->assertArrayNotHasKey('from_casts_method', $casts->getValue($this->prepare(CastsMethodModel::class)));
+    }
+
+    #[Test]
+    public function the_model_attributes_phase_runs_after_the_walk(): void
+    {
+        if (!\class_exists(Table::class)) {
+            self::markTestSkipped('Eloquent PHP class attributes require Laravel >= 13.0.');
+        }
+
+        // A trait initializer and #[Table(keyType:)] write the same property, and Laravel's `=== 'int'` guard
+        // makes the order decide the answer: phase last (runtime) yields 'string', phase hoisted ahead of the
+        // walk yields 'int'. Runtime as oracle, never a literal.
+        $this->assertSame(
+            (new KeyTypeInitializerOrderModel())->getKeyType(),
+            $this->prepare(KeyTypeInitializerOrderModel::class)->getKeyType(),
+        );
+
+        // Pin the premise: without it both sides agree on the 'int' default and the oracle proves nothing.
+        $this->assertSame('string', (new KeyTypeInitializerOrderModel())->getKeyType());
+    }
+
+    #[Test]
+    public function the_model_attributes_phase_applies_the_table_attribute(): void
+    {
+        if (!\class_exists(Table::class)) {
+            self::markTestSkipped('Eloquent PHP class attributes require Laravel >= 13.0.');
+        }
+
+        // #[Table(key:)] with no name, on a class that INHERITS $table. The table half is version-split inside
+        // the supported range (13.3-13.5's `??=` keeps the inherited name; 13.6+ force-nulls it so getTable()
+        // re-derives) — which is the case for invoking the real method rather than reproducing it, and why
+        // this reads a runtime oracle instead of a literal.
+        $this->assertSame(
+            (new TableKeyOnlyModel())->getTable(),
+            $this->prepare(TableKeyOnlyModel::class)->getTable(),
+        );
+
+        // The key half has no such split: it reaches the key on every supported release.
+        $this->assertSame('uuid', $this->prepare(TableKeyOnlyModel::class)->getKeyName());
     }
 
     #[Test]

--- a/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
+++ b/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
@@ -16,10 +16,12 @@ use App\Models\UlidModel;
 use App\Models\UnguardedModel;
 use App\Models\UuidModel;
 use App\Models\WorkOrder;
+use Illuminate\Database\Eloquent\Attributes\Connection;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
+use Illuminate\Database\Eloquent\Attributes\WithoutIncrementing;
 use Illuminate\Database\Eloquent\Attributes\WithoutTimestamps;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
@@ -81,8 +83,10 @@ use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\CollectionCastVariantsModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\CustomDeletedAtModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\EnumConnectionModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\InboundCastModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\PlainEnumConnectionModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\ScalarFieldsModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\SectionFailureModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\TableKeyAttributeModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\TableTimestampsAttributeModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\TableTimestampsEnabledModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\TimestampsAttributeInheritedModel;
@@ -90,6 +94,7 @@ use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\TimestampsAttributePrecedence
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\TimestampsInitializerOrderModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\TraitInitializedConfigModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\UnguardedAttributeModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\WithoutIncrementingAttributeModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\WithoutTimestampsAttributeModel;
 
 #[CoversClass(ModelMetadataRegistry::class)]
@@ -247,8 +252,8 @@ final class ModelMetadataRegistryTest extends TestCase
     public function class_attributes_are_merged_at_warm_up(): void
     {
         // newInstanceWithoutConstructor() skips initializeTraits()/initializeModelAttributes(), so the
-        // PHP-attribute config is missed unless ModelInstancePreparer::prepare() mirrors it. The #[*] classes
-        // only exist from Laravel 13.0, below which this fixture is never loaded.
+        // PHP-attribute config is missed unless ModelInstancePreparer::prepare() replays them. The #[*]
+        // classes only exist from Laravel 13.0, below which this fixture is never loaded.
         if (!class_exists(Hidden::class)) {
             self::markTestSkipped('Eloquent PHP class attributes require Laravel >= 13.0.');
         }
@@ -375,9 +380,8 @@ final class ModelMetadataRegistryTest extends TestCase
     public function timestamps_attributes_reach_the_registry(string $modelFqcn, bool $expected): void
     {
         // #[WithoutTimestamps] is Laravel 13.2 (#[Table] 13.0). Below that these fixtures' attributes are
-        // either inert (12.x has no initializeHasTimestamps() to mirror, so the premise assertion fails)
-        // or unresolvable (the #[Table] carriers name-match a class absent on 12.x, and applyTableAttribute()
-        // — which runs regardless of the walk — then throws inside classAttribute()'s newInstance()).
+        // inert: 12.x has neither an initializeHasTimestamps() for the walk to invoke nor an
+        // initializeModelAttributes() phase, so the premise assertion fails.
         if (!class_exists(WithoutTimestamps::class)) {
             self::markTestSkipped('#[WithoutTimestamps] requires Laravel >= 13.2.');
         }
@@ -405,8 +409,66 @@ final class ModelMetadataRegistryTest extends TestCase
         $this->assertSame($runtime, $metadata->traits->usesTimestamps);
     }
 
+    /**
+     * @return iterable<string, array{class-string<Model>, string, string, bool}>
+     */
+    public static function primaryKeyAttributeCases(): iterable
+    {
+        yield '#[Table] key/keyType/incrementing sub-overrides' => [TableKeyAttributeModel::class, 'uuid', 'string', false];
+        yield '#[WithoutIncrementing]' => [WithoutIncrementingAttributeModel::class, 'id', 'int', false];
+    }
+
+    /**
+     * @param class-string<Model> $modelFqcn
+     */
     #[Test]
-    public function trait_initializer_ordering_decides_the_timestamps_mirror(): void
+    #[DataProvider('primaryKeyAttributeCases')]
+    public function primary_key_attributes_reach_the_registry(
+        string $modelFqcn,
+        string $expectedKeyName,
+        string $expectedKeyType,
+        bool $expectedIncrementing,
+    ): void {
+        // Gated on the LATER of the two attributes: `#[Table]` is 13.0 but `#[WithoutIncrementing]` is 13.2,
+        // and 12.x has no initializeModelAttributes() phase to apply either — the premise assertions would
+        // fail there. Below 13.2 the `#[WithoutIncrementing]` row would also name-match a class that is not
+        // installed, which resolveClassAttribute()'s newInstance() throws on.
+        if (!class_exists(WithoutIncrementing::class)) {
+            self::markTestSkipped('#[WithoutIncrementing] requires Laravel >= 13.2.');
+        }
+
+        $codebase = $this->makeCodebase();
+        $this->registerStorage($modelFqcn);
+
+        ModelMetadataRegistryBuilder::warmUp($codebase, $modelFqcn);
+
+        $metadata = ModelMetadataRegistry::for($modelFqcn);
+        $this->assertInstanceOf(ModelMetadata::class, $metadata);
+
+        // Warm-up must have COMPLETED, not degraded: the fallback key is ('id', Integer, incrementing: true),
+        // which the expectations below could not tell from a correct read of a default-keyed model.
+        $this->assertTrue($metadata->isComplete(ModelMetadata::SECTION_PRIMARY_KEY));
+
+        // A constructed model is the oracle: it runs the real initializeModelAttributes() that
+        // newInstanceWithoutConstructor() skips, so this stays honest if Laravel changes the rules.
+        $runtime = new $modelFqcn();
+
+        // Pin the premise first. Without it, a Laravel that stopped applying these attributes would leave the
+        // oracle and the registry agreeing on the defaults and the comparison below would test nothing.
+        $this->assertSame($expectedKeyName, $runtime->getKeyName(), 'fixture premise drifted from Laravel behaviour');
+        $this->assertSame($expectedKeyType, $runtime->getKeyType(), 'fixture premise drifted from Laravel behaviour');
+        $this->assertSame($expectedIncrementing, $runtime->getIncrementing(), 'fixture premise drifted from Laravel behaviour');
+
+        $this->assertSame($runtime->getKeyName(), $metadata->primaryKey->name);
+        $this->assertSame(
+            $expectedKeyType === 'string' ? PrimaryKeyType::String : PrimaryKeyType::Integer,
+            $metadata->primaryKey->type,
+        );
+        $this->assertSame($runtime->getIncrementing(), $metadata->primaryKey->incrementing);
+    }
+
+    #[Test]
+    public function trait_initializer_ordering_decides_the_timestamps_outcome(): void
     {
         if (!class_exists(WithoutTimestamps::class)) {
             self::markTestSkipped('#[WithoutTimestamps] requires Laravel >= 13.2.');
@@ -422,12 +484,13 @@ final class ModelMetadataRegistryTest extends TestCase
 
         // Runtime construction is the ONLY oracle — never a literal: getMethods() ranks the user
         // initializer against Model's inherited initializeHasTimestamps() differently per PHP version, so
-        // the correct answer is true on 8.4 and false on 8.5. The mirror is right only if it runs at the
-        // framework initializer's own position; hoisting it out of the walk diverges under 8.4.
+        // the correct answer is true on 8.4 and false on 8.5. The replay is right only because it invokes
+        // each initializer at its own rank; sorting the walk, or splitting it user-first/framework-last,
+        // diverges under 8.4.
         $this->assertSame(
             (new TimestampsInitializerOrderModel())->usesTimestamps(),
             $metadata->traits->usesTimestamps,
-            'the timestamps mirror must run at initializeHasTimestamps() position in the getMethods() walk',
+            'initializeHasTimestamps() must be invoked at its own position in the getMethods() walk',
         );
     }
 
@@ -445,27 +508,54 @@ final class ModelMetadataRegistryTest extends TestCase
 
         $metadata = ModelMetadataRegistry::for(AttributeConfiguredChild::class);
         $this->assertInstanceOf(ModelMetadata::class, $metadata);
-        // #[Hidden]/#[Appends] declared on the abstract base resolve on the concrete child via the
-        // classAttribute() parent walk (mirroring Model::resolveClassAttribute()).
+        // #[Hidden]/#[Appends] declared on the abstract base resolve on the concrete child. Two different
+        // ancestor walks now: Laravel's own resolveClassAttribute() inside the invoked
+        // initializeHidesAttributes() for #[Hidden], the plugin's classAttribute() for #[Appends].
         $this->assertSame(['base_hidden'], $metadata->hidden);
         $this->assertSame(['base_append'], $metadata->appends);
     }
 
     #[Test]
-    public function an_int_backed_enum_connection_is_normalized_to_a_string(): void
+    public function an_int_backed_enum_connection_attribute_is_normalized_to_a_string(): void
     {
-        if (!class_exists(Hidden::class)) {
-            self::markTestSkipped('Eloquent PHP class attributes require Laravel >= 13.0.');
+        // `#[Connection]` is 13.0 — gated on the attribute this row actually carries, not on the enum
+        // support it relies on, which is older (see the property-default twin below).
+        if (!class_exists(Connection::class)) {
+            self::markTestSkipped('#[Connection] requires Laravel >= 13.0.');
         }
 
+        $this->assertNormalizedEnumConnection(EnumConnectionModel::class);
+    }
+
+    #[Test]
+    public function an_int_backed_enum_connection_property_is_normalized_to_a_string(): void
+    {
+        // No attribute here, so no attribute to gate on: the real boundary is Laravel 12.28, where
+        // `$connection` widened to `\UnitEnum|string|null` and getConnectionName() started applying
+        // enum_value(). Below it the getter hands back the enum object and null is the honest answer, so the
+        // assertion would rightly fail. Gate on the CAPABILITY rather than re-encode that version number —
+        // an int here means enum_value() ran.
+        if (!\is_int((new PlainEnumConnectionModel())->getConnectionName())) {
+            self::markTestSkipped('enum_value() on $connection requires Laravel >= 12.28.');
+        }
+
+        $this->assertNormalizedEnumConnection(PlainEnumConnectionModel::class);
+    }
+
+    /**
+     * @param class-string<Model> $modelFqcn
+     */
+    private function assertNormalizedEnumConnection(string $modelFqcn): void
+    {
         $codebase = $this->makeCodebase();
-        $this->registerStorage(EnumConnectionModel::class);
+        $this->registerStorage($modelFqcn);
 
-        ModelMetadataRegistryBuilder::warmUp($codebase, EnumConnectionModel::class);
+        ModelMetadataRegistryBuilder::warmUp($codebase, $modelFqcn);
 
-        $metadata = ModelMetadataRegistry::for(EnumConnectionModel::class);
-        // The model must survive warm-up: an un-normalized int connection would TypeError the ?string
-        // field and drop the whole entry. The connection resolves to the enum's stringified backing value.
+        $metadata = ModelMetadataRegistry::for($modelFqcn);
+        // The model must survive warm-up: getConnectionName()'s enum_value() yields the enum's raw int
+        // backing value, and that TypeErrors the ?string field OUTSIDE every section guard — so a regression
+        // drops the whole entry rather than degrading one section, and this assertInstanceOf goes red.
         $this->assertInstanceOf(ModelMetadata::class, $metadata);
         $this->assertSame('1', $metadata->connection);
     }


### PR DESCRIPTION
## Issue to Solve

`ModelInstancePreparer::prepare()` replays `Model::__construct()`'s initializer lifecycle onto the `newInstanceWithoutConstructor()` throwaway the registry reads. Discovery was already right, but dispatch was not: the framework's own initializers were sent to hand-written mirrors instead of being run. Every mirror was a copy of Laravel that had to be re-synced by hand.

That copy is the maintenance tax. #1276 was a mirror that was simply missing, and three more gaps sat documented in comments rather than fixed: `#[Table]`'s `key`/`keyType`/`incrementing` sub-overrides, `#[WithoutIncrementing]`, and the key-only `#[Table]` force branch.

The mirrors also pinned one release's semantics, so some were **already wrong inside the supported range**. `initializeModelAttributes()` has no `$declaresTable` force branch on 13.3–13.5 and does from 13.6, but `applyTableAttribute()` implemented the later shape unconditionally — force-nulling an inherited `$table` where real Laravel keeps it:

```php
abstract class Base extends Model { protected $table = 'inherited_table'; }

#[Table(key: 'uuid')]
final class Child extends Base {}

// Laravel 13.3–13.5:  getTable() => 'inherited_table'   (plugin said 'children')
```

## Related

Refs #1276.

Follow-ups filed, deliberately not folded in: #1281 (the un-mirrored `ensureCastsAreStringValues()`), #1282 (unit-test CI never runs PHP 8.5 or the `^13.3` floor).

## Solution Description

Invoke Laravel's own initializers. The replay becomes version-correct by construction, and the #1276 class of gap stops being possible.

**Discovery is untouched** — the `getMethods()` walk still mirrors `bootTraits()` exactly. Only dispatch changed.

**One initializer is still stood in for, and the reason is information, not authorship.** Invoking the framework's `initializeHasAttributes()` would execute the user's `casts()` — the one initializer input the registry *already has statically*, since `CastsMethodParser` AST-parses it and `computeCasts()` merges that result last. Running it would buy nothing and cost arbitrary user expression evaluation inside warm-up. A user trait initializer has no static equivalent, which is exactly why those *are* invoked. The rule's honest limit is documented: an override of `initializeHasAttributes` in the user's own file takes the invoke branch and does reach `casts()` — not fixable by discrimination, since no reflection distinguishes an override that calls up from one that doesn't.

**`initializeModelAttributes()` replaces the `#[Connection]`/`#[Table]` mirrors**, guarded by `method_exists()`: it is Laravel 13.0+ while the floor is `illuminate/database: ^12.14 || ^13.3`. Psalm honours the guard — verified by self-analysing against 12.14.

**The primary-key sub-overrides land for free.** `computePrimaryKey()` already reads instance state rather than raw getter defaults, so no reader changed.

**`computeCasts()`'s manual SoftDeletes cast is gone.** The real `initializeSoftDeletes()` writes it now, and its `isset` guard preserves the old lowest-priority semantics exactly. Neither reason to keep the step survives: the initializer exists on 12.14, so there is no pre-13 hole, and it could not fire on a degraded walk anyway, since the casts section is gated on a complete `prepare()`. It is also *strictly better* — the old step gated on Psalm's `used_traits`, which is direct-only, so it missed `class Post extends SoftDeletingBase`.

**The connection coercion moved to the read site.** `getConnectionName()` is annotated `@return string|null` but returns `enum_value($this->connection)` — a `BackedEnum`'s raw `->value`, an `int` for an int-backed enum. `ModelMetadata`'s native `?string $connection` rejects that under `strict_types`, and the TypeError lands outside every `computeSection()` guard, so `warmUp()` drops the **whole model**. `readRuntimeConfiguration()` now coerces the single expression whose value reaches the field. Normalizing the *instance* instead would still miss a model that overrides `getConnectionName()`, and would call user-overridable `setConnection()` on every model.

### Behaviour

Behaviour-preserving for everything the registry stores today, plus four fixes that fall out of it:

- new coverage for the primary-key attribute family (`#[Table(key:/keyType:/incrementing:)]`, `#[WithoutIncrementing]`);
- the 13.3–13.5 table force-branch divergence above;
- `protected $connection = <int-backed enum>;`, previously a whole-model drop;
- SoftDeletes casts on models that inherit the trait from a parent.

The registry fixture suite asserts registry-vs-constructed-model and is implementation-agnostic. **It passes unchanged** — that was the acceptance bar for calling this behaviour-preserving.

### How it was verified

Six of the eight new/changed tests fail against the previous mirrors, so they pin the closed gaps rather than restating current behaviour. The two that pass on both are meant to: one guards the preserved `casts()` policy, which nothing pinned before (delete the last mirror and `CastsMethodModel`'s cast appears on the replayed instance), and the other is the `#[Connection]` row the old mirror already handled.

`KeyTypeInitializerOrderModel` is mutation-tested: hoisting the `initializeModelAttributes()` phase ahead of the walk makes it fail, restoring makes it pass. It collides a trait initializer with `#[Table(keyType:)]` behind Laravel's `=== 'int'` guard — chosen over the `$table` force-branch because the `keyType` guard is byte-identical from 13.3 to 13.20, so it discriminates across the whole range.

Enum connections turn out to be **Laravel 12.28+, not 13.0**: `$connection` widened to `\UnitEnum|string|null` well before the 13.0 `#[Connection]` attribute. The two enum-connection tests therefore gate separately — the attribute one on `#[Connection]`, the property-default one on the capability itself (an int back from the getter) rather than on a version number.

Run green on PHP 8.5/Laravel 13.20, 8.4/13.20 (the opposite `getMethods()` ranking, which both order-pinning fixtures exercise), 8.2/12.64, and 8.2/12.14.0.

`psalm-delta` across 18 real apps: **zero issue delta, zero coverage delta, no significant time change**. (The first pass showed +2 on filament — the known multi-thread flake; re-running the base side recomputed it to zero.)

### Upstream notes

`Model::getConnectionName()`'s `@return string|null` is wrong in Laravel itself — it returns `enum_value()`'s raw `->value`, an int for an int-backed enum. Worth an upstream docblock fix; the coercion here is the plugin-level workaround meanwhile.

Separately, `Model::resolveClassAttribute()`'s cache key omits its `$property` argument, so `isIgnoringTouch()` can read a cached `Table` object where it expects a `?bool` and silently ignore `#[Table(timestamps: false)]`. Not plugin-triggerable — warm-up only ever uses the no-property form — but a real upstream bug found while verifying this change.

## Checklist
- [x] Tests cover the change (unit tests in `tests/Unit/`; this is warm-up metadata, with no type-level surface of its own)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786821593&installation_id=141955579&pr_number=1283&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1283&signature=cc3e95f0fc25cf6649c813af96eea208351ae0e228ac5e41c46bf9a4d257d918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->