### PR TITLE
Fix: pluck() and aggregate narrowing on custom subclasses, raw aliases, and schema-typed columns

### DIFF
--- a/src/Handlers/Eloquent/BuilderAggregateHandler.php
+++ b/src/Handlers/Eloquent/BuilderAggregateHandler.php
@@ -144,6 +144,13 @@ final class BuilderAggregateHandler implements MethodReturnTypeProviderInterface
      * LHS fallback handles @mixin chains where event template params arrive
      * unsubstituted (mirrors {@see ModelPropertyResolver::resolvePluckReturnType}).
      *
+     * A non-generic custom Builder subclass (`final class TaskBuilder extends
+     * Builder<Task> {}`, wired via `#[UseEloquentBuilder]`) is neither generic itself
+     * (so the template-params loop above finds nothing) nor a TGenericObject LHS (so
+     * the loop just below finds nothing either) — the same gap issue #1287 fixed for
+     * `pluck()`. Falls back to the identical `template_extended_params[Builder::class]`
+     * lookup {@see ModelPropertyResolver::extractModelFromLhsBuilderExtends()} (issue #1294).
+     *
      * @return class-string<Model>|null
      */
     private static function resolveModelClass(MethodReturnTypeProviderEvent $event): ?string
@@ -178,7 +185,7 @@ final class BuilderAggregateHandler implements MethodReturnTypeProviderInterface
             }
         }
 
-        return null;
+        return ModelPropertyResolver::extractModelFromLhsBuilderExtends($lhsType, $event->getSource()->getCodebase());
     }
 
     /**

--- a/src/Handlers/Eloquent/Support/ModelPropertyResolver.php
+++ b/src/Handlers/Eloquent/Support/ModelPropertyResolver.php
@@ -8,11 +8,12 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Psalm\Codebase;
+use Psalm\Internal\Type\Comparator\UnionTypeComparator;
 // UnionTypeComparator is in Psalm\Internal\* but is the established convention for
 // type-containment checks in plugins (Psalm's own bundled providers use it directly,
 // and several other handlers in this codebase already depend on Psalm\Internal\*).
 // Re-verify when bumping Psalm to a new minor/major version.
-use Psalm\Internal\Type\Comparator\UnionTypeComparator;
+use Psalm\LaravelPlugin\Handlers\Eloquent\ModelPropertyHandler;
 use Psalm\NodeTypeProvider;
 use Psalm\Type;
 use Psalm\Type\Atomic\TGenericObject;
@@ -142,7 +143,11 @@ final class ModelPropertyResolver
         // columns (`selectRaw('COUNT(*) AS cnt')`) have no model annotation to resolve.
         // Don't bail on that alone — fall back to mixed for the value and still attempt
         // to narrow the key below, since the two axes are independent.
-        $resolvedPropertyType = self::resolvePropertyType($codebase, $modelClass, $columnName);
+        //
+        // resolveColumnType() (not the lower-level resolvePropertyType() below) so a
+        // column with no @property still narrows from migration schema / casts, mirroring
+        // ordinary `$model->column` reads and BuilderAggregateHandler's column resolution.
+        $resolvedPropertyType = ModelPropertyHandler::resolveColumnType($codebase, $modelClass, $columnName);
         $valueResolved = $resolvedPropertyType instanceof \Psalm\Type\Union;
         $propertyType = $resolvedPropertyType ?? Type::getMixed();
 
@@ -289,7 +294,9 @@ final class ModelPropertyResolver
             $keyColumn = $keyArg->value->value;
         }
 
-        $keyPropertyType = self::resolvePropertyType($codebase, $modelClass, $keyColumn);
+        // Registry-aware resolution (see resolvePluckReturnType() above): a key column
+        // with no @property still narrows from migration schema / casts.
+        $keyPropertyType = ModelPropertyHandler::resolveColumnType($codebase, $modelClass, $keyColumn);
         if (!$keyPropertyType instanceof Union) {
             return null;
         }

--- a/src/Handlers/Eloquent/Support/ModelPropertyResolver.php
+++ b/src/Handlers/Eloquent/Support/ModelPropertyResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Handlers\Eloquent\Support;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Psalm\Codebase;
@@ -110,7 +111,23 @@ final class ModelPropertyResolver
         // concrete model. Fall back to inspecting the call's LHS expression, whose
         // type carries the concrete generic arguments.
         if ($modelClass === null && $lhsExpr instanceof \PhpParser\Node\Expr) {
-            $modelClass = self::extractModelFromLhsType($nodeTypeProvider->getType($lhsExpr), $modelTemplateIndex);
+            $lhsType = $nodeTypeProvider->getType($lhsExpr);
+            $modelClass = self::extractModelFromLhsType($lhsType, $modelTemplateIndex);
+
+            // Custom Builder subclasses declared as `/** @extends Builder<Task> */
+            // final class TaskBuilder extends Builder {}` are not themselves generic,
+            // so the LHS type above is a plain TNamedObject (no type_params for the
+            // fallback just above to read) and the event's template parameters are
+            // empty. Resolve TModel from the classlike storage's
+            // template_extended_params[Builder::class]['TModel'], which Psalm
+            // populates from the @extends docblock — the same mechanism
+            // ModelFactoryMethodTypeProvider/FactoryCountTypeProvider use for
+            // Factory<TModel>. Scoped to Builder: this only ever contributes a result
+            // when $modelTemplateIndex is Builder's own (0), since a Collection
+            // subclass's storage has no Builder entry in template_extended_params.
+            if ($modelClass === null) {
+                $modelClass = self::extractModelFromLhsBuilderExtends($lhsType, $codebase);
+            }
         }
 
         if ($modelClass === null) {
@@ -168,6 +185,55 @@ final class ModelPropertyResolver
 
             $modelType = $atomic->type_params[$modelTemplateIndex] ?? null;
             $modelClass = self::extractModelFromUnion($modelType);
+            if ($modelClass !== null) {
+                return $modelClass;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolve TModel for a custom, non-generic Builder subclass from its classlike
+     * storage's `@extends Builder<TModel>` binding.
+     *
+     * `ClassLikeStorageProvider::get()` lowercases internally, so the FQCN is passed
+     * through untouched. `template_extended_params` is keyed on the canonical class
+     * name (`$parent_storage->name`), which matches `Builder::class` for any
+     * vendor-stable Laravel install, and flattens through intermediate,
+     * non-generic ancestors (e.g. `TaskBuilder extends BaseTaskBuilder extends
+     * Builder`), so deeper inheritance chains resolve the same way.
+     *
+     * A generic custom builder (`@template T of Model` / `@extends Builder<T>`),
+     * used as `TaskBuilder<Task>`, is a TGenericObject and already handled by
+     * {@see self::extractModelFromLhsType()}; when reached from here instead, its
+     * own TModel binding resolves to the unsubstituted template `T`, which
+     * {@see self::extractModelFromUnion()} does not recognize as a Model, so this
+     * method correctly yields null for that case rather than a wrong binding.
+     *
+     * @return class-string<Model>|null
+     * @psalm-mutation-free
+     */
+    private static function extractModelFromLhsBuilderExtends(?Union $lhsType, Codebase $codebase): ?string
+    {
+        if (!$lhsType instanceof Union) {
+            return null;
+        }
+
+        foreach ($lhsType->getAtomicTypes() as $atomic) {
+            if (!$atomic instanceof TNamedObject) {
+                continue;
+            }
+
+            try {
+                $classStorage = $codebase->classlike_storage_provider->get($atomic->value);
+            } catch (\InvalidArgumentException) {
+                continue;
+            }
+
+            $modelClass = self::extractModelFromUnion(
+                $classStorage->template_extended_params[Builder::class]['TModel'] ?? null,
+            );
             if ($modelClass !== null) {
                 return $modelClass;
             }

--- a/src/Handlers/Eloquent/Support/ModelPropertyResolver.php
+++ b/src/Handlers/Eloquent/Support/ModelPropertyResolver.php
@@ -53,23 +53,6 @@ final class ModelPropertyResolver
     }
 
     /**
-     * Look up the type of a model property from @property / @property-read PHPDoc annotations.
-     *
-     * @param class-string<Model> $modelClass
-     * @psalm-mutation-free
-     */
-    public static function resolvePropertyType(Codebase $codebase, string $modelClass, string $propertyName): ?Union
-    {
-        try {
-            $classStorage = $codebase->classlike_storage_provider->get($modelClass);
-        } catch (\InvalidArgumentException) {
-            return null;
-        }
-
-        return $classStorage->pseudo_property_get_types['$' . $propertyName] ?? null;
-    }
-
-    /**
      * Build a typed Collection return type for pluck().
      *
      * Resolves the model property type from @property annotations and determines
@@ -161,9 +144,9 @@ final class ModelPropertyResolver
         // Don't bail on that alone — fall back to mixed for the value and still attempt
         // to narrow the key below, since the two axes are independent.
         //
-        // resolveColumnType() (not the lower-level resolvePropertyType() below) so a
-        // column with no @property still narrows from migration schema / casts, mirroring
-        // ordinary `$model->column` reads and BuilderAggregateHandler's column resolution.
+        // resolveColumnType() so a column with no @property still narrows from
+        // migration schema / casts, mirroring ordinary `$model->column` reads and
+        // BuilderAggregateHandler's column resolution.
         $resolvedPropertyType = ModelPropertyHandler::resolveColumnType($codebase, $modelClass, $columnName);
         $valueResolved = $resolvedPropertyType instanceof \Psalm\Type\Union;
         $propertyType = $resolvedPropertyType ?? Type::getMixed();

--- a/src/Handlers/Eloquent/Support/ModelPropertyResolver.php
+++ b/src/Handlers/Eloquent/Support/ModelPropertyResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Psalm\LaravelPlugin\Handlers\Eloquent\Support;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Psalm\Codebase;
@@ -133,6 +134,18 @@ final class ModelPropertyResolver
             if ($modelClass === null) {
                 $modelClass = self::extractModelFromLhsBuilderExtends($lhsType, $codebase);
             }
+
+            // Mirror-image gap on the Collection side (issue #1295): a non-generic
+            // custom Collection subclass (`final class TaskCollection extends
+            // Collection<int, Task> {}`, no own @template) is likewise neither
+            // generic itself nor a TGenericObject LHS. Naturally scoped to Collection
+            // subclasses the same way the Builder fallback above is scoped to Builder
+            // subclasses: a Builder LHS's storage never has a
+            // template_extended_params[...Collection::class] entry, so this yields
+            // null for Builder callers regardless of $modelTemplateIndex.
+            if ($modelClass === null) {
+                $modelClass = self::extractModelFromLhsCollectionExtends($lhsType, $codebase);
+            }
         }
 
         if ($modelClass === null) {
@@ -259,6 +272,61 @@ final class ModelPropertyResolver
 
             $modelClass = self::extractModelFromUnion(
                 $classStorage->template_extended_params[Builder::class]['TModel'] ?? null,
+            );
+            if ($modelClass !== null) {
+                return $modelClass;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolve TModel for a custom, non-generic Collection subclass from its classlike
+     * storage's `@extends Collection<TKey, TModel>` binding — the Collection-side
+     * analogue of {@see self::extractModelFromLhsBuilderExtends()} (issue #1295).
+     *
+     * Checks two ancestor keys, in order, because Psalm's Populator flattens the
+     * *entire* generic ancestry into `template_extended_params`, not just the direct
+     * parent, and a custom collection can be declared against either level:
+     *
+     * 1. `Illuminate\Database\Eloquent\Collection::class`, template `TModel` — matches
+     *    how users actually write `@extends Collection<int, Task>` in the standard
+     *    pattern (`Collection` there resolves to the Eloquent subclass), verified
+     *    empirically against a fixture shaped exactly like that (`InvoiceCollection`):
+     *    `template_extended_params['Illuminate\Database\Eloquent\Collection'] =
+     *    ['TKey' => int, 'TModel' => Invoice]`.
+     * 2. `Illuminate\Support\Collection::class`, template `TValue` — covers a custom
+     *    collection extending the base Support collection directly, without going
+     *    through the Eloquent subclass. The same fixture also carries this entry
+     *    (`Eloquent\Collection<TKey, TModel> extends Support\Collection<TKey,
+     *    TModel>`, so it flattens through): `template_extended_params
+     *    ['Illuminate\Support\Collection'] = ['TKey' => int, 'TValue' => Invoice]`.
+     *
+     * @return class-string<Model>|null
+     * @psalm-mutation-free
+     */
+    private static function extractModelFromLhsCollectionExtends(?Union $lhsType, Codebase $codebase): ?string
+    {
+        if (!$lhsType instanceof Union) {
+            return null;
+        }
+
+        foreach ($lhsType->getAtomicTypes() as $atomic) {
+            if (!$atomic instanceof TNamedObject) {
+                continue;
+            }
+
+            try {
+                $classStorage = $codebase->classlike_storage_provider->get($atomic->value);
+            } catch (\InvalidArgumentException) {
+                continue;
+            }
+
+            $modelClass = self::extractModelFromUnion(
+                $classStorage->template_extended_params[EloquentCollection::class]['TModel'] ?? null,
+            ) ?? self::extractModelFromUnion(
+                $classStorage->template_extended_params[Collection::class]['TValue'] ?? null,
             );
             if ($modelClass !== null) {
                 return $modelClass;

--- a/src/Handlers/Eloquent/Support/ModelPropertyResolver.php
+++ b/src/Handlers/Eloquent/Support/ModelPropertyResolver.php
@@ -134,27 +134,40 @@ final class ModelPropertyResolver
             return null;
         }
 
-        $propertyType = self::resolvePropertyType($codebase, $modelClass, $columnName);
-        if (!$propertyType instanceof \Psalm\Type\Union) {
-            return null;
-        }
+        // The value column is often not a @property: raw select aliases and computed
+        // columns (`selectRaw('COUNT(*) AS cnt')`) have no model annotation to resolve.
+        // Don't bail on that alone — fall back to mixed for the value and still attempt
+        // to narrow the key below, since the two axes are independent.
+        $resolvedPropertyType = self::resolvePropertyType($codebase, $modelClass, $columnName);
+        $valueResolved = $resolvedPropertyType instanceof \Psalm\Type\Union;
+        $propertyType = $resolvedPropertyType ?? Type::getMixed();
 
         // Determine key type:
-        //   - no $key argument        → int (positional Laravel key)
+        //   - no $key argument        → int, always (Laravel's positional pluck() yields
+        //                                sequential int keys regardless of the value column)
         //   - $key arg with @property → @property type if subset of array-key, else array-key
         //   - $key arg without @property → array-key
         //
         // We only adopt the @property type when it is a subset of int|string, because
         // Collection<TKey, TValue> requires TKey to be array-key. A property declared as
         // CarbonInterface|null (cast type) would produce an invalid TKey, so we fall back.
+        $keyResolved = \count($args) < 2;
         $keyType = Type::getInt();
         if (\count($args) >= 2) {
-            $keyType = self::resolveKeyType(
+            $resolvedKeyType = self::resolveKeyType(
                 keyArg: $args[1],
                 modelClass: $modelClass,
                 nodeTypeProvider: $nodeTypeProvider,
                 codebase: $codebase,
             );
+            $keyResolved = $resolvedKeyType instanceof Union;
+            $keyType = $resolvedKeyType ?? Type::getArrayKey();
+        }
+
+        // Neither axis narrowed past the stub's default `Collection<array-key, mixed>` —
+        // defer to it instead of constructing an identical type via this handler.
+        if (!$valueResolved && !$keyResolved) {
+            return null;
         }
 
         return new Union([
@@ -246,8 +259,10 @@ final class ModelPropertyResolver
      * Resolve the TKey type for pluck($value, $key) when a key argument is provided.
      *
      * Returns the @property type of the key column when it is a subset of array-key
-     * (int|string); otherwise returns array-key. Returns array-key for dynamic/unknown
-     * key columns.
+     * (int|string); otherwise returns null — the caller falls back to array-key, but
+     * needs to know whether narrowing actually happened (a raw-alias value column
+     * combined with an equally-unresolved key column means neither axis narrowed, so
+     * the caller defers to the stub entirely instead of restating its default).
      *
      * @param class-string<Model> $modelClass
      */
@@ -256,13 +271,13 @@ final class ModelPropertyResolver
         string $modelClass,
         NodeTypeProvider $nodeTypeProvider,
         Codebase $codebase,
-    ): Union {
+    ): ?Union {
         // Cheap AST pre-check: avoid a NodeTypeProvider lookup for non-literal key columns,
         // which is the common case (variables, expressions).
         if (!$keyArg->value instanceof \PhpParser\Node\Scalar\String_) {
             $keyArgType = $nodeTypeProvider->getType($keyArg->value);
             if (!$keyArgType instanceof Union || !$keyArgType->isSingleStringLiteral()) {
-                return Type::getArrayKey();
+                return null;
             }
 
             $keyColumn = $keyArgType->getSingleStringLiteral()->value;
@@ -272,11 +287,11 @@ final class ModelPropertyResolver
 
         $keyPropertyType = self::resolvePropertyType($codebase, $modelClass, $keyColumn);
         if (!$keyPropertyType instanceof Union) {
-            return Type::getArrayKey();
+            return null;
         }
 
         if (!UnionTypeComparator::isContainedBy($codebase, $keyPropertyType, Type::getArrayKey())) {
-            return Type::getArrayKey();
+            return null;
         }
 
         return $keyPropertyType;

--- a/src/Handlers/Eloquent/Support/ModelPropertyResolver.php
+++ b/src/Handlers/Eloquent/Support/ModelPropertyResolver.php
@@ -233,10 +233,14 @@ final class ModelPropertyResolver
      * {@see self::extractModelFromUnion()} does not recognize as a Model, so this
      * method correctly yields null for that case rather than a wrong binding.
      *
+     * Public: shared with {@see \Psalm\LaravelPlugin\Handlers\Eloquent\BuilderAggregateHandler},
+     * which has the identical non-generic-custom-builder gap for sum()/avg()/min()/max()
+     * (issue #1294), the same way {@see self::extractModelFromUnion()} already is.
+     *
      * @return class-string<Model>|null
      * @psalm-mutation-free
      */
-    private static function extractModelFromLhsBuilderExtends(?Union $lhsType, Codebase $codebase): ?string
+    public static function extractModelFromLhsBuilderExtends(?Union $lhsType, Codebase $codebase): ?string
     {
         if (!$lhsType instanceof Union) {
             return null;

--- a/src/Handlers/Eloquent/Support/ModelPropertyResolver.php
+++ b/src/Handlers/Eloquent/Support/ModelPropertyResolver.php
@@ -122,9 +122,13 @@ final class ModelPropertyResolver
             // template_extended_params[Builder::class]['TModel'], which Psalm
             // populates from the @extends docblock — the same mechanism
             // ModelFactoryMethodTypeProvider/FactoryCountTypeProvider use for
-            // Factory<TModel>. Scoped to Builder: this only ever contributes a result
-            // when $modelTemplateIndex is Builder's own (0), since a Collection
-            // subclass's storage has no Builder entry in template_extended_params.
+            // Factory<TModel>. Naturally scoped to Builder subclasses regardless of
+            // caller: Psalm's Populator only ever creates a
+            // template_extended_params[Builder::class] entry when Builder is a
+            // generic ancestor somewhere in the class's hierarchy, so a Collection
+            // subclass's storage (reached when this runs from CollectionPluckHandler,
+            // $modelTemplateIndex 1) simply has no such key and this fallback yields
+            // null there — no explicit index check is needed or performed.
             if ($modelClass === null) {
                 $modelClass = self::extractModelFromLhsBuilderExtends($lhsType, $codebase);
             }

--- a/src/Handlers/Eloquent/Support/ModelPropertyResolver.php
+++ b/src/Handlers/Eloquent/Support/ModelPropertyResolver.php
@@ -97,7 +97,11 @@ final class ModelPropertyResolver
             return null;
         }
 
-        // Extract column name from the first argument as a string literal
+        // Extract column name from the first argument as a string literal. $args[0]/
+        // $args[1] below are positional (the $value, $key parameter order) — a call
+        // using PHP named arguments to reorder them (pluck(key: 'k', value: 'v'))
+        // would misindex here. Deliberate scope cut: no known real-world caller does
+        // this for pluck()'s two-parameter signature.
         $argType = $nodeTypeProvider->getType($args[0]->value);
         if (!$argType instanceof \Psalm\Type\Union || !$argType->isSingleStringLiteral()) {
             return null;
@@ -173,6 +177,9 @@ final class ModelPropertyResolver
         // We only adopt the @property type when it is a subset of int|string, because
         // Collection<TKey, TValue> requires TKey to be array-key. A property declared as
         // CarbonInterface|null (cast type) would produce an invalid TKey, so we fall back.
+        // $args[1] is positional too (see the $args[0] note above) — "has a $key
+        // argument" here means "has a second positional argument", not "named the
+        // $key parameter".
         $keyResolved = \count($args) < 2;
         $keyType = Type::getInt();
         if (\count($args) >= 2) {
@@ -213,6 +220,16 @@ final class ModelPropertyResolver
             return null;
         }
 
+        // First resolved model wins. A union LHS spanning builders/collections over
+        // DIFFERENT models (e.g. `FooBuilder<Foo>|BarBuilder<Bar>`) resolves to
+        // whichever atomic happens to match first, not a validated agreement across
+        // the whole union — a real type error in the caller's code could silently
+        // narrow pluck() against the wrong model instead of surfacing. Deliberate:
+        // this shape is vanishingly rare in practice (same pattern in
+        // extractModelFromLhsBuilderExtends() and extractModelFromLhsCollectionExtends()
+        // below). If ever tightened, the correct semantics are "every atomic that
+        // resolves to a model must resolve to the SAME model, else null" rather than
+        // first-match.
         foreach ($lhsType->getAtomicTypes() as $atomic) {
             if (!$atomic instanceof TGenericObject) {
                 continue;
@@ -259,6 +276,8 @@ final class ModelPropertyResolver
             return null;
         }
 
+        // First resolved model wins — same deliberate first-match limitation as
+        // extractModelFromLhsType() above.
         foreach ($lhsType->getAtomicTypes() as $atomic) {
             if (!$atomic instanceof TNamedObject) {
                 continue;
@@ -312,6 +331,8 @@ final class ModelPropertyResolver
             return null;
         }
 
+        // First resolved model wins — same deliberate first-match limitation as
+        // extractModelFromLhsType() above.
         foreach ($lhsType->getAtomicTypes() as $atomic) {
             if (!$atomic instanceof TNamedObject) {
                 continue;

--- a/tests/Application/app/Builders/AbstractPluckableBuilder.php
+++ b/tests/Application/app/Builders/AbstractPluckableBuilder.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Builders;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Abstract generic intermediate in a two-level custom-builder hierarchy, used to verify
+ * that Builder::pluck() narrowing resolves TModel through a non-direct
+ * @extends Builder<TModel> binding (issue #1287's "deeper chain" case).
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1287
+ *
+ * @template TModel of Model
+ * @extends Builder<TModel>
+ */
+abstract class AbstractPluckableBuilder extends Builder {}

--- a/tests/Application/app/Builders/InvoiceDeepBuilder.php
+++ b/tests/Application/app/Builders/InvoiceDeepBuilder.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Builders;
+
+/**
+ * Concrete, non-generic leaf two levels below Builder
+ * (InvoiceDeepBuilder extends AbstractPluckableBuilder<Invoice> extends Builder<TModel>).
+ * Regression fixture for issue #1287: pluck() must resolve TModel through the
+ * flattened template_extended_params chain, not just a direct Builder subclass.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1287
+ *
+ * @extends AbstractPluckableBuilder<\App\Models\Invoice>
+ */
+final class InvoiceDeepBuilder extends AbstractPluckableBuilder {}

--- a/tests/Application/app/Models/Invoice.php
+++ b/tests/Application/app/Models/Invoice.php
@@ -32,6 +32,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
  *
  * @property string $invoice_number Human-readable invoice identifier (e.g. "INV-2024-001")
  * @property string $status         Lifecycle status: draft, sent, paid, void
+ * @property float $total_amount    Invoice total, in the connection's base currency unit
  */
 #[UseEloquentBuilder(InvoiceBuilder::class)]
 #[CollectedBy(InvoiceCollection::class)]

--- a/tests/Type/tests/Builder/BuilderAggregateCustomBuilderTest.phpt
+++ b/tests/Type/tests/Builder/BuilderAggregateCustomBuilderTest.phpt
@@ -1,0 +1,80 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Builders\InvoiceDeepBuilder;
+use App\Models\Customer;
+use App\Models\Invoice;
+
+/**
+ * sum()/min()/max() narrowing on custom Builder subclasses that are not themselves
+ * generic — the aggregate-side analogue of #1287 (fixed for pluck()).
+ *
+ * BuilderAggregateHandler::resolveModelClass() had the identical gap
+ * BuilderPluckHandler had before #1287: the event's template parameters are empty
+ * for a non-generic custom builder (no own @template), and the LHS fallback only
+ * inspected TGenericObject atomics, missing the plain TNamedObject a non-generic
+ * custom builder's LHS type actually is.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1294
+ */
+
+// --- Direct, non-generic custom Builder subclass ---
+
+/**
+ * Invoice::query() returns InvoiceBuilder (`final class InvoiceBuilder extends
+ * Builder<Invoice>`, wired via #[UseEloquentBuilder]). total_amount is
+ * `@property float`.
+ */
+function test_sum_on_direct_custom_builder(): void
+{
+    $_result = Invoice::query()->sum('total_amount');
+    /** @psalm-check-type-exact $_result = float */
+}
+
+/** min()/max() add null for the empty-table case, same as on a plain Builder<Model>. */
+function test_min_on_direct_custom_builder(): void
+{
+    $_result = Invoice::query()->min('total_amount');
+    /** @psalm-check-type-exact $_result = float|null */
+}
+
+function test_max_on_direct_custom_builder(): void
+{
+    $_result = Invoice::query()->max('total_amount');
+    /** @psalm-check-type-exact $_result = float|null */
+}
+
+/** Unknown column on a non-generic custom builder falls back to the stub type, no crash. */
+function test_sum_unknown_column_on_direct_custom_builder(): void
+{
+    $_result = Invoice::query()->sum('unknown_column');
+    /** @psalm-check-type-exact $_result = float|int|numeric-string */
+}
+
+// --- Deeper inheritance chain ---
+
+/**
+ * InvoiceDeepBuilder extends AbstractPluckableBuilder<Invoice> extends Builder<TModel>
+ * (the same #1287 fixture reused from BuilderPluckCustomBuilderTest.phpt) — TModel
+ * must resolve through the flattened ancestor chain, not just a direct parent.
+ */
+function test_sum_on_deep_custom_builder_chain(InvoiceDeepBuilder $builder): void
+{
+    $_result = $builder->sum('total_amount');
+    /** @psalm-check-type-exact $_result = float */
+}
+
+// --- Regression guard: plain Builder<Model> aggregate unaffected ---
+
+/**
+ * Customer is queried through a plain Builder<Customer> (no custom builder) — the
+ * event's template parameters already resolve the model, so the new fallback must
+ * never be reached and behavior stays exactly as covered by BuilderAggregateTest.phpt.
+ */
+function test_sum_on_plain_builder_unaffected(): void
+{
+    $_result = Customer::query()->sum('vehicles_count');
+    /** @psalm-check-type-exact $_result = int */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Builder/BuilderPluckCustomBuilderTest.phpt
+++ b/tests/Type/tests/Builder/BuilderPluckCustomBuilderTest.phpt
@@ -40,11 +40,14 @@ function test_pluck_value_only_on_direct_custom_builder(): void
     /** @psalm-check-type-exact $_result = Collection<int, string> */
 }
 
-/** Unknown column on a non-generic custom builder falls back to the stub type, no crash. */
+/**
+ * Unknown column on a non-generic custom builder: value falls back to mixed, key
+ * stays int (no $key argument) — see issue #1286. No crash either way.
+ */
 function test_pluck_unknown_column_on_direct_custom_builder(): void
 {
     $_result = Invoice::query()->pluck('unknown_column');
-    /** @psalm-check-type-exact $_result = Collection<array-key, mixed> */
+    /** @psalm-check-type-exact $_result = Collection<int, mixed> */
 }
 
 // --- Deeper inheritance chain ---

--- a/tests/Type/tests/Builder/BuilderPluckCustomBuilderTest.phpt
+++ b/tests/Type/tests/Builder/BuilderPluckCustomBuilderTest.phpt
@@ -80,19 +80,29 @@ function test_pluck_on_generic_custom_builder_instance_unaffected(VehicleBuilder
     /** @psalm-check-type-exact $_result = Collection<string, string> */
 }
 
-// --- Non-Builder custom subclass (must not be affected by the new fallback) ---
+// --- Non-Builder custom subclass ---
 
 /**
  * InvoiceCollection is a non-generic custom Collection subclass — the Collection
  * analogue of InvoiceBuilder's shape (`@extends Collection<int, Invoice>`, no own
- * @template). Collection does not extend Builder, so the new
- * template_extended_params[Builder::class] fallback must never fire for it; narrowing
- * such Collection subclasses is a separate, out-of-scope gap this fix does not touch.
+ * @template). Collection does not extend Builder, so the Builder-scoped
+ * template_extended_params[Builder::class] fallback added by this fix never fires
+ * for it — narrowing custom Collection subclasses was a separate, out-of-scope gap
+ * when this file was first written.
+ *
+ * That gap has since been closed by #1295 (a mirror-image
+ * template_extended_params[...Collection::class] fallback), so this now narrows the
+ * same way InvoiceBuilder does — this test intentionally stayed in the #1287 file
+ * rather than moving to the #1295 one, since its point is exactly that the two
+ * fallbacks are independent and this is the boundary between them.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1295
  */
-function test_pluck_on_non_builder_custom_collection_unaffected(InvoiceCollection $collection): void
-{
+function test_pluck_on_non_builder_custom_collection_narrows_via_the_collection_side_fallback(
+    InvoiceCollection $collection,
+): void {
     $_result = $collection->pluck('invoice_number');
-    /** @psalm-check-type-exact $_result = Collection<array-key, mixed> */
+    /** @psalm-check-type-exact $_result = Collection<int, string> */
 }
 
 // --- Union LHS over the same model (lock-in) ---

--- a/tests/Type/tests/Builder/BuilderPluckCustomBuilderTest.phpt
+++ b/tests/Type/tests/Builder/BuilderPluckCustomBuilderTest.phpt
@@ -1,0 +1,93 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Builders\InvoiceDeepBuilder;
+use App\Builders\VehicleBuilder;
+use App\Collections\InvoiceCollection;
+use App\Models\Invoice;
+use Illuminate\Support\Collection;
+
+/**
+ * pluck() narrowing on custom Builder subclasses that are not themselves generic.
+ *
+ * Builder::pluck() infers the model from `$event->getTemplateTypeParameters()`, which is
+ * empty for a non-generic custom builder (e.g. `final class InvoiceBuilder extends
+ * Builder<Invoice>` — no own @template), and from the LHS type's TGenericObject
+ * type_params, which a plain TNamedObject LHS also lacks. ModelPropertyResolver now
+ * falls back to the classlike storage's `@extends Builder<TModel>` binding
+ * (`template_extended_params[Builder::class]['TModel']`) for this case.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1287
+ */
+
+// --- Direct, non-generic custom Builder subclass ---
+
+/**
+ * Invoice::query() returns InvoiceBuilder (`final class InvoiceBuilder extends
+ * Builder<Invoice>`, wired via #[UseEloquentBuilder] — the "standard pattern" the issue
+ * describes). Both value and key narrow from Invoice's @property annotations.
+ */
+function test_pluck_value_and_key_on_direct_custom_builder(): void
+{
+    $_result = Invoice::query()->pluck('invoice_number', 'status');
+    /** @psalm-check-type-exact $_result = Collection<string, string> */
+}
+
+/** Value-only pluck on the same non-generic custom builder: key stays int. */
+function test_pluck_value_only_on_direct_custom_builder(): void
+{
+    $_result = Invoice::query()->pluck('invoice_number');
+    /** @psalm-check-type-exact $_result = Collection<int, string> */
+}
+
+/** Unknown column on a non-generic custom builder falls back to the stub type, no crash. */
+function test_pluck_unknown_column_on_direct_custom_builder(): void
+{
+    $_result = Invoice::query()->pluck('unknown_column');
+    /** @psalm-check-type-exact $_result = Collection<array-key, mixed> */
+}
+
+// --- Deeper inheritance chain ---
+
+/**
+ * InvoiceDeepBuilder extends AbstractPluckableBuilder<Invoice> extends Builder<TModel> —
+ * TModel must resolve through the flattened ancestor chain, not just a direct parent.
+ */
+function test_pluck_on_deep_custom_builder_chain(InvoiceDeepBuilder $builder): void
+{
+    $_result = $builder->pluck('invoice_number', 'status');
+    /** @psalm-check-type-exact $_result = Collection<string, string> */
+}
+
+// --- Generic custom builder used with a concrete instantiation (regression guard) ---
+
+/**
+ * VehicleBuilder is itself generic (`@template TModel of Model`). Concretely
+ * instantiated as VehicleBuilder<Vehicle>, the LHS type is a TGenericObject and was
+ * already resolved by the existing type_params fallback before this fix — must keep
+ * working unchanged.
+ *
+ * @param VehicleBuilder<\App\Models\Vehicle> $builder
+ */
+function test_pluck_on_generic_custom_builder_instance_unaffected(VehicleBuilder $builder): void
+{
+    $_result = $builder->pluck('make', 'model');
+    /** @psalm-check-type-exact $_result = Collection<string, string> */
+}
+
+// --- Non-Builder custom subclass (must not be affected by the new fallback) ---
+
+/**
+ * InvoiceCollection is a non-generic custom Collection subclass — the Collection
+ * analogue of InvoiceBuilder's shape (`@extends Collection<int, Invoice>`, no own
+ * @template). Collection does not extend Builder, so the new
+ * template_extended_params[Builder::class] fallback must never fire for it; narrowing
+ * such Collection subclasses is a separate, out-of-scope gap this fix does not touch.
+ */
+function test_pluck_on_non_builder_custom_collection_unaffected(InvoiceCollection $collection): void
+{
+    $_result = $collection->pluck('invoice_number');
+    /** @psalm-check-type-exact $_result = Collection<array-key, mixed> */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Builder/BuilderPluckCustomBuilderTest.phpt
+++ b/tests/Type/tests/Builder/BuilderPluckCustomBuilderTest.phpt
@@ -1,10 +1,12 @@
 --FILE--
 <?php declare(strict_types=1);
 
+use App\Builders\InvoiceBuilder;
 use App\Builders\InvoiceDeepBuilder;
 use App\Builders\VehicleBuilder;
 use App\Collections\InvoiceCollection;
 use App\Models\Invoice;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 
 /**
@@ -90,6 +92,54 @@ function test_pluck_on_generic_custom_builder_instance_unaffected(VehicleBuilder
 function test_pluck_on_non_builder_custom_collection_unaffected(InvoiceCollection $collection): void
 {
     $_result = $collection->pluck('invoice_number');
+    /** @psalm-check-type-exact $_result = Collection<array-key, mixed> */
+}
+
+// --- Union LHS over the same model (lock-in) ---
+
+/**
+ * Receiver typed as a union of two Builder shapes over the SAME model: InvoiceBuilder
+ * (the non-generic #1287 fallback) and the plain generic Builder<Invoice> (the
+ * pre-existing template_params path). Locks in that narrowing still applies when the
+ * static type isn't a single atomic — each union member independently resolves to
+ * Invoice, so the value narrows from Invoice's `@property string $invoice_number`.
+ *
+ * @param InvoiceBuilder|Builder<Invoice> $builder
+ */
+function test_pluck_on_union_of_builder_types_over_same_model($builder): void
+{
+    $_result = $builder->pluck('invoice_number');
+    /** @psalm-check-type-exact $_result = Collection<int, string> */
+}
+
+// --- Generic builder's own unsubstituted template (lock-in) ---
+
+/**
+ * Locks in the safe-null path for a generic custom builder's OWN TModel while it is
+ * still unsubstituted — the shape a method declared inside such a builder's class body
+ * sees via `$this` (e.g. a hypothetical method on VehicleBuilder calling
+ * `$this->pluck('id')`).
+ *
+ * We deliberately do NOT add that method to App\Builders\VehicleBuilder and assert on
+ * it there: psalm-tester passes this .phpt as a bare file argument, so referenced
+ * classes are reflected but their method bodies are never analyzed by this suite (see
+ * tests/Type/README.md gotcha #4 and ArtistBuilder.php's docblock for the same
+ * limitation) — a `@psalm-check-type-exact` embedded in a fixture's method body would
+ * silently assert nothing. Reproducing the identical LHS shape from an analyzed
+ * function — VehicleBuilder<TModel> with TModel a template LOCAL to this function,
+ * standing in for VehicleBuilder's own unresolved template — exercises the exact same
+ * path in extractModelFromLhsBuilderExtends(): it fetches VehicleBuilder's own class
+ * storage, finds template_extended_params[Builder::class]['TModel'] bound to
+ * VehicleBuilder's own (unsubstituted) TModel, and extractModelFromUnion() correctly
+ * yields null for it since a TTemplateParam is never a resolved Model. No crash;
+ * pluck() falls back to its stub type.
+ *
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ * @param VehicleBuilder<TModel> $builder
+ */
+function test_pluck_with_unsubstituted_generic_builder_template($builder): void
+{
+    $_result = $builder->pluck('id');
     /** @psalm-check-type-exact $_result = Collection<array-key, mixed> */
 }
 ?>

--- a/tests/Type/tests/Builder/BuilderPluckRawAliasTest.phpt
+++ b/tests/Type/tests/Builder/BuilderPluckRawAliasTest.phpt
@@ -1,0 +1,80 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use App\Models\Invoice;
+use Illuminate\Support\Collection;
+
+/**
+ * pluck($value, $key) must not discard achievable key narrowing when the value column
+ * is a raw select alias or otherwise not a @property (e.g.
+ * `selectRaw('COUNT(*) AS cnt')->groupBy(...)->pluck('cnt', 'id')`). The value type
+ * falls back to mixed instead of bailing the whole result to null, since the value
+ * and key axes are resolved independently.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1286
+ */
+
+/**
+ * Raw select alias for the value column, known @property for the key column: key
+ * narrows to Customer's `@property string $id`, value stays mixed.
+ */
+function test_pluck_raw_alias_value_with_known_key(): void
+{
+    $_result = Customer::query()
+        ->selectRaw('id, COUNT(*) AS raw_count')
+        ->groupBy('id')
+        ->pluck('raw_count', 'id');
+    /** @psalm-check-type-exact $_result = Collection<string, mixed> */
+}
+
+/**
+ * Raw select alias with no $key argument: Laravel's positional pluck() always yields
+ * sequential int keys, so this is still strictly more precise than the stub default,
+ * even though the value column can't be narrowed.
+ */
+function test_pluck_raw_alias_value_without_key(): void
+{
+    $_result = Customer::query()->pluck('raw_count');
+    /** @psalm-check-type-exact $_result = Collection<int, mixed> */
+}
+
+/**
+ * Both the value and the key columns are unresolvable: neither axis narrows past the
+ * stub's default `Collection<array-key, mixed>`, so the handler defers to it instead
+ * of constructing an identical type.
+ */
+function test_pluck_raw_alias_value_with_unknown_key(): void
+{
+    $_result = Customer::query()->pluck('raw_count', 'unknown_key');
+    /** @psalm-check-type-exact $_result = Collection<array-key, mixed> */
+}
+
+/**
+ * Combined case cited by both #1286 and #1287: a raw select alias on a non-generic
+ * custom Builder subclass (InvoiceBuilder, resolved via the #1287 fix to
+ * template_extended_params[Builder::class]) whose key column IS a @property. This is
+ * the real-world aggregate-pluck shape both issues describe.
+ */
+function test_pluck_raw_alias_value_on_custom_builder_with_known_key(): void
+{
+    $_result = Invoice::query()
+        ->selectRaw('status, COUNT(*) AS raw_count')
+        ->groupBy('status')
+        ->pluck('raw_count', 'status');
+    /** @psalm-check-type-exact $_result = Collection<string, mixed> */
+}
+
+/**
+ * CollectionPluckHandler shares resolvePluckReturnType() with BuilderPluckHandler —
+ * confirm the same mixed-value fallback and key narrowing apply on an in-memory
+ * Collection, not just a Builder.
+ */
+function test_pluck_raw_alias_value_on_collection_with_known_key(): void
+{
+    $customers = Customer::all();
+    $_result = $customers->pluck('raw_count', 'id');
+    /** @psalm-check-type-exact $_result = Collection<string, mixed> */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Builder/BuilderPluckTest.phpt
+++ b/tests/Type/tests/Builder/BuilderPluckTest.phpt
@@ -30,11 +30,16 @@ function test_pluck_with_nullable_property(): void
     /** @psalm-check-type-exact $_result = Collection<int, \Carbon\CarbonInterface|null> */
 }
 
-/** When the column name is not a known @property, fall back to default behavior */
+/**
+ * When the column name is not a known @property, the value falls back to mixed. No
+ * $key argument means Laravel's positional pluck() still yields sequential int keys.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1286
+ */
 function test_pluck_with_unknown_column(): void
 {
     $_result = Customer::query()->pluck('unknown_column');
-    /** @psalm-check-type-exact $_result = Collection<array-key, mixed> */
+    /** @psalm-check-type-exact $_result = Collection<int, mixed> */
 }
 
 /** When the column is a variable (not a string literal), fall back to default */
@@ -123,12 +128,15 @@ function test_pluck_on_collection_with_key(): void
     /** @psalm-check-type-exact $_result = Collection<string, \Carbon\CarbonInterface|null> */
 }
 
-/** pluck on Collection with unknown column falls back to default */
+/**
+ * pluck on Collection with an unknown column: value falls back to mixed, key stays
+ * int (no $key argument). Mirrors the Builder-side behavior — see issue #1286.
+ */
 function test_pluck_on_collection_unknown_column(): void
 {
     $customers = Customer::all();
     $_result = $customers->pluck('unknown_column');
-    /** @psalm-check-type-exact $_result = Collection<array-key, mixed> */
+    /** @psalm-check-type-exact $_result = Collection<int, mixed> */
 }
 
 /** Full query pipeline: query()->get()->pluck() preserves template types */

--- a/tests/Type/tests/Builder/CollectionPluckCustomSubclassTest.phpt
+++ b/tests/Type/tests/Builder/CollectionPluckCustomSubclassTest.phpt
@@ -1,0 +1,50 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Builders\InvoiceBuilder;
+use App\Collections\InvoiceCollection;
+use App\Models\Invoice;
+use Illuminate\Support\Collection;
+
+/**
+ * pluck() narrowing on custom Collection subclasses that are not themselves generic —
+ * the Collection-side mirror image of #1287 (fixed for Builder).
+ *
+ * CollectionPluckHandler shares ModelPropertyResolver::resolvePluckReturnType() with
+ * BuilderPluckHandler ($modelTemplateIndex 1 instead of 0). A non-generic custom
+ * Collection subclass (`final class InvoiceCollection extends Collection<int, Invoice>
+ * {}`, no own @template) has the same shape #1287 diagnosed for Builder: the event's
+ * template parameters are empty, and the LHS type is a plain TNamedObject rather than
+ * a TGenericObject, so neither existing fallback matches. #1287's own Builder-scoped
+ * fallback (template_extended_params[Builder::class]) correctly doesn't match either,
+ * since Collection never extends Builder — this needed its own, separately-scoped
+ * fallback keyed on the Collection hierarchy instead.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1295
+ */
+
+/**
+ * Value+key form: InvoiceCollection narrows both from Invoice's @property annotations,
+ * exactly like the direct-Builder case in BuilderPluckCustomBuilderTest.phpt.
+ */
+function test_pluck_value_and_key_on_custom_collection_subclass(InvoiceCollection $collection): void
+{
+    $_result = $collection->pluck('invoice_number', 'status');
+    /** @psalm-check-type-exact $_result = Collection<string, string> */
+}
+
+/**
+ * Regression guard: a non-generic custom BUILDER subclass must be unaffected by the
+ * new Collection-side fallback — the mirror image of the "non-Builder subclass
+ * unaffected" guard #1287 added for the Builder-side fallback. InvoiceBuilder's
+ * classlike storage has no template_extended_params[...Collection::class] entry
+ * (Builder never extends Collection), so the new fallback contributes nothing here;
+ * this continues to resolve via the pre-existing #1287 Builder-side fallback only.
+ */
+function test_pluck_on_custom_builder_subclass_unaffected_by_collection_fallback(InvoiceBuilder $builder): void
+{
+    $_result = $builder->pluck('invoice_number', 'status');
+    /** @psalm-check-type-exact $_result = Collection<string, string> */
+}
+?>
+--EXPECTF--

--- a/tests/Unit/Handlers/Eloquent/Support/ModelPropertyResolverPluckSchemaTest.php
+++ b/tests/Unit/Handlers/Eloquent/Support/ModelPropertyResolverPluckSchemaTest.php
@@ -32,8 +32,8 @@ use Tests\Psalm\LaravelPlugin\Unit\Util\Ast\Concerns\InitializesPsalmConfigSingl
 /**
  * Unit coverage for issue #1293: pluck()'s value/key column resolution now goes through
  * {@see \Psalm\LaravelPlugin\Handlers\Eloquent\ModelPropertyHandler::resolveColumnType()}
- * instead of the `@property`-only {@see ModelPropertyResolver::resolvePropertyType()}, so a
- * column known only from migration schema / casts should narrow too.
+ * instead of a `@property`-only lookup, so a column known only from migration schema /
+ * casts should narrow too.
  *
  * This can't be a `.phpt`: the type-test harness runs no migrations, so `App\Models\*`
  * fixtures always have empty schemas there (see the identical rationale on

--- a/tests/Unit/Handlers/Eloquent/Support/ModelPropertyResolverPluckSchemaTest.php
+++ b/tests/Unit/Handlers/Eloquent/Support/ModelPropertyResolverPluckSchemaTest.php
@@ -1,0 +1,265 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Eloquent\Support;
+
+use App\Models\WorkOrder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\Codebase;
+use Psalm\Internal\Provider\ClassLikeStorageProvider;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\CastInfo;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\CastShape;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ColumnInfo;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadata;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadataRegistryBuilder;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\PrimaryKeyInfo;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\PrimaryKeyType;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\TableSchema;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\TraitFlags;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaColumn;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Support\ModelPropertyResolver;
+use Psalm\NodeTypeProvider;
+use Psalm\Progress\VoidProgress;
+use Psalm\Type\Atomic\TLiteralString;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Union;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Enums\SerializedIntStatus;
+use Tests\Psalm\LaravelPlugin\Unit\Util\Ast\Concerns\InitializesPsalmConfigSingleton;
+
+/**
+ * Unit coverage for issue #1293: pluck()'s value/key column resolution now goes through
+ * {@see \Psalm\LaravelPlugin\Handlers\Eloquent\ModelPropertyHandler::resolveColumnType()}
+ * instead of the `@property`-only {@see ModelPropertyResolver::resolvePropertyType()}, so a
+ * column known only from migration schema / casts should narrow too.
+ *
+ * This can't be a `.phpt`: the type-test harness runs no migrations, so `App\Models\*`
+ * fixtures always have empty schemas there (see the identical rationale on
+ * {@see \Tests\Psalm\LaravelPlugin\Unit\Handlers\Eloquent\ModelSerializationShapeBuilderTest},
+ * #1167). Driven instead from a hand-built {@see ModelMetadata} via `overrideForTesting()`
+ * against a real {@see Codebase}, exactly like that test — {@see WorkOrder} is reused purely
+ * as an autoloadable `is_a(Model::class)` target; its real `@property` docblock never enters
+ * play because {@see ClassLikeStorageProvider::create()} allocates a fresh, empty storage
+ * rather than scanning the file.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1293
+ */
+#[CoversClass(ModelPropertyResolver::class)]
+final class ModelPropertyResolverPluckSchemaTest extends TestCase
+{
+    use InitializesPsalmConfigSingleton;
+
+    private ClassLikeStorageProvider $classLikeStorageProvider;
+
+    private Codebase $codebase;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        ModelMetadataRegistryBuilder::reset();
+
+        $this->classLikeStorageProvider = new ClassLikeStorageProvider();
+        // Fresh empty storage: resolveColumnType() checks pseudo_property_get_types first,
+        // so an empty storage keeps the test driven purely by the overridden schema/casts —
+        // WorkOrder's real @property docblock is never scanned into this provider.
+        $this->classLikeStorageProvider->create(WorkOrder::class);
+        $this->classLikeStorageProvider->create(SerializedIntStatus::class)->is_enum = true;
+
+        $this->codebase = $this->makeCodebase();
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        ModelMetadataRegistryBuilder::reset();
+    }
+
+    #[Test]
+    public function value_column_narrows_from_migration_schema_on_an_annotation_less_model(): void
+    {
+        $this->override(columns: [
+            'provider' => $this->col('provider', SchemaColumn::TYPE_STRING),
+        ]);
+
+        $result = $this->pluck($this->strArg('provider'));
+
+        $this->assertSame('Illuminate\Support\Collection<int, string>', (string) $result);
+    }
+
+    #[Test]
+    public function key_column_narrows_from_migration_schema(): void
+    {
+        $this->override(columns: [
+            // Value column deliberately absent from schema — a raw select alias, per #1286 —
+            // to isolate that THIS test is exercising the key-side schema lookup, not value.
+            'id' => $this->col('id', SchemaColumn::TYPE_INT),
+        ]);
+
+        $result = $this->pluck($this->strArg('raw_count'), $this->strArg('id'));
+
+        $this->assertSame('Illuminate\Support\Collection<int, mixed>', (string) $result);
+    }
+
+    #[Test]
+    public function enum_cast_column_used_as_key_does_not_narrow_tkey(): void
+    {
+        // The column must exist in schema (columnTypeFromRegistry requires it) AND have a
+        // casts() entry — columnTypeFromRegistry returns the cast's psalmType verbatim
+        // without re-checking array-key compatibility itself; that guard lives in
+        // resolveKeyType()'s isContainedBy() check, which is what this test locks in.
+        $this->override(
+            columns: [
+                'id' => $this->col('id', SchemaColumn::TYPE_INT),
+                'status' => $this->col('status', SchemaColumn::TYPE_INT),
+            ],
+            casts: [
+                'status' => new CastInfo(
+                    'status',
+                    CastShape::BackedEnum,
+                    SerializedIntStatus::class,
+                    new Union([new TNamedObject(SerializedIntStatus::class)]),
+                    null,
+                ),
+            ],
+        );
+
+        $result = $this->pluck($this->strArg('id'), $this->strArg('status'));
+
+        // Value narrows (id: int), key falls back to array-key — the enum object type is not
+        // array-key compatible, so it must not leak into TKey.
+        $this->assertSame('Illuminate\Support\Collection<array-key, int>', (string) $result);
+    }
+
+    #[Test]
+    public function nullable_schema_column_used_as_key_falls_back_to_array_key(): void
+    {
+        $this->override(columns: [
+            'id' => $this->col('id', SchemaColumn::TYPE_INT),
+            'nickname' => $this->col('nickname', SchemaColumn::TYPE_STRING, nullable: true),
+        ]);
+
+        $result = $this->pluck($this->strArg('id'), $this->strArg('nickname'));
+
+        // ?string is not array-key compatible (null isn't a valid array key) — key must fall
+        // back to array-key rather than narrowing to a nullable TKey.
+        $this->assertSame('Illuminate\Support\Collection<array-key, int>', (string) $result);
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    private function pluck(\PhpParser\Node\Arg $value, ?\PhpParser\Node\Arg $key = null): ?Union
+    {
+        $args = $key instanceof \PhpParser\Node\Arg ? [$value, $key] : [$value];
+
+        return ModelPropertyResolver::resolvePluckReturnType(
+            args: $args,
+            templateParams: [new Union([new TNamedObject(WorkOrder::class)])],
+            modelTemplateIndex: 0,
+            nodeTypeProvider: $this->nodeTypeProvider($args),
+            codebase: $this->codebase,
+        );
+    }
+
+    /** @param list<\PhpParser\Node\Arg> $args */
+    private function nodeTypeProvider(array $args): NodeTypeProvider
+    {
+        $provider = new class implements NodeTypeProvider {
+            /** @var \SplObjectStorage<\PhpParser\NodeAbstract, Union> */
+            private \SplObjectStorage $types;
+
+            public function __construct()
+            {
+                $this->types = new \SplObjectStorage();
+            }
+
+            #[\Override]
+            public function setType(\PhpParser\NodeAbstract $node, Union $type): void
+            {
+                $this->types[$node] = $type;
+            }
+
+            #[\Override]
+            public function getType(\PhpParser\NodeAbstract $node): ?Union
+            {
+                return $this->types->offsetExists($node) ? $this->types[$node] : null;
+            }
+        };
+
+        foreach ($args as $arg) {
+            \assert($arg->value instanceof \PhpParser\Node\Scalar\String_);
+            $provider->setType($arg->value, new Union([TLiteralString::make($arg->value->value)]));
+        }
+
+        return $provider;
+    }
+
+    private function strArg(string $literal): \PhpParser\Node\Arg
+    {
+        return new \PhpParser\Node\Arg(new \PhpParser\Node\Scalar\String_($literal));
+    }
+
+    /** @param non-empty-string $type */
+    private function col(string $name, string $type, bool $nullable = false): ColumnInfo
+    {
+        return new ColumnInfo($name, $type, $nullable, hasDefault: false);
+    }
+
+    /**
+     * @param array<non-empty-string, ColumnInfo> $columns
+     * @param array<non-empty-string, CastInfo>   $casts
+     */
+    private function override(array $columns, array $casts = []): void
+    {
+        $metadata = new ModelMetadata(
+            fqcn: WorkOrder::class,
+            primaryKey: new PrimaryKeyInfo('id', PrimaryKeyType::Integer, incrementing: true, uuidColumns: []),
+            traits: new TraitFlags(
+                hasSoftDeletes: false,
+                hasUuids: false,
+                hasUlids: false,
+                hasFactory: false,
+                hasApiTokens: false,
+                hasNotifications: false,
+                hasGlobalScopes: false,
+                usesTimestamps: true,
+            ),
+            fillable: [],
+            guarded: [],
+            appends: [],
+            with: [],
+            withCount: [],
+            hidden: [],
+            visible: [],
+            connection: null,
+            morphAlias: null,
+            customBuilder: null,
+            customCollection: null,
+            schemaData: new TableSchema($columns),
+            castsData: $casts,
+            accessorsData: [],
+            mutatorsData: [],
+            scopesData: [],
+            relationsData: [],
+            knownPropertiesData: [],
+            completeSections: ModelMetadata::ALL_SECTIONS,
+        );
+
+        ModelMetadataRegistryBuilder::overrideForTesting(WorkOrder::class, $metadata);
+    }
+
+    private function makeCodebase(): Codebase
+    {
+        $codebase = (new \ReflectionClass(Codebase::class))->newInstanceWithoutConstructor();
+        $codebase->classlike_storage_provider = $this->classLikeStorageProvider;
+
+        // $progress is declared protected(set) readonly in Psalm 7 — bypass via reflection.
+        $progressProperty = new \ReflectionProperty(Codebase::class, 'progress');
+        $progressProperty->setValue($codebase, new VoidProgress());
+
+        return $codebase;
+    }
+}

--- a/tests/Unit/Handlers/Eloquent/Support/ModelPropertyResolverPluckSchemaTest.php
+++ b/tests/Unit/Handlers/Eloquent/Support/ModelPropertyResolverPluckSchemaTest.php
@@ -190,7 +190,7 @@ final class ModelPropertyResolverPluckSchemaTest extends TestCase
         };
 
         foreach ($args as $arg) {
-            \assert($arg->value instanceof \PhpParser\Node\Scalar\String_);
+            \PHPUnit\Framework\Assert::assertInstanceOf(\PhpParser\Node\Scalar\String_::class, $arg->value);
             $provider->setType($arg->value, new Union([TLiteralString::make($arg->value->value)]));
         }
 


### PR DESCRIPTION
## Issue to Solve

Five sibling gaps in `pluck()`/aggregate return-type narrowing that real-world code frequently hits together (e.g. an aggregate `pluck('cnt', 'known_property')` on a custom builder over an annotation-less model):

1. Narrowing from `@property` annotations does not fire when `pluck()` is called on a custom Builder subclass declared with `/** @extends Builder<TModel> */` (the standard `newEloquentBuilder()` pattern). The event's template parameters are empty because the subclass itself is not generic, and the LHS fallback only inspected `TGenericObject` atomics, so a plain `TNamedObject` LHS bailed out to the stub `Collection<array-key, mixed>`.
2. When the *value* column is not a known `@property` (typically a raw select alias like `COUNT(*) AS cnt`), the resolver bailed out entirely, discarding the *key* narrowing that was still achievable from the key column's `@property`.
3. `pluck()` ignored migration-schema and cast-derived column types entirely: on an annotation-less model whose column type the plugin's own schema inference already resolves for `$model->column` reads, `pluck('column')` stayed `mixed` (surfaced by the delta report on this PR: coolify's `OauthSettingSeeder`).
4. `sum()`/`avg()`/`min()`/`max()` had the same custom-Builder-subclass gap as (1).
5. Non-generic custom Collection subclasses (`InvoiceCollection extends Collection<int, Invoice>`) had the same gap as (1) for `Collection::pluck()`.

## Related

Fixes #1287
Fixes #1286
Fixes #1293
Fixes #1294
Fixes #1295

## Solution Description

**#1287** — `ModelPropertyResolver` gains an LHS fallback: when the LHS is a non-generic `TNamedObject`, resolve `TModel` from the classlike storage's `template_extended_params[Builder::class]['TModel']`, which Psalm's Populator populates from the `@extends Builder<Task>` docblock and flattens across deeper inheritance chains. This mirrors the established `template_extended_params[Factory::class]` pattern in `FactoryCountTypeProvider`. The fallback is naturally scoped: only classes with `Builder` as a generic ancestor have that storage key. An unsubstituted template binding (generic custom builder) safely yields no match rather than a wrong one.

**#1286** — instead of returning `null` when the value column has no resolvable type, the resolver falls back to `mixed` for the value type and continues to key resolution, returning `Collection<KeyType, mixed>`. When *both* value and key are unresolvable it still returns `null` (defers to the stub). As a side effect, single-argument `pluck('unknown_column')` now infers `Collection<int, mixed>` instead of the stub's `Collection<array-key, mixed>` — positional pluck always produces sequential int keys, so this is a strict precision gain; three pre-existing tests were updated to the more precise expectation. `resolveKeyType()` now returns `?Union` so the caller can distinguish "narrowed" from "defaulted to array-key".

**#1293** — both pluck column-resolution call sites (value and key) now use `ModelPropertyHandler::resolveColumnType()` (priority chain `@property` → casts → migration schema, already used by the aggregate handler) instead of the `@property`-only lookup. This matches runtime semantics: `Builder::pluck()` hydrates through the model when the column has a cast or accessor, so cast/schema types are the correct source. Key narrowing now also works from schema types; an enum-cast or nullable column used as key correctly falls back to `array-key` via the existing containment guard.

**#1294** — `extractModelFromLhsBuilderExtends()` is now public and wired as the final fallback in `BuilderAggregateHandler::resolveModelClass()`, reusing the #1287 mechanism for aggregates.

**#1295** — new `extractModelFromLhsCollectionExtends()` resolves the model for non-generic custom Collection subclasses from `template_extended_params` (checks `Eloquent\Collection['TModel']`, then `Support\Collection['TValue']`; both verified empirically to be present and flattened by Psalm's Populator). Naturally inert for Builder LHS the same way the Builder fallback is inert for Collections — neither hierarchy's storage carries the other's key.

Two low-value limitations are deliberately documented in code comments instead of fixed: union-LHS resolution is first-match (a union of builders over *different* models would narrow against the first resolvable atom), and argument extraction is positional (PHP named arguments would misindex). Both are vanishingly rare in real code.

Verified with type tests in `tests/Type/tests/Builder/` (`BuilderPluckCustomBuilderTest.phpt`, `BuilderPluckRawAliasTest.phpt`, `BuilderAggregateCustomBuilderTest.phpt`, `CollectionPluckCustomSubclassTest.phpt`) covering direct non-generic subclasses via the real `#[UseEloquentBuilder]` pattern, deeper inheritance chains, generic-instantiation and non-Builder regression guards, union LHS, self-referential unsubstituted templates, raw-alias value with known/unknown/no key, the combined custom-builder + raw-alias case, and `Collection::pluck()` sharing. Migration-schema and cast behavior (including enum-cast and nullable key columns) is covered by `tests/Unit/.../ModelPropertyResolverPluckSchemaTest.php` with a synthetic metadata registry, since the phpt harness does not run migrations. Full type suite, unit suite, Psalm self-analysis (`--find-dead-code --find-unused-psalm-suppress`), php-cs-fixer, and the phpt-conventions check all pass; each fix commit is independently green (bisectable).

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)
