### PR TITLE
Coerce non-string `$casts` values to `mixed` at model warm-up

### DIFF
--- a/src/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php
+++ b/src/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php
@@ -1369,7 +1369,7 @@ final class ModelMetadataRegistryBuilder
         }
 
         try {
-            /** @var array<string, string> $instanceCasts */
+            /** @var array<string, mixed> $instanceCasts */
             $instanceCasts = $instance->getCasts();
         } finally {
             if ($disableImplicitKeyCast) {
@@ -1389,6 +1389,16 @@ final class ModelMetadataRegistryBuilder
             $merged = \array_merge($merged, CastsMethodParser::parse($codebase, $modelFqcn));
         }
 
+        // ensureCastsAreStringValues() only rewrites the object/array match arms; every other
+        // shape (int, bool, float, null, a single-element array) falls through its `default =>
+        // $cast` identity arm untouched, and a trait initializer can also write $this->casts[...]
+        // directly, bypassing normalization on some PHP versions. A non-string here would hit
+        // buildCastInfo()'s `string $castString` under strict_types and TypeError the whole
+        // section into the empty-array fallback, silently dropping every valid cast on the model
+        // alongside it. Coerce instead of dropping the key so the map — and SECTION_CASTS — stay
+        // honest; 'mixed' matches CastsMethodParser's own `$value ?? 'mixed'` convention.
+        $merged = \array_map(self::asCastString(...), $merged);
+
         // KNOWN DIVERGENCE (Laravel 12.14–12.21 only): when a user trait initializer mergeCasts() a key that
         // casts() ALSO declares, runtime there runs casts() first (bootTraits walks class_uses_recursive
         // parents-first) then the user init, so the USER value wins; from 12.22+ the order flips and casts()
@@ -1399,7 +1409,7 @@ final class ModelMetadataRegistryBuilder
 
         $result = [];
         foreach ($merged as $columnName => $castString) {
-            if ($columnName === '' || $castString === '') {
+            if ($columnName === '') {
                 continue;
             }
 
@@ -1422,6 +1432,18 @@ final class ModelMetadataRegistryBuilder
         }
 
         return $result;
+    }
+
+    // Takes `mixed` (not `string`) so the is_string() check below is analysable: getCasts()'s own
+    // stub promises array<string, string>, which would make an inline check at the call site look
+    // redundant to Psalm.
+    /**
+     * @return non-empty-string
+     * @psalm-pure
+     */
+    private static function asCastString(mixed $cast): string
+    {
+        return \is_string($cast) && $cast !== '' ? $cast : 'mixed';
     }
 
     /**

--- a/tests/Unit/Fixtures/Concerns/WritesRawCast.php
+++ b/tests/Unit/Fixtures/Concerns/WritesRawCast.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Concerns;
+
+/**
+ * Writes `$this->casts['raw_col']` directly (the exact idiom `SoftDeletes::initializeSoftDeletes()`
+ * models for framework traits), bypassing `mergeCasts()` and its `ensureCastsAreStringValues()` call
+ * entirely. An int value is used deliberately: `ensureCastsAreStringValues()` passes ints through its
+ * `default` arm untouched regardless of walk order, so the resulting cast value is non-string on every
+ * supported PHP version whether this initializer runs before or after the framework's own cast mirror —
+ * unlike an array value, whose survival would depend on which side of that ordering wins.
+ *
+ * @psalm-require-extends \Illuminate\Database\Eloquent\Model
+ */
+trait WritesRawCast
+{
+    public function initializeWritesRawCast(): void
+    {
+        $this->casts['raw_col'] = 123;
+    }
+}

--- a/tests/Unit/Fixtures/Models/NonStringDeclaredCastsModel.php
+++ b/tests/Unit/Fixtures/Models/NonStringDeclaredCastsModel.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * `HasAttributes::ensureCastsAreStringValues()` only rewrites its `object`/`array` (multi-element)
+ * match arms; every other shape hits the unconditional `default => $cast` identity arm and survives
+ * construction untouched. Left raw, a non-string value reaches
+ * `ModelMetadataRegistryBuilder::buildCastInfo()`'s `string $castString` under `strict_types=1` and
+ * TypeErrors, withholding the model's WHOLE casts section (#1290) — `good_col` included, which is the
+ * regression this fixture guards against.
+ *
+ * `nested_col` is a ONE-element outer array (its sole element is itself an array), so it takes the
+ * OPPOSITE path from the scalars above: the normalizer's `count() === 1` collapse (see
+ * {@see ArrayFormCastsModel}) fires and returns that inner array unchanged — still non-string, just
+ * via a different arm. Do NOT "flatten" this to a plain multi-element array like `['a', 'b']`: that
+ * collapses to the STRING `'a:b'` and silently deletes this key's coverage.
+ *
+ * @internal fixture used by ModelMetadataRegistryTest
+ */
+final class NonStringDeclaredCastsModel extends Model
+{
+    /** @var array<string, string|int|bool|float|array<int, array<int, string>>|null> */
+    protected $casts = [
+        'good_col' => 'int',
+        'null_col' => null,
+        'int_col' => 123,
+        'bool_col' => true,
+        'float_col' => 1.5,
+        'nested_col' => [['a']],
+    ];
+}

--- a/tests/Unit/Fixtures/Models/RawCastInitializerModel.php
+++ b/tests/Unit/Fixtures/Models/RawCastInitializerModel.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Concerns\WritesRawCast;
+
+/**
+ * Drives the {@see \Tests\Psalm\LaravelPlugin\Unit\Fixtures\Concerns\WritesRawCast} trait initializer,
+ * which writes an int cast value straight into `$this->casts`, bypassing normalization (#1290).
+ *
+ * @internal fixture used by ModelMetadataRegistryTest
+ */
+final class RawCastInitializerModel extends Model
+{
+    use WritesRawCast;
+}

--- a/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
+++ b/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
@@ -85,7 +85,9 @@ use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\CollectionCastVariantsModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\CustomDeletedAtModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\EnumConnectionModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\InboundCastModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\NonStringDeclaredCastsModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\PlainEnumConnectionModel;
+use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\RawCastInitializerModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\ScalarFieldsModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\SectionFailureModel;
 use Tests\Psalm\LaravelPlugin\Unit\Fixtures\Models\TableKeyAttributeModel;
@@ -1114,6 +1116,57 @@ final class ModelMetadataRegistryTest extends TestCase
         $this->assertNull($metadata->casts()['single']->parameter);
         // The collateral damage: an unrelated string cast on the same model, back only because the section is.
         $this->assertSame(CastShape::Primitive, $metadata->casts()['plain_tags']->shape);
+    }
+
+    #[Test]
+    public function non_string_declared_cast_values_are_coerced_to_mixed_and_keep_the_casts_section(): void
+    {
+        // #1290: ensureCastsAreStringValues()'s `default => $cast` arm passes non-object/array shapes
+        // through untouched, so `null_col`/`int_col`/`bool_col`/`float_col`/`nested_col` all reach
+        // computeCasts() non-string. Left uncoerced, the first one TypeErrors buildCastInfo()'s
+        // `string $castString` and withholds the model's WHOLE casts section — `good_col` included,
+        // which is the regression this test's section-completeness assert guards against.
+        $codebase = $this->makeCodebase();
+        $this->registerStorage(NonStringDeclaredCastsModel::class);
+
+        ModelMetadataRegistryBuilder::warmUp($codebase, NonStringDeclaredCastsModel::class);
+
+        $metadata = $this->metadataFor(NonStringDeclaredCastsModel::class);
+
+        $this->assertTrue($metadata->isComplete(ModelMetadata::SECTION_CASTS));
+        // A genuinely string-valued cast on the same model survives the coercion map untouched.
+        $this->assertSame('int|null', $metadata->casts()['good_col']->psalmType->getId());
+        // Each non-string value is coerced to 'mixed' rather than dropped: the key stays present
+        // (so the section keeps reporting the column at all) and the resolved type stays honest
+        // about not knowing the real one.
+        $this->assertArrayHasKey('null_col', $metadata->casts());
+        $this->assertTrue($metadata->casts()['null_col']->psalmType->hasMixed());
+        $this->assertArrayHasKey('int_col', $metadata->casts());
+        $this->assertTrue($metadata->casts()['int_col']->psalmType->hasMixed());
+        $this->assertArrayHasKey('bool_col', $metadata->casts());
+        $this->assertTrue($metadata->casts()['bool_col']->psalmType->hasMixed());
+        $this->assertArrayHasKey('float_col', $metadata->casts());
+        $this->assertTrue($metadata->casts()['float_col']->psalmType->hasMixed());
+        $this->assertArrayHasKey('nested_col', $metadata->casts());
+        $this->assertTrue($metadata->casts()['nested_col']->psalmType->hasMixed());
+    }
+
+    #[Test]
+    public function trait_initializer_writing_raw_cast_value_is_coerced_and_keeps_the_casts_section(): void
+    {
+        // #1290: a trait initializer writing $this->casts[...] directly (the idiom
+        // SoftDeletes::initializeSoftDeletes() itself uses) bypasses mergeCasts()'s normalization
+        // entirely, so its value reaches computeCasts() exactly as written by user code.
+        $codebase = $this->makeCodebase();
+        $this->registerStorage(RawCastInitializerModel::class);
+
+        ModelMetadataRegistryBuilder::warmUp($codebase, RawCastInitializerModel::class);
+
+        $metadata = $this->metadataFor(RawCastInitializerModel::class);
+
+        $this->assertTrue($metadata->isComplete(ModelMetadata::SECTION_CASTS));
+        $this->assertArrayHasKey('raw_col', $metadata->casts());
+        $this->assertTrue($metadata->casts()['raw_col']->psalmType->hasMixed());
     }
 
     #[Test]


### PR DESCRIPTION
## Issue to Solve

`ModelMetadataRegistryBuilder::computeCasts()` asserted `/** @var array<string, string> */` over `$instance->getCasts()`, but Laravel's `ensureCastsAreStringValues()` does not guarantee string values: its `match(true)` rewrites only the object and array arms, and everything else falls through an unconditional `default => $cast` identity arm. Declared cast values like `123`, `null`, `true`, `1.5`, `[123]` (collapses to int) and `[['a']]` (collapses to an inner array) all survive as non-strings, as does anything a trait initializer writes into `$this->casts` directly (the `SoftDeletes::initializeSoftDeletes()` idiom, which bypasses `mergeCasts()` and can land after normalization depending on the PHP version's `getMethods()` order).

Under `strict_types=1`, the first surviving non-string TypeErrors `buildCastInfo(string $castString)`, the wrapping `computeSection()` catches it, and the model's entire casts section is withheld, taking every valid cast on that model with it. One nonsense cast value silently costs the whole section.

## Related

Closes #1290. Follow-up to #1281 / #1292 (which narrowed the array-form case but left the identity-arm passthrough open).

## Solution Description

Coerce rather than drop: after both cast sources merge (instance `getCasts()` + AST-parsed `casts()`), map every value through a new `asCastString(mixed): non-empty-string` helper that passes non-empty strings through and turns anything else into `'mixed'`.

Why `'mixed'` and not dropping the key: dropping would leave `SECTION_CASTS` set over a map silently missing a column, so the consumers gated on that bit (including the issue-emitting rules) would trust the map and infer against the raw schema type — a false-positive generator. `'mixed'` is a sound widening that keeps the key and the section honest, matching `CastsMethodParser`'s own `$value ?? 'mixed'` convention. The helper takes `mixed` so the `is_string()` check is analysable at all (the plugin's own `getCasts()` stub promises `array<string, string>`, which would make an inline check look redundant to Psalm). The false `@var` is widened to `array<string, mixed>`, and the now-dead `$castString === ''` skip is removed.

Verified with two unit tests, both asserting `isComplete(SECTION_CASTS)` so they cannot pass vacuously via the fallback path:
- declared non-string cast values (`null`/int/bool/float/nested array) are each kept with a mixed `psalmType`, while a valid `'int'` cast on the same model still resolves to `int|null` (the regression guard: pre-fix, both tests fail with the exact TypeError and the whole section drops);
- a trait initializer writing `$this->casts['raw_col'] = 123` directly is coerced the same way (an int value keeps the test deterministic across PHP 8.2–8.5 initializer-walk orders, since the normalizer passes ints through in both orders).

## Checklist
- [x] Tests cover the change (unit tests in `tests/Unit/`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786889964&installation_id=141955579&pr_number=1296&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1296&signature=33cdf1e97e29e497df6a86a9f73918b8ce8b05d82bdc8210cd03ff4956f5f1df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->