### PR TITLE
Taint Analysis: SQL sinks for `whereColumn()` / `orWhereColumn()`

### DIFF
--- a/stubs/common/Database/Query/Builder.phpstub
+++ b/stubs/common/Database/Query/Builder.phpstub
@@ -215,6 +215,43 @@ class Builder implements BuilderContract
     public function orWhereNotLike($column, $value, $caseSensitive = false) {}
 
     /**
+     * Add a "where" clause comparing two columns to the query.
+     *
+     * Nothing here is PDO-bound: the grammar wraps both `$first` and `$second` as raw identifiers,
+     * and a `$operator` that fails Laravel's whitelist is demoted into `$second` by
+     * `invalidOperator()` (Query/Builder.php:1184) rather than discarded, so every position reaches
+     * SQL raw. Unlike `where()`, there is no bound-value corridor to preserve with
+     * `@psalm-flow`/`@psalm-taint-escape` — mirrors the raw-method pattern below (`whereRaw()` et al.):
+     * nothing is sanitized, so nothing is escaped.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string|array  $first
+     * @param  string|null  $operator
+     * @param  string|null  $second
+     * @param  string|null  $boolean
+     * @return $this
+     *
+     * @psalm-taint-sink sql $first
+     * @psalm-taint-sink sql $operator
+     * @psalm-taint-sink sql $second
+     */
+    public function whereColumn($first, $operator = null, $second = null, $boolean = 'and') {}
+
+    /**
+     * Add an "or where" clause comparing two columns to the query. See {@see whereColumn()} for why
+     * every position is a sink and none is escaped.
+     *
+     * @param  \Illuminate\Contracts\Database\Query\Expression|string|array  $first
+     * @param  string|null  $operator
+     * @param  string|null  $second
+     * @return $this
+     *
+     * @psalm-taint-sink sql $first
+     * @psalm-taint-sink sql $operator
+     * @psalm-taint-sink sql $second
+     */
+    public function orWhereColumn($first, $operator = null, $second = null) {}
+
+    /**
      * Add a "having" clause to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|\Closure|string  $column

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlEloquentWhereColumnCompareSink.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlEloquentWhereColumnCompareSink.phpt
@@ -1,0 +1,20 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+class EloquentWhereColumnCompareModel extends \Illuminate\Database\Eloquent\Model {}
+
+/**
+ * `whereColumn()` reaches Eloquent chains through `Eloquent\Builder`'s `@mixin
+ * \Illuminate\Database\Query\Builder` (Eloquent/Builder.phpstub), so the plain Query\Builder sink
+ * stub covers `Model::query()->whereColumn(...)` without a separate Eloquent-side stub. #1303
+ */
+function unsafeEloquentWhereColumn(\Illuminate\Http\Request $request): void {
+    $tainted = (string) $request->input('col');
+
+    EloquentWhereColumnCompareModel::query()->whereColumn($tainted, '=', 'x');
+}
+?>
+--EXPECTF--
+%ATaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereColumnCompareArraySink.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereColumnCompareArraySink.phpt
@@ -1,0 +1,40 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis --threads=1
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Regression pin: `WhereColumnTaintHandler::WHERE_MAP_METHODS` must NOT include `wherecolumn`. That
+ * list strips `sql` from the position `addArrayOfWheres()` re-dispatches as a PDO-bound value for
+ * `where()`/`orWhere()`/etc. — but `whereColumn`'s array form re-dispatches through `whereColumn`
+ * itself, whose grammar never binds anything (see the stub docblock), so both array shapes below
+ * must keep flagging. If a future change adds `wherecolumn` to that list, this test goes silent.
+ *
+ * Runs in the separate `--threads=1` ARGS group: the default taint group already holds four direct
+ * (non-array) sources reaching `whereColumn`'s `$first` sink node (this file's siblings plus the
+ * Eloquent-chain test), and the nested-array source below is silently swallowed once it joins them —
+ * same upstream batch-visitation artifact as `TaintedSqlWhereNestedConditionKeyedElement.phpt`. Both
+ * shapes flag reliably in a process that is not saturated. #1303
+ *
+ * @psalm-suppress TooFewArguments
+ */
+function unsafeWhereColumnNestedArray(\Illuminate\Http\Request $request): void {
+    $builder = new \Illuminate\Database\Query\Builder();
+    $tainted = (string) $request->input('col');
+
+    $builder->whereColumn([[$tainted, '=', 'other']]);
+}
+
+/**
+ * @psalm-suppress TooFewArguments
+ */
+function unsafeWhereColumnKeyedMap(\Illuminate\Http\Request $request): void {
+    $builder = new \Illuminate\Database\Query\Builder();
+    $tainted = (string) $request->input('col');
+
+    $builder->whereColumn([$tainted => 'x']);
+}
+?>
+--EXPECTF--
+%ATaintedSql on line %d: Detected tainted SQL
+%ATaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereColumnCompareSink.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereColumnCompareSink.phpt
@@ -1,0 +1,59 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * `whereColumn()`/`orWhereColumn()` bind nothing: the grammar wraps `$first` and `$second` as raw
+ * identifiers, and a `$operator` that fails Laravel's whitelist is demoted into `$second` by
+ * `invalidOperator()` rather than discarded. So a tainted value flags whichever positional slot it
+ * lands in — `$first`, `$operator`, or `$second` — and `orWhereColumn` shares the same three sinks.
+ * #1303
+ *
+ * @psalm-suppress TooFewArguments
+ */
+function unsafeWhereColumnFirst(\Illuminate\Http\Request $request): void {
+    $builder = new \Illuminate\Database\Query\Builder();
+    $tainted = (string) $request->input('col');
+
+    $builder->whereColumn($tainted, '=', 'x');
+}
+
+/**
+ * @psalm-suppress TooFewArguments
+ */
+function unsafeWhereColumnSecond(\Illuminate\Http\Request $request): void {
+    $builder = new \Illuminate\Database\Query\Builder();
+    $tainted = (string) $request->input('col');
+
+    $builder->whereColumn('a', '=', $tainted);
+}
+
+/**
+ * @psalm-suppress TooFewArguments
+ */
+function unsafeOrWhereColumnFirst(\Illuminate\Http\Request $request): void {
+    $builder = new \Illuminate\Database\Query\Builder();
+    $tainted = (string) $request->input('col');
+
+    $builder->orWhereColumn($tainted, '=', 'x');
+}
+
+/**
+ * The operator itself is a sink: an operator that does not match Laravel's whitelist is swapped into
+ * `$second` by `invalidOperator()` (Query/Builder.php:1184) and compiled raw either way.
+ *
+ * @psalm-suppress TooFewArguments
+ */
+function unsafeWhereColumnOperator(\Illuminate\Http\Request $request): void {
+    $builder = new \Illuminate\Database\Query\Builder();
+    $tainted = (string) $request->input('op');
+
+    $builder->whereColumn('a', $tainted, 'b');
+}
+?>
+--EXPECTF--
+%ATaintedSql on line %d: Detected tainted SQL
+%ATaintedSql on line %d: Detected tainted SQL
+%ATaintedSql on line %d: Detected tainted SQL
+%ATaintedSql on line %d: Detected tainted SQL


### PR DESCRIPTION
## Issue to Solve

`whereColumn()` / `orWhereColumn()` were not stubbed, so no parameter carried a SQL taint sink and this was silent (false negative):

```php
$builder->whereColumn((string) $request->input('c'), '=', 'other_column'); // no TaintedSql
```

## Related

Fixes #1303

## Solution Description

- Adds both methods to `stubs/common/Database/Query/Builder.phpstub` with `@psalm-taint-sink sql` on `$first`, `$operator`, and `$second`. Grammar proof that all three positions reach SQL raw (`Query/Grammars/Grammar.php`, `whereColumn` compiler): `return $this->wrap($where['first']).' '.$where['operator'].' '.$this->wrap($where['second']);` — nothing is bound.
- `$operator` is sunk because of a divergence from `where()`: `where()` degrades an invalid operator into a bound value, while `whereColumn()` swaps it into `$second` (`[$second, $operator] = [$operator, '=']`), which is `wrap()`ed as a raw identifier.
- No `@psalm-taint-escape sql` / `@psalm-flow` (unlike the `where()` sibling): there is no bound-value corridor to model, and a sink-only stub propagates no taint to the returned builder (probed empirically against the `raw()`-family precedent).
- The Eloquent side resolves through the existing `@mixin \Illuminate\Database\Query\Builder`, so one stub covers both builders (same mechanism as the `whereLike` family, #1302).
- Regression pin: `whereColumn` is deliberately absent from `WhereColumnTaintHandler::WHERE_MAP_METHODS` — in its array form every position is an identifier and none is PDO-bound, so the element-wise strip from #1302 must never apply. A dedicated phpt makes adding it to that allowlist impossible to do silently.

Verification:

- 6 phpt scenarios across 3 files (each sink position, `orWhereColumn`, Eloquent `::query()` chain, both array forms), each teeth-checked RED before the stub existed.
- One array-form phpt sits in the `--threads=1` ARGS group, matching the documented batch-interference precedent (`TaintedSqlWhereNestedConditionKeyedElement.phpt`); its docblock explains why.
- psalm-delta over the 18-app benchmark corpus (`b9168f19` → `7011ea69`): zero issue delta, zero type-coverage delta. The corpus uses `whereColumn` exclusively with literal or internal identifiers (e.g. BookStack's joint-permission queries), so the new sinks add no FP noise on idiomatic usage; there were no tainted flows to surface, and detection itself is proven by the phpts.

Reviewer notes (accepted imprecision):

- `$boolean` (4th parameter) is also grammar-concatenated raw but left unsunk: user-controlled boolean glue is implausible, and this matches the `where()`-family baseline (FN-over-FP accepted for this tier).
- Bare-static `Model::whereColumn(...)` still reports `UndefinedMagicMethod` on models lacking the plugin's builder mixin path; probing showed this is method-agnostic (hits `whereLike` identically) and pre-existing (#1070 / #1215 territory), so no new issue was filed.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787412969&installation_model_id=424990&pr_number=1308&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1308&signature=676a8c4776e3c8850b0411cb77180944cf689473fe20cb58e1e0b9272599bec4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->