### PR TITLE
Normalize array-form $casts at model warm-up

### DIFF
--- a/src/Handlers/Eloquent/Metadata/ModelInstancePreparer.php
+++ b/src/Handlers/Eloquent/Metadata/ModelInstancePreparer.php
@@ -33,7 +33,7 @@ final class ModelInstancePreparer
      *
      * Framework and user initializers are INVOKED alike, so each does whatever the INSTALLED Laravel does —
      * version-correct by construction, with no hand-written mirror to drift when a release moves one. Exactly
-     * one is not invoked: the framework's `initializeHasAttributes` ({@see applyAppendsAttribute()}).
+     * one is not invoked: the framework's `initializeHasAttributes` ({@see mirrorHasAttributesInitializer()}).
      *
      * Not `initializeTraits()`: it reads `static::$traitInitializers`, populated only by `bootTraits()` — and
      * booting registers global scopes, a Psalm hang. `boot{Trait}()` is skipped for the same reason, so an
@@ -77,7 +77,7 @@ final class ModelInstancePreparer
                 && \str_starts_with(\str_replace('\\', '/', (string) $method->getFileName()), $eloquentRoot . '/');
 
             if ($isFrameworkHasAttributes) {
-                self::applyAppendsAttribute($reflection, $instance);
+                self::mirrorHasAttributesInitializer($reflection, $instance);
             } else {
                 // Reflection, NOT $instance->{$name}(): a protected initializer called from outside routes to
                 // Model::__call() query-builder forwarding instead of running. Bare statement keeps the mixed
@@ -100,30 +100,55 @@ final class ModelInstancePreparer
      * The framework's `initializeHasAttributes` is the one initializer stood in for rather than invoked.
      *
      * NOT because it runs user code: the walk above invokes user trait initializers deliberately, and doing so
-     * is the only way to observe them at all. Because `casts()` is the one initializer input already available
+     * is the only way to observe them at all. Because `casts()` is the one initializer input available
      * STATICALLY — {@see \Psalm\LaravelPlugin\Handlers\Eloquent\Schema\CastsMethodParser} AST-parses it and
-     * {@see ModelMetadataRegistryBuilder::computeCasts()} merges that result last. Executing it would buy no
-     * information the registry does not already have, at the cost of evaluating arbitrary user expressions
-     * inside warm-up. A user trait initializer has no such static equivalent, which is what makes the two
-     * different — not who wrote them.
+     * {@see ModelMetadataRegistryBuilder::computeCasts()} merges that result last. Executing it would buy
+     * little the registry lacks (the parser degrades what it cannot resolve to `'mixed'`), at the cost of
+     * evaluating arbitrary user expressions inside warm-up.
      *
-     * Standing in for it costs three effects, of which only the third is reproduced:
-     *  - `ensureCastsAreStringValues()`, which also normalizes the DECLARED `$casts`. No `casts()` call is
-     *    involved, so the rule above does NOT excuse skipping it: a `protected $casts = ['x' => [Foo::class,
-     *    'arg']]` stays an array here where a constructed model holds `'Foo:arg'`, and computeCasts() then
-     *    drops that model's whole casts section on the resulting TypeError. Pre-existing, not this rework's
-     *    doing, tracked as #1281 — do not read this mirror as evidence the gap is intended.
+     * `casts()` is the only skipped PART, not the statement wrapping it. The initializer's three effects:
+     *  - `ensureCastsAreStringValues()`, called below over the DECLARED `$casts` alone. It runs no `casts()`,
+     *    so the rule above does not excuse skipping it: unnormalized, `protected $casts = ['x' =>
+     *    [Foo::class, 'arg']]` stays an array where a constructed model holds `'Foo:arg'`, and computeCasts()
+     *    drops that model's WHOLE casts section on the resulting TypeError (#1281).
      *  - `$dateFormat`, which nothing stores.
-     *  - `mergeAppends()`, mirrored below.
+     *  - `mergeAppends()`, called below.
      *
-     * `#[Appends]` is Laravel 13.0+; below it classAttribute() matches nothing and this no-ops — so
-     * `mergeAppends()`, absent on 12.14–12.24, is never called and cannot crash warm-up. Identical across the
-     * whole `illuminate/database: ^12.14 || ^13.3` range.
+     * The normalizer is CALLED, never copied: it is version-split inside the supported range — 12.14–12.25
+     * has no `is_object` branch, 12.26+ adds one throwing `InvalidArgumentException` on a non-Stringable
+     * object cast — so a copy would carry a gate that calling tracks for free. The `is_array` branch this
+     * exists for is byte-identical across `illuminate/database: ^12.14 || ^13.3`, so it needs no gate.
+     *
+     * Built from `$instance`, never `Model::class`: `ReflectionMethod::invoke()` dispatches NON-virtually and
+     * does not complain about a foreign receiver, so a `Model::class` handle would silently run the
+     * framework's body on a model that overrides the normalizer. Not the public `mergeCasts()`, which
+     * normalizes too: it merges from OUTSIDE over `$this->casts`, so the only raw-casts reader it could be
+     * paired with — `getCasts()` — would bake the implicit key cast permanently into the property and defeat
+     * computeCasts()'s setIncrementing() suppression.
+     *
+     * `#[Appends]` is Laravel 13.0+; below it classAttribute() matches nothing and that half no-ops — so
+     * `mergeAppends()`, absent on 12.14–12.24, is never called and cannot crash warm-up.
      *
      * @param \ReflectionClass<Model> $reflection
      */
-    private static function applyAppendsAttribute(\ReflectionClass $reflection, Model $instance): void
+    private static function mirrorHasAttributesInitializer(\ReflectionClass $reflection, Model $instance): void
     {
+        $declaredCasts = new \ReflectionProperty(Model::class, 'casts');
+        $normalize = new \ReflectionMethod($instance, 'ensureCastsAreStringValues');
+
+        try {
+            // Read-normalize-write as ONE statement: getValue() and invoke() both return mixed, and binding
+            // either to a local would count against the plugin's 100% type-coverage target.
+            $declaredCasts->setValue($instance, $normalize->invoke($instance, $declaredCasts->getValue($instance)));
+        } catch (\InvalidArgumentException) {
+            // 12.26+ raises this for a non-Stringable object cast. Runtime normalizes the MERGED map and
+            // `casts()` wins on collisions, so a declared object cast that `casts()` overrides never reaches
+            // the throw at construction. Seeing the declared half alone, this cannot tell that model from an
+            // unconstructable one — so leave `$casts` raw and defer to computeCasts(), which holds the
+            // AST-parsed `casts()`, merges it last, and widens whatever survives. Nothing is written when
+            // invoke() throws, so the raw value stands.
+        }
+
         $appends = self::classAttribute($reflection, Appends::class);
         if ($appends !== null) {
             $instance->mergeAppends($appends->columns);

--- a/tests/Unit/Fixtures/Enums/CastFlavour.php
+++ b/tests/Unit/Fixtures/Enums/CastFlavour.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Enums;
+
+/**
+ * Stands in as a non-Stringable object inside a `$casts` declaration
+ * ({@see \Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\ObjectCastOverriddenByCastsMethodModel}).
+ *
+ * An enum case is the ONLY object a property default can hold — `new` is rejected in a property initializer —
+ * and PHP forbids `__toString` on an enum, so it can never satisfy the `Stringable` check that
+ * `HasAttributes::ensureCastsAreStringValues()` applies before throwing.
+ */
+enum CastFlavour: string
+{
+    case Vanilla = 'vanilla';
+}

--- a/tests/Unit/Fixtures/Models/AppendsOrderModel.php
+++ b/tests/Unit/Fixtures/Models/AppendsOrderModel.php
@@ -9,9 +9,12 @@ use Illuminate\Database\Eloquent\Model;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Concerns\SetsAppendInInitializer;
 
 /**
- * `#[Appends('attribute_append')]` plus a trait `setAppends(['trait_only'])`. Runtime `getAppends()` returns
- * BOTH, because the user initializer runs before `initializeHasAttributes`' `mergeAppends()`. The registry
- * must reproduce that exactly — running the initializer and the attribute mirror in the same reflection order Laravel observes.
+ * `#[Appends('attribute_append')]` plus a trait `setAppends(['trait_only'])`. Which survives is PHP-dependent:
+ * `getMethods()` ranks the user initializer against `initializeHasAttributes`' `mergeAppends()` differently on
+ * 8.4 and 8.5 (see {@see SetsAppendInInitializer}), so runtime `getAppends()` yields both on 8.5 and
+ * `['trait_only']` on 8.4. The registry must reproduce whichever the installed PHP produces — running the
+ * initializer and the framework initializer's stand-in in the same reflection order Laravel observes — which
+ * is why the consuming test reads a constructed model as its oracle instead of pinning a literal.
  *
  * The `#[Appends]` attribute exists from Laravel 13.0, so the consuming test is gated on `class_exists()`.
  *

--- a/tests/Unit/Fixtures/Models/ArrayFormCastsModel.php
+++ b/tests/Unit/Fixtures/Models/ArrayFormCastsModel.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Casts\AsCollection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+
+/**
+ * Declares `$casts` in Laravel's ARRAY form, which `HasAttributes::ensureCastsAreStringValues()` collapses
+ * to a string while constructing the model: `[Foo::class, 'arg']` → `'Foo:arg'`, single-element → `Foo::class`.
+ *
+ * Warm-up reads a constructor-less instance, so it must reproduce that collapse itself. Left raw, the array
+ * reaches `ModelMetadataRegistryBuilder::buildCastInfo()`'s `string $castString` and TypeErrors, withholding
+ * the model's WHOLE casts section — `plain_tags` included (#1281).
+ *
+ * POSITIONAL, matching Laravel's own `[AsCollection::class, CustomCollection::class]` test stub: `implode(',')`
+ * takes values, so argument 0 IS the collection class and an `'of' =>` key would be decorative rather than
+ * meaningful. (The fluent `AsCollection::of()` emits a different string again — `AsCollection:,Foo` — and is a
+ * method call, so it can only live in `casts()`, which warm-up never executes.)
+ *
+ * `plain_tags` is the control: a string cast the normalizer passes through untouched, so a test can tell
+ * "normalization ran and was selective" from "the map was rebuilt" or "this key merely survived".
+ *
+ * Both array forms are expressible on every supported release — `ensureCastsAreStringValues()`'s `is_array`
+ * branch is byte-identical across `illuminate/database: ^12.14 || ^13.3` — so this fixture needs no gate.
+ *
+ * @internal fixture used by ModelInstancePreparerTest and ModelMetadataRegistryTest
+ */
+final class ArrayFormCastsModel extends Model
+{
+    /** @var array<string, string|array<array-key, string>> */
+    protected $casts = [
+        'options' => [AsCollection::class, Collection::class],
+        'single' => [AsCollection::class],
+        'plain_tags' => 'collection',
+    ];
+}

--- a/tests/Unit/Fixtures/Models/CastsMethodModel.php
+++ b/tests/Unit/Fixtures/Models/CastsMethodModel.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Eloquent\Model;
  *
  * That execution is the whole reason the warm-up replay stands in for that one initializer instead of
  * invoking it (see
- * {@see \Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelInstancePreparer::applyAppendsAttribute()}) —
+ * {@see \Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelInstancePreparer::mirrorHasAttributesInitializer()}) —
  * not because `casts()` is user code, but because it is the one initializer input the registry ALREADY has
  * statically: {@see \Psalm\LaravelPlugin\Handlers\Eloquent\Schema\CastsMethodParser} AST-parses it and the
  * builder merges that result last. The cast is therefore absent from the replayed instance and present on a

--- a/tests/Unit/Fixtures/Models/ObjectCastOverriddenByCastsMethodModel.php
+++ b/tests/Unit/Fixtures/Models/ObjectCastOverriddenByCastsMethodModel.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Enums\CastFlavour;
+
+/**
+ * Declares an OBJECT cast that `casts()` then overrides — the one shape where warm-up's normalizer can throw
+ * for a model Laravel constructs perfectly well.
+ *
+ * Laravel normalizes `array_merge($this->casts, $this->casts())` and `casts()` WINS on collisions, so the enum
+ * below never reaches `ensureCastsAreStringValues()`'s `is_object` arm at construction. Warm-up sees the
+ * declared half ALONE, so it would throw (12.26+, where that arm exists) and take all four instance-derived
+ * sections with it — while `new` on this model returns fine. Hence the mirror's catch.
+ *
+ * An enum case is the only object a `$casts` property default can hold (`new` is rejected in a property
+ * initializer) and an enum cannot be Stringable (PHP forbids `__toString` on enums), so that arm is only ever
+ * reachable here as a throw.
+ *
+ * @internal fixture used by ModelInstancePreparerTest and ModelMetadataRegistryTest
+ */
+final class ObjectCastOverriddenByCastsMethodModel extends Model
+{
+    /** @var array<string, string|CastFlavour> */
+    protected $casts = [
+        'flavour' => CastFlavour::Vanilla,
+    ];
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return ['flavour' => 'string'];
+    }
+}

--- a/tests/Unit/Providers/ModelMetadata/ModelInstancePreparerTest.php
+++ b/tests/Unit/Providers/ModelMetadata/ModelInstancePreparerTest.php
@@ -10,14 +10,18 @@ use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelInstancePreparer;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Enums\CastFlavour;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\AppendsOrderModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\ArrayFormCastsModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\CastsMethodModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\CustomDeletedAtModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\KeyTypeInitializerOrderModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\ObjectCastOverriddenByCastsMethodModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\SectionFailureModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\TableKeyOnlyModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\TraitInitializedConfigModel;
@@ -119,6 +123,48 @@ final class ModelInstancePreparerTest extends TestCase
         // The key, not the whole map: a future Laravel initializer writing some OTHER cast is not this
         // test's business, and asserting [] would turn that into a false alarm.
         $this->assertArrayNotHasKey('from_casts_method', $casts->getValue($this->prepare(CastsMethodModel::class)));
+    }
+
+    #[Test]
+    public function the_has_attributes_mirror_normalizes_the_declared_casts(): void
+    {
+        // initializeHasAttributes()'s first statement does TWO things, and only one is excused: it runs
+        // casts() (skipped — the registry already has it statically) and it normalizes the DECLARED $casts,
+        // which involves no casts() at all. Skipping the second dropped the model's whole casts section
+        // downstream (#1281).
+        $casts = new \ReflectionProperty(Model::class, 'casts');
+
+        // Pin the premise: Laravel collapses both array forms and leaves the string one alone. Without it,
+        // the oracle below cannot tell "normalized" from "both sides equally raw".
+        $this->assertSame([
+            'options' => AsCollection::class . ':' . Collection::class,
+            'single' => AsCollection::class,
+            'plain_tags' => 'collection',
+        ], $casts->getValue(new ArrayFormCastsModel()));
+
+        // Runtime as oracle: the mirror calls Laravel's own normalizer, so whatever the installed release
+        // does IS the answer.
+        $this->assertSame($casts->getValue(new ArrayFormCastsModel()), $casts->getValue($this->prepare(ArrayFormCastsModel::class)));
+    }
+
+    #[Test]
+    public function an_object_cast_the_casts_method_overrides_does_not_break_the_replay(): void
+    {
+        // Laravel normalizes array_merge($casts, casts()) and casts() WINS on collisions, so this model
+        // constructs fine — the enum never reaches the is_object arm. The mirror sees the declared half alone
+        // and would throw (12.26+), taking all four instance-derived sections with it. Master gets this right
+        // by never normalizing, so the throw would be a REGRESSION, not merely an escalation.
+        $casts = new \ReflectionProperty(Model::class, 'casts');
+
+        // Pin the premise: the model really is constructable, and casts() really does win.
+        $this->assertSame(['flavour' => 'string'], $casts->getValue(new ObjectCastOverriddenByCastsMethodModel()));
+
+        // Left raw rather than normalized or thrown on: computeCasts() holds the AST-parsed casts() and
+        // merges it over this, reaching the same answer the constructor did.
+        $this->assertSame(
+            ['flavour' => CastFlavour::Vanilla],
+            $casts->getValue($this->prepare(ObjectCastOverriddenByCastsMethodModel::class)),
+        );
     }
 
     #[Test]

--- a/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
+++ b/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
@@ -34,6 +34,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Collection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -76,6 +77,7 @@ use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Union;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\AbstractKeylessModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\AppendsOrderModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\ArrayFormCastsModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\AttributeConfiguredChild;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\AttributeConfiguredModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\AttributeOverriddenByPropertyModel;
@@ -1083,6 +1085,35 @@ final class ModelMetadataRegistryTest extends TestCase
         $shape = $metadata->casts()['modern_tags']->shape;
         $this->assertSame(CastShape::CustomCastsAttributes, $shape);
         $this->assertTrue($shape->isClassCastable());
+    }
+
+    #[Test]
+    public function array_form_declared_cast_normalizes_and_keeps_the_casts_section(): void
+    {
+        // #1281: warm-up left `options` as the raw array Laravel would have collapsed to a string, which
+        // TypeErrored inside computeCasts() against buildCastInfo()'s `string $castString` — taking the
+        // model's ENTIRE casts section with it. `plain_tags` shares nothing with the array form and
+        // disappeared anyway; the section bit below is the regression net, the per-key asserts show the cost.
+        \class_exists(AsCollection::class);
+
+        $codebase = $this->makeCodebase();
+        $this->registerStorage(ArrayFormCastsModel::class);
+
+        ModelMetadataRegistryBuilder::warmUp($codebase, ArrayFormCastsModel::class);
+
+        $metadata = $this->metadataFor(ArrayFormCastsModel::class);
+
+        $this->assertTrue($metadata->isComplete(ModelMetadata::SECTION_CASTS));
+        // Resolved, not merely retained. The `parameter` assert is what makes this bite: both keys reach the
+        // same shape, so shape alone would still pass if the collapse dropped the argument — which is the
+        // whole point of the two-element form.
+        $this->assertSame(CastShape::CustomCastsAttributes, $metadata->casts()['options']->shape);
+        $this->assertSame(Collection::class, $metadata->casts()['options']->parameter);
+        // Single-element form collapses to a bare class, carrying no argument.
+        $this->assertSame(CastShape::CustomCastsAttributes, $metadata->casts()['single']->shape);
+        $this->assertNull($metadata->casts()['single']->parameter);
+        // The collateral damage: an unrelated string cast on the same model, back only because the section is.
+        $this->assertSame(CastShape::Primitive, $metadata->casts()['plain_tags']->shape);
     }
 
     #[Test]


### PR DESCRIPTION
## Issue to Solve

Warm-up stands in for the framework's `initializeHasAttributes()` rather than invoking it, because invoking it would execute the user's `casts()` — which the registry already reads statically via `CastsMethodParser`.

That stand-in reproduced only `mergeAppends(#[Appends])`. The initializer's first statement does **two** things, and the second involves no `casts()` at all:

```php
$this->casts = $this->ensureCastsAreStringValues(
    array_merge($this->casts, $this->casts()),   // (a) run casts()   (b) normalize ALL of $this->casts
);
```

So a model declaring `$casts` in Laravel's array form diverged from a constructed one:

```php
protected $casts = ['options' => [AsCollection::class, Collection::class]];
```

```
CONSTRUCTED  'options' => 'Illuminate\...\AsCollection:Illuminate\Support\Collection'  (string)
REPLAYED     'options' => ['Illuminate\...\AsCollection', 'Illuminate\Support\Collection']  (array)
```

`computeCasts()` then handed that array to `buildCastInfo(..., string $castString, ...)`. Under `strict_types` that is a TypeError, caught by `computeSection()` — so the model's **entire casts section** was silently withheld, taking unrelated casts on the same model with it. Not just the one cast.

Pre-existing: the previous hand-written mirror layer skipped the same statement, and on all of 12.x `initializeHasAttributes()` is *only* the casts statement, so the stand-in was a total no-op there.

## Related

Fixes #1281

Follow-ups filed from the review, deliberately **not** in this PR:
- #1289 — the `casts()`-**method** array form still resolves to `'mixed'`. **Closed as won't fix**: zero prevalence in the corpus, it degrades safely, and no suite here resolves a cast to a property type, so a test seam would cost more than the fix.
- #1290 — `computeCasts()`'s `@var array<string, string>` is a false assertion; `ensureCastsAreStringValues()`'s `default` arm passes non-strings through.
- #1291 — `warnFailures()` does not name the withheld sections on a 4-section degradation.

## Solution Description

**Call Laravel's own `ensureCastsAreStringValues()`; never copy it.** The method is version-split inside `illuminate/database: ^12.14 || ^13.3` — there is no `is_object` arm before **12.26** (bisected: absent 12.25, present 12.26) — so a hand-written copy would need a version gate that calling tracks for free. The `is_array` arm this fix actually relies on is **byte-identical across the whole range**, so the fix itself needs no gate and no test gate.

Built from `$instance`, never `Model::class`: `ReflectionMethod::invoke()` dispatches **non-virtually** and does not object to a foreign receiver, so a `Model::class` handle would silently run the framework's body on a model that overrides the normalizer. Not the public `mergeCasts()` either — it merges from outside over `$this->casts`, so the only raw-casts reader it could pair with (`getCasts()`) would bake the implicit key cast permanently into the property and defeat `computeCasts()`'s `setIncrementing()` suppression.

**The `InvalidArgumentException` is caught, not propagated** — this is the least obvious line in the diff and it is load-bearing. Runtime normalizes the **merged** map and `casts()` wins collisions, so a declared object cast that `casts()` overrides never reaches the throw at construction:

```php
protected $casts = ['x' => Suit::Hearts];                      // enum case: an object
protected function casts(): array { return ['x' => 'string']; } // overrides the same key
```

`new Model()` returns fine (`$casts === ['x' => 'string']`). Warm-up sees the declared half **alone** and cannot tell that model from an unconstructable one. Propagating would degrade all four instance-derived sections for a model that runs fine — and `master` handles this shape **correctly** today, so propagating would have been a regression, not merely an escalation. Left raw, `computeCasts()` merges the AST-parsed `casts()` over it and reaches the constructor's answer.

(An enum case is the only object a `$casts` property default can hold — `new` is rejected in a property initializer — and an enum can never be `Stringable`, since PHP forbids `__toString` on enums. So that arm is only ever reachable here as a throw.)

### Verification

New: `ArrayFormCastsModel` (positional, matching Laravel's own `[AsCollection::class, CustomCollection::class]` stub — `implode(',')` drops keys, so an `'of' =>` key would be decorative), `ObjectCastOverriddenByCastsMethodModel`, and three tests — replay-level normalization, the catch, and an end-to-end registry test asserting `isComplete(SECTION_CASTS)` plus the resolved `parameter`.

Each test pins its premise against a runtime-constructed model first, so it goes red rather than silently green if the framework behaviour it discriminates against ever moves. All three fail on a revert.

Green on four cells: PHP 8.5/L13.20, 8.4/L13.20 (where the `getMethods()` walk order flips), 8.2/L12.64, and 8.2/**L12.14.0** — the genuine floor, which lacks the `is_object` arm. (Note `--with=laravel/framework:^12.14` resolves to 12.64; 12.14.0 is blocked by composer advisories and needs the policy disabled to test.)

`psalm-delta`: **zero movement across all 18 apps.** Filament's ±2 is the documented flake, confirmed rather than assumed — the identical base commit yields both 793/297 and 794/298 across runs, and instrumentation showed the normalizer is a pure identity for every model in the corpus (no cast value changed, no throw).

**Prevalence, stated plainly:** the array form appears **zero** times across the 17 public benchmark apps (vs 2,344 string-form casts) and in none of Laravel's docs — the fluent `AsCollection::of()` helpers return strings. It is a first-party, framework-tested path (two array-form entries in Laravel's own `EloquentModelCastingStub`, one in the `$casts` property), and the failure mode is catastrophic and silent, which is what justifies three lines of delegation to the framework's own method.

Scope: T3 — metadata machinery. ~10 executable src lines in one file.

## Checklist
- [x] Tests cover the change (unit tests in `tests/Unit/`; casts resolve to no property type in the type suite, which ships no migrations — see #1289)
- [ ] Documentation is updated (not needed: no `registerHandlers()`/`registerStubs()`/stub-layout change; `docs/` has zero references to the warm-up layer)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786886811&installation_id=141955579&pr_number=1292&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1292&signature=2cc5d141790c90c313c1e97b47f2d6b93d48900298fc6f514469bb3300a4f141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
