### PR TITLE
Taint Analysis: source `Request::__get()` as user input

### DIFF
--- a/src/Handlers/Validation/ValidationTaintHandler.php
+++ b/src/Handlers/Validation/ValidationTaintHandler.php
@@ -24,8 +24,10 @@ use Psalm\Plugin\EventHandler\RemoveTaintsInterface;
  *
  *   1. addTaints re-introduces the source dropped by a type override
  *      ({@see ValidatedTypeHandler} / {@see FormRequestPropertyHandler}). For
- *      `$req->email` no `Request::__get` stub source exists and a provider type
- *      bypasses `__get`, so the re-source is the only thing tainting the read.
+ *      `$req->email` (undeclared, rule guarantees presence),
+ *      FormRequestPropertyHandler's `doesPropertyExist()` claims it before
+ *      Psalm ever reaches `Request::__get`, so that stub's own source can't
+ *      apply; the re-source is the only thing tainting the read.
  *   2. removeTaints applies the rule's per-field escape (e.g. `email` → safe
  *      for header/cookie).
  *
@@ -62,7 +64,10 @@ final class ValidationTaintHandler implements
 
     /**
      * Re-source the taint a validated read carries, when the stub source was
-     * dropped by a type override (or never existed, as on `Request::__get`).
+     * dropped by a type override, or never reached at all because
+     * FormRequestPropertyHandler's `doesPropertyExist()` claims an undeclared,
+     * presence-guaranteed property before Psalm gets to `Request::__get`
+     * (e.g. `$req->email`).
      */
     #[\Override]
     public static function addTaints(AddRemoveTaintsEvent $event): int

--- a/stubs/common/Http/Request.phpstub
+++ b/stubs/common/Http/Request.phpstub
@@ -252,4 +252,24 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      * @psalm-taint-source input
      */
     public function getPassword() {}
+
+    /**
+     * Get an input element from the request (magic property access, e.g. `$request->term`).
+     *
+     * Fires via Psalm's synthesized __get call for undeclared property fetches on a plain
+     * Illuminate\Http\Request or request(). Userland subclasses are sealed (Psalm 7 defaults
+     * sealAllProperties to true), so this source is dropped there.
+     *
+     * An undeclared FormRequest property whose rule guarantees presence is
+     * claimed by FormRequestPropertyHandler's doesPropertyExist() (paired with
+     * isPropertyVisible()) before Psalm ever reaches __get; ValidationTaintHandler
+     * re-sources that read separately. The two paths are disjoint by
+     * construction, so this stub never double-sources a validated field.
+     *
+     * @param string $key
+     * @return mixed
+     *
+     * @psalm-taint-source input
+     */
+    public function __get($key) {}
 }

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestSelfPropertyEmailEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestSelfPropertyEmailEscapesHeader.phpt
@@ -12,9 +12,12 @@ use Illuminate\Foundation\Http\FormRequest;
  * a FormRequest narrow via FormRequestPropertyHandler, and the paired taint
  * paths in ValidationTaintHandler must:
  *
- *   1. Re-source ALL_INPUT (no stub `@psalm-taint-source` exists on `__get`,
- *      so the property handler returning a Union would otherwise leak the
- *      input pool with no taint at all).
+ *   1. Re-source ALL_INPUT. FormRequestPropertyHandler's `doesPropertyExist()`
+ *      claims the fetch before Psalm ever reaches `Request::__get`, so that
+ *      stub's own `@psalm-taint-source` (added for bare Request reads in
+ *      #1301) never applies here. Without the manual re-source, the
+ *      property handler's Union would leak the input pool with no taint
+ *      at all.
  *   2. Apply the rule's `removedTaints` mask so the same per-rule escape
  *      that fires on `$this->input('email')` also fires on `$this->email`.
  *

--- a/tests/Type/tests/TaintAnalysis/SafeSqlEloquentWhereNestedConditionMagicProperty.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeSqlEloquentWhereNestedConditionMagicProperty.phpt
@@ -1,0 +1,26 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+class NestedConditionMagicPropertyArticle extends \Illuminate\Database\Eloquent\Model {}
+
+/**
+ * Interaction guard for #1301 x #1302, pinning #1300's exact third snippet: `request->term`
+ * (a magic-property read) as the where()-array source instead of `request('term')` /
+ * `$request->input('term')`. It reported no error at the time only because `__get` carried
+ * no taint source at all — #1301 gives it one, so the ordinal-2 PDO-bound strip added by
+ * #1302 must still apply when the source is a magic-property read, not just a method call.
+ *
+ * Same canary caveat as SafeSqlWhereNestedConditionValues.phpt: teeth-verified in an
+ * isolated psalm process — both this shape (silent) and the same chain with the tainted
+ * value moved to the ordinal-0 column position (still reports TaintedSql) — batch-swallowed
+ * in the suite.
+ */
+function safeEloquentNestedConditionMagicPropertyWhere(): void {
+    $term = (string) request()->term;
+
+    NestedConditionMagicPropertyArticle::query()->select('id')->where([['name', 'LIKE', "%{$term}%"]])->get();
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestMagicProperty.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestMagicProperty.phpt
@@ -1,0 +1,12 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+function renderBreadcrumb(\Illuminate\Http\Request $request) {
+    echo (string) $request->term;
+}
+?>
+--EXPECTF--
+%ATaintedHtml on line %d: Detected tainted HTML
+%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlRequestMagicProperty.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlRequestMagicProperty.phpt
@@ -1,0 +1,12 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+function filterPosts(\Illuminate\Http\Request $request) {
+    $builder = new \Illuminate\Database\Query\Builder();
+    $builder->whereRaw((string) $request->filter);
+}
+?>
+--EXPECTF--
+%ATaintedSql on line %d: Detected tainted SQL


### PR DESCRIPTION
Fixes #1301.

Scope: T2 — new taint source; `__get` only. Src diff 20 stub lines + 9 comment lines; 3 new phpts.

## The gap

`Illuminate\Http\Request::__get()` returns user input:

```php
public function __get($key)
{
    return Arr::get($this->all(), $key, fn () => $this->route($key));
}
```

Every sibling accessor is already a source in `stubs/common/Http/Request.phpstub` (`input()`, `query()`, `post()`, `get()`, `only()`, `header()`, `route()`, `ip()`, `path()`, ~20 in all). `__get` was the one hole, and the stub did not declare it at all. So these two spellings of the same value analysed differently:

```php
DB::table('t')->whereRaw((string) $request->input('term'));  // TaintedSql
DB::table('t')->whereRaw((string) $request->term);           // silent
```

This is case C of #1300 — the reporter's third snippet was silent for this reason, not because the `where()` shape was safe.

## Coverage boundary

The source fires through the `__get` call node Psalm synthesises for an undeclared property fetch. That gives it a precise reach, which is worth stating because it is narrower than "every request property everywhere":

| Receiver | Covered | Why |
|---|---|---|
| `Illuminate\Http\Request` (injected, `request()`, `Request::instance()`) | **yes** | no property provider claims it; Psalm synthesises the `__get` call |
| userland `class X extends Request` | no | sealed (Psalm 7 `sealAllProperties` defaults true); the sealed path discards the `__get` return type. Already emitted `UndefinedMagicPropertyFetch` at baseline |
| `FormRequest` property, undeclared **and** with a presence-guaranteeing rule | n/a — already covered | `FormRequestPropertyHandler::doesPropertyExist()` claims the fetch before Psalm reaches `__get`; `ValidationTaintHandler` sources it with rule escapes |
| `FormRequest` property with no rule, a non-presence-guaranteeing rule (`sometimes|email`), or a real/`@property` declaration | no | not claimed by the provider (`doResolve()` refuses declared fields and requires `guaranteesPresence()`), so it falls toward `__get` and is then dropped by sealing; emits `UndefinedThisPropertyFetch` |

The two mechanisms are **disjoint by construction** — the provider either claims a property (handler sources it) or defers (sealed-drop). Confirmed by probe: a validated FormRequest property yields exactly one `TaintedHtml`, not two. No double-sourcing, and the `route()` fallback arm does not double-emit either (`$request->term` and `$request->route('term')` are two expressions, two correct findings).

Kind is bare `input`, matching all ~20 siblings.

## Interaction with #1302

#1302 (merged, `b9168f19`) strips the SQL sink element-wise from PDO-bound positions of `where()` array literals. This PR makes those positions reachable from a magic-property source for the first time, so #1300's exact third snippet is now a real interaction:

```php
$term = (string) request()->term;
Model::query()->select('id')->where([['name', 'LIKE', "%{$term}%"]])->get();  // must stay silent
```

`SafeSqlEloquentWhereNestedConditionMagicProperty.phpt` pins it. The strip keys on `spl_object_id($item)` + ordinal on the `ArrayItem`, downstream of and agnostic to the source expression shape, so no new wrong-report shape is reachable. Verified non-vacuous: moving the same tainted value to ordinal 0 (the raw-column position) still fires `TaintedSql`.

Merge order mattered here — landing this before #1302 would have converted #1300's snippet 3 from a silent false negative into an active false positive.

## Accepted imprecision

- **Sealed userland subclasses** drop the source (table above). Psalm discards the `__get` return type, and its taint nodes with it, on the sealed path. Arguably an upstream Psalm issue; out of scope here.
- **`Request::all()` merges `allFiles()`**, so `(string) $request->photo` can yield `TaintedFile`/`TaintedSSRF` on an `UploadedFile` whose only string form is a server-controlled temp path — the false-positive class `Request::file()` was carved out for in #1134. Verified pre-existing: `input()`'s and `file()`'s stub bodies are byte-identical between `origin/master` and this branch (the only delta is the `__get` addition), and on both, `$request->avatar` and `$request->input('avatar')` report identically while `$request->file('avatar')` reports neither. So the #1134 carve-out on `file()` still holds; this is a new spelling of the hole `input()` already had (baseline rule).
- **Guarded and defaulted reads are not sourced** — `$request->term ?? ''` and a read behind `isset($request->term)` stay silent, because Psalm's coalesce/isset analysis does not synthesise the `__get` call the annotation attaches to. Pre-existing: all three forms were silent before this PR, which strictly adds coverage for the bare read. Tracked as #1309.
- **Inline `validate()` escapes do not reach magic reads.** After `$request->validate(['email' => 'required|email'])`, `redirect()->to($request->email)` reports `TaintedSSRF` + `TaintedHeader` while `redirect()->to($request->input('email'))` correctly reports only `TaintedSSRF` — `ValidatedFieldReadResolver::fromPropertyFetch()` consults `FormRequest` rules only, so the inline-collected header escape never reaches the property spelling. Unlike the two above, this inconsistency **is** introduced here (the read was previously silent, so nothing could disagree). Fixing it requires the receiver-side inline-validate machinery from item 3 of #1239, which was built and deliberately dropped on complexity — out of contract for a stub-annotation PR. Tracked as #1310.

## Reviewer notes

- The stub docblock and the refreshed test comment credit `doesPropertyExist()` (with `isPropertyVisible()`) with bypassing `__get`, not `getPropertyType()` — the type provider only supplies the Union after existence/visibility have already gated the fetch. All three gate on the same `resolveRuleForProperty`.
- The new `Safe*` guard is a batch canary: it stays green in-suite even if the strip were reverted, the same disclosed limitation as its `SafeSqlWhereNestedConditionValues.phpt` sibling. The isolated control run is what actually proves it.
- This commit falsified two comments in `ValidationTaintHandler` that were true at the parent commit ("no `Request::__get` stub source exists", "or never existed"). Both refreshed here.

## Note for anyone revisiting receiver-side `validate()` narrowing

Type inference is unchanged by this PR: on a plain `Request`, `$request->filter` was `mixed` before and is `mixed` after — only the taint edge is new. Inline `$request->validate([...])` narrows its **return value** (`ValidatedTypeHandler::resolveInlineValidate()`), but receiver-side narrowing of subsequent `$request->foo` reads was item 3 of #1239 and was dropped.

If that work is ever revisited: **`__get` now belongs to the same exclusion set as `input()`**. The #1239 post-mortem established that overriding `input()`'s return type from a provider drops its stub `@psalm-taint-source` entirely, with no re-emission mechanism on the inline-validate path (the FormRequest path has one via `ValidatedFieldReadResolver::methodSourcesInput()`) — it silently killed taint on 7 existing phpts until a full-suite run caught it. As of this PR `__get` carries a stub source too, so narrowing its return type the same way would drop it the same way. `integer()`/`boolean()` remain safe to narrow, as they carry no source.

## Tests

- `TaintedSqlRequestMagicProperty.phpt` — `whereRaw((string) $request->filter)` → `TaintedSql`.
- `TaintedHtmlRequestMagicProperty.phpt` — `echo (string) $request->term` → `TaintedHtml` + `TaintedTextWithQuotes`.
- `SafeSqlEloquentWhereNestedConditionMagicProperty.phpt` — the #1302 interaction guard above.
- `SafeFormRequestSelfPropertyEmailEscapesHeader.phpt` is the seam guard proving the stub never leaks into provider-claimed fetches; green, so rule escapes survive.

Phpts use plain `\Illuminate\Http\Request` deliberately: a userland subclass receiver is silent (sealed) and would make a positive assertion born-red.

## Follow-ups

- #1309 — guarded/defaulted magic reads (`isset`, `??`) are still not sourced.
- #1310 — inline `validate()` escapes do not reach magic-property reads (the one inconsistency this PR introduces).
- #1304 — `Request::offsetGet()` (ArrayAccess) has the same gap; `$request['term']` is still silent. Kept separate so each source's blast radius is measured on its own.
- `__isset()` was checked and needs nothing: returns `bool`, no flow to a sink.
