### PR TITLE
fix(stubs): widen whereLike-family $value param to mixed

### DIFF
--- a/stubs/common/Database/Query/Builder.phpstub
+++ b/stubs/common/Database/Query/Builder.phpstub
@@ -153,13 +153,15 @@ class Builder implements BuilderContract
     /**
      * Add a "where like" clause to the query.
      *
-     * Laravel >= 11.17. Stubbed for the taint annotations only: `$column` is wrapped as a raw
-     * identifier while `$value` goes through `addBinding()`, so the sink belongs on `$column` alone.
+     * Laravel >= 11.17. Stubbed both for the taint annotations below and to widen `$value` to `mixed`:
+     * Laravel's docblock types it `string`, but the runtime binds any value via `addBinding()` (parity
+     * with the `where()` sibling). `$column` is wrapped as a raw identifier while `$value` is bound, so
+     * the sink belongs on `$column` alone.
      * No `@psalm-taint-specialize` — it would break the `@psalm-flow` of non-SQL taint through
      * `$value` (see TaintedShellWhereValueFlowPreserved.phpt).
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
-     * @param  string  $value
+     * @param  mixed  $value
      * @param  bool  $caseSensitive
      * @param  string  $boolean
      * @param  bool  $not
@@ -175,7 +177,7 @@ class Builder implements BuilderContract
      * Add an "or where like" clause to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
-     * @param  string  $value
+     * @param  mixed  $value
      * @param  bool  $caseSensitive
      * @return $this
      *
@@ -189,7 +191,7 @@ class Builder implements BuilderContract
      * Add a "where not like" clause to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
-     * @param  string  $value
+     * @param  mixed  $value
      * @param  bool  $caseSensitive
      * @param  string  $boolean
      * @return $this
@@ -204,7 +206,7 @@ class Builder implements BuilderContract
      * Add an "or where not like" clause to the query.
      *
      * @param  \Illuminate\Contracts\Database\Query\Expression|string  $column
-     * @param  string  $value
+     * @param  mixed  $value
      * @param  bool  $caseSensitive
      * @return $this
      *

--- a/tests/Type/tests/TaintAnalysis/SafeSqlWhereLikeValues.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeSqlWhereLikeValues.phpt
@@ -9,6 +9,14 @@
  * family and leave $value unsinked, so a tainted value must not be flagged on any of the four
  * variants. #1300
  *
+ * $value is typed `mixed`, not `string`, to match the where() sibling stub and the plugin's
+ * loose-param / strict-return policy. Laravel's own docblock types it `string` (Psalm reads that off
+ * reflection, with or without a stub), which flags idiomatic calls like
+ * whereLike('name', $request->query('q')) (query() is string|array|null) as PossiblyInvalidArgument.
+ * The widening is signature and policy alignment, not a claim of universal runtime validity: an array
+ * value still mismatches the single `?` placeholder at execute time. The raw-value calls below pin
+ * the widening so a revert to `string` fails here. #1300
+ *
  * @psalm-suppress TooFewArguments
  */
 function safeWhereLikeFamilyValues(\Illuminate\Http\Request $request): void {
@@ -19,6 +27,13 @@ function safeWhereLikeFamilyValues(\Illuminate\Http\Request $request): void {
     $builder->orWhereLike('name', $term);
     $builder->whereNotLike('name', $term);
     $builder->orWhereNotLike('name', $term);
+
+    // Raw, un-cast query-string input is string|array|null; a `mixed` $value accepts it with no
+    // PossiblyInvalidArgument. Teeth for the widening: a `string` param flags all four here.
+    $builder->whereLike('name', $request->query('q'));
+    $builder->orWhereLike('name', $request->query('q'));
+    $builder->whereNotLike('name', $request->query('q'));
+    $builder->orWhereNotLike('name', $request->query('q'));
 }
 ?>
 --EXPECTF--


### PR DESCRIPTION
Follow-up to #1302; relates to #1300.

#1302 added the first stubs for the `whereLike` family (`whereLike`, `orWhereLike`, `whereNotLike`, `orWhereNotLike`; Laravel >= 11.17) and copied Laravel's own `@param  string  $value` verbatim. That type is over-strict for a param that is untyped at runtime and PDO-bound via `addBinding()`.

## Why `mixed`

- The runtime accepts any scalar/array/null and binds it — the value is never interpolated into SQL. The `where()` sibling stub already types its `$value` as `mixed`; this restores parity.
- `string` flags idiomatic calls that run fine:
  - `whereLike('name', $request->query('q'))` -> `PossiblyInvalidArgument` (`query()` returns `string|array|null`)
  - `whereLike('code', 123)` -> `InvalidArgument`
  - nullable input (`?string`) -> `PossiblyNullArgument`
  - The same values passed to `where('col', 'like', $v)` are already clean.

## Pre-existing, not a #1302 regression

The false positive is **not** introduced by #1302. Psalm reads `@param string $value` straight off Laravel's reflected source, so all three reports above already fire on pre-#1302 master with no stub present (verified by running the regression test against `b9168f19^`). #1302's body flagged this widening as a deliberate follow-up:

> Widening it to `mixed` would silence a pre-existing warning on every `whereLike` call rather than fix anything in this PR's scope.

Now that the stub owns these signatures, correcting the type is in scope — the stub is the right layer to override Laravel's loose docblock, exactly as it already does for `where()`.

## Scope

- Only the four `@param  string  $value` lines become `@param  mixed  $value`. The `@psalm-taint-sink sql $column`, `@psalm-taint-escape sql`, and `@psalm-flow ($value) -> return` annotations stay byte-identical, as do the `$column` / `$caseSensitive` / `$boolean` / `$not` params.
- `SafeSqlWhereLikeValues.phpt` gains raw, un-cast `query()` calls into all four variants as the regression guard. Teeth-verified: **red** without the stub fix (`PossiblyInvalidArgument` + `PossiblyInvalidCast` on each of the four), **green** with it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787418973&installation_model_id=424990&pr_number=1312&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1312&signature=3e06c4b0b17c748fbcbd01dfbc38ca61ca98d44e64aa9f6c586e420c880fa0a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->