### PR TITLE
Narrow single-argument `pluck()->all()` to `list<TValue>`

### DIFF
--- a/src/Handlers/Collections/CollectionReindexAllHandler.php
+++ b/src/Handlers/Collections/CollectionReindexAllHandler.php
@@ -7,6 +7,7 @@ namespace Psalm\LaravelPlugin\Handlers\Collections;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
@@ -16,12 +17,15 @@ use Psalm\Type\Union;
 
 /**
  * Narrows Collection::all() to list<TValue> when the call is chained
- * immediately after values() (i.e. `$c->values()->all()`).
+ * immediately after a receiver that is guaranteed to reindex sequentially:
+ * values() (i.e. `$c->values()->all()`) or single-argument pluck() (i.e.
+ * `$c->pluck('col')->all()`).
  *
  * The chain is the only call shape where the result is guaranteed to be a
- * list — values() calls array_values() (or a generator yielding without
- * keys for LazyCollection), so the inner array always has consecutive
- * 0-based integer keys.
+ * list. values() calls array_values() (or a generator yielding without
+ * keys for LazyCollection); a one-argument pluck() has no $key column to
+ * key by, so Arr::pluck() falls through to sequential int keys too. Either
+ * way the inner array always has consecutive 0-based integer keys.
  *
  * A purely stub-based conditional return on all() (e.g. keyed on
  * `TKey is int<0, max>`) would mislabel any int-keyed collection whose
@@ -31,15 +35,15 @@ use Psalm\Type\Union;
  * Known limitations (both purely syntactic — Psalm's stubbed return type
  * applies instead of list<TValue>):
  *  - Variable-bound form: `$v = $c->values(); $v->all();`. The receiver
- *    of all() is a Variable, not an immediate values() MethodCall.
+ *    of all() is a Variable, not an immediate values()/pluck() MethodCall.
  *  - Nullsafe operators: `$c?->values()?->all()`. Psalm's NullsafeAnalyzer
  *    desugars `?->all()` into a VirtualMethodCall (subclass of MethodCall)
  *    whose receiver is a synthesized temp variable, not the inner values()
- *    call, so the receiver-shape check in isImmediateChainFromValues fails.
+ *    call, so the receiver-shape check in isImmediateChainFromReindex fails.
  * Users who need the list shape should keep the chain inline and avoid
  * nullsafe on the inner call.
  */
-final class CollectionValuesAllHandler implements MethodReturnTypeProviderInterface
+final class CollectionReindexAllHandler implements MethodReturnTypeProviderInterface
 {
     /**
      * @return list<string>
@@ -64,7 +68,7 @@ final class CollectionValuesAllHandler implements MethodReturnTypeProviderInterf
             return null;
         }
 
-        if (!self::isImmediateChainFromValues($stmt)) {
+        if (!self::isImmediateChainFromReindex($stmt)) {
             return null;
         }
 
@@ -79,13 +83,17 @@ final class CollectionValuesAllHandler implements MethodReturnTypeProviderInterf
     }
 
     /**
-     * True when $stmt is `<expr>->values()->all()` — the receiver of all()
-     * is itself an immediate values() call. This excludes any intermediate
-     * method (e.g. ->values()->filter()->all()) and variable-bound chains.
+     * True when $stmt is `<expr>->values()->all()` or `<expr>->pluck($col)->all()`
+     * — the receiver of all() is itself an immediate values() call (any arity) or
+     * a single-argument pluck() call. This excludes any intermediate method (e.g.
+     * ->values()->filter()->all()) and variable-bound chains.
+     *
+     * Two-argument pluck() (a $key column is given) is excluded: Arr::pluck() then
+     * keys the result by that column, so the output is not list-shaped.
      *
      * @psalm-mutation-free
      */
-    private static function isImmediateChainFromValues(MethodCall $stmt): bool
+    private static function isImmediateChainFromReindex(MethodCall $stmt): bool
     {
         $receiver = $stmt->var;
         if (!$receiver instanceof MethodCall) {
@@ -96,6 +104,24 @@ final class CollectionValuesAllHandler implements MethodReturnTypeProviderInterf
             return false;
         }
 
-        return \strtolower($receiver->name->name) === 'values';
+        $receiverName = \strtolower($receiver->name->name);
+
+        if ($receiverName === 'values') {
+            return true;
+        }
+
+        if ($receiverName !== 'pluck') {
+            return false;
+        }
+
+        if ($receiver->args === []) {
+            return true;
+        }
+
+        // pluck(...$cols) is a single Arg with unpack=true — $cols may carry a
+        // $key column at runtime, so it can't be trusted to be list-shaped.
+        return \count($receiver->args) === 1
+            && $receiver->args[0] instanceof Arg
+            && !$receiver->args[0]->unpack;
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -362,8 +362,8 @@ final class Plugin implements PluginEntryPointInterface
         $registration->registerHooksFromClass(Handlers\Collections\CollectionMakeHandler::class);
         require_once __DIR__ . '/Handlers/Collections/CollectionPluckHandler.php';
         $registration->registerHooksFromClass(Handlers\Collections\CollectionPluckHandler::class);
-        require_once __DIR__ . '/Handlers/Collections/CollectionValuesAllHandler.php';
-        $registration->registerHooksFromClass(Handlers\Collections\CollectionValuesAllHandler::class);
+        require_once __DIR__ . '/Handlers/Collections/CollectionReindexAllHandler.php';
+        $registration->registerHooksFromClass(Handlers\Collections\CollectionReindexAllHandler::class);
         require_once __DIR__ . '/Handlers/Collections/HigherOrderCollectionProxyHandler.php';
         $registration->registerHooksFromClass(Handlers\Collections\HigherOrderCollectionProxyHandler::class);
 

--- a/tests/Type/tests/Collection/CollectionReindexAllTest.phpt
+++ b/tests/Type/tests/Collection/CollectionReindexAllTest.phpt
@@ -7,18 +7,20 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
 
 /**
- * CollectionValuesAllHandler narrows Collection::all() to list<TValue>
- * when the call is chained immediately after values():
+ * CollectionReindexAllHandler narrows Collection::all() to list<TValue> when
+ * the call is chained immediately after a receiver that is guaranteed to
+ * reindex sequentially:
  *
- *     $c->values()->all()  // list<TValue>
- *     $c->all()            // array<TKey, TValue>  (unchanged)
+ *     $c->values()->all()       // list<TValue>
+ *     $c->pluck('col')->all()   // list<TValue>  (single-argument pluck only)
+ *     $c->all()                 // array<TKey, TValue>  (unchanged)
  *
  * The handler keys on the AST shape — a Collection<TKey, TValue> typed
  * with TKey = int<0, max> does NOT trigger narrowing, because keys
  * matching that bound (e.g. [1 => ..., 3 => ...]) are not necessarily
  * list-shaped.
  */
-final class CollectionValuesAllTest
+final class CollectionReindexAllTest
 {
     /**
      * Chain on array-key-keyed source: list inferred.
@@ -88,9 +90,11 @@ final class CollectionValuesAllTest
     }
 
     /**
-     * Documented limitation: nullsafe chains are not narrowed. The outer
-     * node `?->all()` is a NullsafeMethodCall, not a MethodCall, so the
-     * handler returns null. Pins current behavior so a future AST
+     * Documented limitation: nullsafe chains are not narrowed. Psalm's
+     * NullsafeAnalyzer desugars `?->all()` into a VirtualMethodCall (a
+     * MethodCall subclass) whose receiver is a synthesized temp variable,
+     * not the inner values() call, so the receiver-shape check fails and
+     * the handler returns null. Pins current behavior so a future AST
      * broadening is observable.
      *
      * @param Collection<array-key, string>|null $c
@@ -137,6 +141,54 @@ final class CollectionValuesAllTest
         $r = $c->all();
         /** @psalm-check-type-exact $r = array<int, Customer> */;
         echo array_values($r)[0]?->id ?? '';
+    }
+
+    /**
+     * Single-argument pluck() on a Builder reindexes sequentially, so all()
+     * narrows to list<TValue> — same rule as values()->all().
+     */
+    public function pluckThenAllProducesList(): void
+    {
+        $r = Customer::query()->pluck('id')->all();
+        /** @psalm-check-type-exact $r = list<string> */;
+        echo $r[0] ?? '';
+    }
+
+    /**
+     * Two-argument pluck() keys the result by the $key column, so it is not
+     * list-shaped: the arity check in isImmediateChainFromReindex excludes it.
+     */
+    public function pluckWithKeyThenAllStaysArray(): void
+    {
+        $r = Customer::query()->pluck('email_verified_at', 'id')->all();
+        /** @psalm-check-type-exact $r = array<string, \Carbon\CarbonInterface|null> */;
+        echo array_key_first($r) ?? '';
+    }
+
+    /**
+     * Unknown column: value type falls back to mixed, but the chain is still
+     * list-shaped because no $key column was given.
+     */
+    public function pluckUnknownColumnThenAllProducesList(): void
+    {
+        $r = Customer::query()->pluck('unknown_column')->all();
+        /** @psalm-check-type-exact $r = list<mixed> */;
+        echo isset($r[0]) ? 'y' : 'n';
+    }
+
+    /**
+     * Spread-form pluck(...$cols) is a single Arg with unpack=true, not a plain
+     * positional argument — $cols may carry a $key column at runtime, so the
+     * result can't be trusted to be list-shaped. Regression guard for the arity
+     * check misclassifying this shape as single-argument pluck.
+     *
+     * @param non-empty-list<string> $cols
+     */
+    public function pluckSpreadArgsStaysArray(array $cols): void
+    {
+        $r = Customer::query()->pluck(...$cols)->all();
+        /** @psalm-check-type-exact $r = array<array-key, mixed> */;
+        echo (string) (array_key_first($r) ?? '');
     }
 }
 ?>


### PR DESCRIPTION
## Issue to Solve

`CollectionValuesAllHandler` narrows `->values()->all()` to `list<TValue>` via AST chain detection, but single-argument `pluck()` carries the same guarantee (it always reindexes sequentially) and was not covered. `Task::all()->pluck('id')->all()` stayed `array<int, int>` and was rejected by `list<int>` return types, the last gap in the common `pluck('id')->all()` idiom after #1288 narrowed the pluck value type itself.

## Related

Fixes #1298

## Solution Description

- Generalized the receiver whitelist in the handler (renamed `CollectionValuesAllHandler` -> `CollectionReindexAllHandler`): the receiver may now be `values()` (any arity, as before) or a list-producing `pluck()`.
- The pluck rule is arity-only, no argument-type inspection: zero args, or exactly one plain argument. An explicit second argument keys the result by that column, so it is excluded; a spread argument (`pluck(...$cols)`) is a single AST node that may carry a key column at runtime, so it is excluded too (unsound to trust). First-class callable `pluck(...)` never reaches the handler (it evaluates to a `Closure`).
- `TValue` still comes from the collection's template parameters, so this composes with the #1288 pluck value narrowing and the #1286 unknown-column `mixed` fallback for free.
- Registration in `Plugin.php` updated for the rename; docblock rationale (AST provenance vs. stub conditional) kept and extended with the pluck arity rule. Known limitations (variable-bound chains, nullsafe) unchanged.

Verified by extending the existing type test (renamed to `CollectionReindexAllTest.phpt`):

- `pluck('id')->all()` on a builder -> `list<string>` (composes with #1288)
- `pluck('unknown_column')->all()` -> `list<mixed>` (composes with #1286)
- `pluck('value', 'key')->all()` -> stays `array<string, ...>` (2-arg regression guard)
- `pluck(...$cols)->all()` -> stays `array<array-key, mixed>` (spread regression guard)
- all pre-existing `values()->all()` cases unchanged

Psalm self-analysis clean at 100% inferred type coverage.

## Checklist

- [x] Tests cover the change (type test in `tests/Type/`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786893905&installation_id=141955579&pr_number=1299&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1299&signature=ed5c42e5ce4ee7f68b20752a4725cc039d6638f46fd593ed944d0b59216ac6e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->