### PR TITLE
Name withheld metadata sections in warm-up degradation warnings

### DIFF
--- a/src/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php
+++ b/src/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php
@@ -65,6 +65,22 @@ final class ModelMetadataRegistryBuilder
     private const TRAIT_HAS_API_TOKENS_PASSPORT_LC = 'laravel\\passport\\hasapitokens';
 
     /**
+     * Section bit → the same human label used as its {@see self::computeSection()} `$failures` key,
+     * so {@see self::warnFailures()} can name every section a consumer's `isComplete()` will report
+     * incomplete, not only the one that actually threw.
+     *
+     * @var array<int, non-empty-string>
+     */
+    private const SECTION_NAMES = [
+        ModelMetadata::SECTION_METHODS => 'methods',
+        ModelMetadata::SECTION_RELATIONS => 'relations',
+        ModelMetadata::SECTION_RUNTIME_CONFIGURATION => 'runtime configuration',
+        ModelMetadata::SECTION_SCHEMA => 'schema',
+        ModelMetadata::SECTION_CASTS => 'casts',
+        ModelMetadata::SECTION_PRIMARY_KEY => 'primary key',
+    ];
+
+    /**
      * Pre-compute metadata for a single model. Idempotent — re-computation
      * on a cached FQCN is a no-op.
      *
@@ -273,7 +289,7 @@ final class ModelMetadataRegistryBuilder
                 );
         }
 
-        self::warnFailures($codebase, $modelFqcn, $failures);
+        self::warnFailures($codebase, $modelFqcn, $failures, $completeSections);
 
         return $metadata;
     }
@@ -529,6 +545,9 @@ final class ModelMetadataRegistryBuilder
         array $mutators,
         array $scopes,
         array $relations,
+        // By value, unlike its siblings: this path sets no section bits. If a future edit adds one,
+        // switch this to by-ref too, or warnFailures()'s withheld list will diverge from the bits
+        // actually stored on ModelMetadata.
         int $completeSections,
     ): ModelMetadata {
         $defaults = $reflection->getDefaultProperties();
@@ -695,7 +714,7 @@ final class ModelMetadataRegistryBuilder
      * @param class-string<Model> $modelFqcn
      * @param array<string, \Throwable> $failures
      */
-    private static function warnFailures(Codebase $codebase, string $modelFqcn, array $failures): void
+    private static function warnFailures(Codebase $codebase, string $modelFqcn, array $failures, int $completeSections): void
     {
         if ($failures === []) {
             return;
@@ -708,6 +727,23 @@ final class ModelMetadataRegistryBuilder
 
         $message = "Laravel plugin: ModelMetadataRegistry warm-up failed for '{$modelFqcn}' "
             . '(partial metadata stored): ' . \implode('; ', $details);
+
+        // Naming the blast radius, not the cause: this lists every section a consumer's
+        // isComplete() will now report incomplete, which is broader than "sections that threw" —
+        // e.g. schema/casts are structurally skipped (never attempted) on a failed instance
+        // prepare, and relations are gated off entirely in a Codebase-less unit harness. Those
+        // still belong here because registry-backed consumers are blind to them for this model.
+        $withheld = [];
+        foreach (self::SECTION_NAMES as $bit => $name) {
+            if (($completeSections & $bit) === 0) {
+                $withheld[] = $name;
+            }
+        }
+
+        if ($withheld !== []) {
+            $message .= '; withheld sections: ' . \implode(', ', $withheld);
+        }
+
         $codebase->progress->warning($message);
 
         if ($codebase->progress instanceof VoidProgress) {

--- a/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
+++ b/tests/Unit/Providers/ModelMetadata/ModelMetadataRegistryTest.php
@@ -771,6 +771,36 @@ final class ModelMetadataRegistryTest extends TestCase
         ));
     }
 
+    #[Test]
+    public function warning_names_every_withheld_section_not_only_the_thrown_one(): void
+    {
+        // A trait-initializer replay failure withholds runtime configuration, schema, casts and
+        // primary key (see a_failed_section_preserves_independent_metadata above) — only ONE
+        // ('trait initializers') is a recorded failure, so the other three would otherwise be
+        // invisible to a reader of the warning. 'relations' also withholds here: the unit-test
+        // Codebase (built via newInstanceWithoutConstructor()) never initializes Codebase::$methods,
+        // so codebaseMethodsInitialized() is false and SECTION_RELATIONS is never attempted —
+        // registry consumers are blind to relations for every model in this test class.
+        $captured = null;
+        $progress = $this->createMock(Progress::class);
+        $progress->expects($this->once())
+            ->method('warning')
+            ->willReturnCallback(function (string $message) use (&$captured): void {
+                $captured = $message;
+            });
+        $codebase = $this->makeCodebase($progress);
+        $this->registerStorage(SectionFailureModel::class, [HasUuids::class]);
+        SectionFailureModel::$failures = ['trait initializers' => true];
+
+        ModelMetadataRegistryBuilder::warmUp($codebase, SectionFailureModel::class);
+
+        $this->assertNotNull($captured);
+        $this->assertStringEndsWith(
+            'withheld sections: relations, runtime configuration, schema, casts, primary key',
+            $captured,
+        );
+    }
+
     // ---------------------------------------------------------------------
     // Accessors / mutators (storage-derived, full-callable)
     // ---------------------------------------------------------------------


### PR DESCRIPTION
## Issue to Solve

When `ModelInstancePreparer::prepare()` throws during model warm-up, only `$failures['trait initializers']` is recorded. The other instance-derived sections (casts, schema, primary key) are gated off without being attempted, so they record nothing, and 'runtime configuration' runs but has its completeness bit revoked without a failure entry. The user sees a single warning line naming only the thrown section; the real blast radius — four sections gone, every registry-backed consumer and both issue-emitting rules silent for that model — is invisible, and "partial metadata stored" carries all that weight alone.

## Related

Closes #1291. Surfaced during the #1281 review.

## Solution Description

Enumerate the incomplete sections in the warning. The data already exists: `$completeSections` is fully settled at the single `warnFailures()` call site, so the method now receives it, inverts it against a new `SECTION_NAMES` map (section bit → the same label already used as that section's `$failures` key), and appends:

```
...; withheld sections: relations, runtime configuration, schema, casts, primary key
```

The list deliberately names the blast radius, not the cause: every section a consumer's `isComplete()` will report incomplete, which is broader than "sections that threw" (e.g. schema/casts are structurally skipped after a failed instance prepare). The suffix is omitted when nothing is withheld, and the `VoidProgress` STDERR fallback path is unchanged, so the message still reaches users under `--no-progress`.

`computeWithoutInstance()` keeps its by-value `$completeSections` parameter but now carries a comment pinning the invariant: it must stay non-mutating, or the reported list would diverge from the bits actually stored on `ModelMetadata`.

Verified with a unit test extending the existing `SectionFailureModel` degradation harness: a trait-initializer failure must produce a warning ending with the exact five-section withheld list above (asserted with `assertStringEndsWith`, so both content and order are locked). The existing message-prefix assertions in `WarmUpFailureVisibilityTest` are unaffected by the appended suffix.

## Checklist
- [x] Tests cover the change (unit test in `tests/Unit/`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786889969&installation_id=141955579&pr_number=1297&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1297&signature=30b49130cca82d730ba62fbbe6b9c920e52915db437eb3ec0190c075f8890215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->