### PR TITLE
Run unit suite on PHP 8.5 and framework floor cells

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,8 +51,24 @@ jobs:
         run: bash bin/ci/check-phpt-conventions.sh
 
   unit_tests:
-    name: Unit tests
+    name: Unit test P${{ matrix.php }} | L${{ matrix.laravel || 'lockfile' }}
     runs-on: ubuntu-latest
+    strategy:
+      # Version-split fixtures fail per-cell by design; keep every cell's verdict visible.
+      fail-fast: false
+      matrix:
+        include:
+          # Lockfile cells cover both sides of the PHP 8.4/8.5 getMethods() initializer-order split.
+          - php: '8.5'
+          - php: '8.4'
+          # Declared framework floors.
+          - php: '8.4'
+            laravel: '13.3.0'
+          - php: '8.2'
+            laravel: '12.14.0'
+          # Highest 12.x: the enum $connection path is live since 12.28.
+          - php: '8.2'
+            laravel: '^12.14'
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -67,53 +83,52 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
-          php-version: 8.4
+          php-version: ${{ matrix.php }}
           coverage: none
           tools: composer:v2
+
+      - name: Determine composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache composer packages
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: composer-unit-${{ matrix.php }}-${{ matrix.laravel || 'lockfile' }}-${{ hashFiles('composer.json', 'composer.lock') }}
+          restore-keys: |
+            composer-unit-${{ matrix.php }}-
 
       - name: Check Composer configuration
+        if: matrix.php == '8.4' && !matrix.laravel
         run: composer validate --strict
 
-      - name: Install composer dependencies
+      - name: Install composer dependencies (lockfile)
+        if: ${{ !matrix.laravel }}
         run: composer install
 
-      - name: Run Unit tests
-        run: composer test:unit
-
-  laravel_12_14_floor:
-    name: Laravel 12.14.0 floor
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
-        with:
-          php-version: 8.2
-          coverage: none
-          tools: composer:v2
-
-      - name: Install exact Laravel floor
-        # The supported floor may have published advisories; this isolated test install is never deployed.
+      - name: Install with Laravel constraint
+        # Floors may have published advisories; this isolated test install is never deployed.
+        if: matrix.laravel
         run: >-
-          composer update --with="laravel/framework:12.14.0" --with-all-dependencies
+          composer update --with="laravel/framework:${{ matrix.laravel }}" --with-all-dependencies
           --no-interaction --no-progress --prefer-dist --prefer-stable --no-blocking --no-audit
 
       - name: Verify installed Laravel version
+        if: matrix.laravel && !startsWith(matrix.laravel, '^')
+        env:
+          EXPECTED_LARAVEL: v${{ matrix.laravel }}
         run: >-
           php -r 'require "vendor/autoload.php";
-          exit(Composer\InstalledVersions::getPrettyVersion("laravel/framework") === "v12.14.0" ? 0 : 1);'
+          exit(Composer\InstalledVersions::getPrettyVersion("laravel/framework") === getenv("EXPECTED_LARAVEL") ? 0 : 1);'
+
+      - name: Run Unit tests (lockfile)
+        if: ${{ !matrix.laravel }}
+        run: composer test:unit
 
       - name: Run Unit tests
-        # Testbench 10 resolves PHPUnit 11, which does not support --display-phpunit-notices.
+        # Constraint installs may resolve PHPUnit 11 (Testbench 10), which lacks --display-phpunit-notices.
+        if: matrix.laravel
         run: vendor/bin/phpunit --testsuite=unit --display-deprecations --display-notices
 
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,18 +87,6 @@ jobs:
           coverage: none
           tools: composer:v2
 
-      - name: Determine composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache composer packages
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: composer-unit-${{ matrix.php }}-${{ matrix.laravel || 'lockfile' }}-${{ hashFiles('composer.json', 'composer.lock') }}
-          restore-keys: |
-            composer-unit-${{ matrix.php }}-
-
       - name: Check Composer configuration
         if: matrix.php == '8.4' && !matrix.laravel
         run: composer validate --strict
@@ -110,8 +98,10 @@ jobs:
       - name: Install with Laravel constraint
         # Floors may have published advisories; this isolated test install is never deployed.
         if: matrix.laravel
+        env:
+          LARAVEL_CONSTRAINT: ${{ matrix.laravel }}
         run: >-
-          composer update --with="laravel/framework:${{ matrix.laravel }}" --with-all-dependencies
+          composer update --with="laravel/framework:$LARAVEL_CONSTRAINT" --with-all-dependencies
           --no-interaction --no-progress --prefer-dist --prefer-stable --no-blocking --no-audit
 
       - name: Verify installed Laravel version


### PR DESCRIPTION
## Issue to Solve

Unit-test CI only ran two cells (PHP 8.4/lockfile and PHP 8.2/Laravel 12.14.0), so the PHP 8.5 side of the initializer-order fixtures (`TimestampsInitializerOrderModel`, `AppendsOrderModel`) and the declared `^13.3` framework floor were never exercised by the unit suite. A change hard-coding the 8.4 answer would ship green.

## Related

Fixes #1282

## Solution Description

Merged `unit_tests` and `laravel_12_14_floor` into a single matrix job with five cells, exactly the set verified green in the issue:

| PHP | Laravel | Purpose |
|---|---|---|
| 8.5 | lockfile | 8.5 side of the `getMethods()` initializer-order split |
| 8.4 | lockfile | existing baseline |
| 8.4 | 13.3.0 | declared `^13.3` floor |
| 8.2 | `^12.14` highest | enum `$connection` path (live since 12.28) |
| 8.2 | 12.14.0 | existing 12.x floor |

Design choices, why over what:

- `fail-fast: false`: version-split fixtures fail per-cell by design; fail-fast would cancel exactly the cells that carry the diagnostic.
- Lockfile cells run `composer test:unit`; constraint cells call `phpunit` without `--display-phpunit-notices`, because a constraint install may resolve PHPUnit 11 (Testbench 10), which does not support that flag. This is the same split the old floor job made, now expressed per-cell.
- The exact-floor version assert is now matrix-driven, so it covers 13.3.0 as well as 12.14.0. It reads the expected version from `env` rather than interpolating into the script.
- `composer validate --strict` runs once (8.4/lockfile) instead of in every cell.

Wall-clock is unchanged: the cells run in parallel and the `type_tests` matrix remains the critical path.

No composer cache here on purpose. An earlier revision of this PR added one; it drew two code-scanning findings (the `$GITHUB_OUTPUT` write that resolved the cache dir, and the `actions/cache` SHA-vs-tag comment) while buying no wall-clock, since these cells are not the critical path. Caching is worth doing as its own change, covering `type_tests` and `benchmark.yml` consistently, rather than smuggled in here.

Verified with `actionlint` and `zizmor --persona=auditor` locally, both clean for this job. The two `template-injection` findings zizmor still reports on `tests.yml` are on the pre-existing `type_tests` job (line 157) and are untouched by this PR.

## Notes for the merger

- Required status checks referencing the old job names (`Unit tests`, `Laravel 12.14.0 floor`) will need updating to the new matrix cell names.
- The first CI run on this branch was red across every cell for an unrelated reason: a GitHub API outage (`The "https://api.github.com/repos/alies-dev/psalm-tester" file could not be downloaded (HTTP/2 503)`), which every composer install hits via the VCS repository in `composer.json`.

## Checklist
- [ ] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)
