### PR TITLE
Taint Analysis: gate whole-argument sql-taint strip on Laravel builder receiver

### DIFF
--- a/src/Handlers/Eloquent/WhereColumnTaintHandler.php
+++ b/src/Handlers/Eloquent/WhereColumnTaintHandler.php
@@ -72,7 +72,9 @@ use Psalm\Type\Union;
  *   value dies at its own `arrayvalue-assignment` edge and never reaches the argument node, while a
  *   tainted column position still flows through. This is what makes #1300's nested form precise.
  * - **Whole-argument** ({@see isBoundValueMap}) for everything else (a variable, a call result): a
- *   type-level check that only accepts the sealed all-string-key map, where every element is a value.
+ *   type-level check that only accepts the sealed all-string-key map, where every element is a value,
+ *   gated on the receiver via {@see isLaravelBuilder} same as the element-wise path — except a
+ *   StaticCall receiver, always a Model class, which stays unguarded (#1306).
  *
  * ### Why a dynamic key records nothing
  *
@@ -145,11 +147,15 @@ final class WhereColumnTaintHandler implements
 
     /**
      * `spl_object_id` of each recorded where-family first-argument node, consumed by
-     * {@see removeTaints}. Flushed per file at {@see beforeAnalyzeFile} (NOT per function-like — the
-     * record→read gap spans a closure-bearing call's whole analysis; see the class docblock). A stale
-     * cross-file id would wrongly STRIP taint, so the file flush is load-bearing.
+     * {@see removeTaints}. The value is the call's receiver node for a `MethodCall`/
+     * `NullsafeMethodCall` — checked against {@see isLaravelBuilder} at strip time, once its type
+     * exists, since it is unresolved at record time (see {@see beforeExpressionAnalysis}) — or `null`
+     * for a `StaticCall`, whose receiver is always a Model class and so stays unguarded (#1306).
+     * Flushed per file at {@see beforeAnalyzeFile} (NOT per function-like — the record→read gap spans
+     * a closure-bearing call's whole analysis; see the class docblock). A stale cross-file id would
+     * wrongly STRIP taint, so the file flush is load-bearing.
      *
-     * @var array<int, true>
+     * @var array<int, Expr|null>
      */
     private static array $whereColumnArgumentIds = [];
 
@@ -218,7 +224,11 @@ final class WhereColumnTaintHandler implements
 
         $argument = $args[0]->value;
 
-        self::$whereColumnArgumentIds[\spl_object_id($argument)] = true;
+        // The whole-argument strip ({@see isBoundValueMap} in removeTaints) needs the same receiver
+        // gate as the element-wise one below, for the same reason: a project's own `where(array
+        // $parts)` that happens to receive a sealed string-key map is not `addArrayOfWheres()`. A
+        // StaticCall stores null and stays unguarded — see the property docblock. #1306
+        self::$whereColumnArgumentIds[\spl_object_id($argument)] = $expr instanceof StaticCall ? null : $expr->var;
 
         // Element-wise recording additionally needs the receiver, because the method NAME alone does
         // not mean Laravel: a project's own `ReportQuery::where(array $parts)` that interpolates
@@ -251,8 +261,9 @@ final class WhereColumnTaintHandler implements
             return self::removeElementTaints($expr, $event);
         }
 
-        // The load-bearing scoping check #1218 lacked.
-        if (!isset(self::$whereColumnArgumentIds[\spl_object_id($expr)])) {
+        // The load-bearing scoping check #1218 lacked. array_key_exists, not isset: a recorded
+        // StaticCall argument stores `null`, which isset() would treat as absent.
+        if (!\array_key_exists(\spl_object_id($expr), self::$whereColumnArgumentIds)) {
             return 0;
         }
 
@@ -265,6 +276,14 @@ final class WhereColumnTaintHandler implements
         $type = $statements_source->node_data->getType($expr);
 
         if (!$type instanceof Union || !self::isBoundValueMap($type)) {
+            return 0;
+        }
+
+        $receiver = self::$whereColumnArgumentIds[\spl_object_id($expr)];
+
+        // #1306: gate the strip on the receiver, same as removeElementTaints. `null` (StaticCall)
+        // stays unguarded — see the property docblock.
+        if ($receiver instanceof \PhpParser\Node\Expr && !self::isLaravelBuilder($receiver, $statements_source, $event)) {
             return 0;
         }
 

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereWholeArgNonBuilderReceiver.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereWholeArgNonBuilderReceiver.phpt
@@ -1,0 +1,34 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis --threads=1
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * The WHOLE-ARGUMENT strip (`isBoundValueMap`) must gate on the receiver being a Laravel builder,
+ * exactly like the element-wise strip already does via `isLaravelBuilder` — the method name
+ * `where` alone does not mean `Builder::addArrayOfWheres()`. This is the whole-argument
+ * counterpart to TaintedSqlWhereNonBuilderReceiver.phpt: the argument here is a CALL RESULT (not
+ * an array literal), so `recordBoundValuePositions` never runs and only the whole-argument path
+ * is exercised.
+ *
+ * Runs in the `--threads=1` ARGS group; `DB::unprepared` is a distinct sink from the where-family
+ * ones the default taint group saturates (see TaintedSqlWhereNonBuilderReceiver.phpt). #1306
+ */
+final class NonBuilderWholeArgQuery {
+    /** @param array{name: string} $conditions */
+    public function where(array $conditions): void {
+        \Illuminate\Support\Facades\DB::unprepared('select * from t where name = ' . $conditions['name']);
+    }
+}
+
+/** @return array{name: string} */
+function wholeArgTaintedConditions(\Illuminate\Http\Request $request): array {
+    return ['name' => (string) $request->input('name')];
+}
+
+function unsafeNonBuilderWholeArgWhere(\Illuminate\Http\Request $request): void {
+    (new NonBuilderWholeArgQuery())->where(wholeArgTaintedConditions($request));
+}
+?>
+--EXPECTF--
+%ATaintedSql on line %d: Detected tainted SQL


### PR DESCRIPTION
## Issue to Solve

`WhereColumnTaintHandler` records the first argument of every `where()`/`orWhere()`/`firstWhere()` call for the whole-argument sql-taint strip without looking at the receiver, while the element-wise strip verifies the receiver via `isLaravelBuilder()`. A non-builder object with a `where()` method that interpolates array values into raw SQL therefore had its argument's sql taint silently removed: a real false negative (the same shape renamed to `filter()` reports `TaintedSql`).

## Related

Fixes #1306

Scope note: #1304 (`Request::offsetGet()` taint source) was investigated in the same cycle and dropped. A stub-side `@psalm-taint-source` on `offsetGet()` cannot work: Psalm's `ArrayFetchAnalyzer` synthesizes the `offsetGet()` call in a cloned node-data set, copies only the return type, and discards the taint edge. Wrong layer for this plugin; details are on the closed issue.

## Solution Description

Contract: T1, taint fix, budget 60 src lines (actual ~27 insertions in `src/`), 1 reviewer, no corpus delta run (measured low prevalence; behaviour proven by phpts).

- `$whereColumnArgumentIds` now stores the receiver expression (`array<int, Expr|null>`) instead of `true`. The receiver still cannot be type-resolved at record time (`AfterExpressionAnalysis` fires before the strip), so it is stored and checked at strip time with the existing `isLaravelBuilder()`, mirroring the element-wise path.
- `StaticCall` stores `null` and keeps the current unguarded strip. Its receiver is always a Model class routed through the pseudo-method path, never the non-builder shape, and `SafeSqlEloquentWhereArrayValues.phpt` depends on the whole-argument strip there (the element-wise path skips `StaticCall`).
- Membership check moved from `isset()` to `array_key_exists()`: `null`-valued `StaticCall` entries must survive the lookup.
- New type test `tests/Type/tests/TaintedSqlWhereWholeArgNonBuilderReceiver.phpt` (isolated `--threads=1` group): sealed-map call result into a non-builder `where()` reaching `DB::unprepared()`, verified red on master and green at HEAD.

Reviewer notes:

- Follow-up idea, pre-existing gap not worsened here: a positive regression phpt for the real-builder whole-argument strip (unsealed call-result flags, sealed map safe). The existing `SafeSql*WhereArrayVariable*` tests are self-labeled canaries that stay green even with the handler disabled.
- Accepted imprecision: a nullsafe `?->where()` receiver typed `Builder|null` resolves `isLaravelBuilder()` to false (identical to the pre-existing element-wise behaviour); `spl_object_id` per-file-flush lifecycle is pre-existing.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787417274&installation_model_id=424990&pr_number=1311&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1311&signature=73c293e4b483835ccde10d648b1c9b6da210722684dc6c13e51714ac650efe56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->