### PR TITLE
Fix: redirect responses are not SSRF sinks

### DIFF
--- a/stubs/common/Foundation/helpers.phpstub
+++ b/stubs/common/Foundation/helpers.phpstub
@@ -256,7 +256,6 @@ function precognitive($callable = null) {}
  * @param  bool|null  $secure
  * @return ($to is null ? \Illuminate\Routing\Redirector : \Illuminate\Http\RedirectResponse)
  *
- * @psalm-taint-sink ssrf $to
  * @psalm-taint-sink header $to
  */
 function redirect($to = null, $status = 302, $headers = [], $secure = null) {}

--- a/stubs/common/Routing/Redirector.phpstub
+++ b/stubs/common/Routing/Redirector.phpstub
@@ -13,7 +13,6 @@ class Redirector
      * @param  bool|null  $secure
      * @return \Illuminate\Http\RedirectResponse
      *
-     * @psalm-taint-sink ssrf $path
      * @psalm-taint-sink header $path
      */
     public function to($path, $status = 302, $headers = [], $secure = null) {}
@@ -26,7 +25,6 @@ class Redirector
      * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse
      *
-     * @psalm-taint-sink ssrf $path
      * @psalm-taint-sink header $path
      */
     public function away($path, $status = 302, $headers = []) {}
@@ -39,7 +37,6 @@ class Redirector
      * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse
      *
-     * @psalm-taint-sink ssrf $path
      * @psalm-taint-sink header $path
      */
     public function secure($path, $status = 302, $headers = []) {}
@@ -53,7 +50,6 @@ class Redirector
      * @param  bool|null  $secure
      * @return \Illuminate\Http\RedirectResponse
      *
-     * @psalm-taint-sink ssrf $path
      * @psalm-taint-sink header $path
      */
     public function guest($path, $status = 302, $headers = [], $secure = null) {}
@@ -67,7 +63,6 @@ class Redirector
      * @param  bool|null  $secure
      * @return \Illuminate\Http\RedirectResponse
      *
-     * @psalm-taint-sink ssrf $default
      * @psalm-taint-sink header $default
      */
     public function intended($default = '/', $status = 302, $headers = [], $secure = null) {}

--- a/stubs/common/Routing/ResponseFactory.phpstub
+++ b/stubs/common/Routing/ResponseFactory.phpstub
@@ -92,7 +92,6 @@ class ResponseFactory implements FactoryContract
      * @param  bool|null  $secure
      * @return \Illuminate\Http\RedirectResponse
      *
-     * @psalm-taint-sink ssrf $path
      * @psalm-taint-sink header $path
      */
     public function redirectTo($path, $status = 302, $headers = [], $secure = null) {}
@@ -106,7 +105,6 @@ class ResponseFactory implements FactoryContract
      * @param  bool|null  $secure
      * @return \Illuminate\Http\RedirectResponse
      *
-     * @psalm-taint-sink ssrf $path
      * @psalm-taint-sink header $path
      */
     public function redirectGuest($path, $status = 302, $headers = [], $secure = null) {}
@@ -120,7 +118,6 @@ class ResponseFactory implements FactoryContract
      * @param  bool|null  $secure
      * @return \Illuminate\Http\RedirectResponse
      *
-     * @psalm-taint-sink ssrf $default
      * @psalm-taint-sink header $default
      */
     public function redirectToIntended($default = '/', $status = 302, $headers = [], $secure = null) {}

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestArrayAccessorWildcardForeachKnownLimitation.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestArrayAccessorWildcardForeachKnownLimitation.phpt
@@ -58,4 +58,3 @@ function storeFormRequestArrayAccessorForeach(WildcardEmailArrayForeachLimitatio
 ?>
 --EXPECTF--
 TaintedHeader on line %d: Detected tainted header
-TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestCustomRuleEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestCustomRuleEscapesHeader.phpt
@@ -11,8 +11,9 @@ use Illuminate\Foundation\Http\FormRequest;
 /**
  * Custom Rule class with a class-level @psalm-taint-escape. When used via
  * `new DnsEmailRule()` in a rules() array, the class-level escape is
- * OR-ed into the field's removedTaints, so redirect()->to() only fires
- * TaintedSSRF — TaintedHeader is suppressed.
+ * OR-ed into the field's removedTaints, so the header-sinking
+ * redirect()->to() stays silent; the http-client ssrf sink still fires
+ * TaintedSSRF, proving the value itself is still tainted.
  *
  * The 'string' rule pins the type (so Redirector::to() doesn't see `mixed`)
  * but removes no taint, isolating the escape to the class-level annotation.
@@ -35,6 +36,7 @@ final class ContactRequestNew extends FormRequest
 }
 
 function direct(ContactRequestNew $request): \Illuminate\Http\RedirectResponse {
+    (new \Illuminate\Http\Client\PendingRequest())->get($request->safe()->input('team_email'));
     return redirect()->to($request->safe()->input('team_email'));
 }
 ?>

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestCustomRuleStaticFactoryEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestCustomRuleStaticFactoryEscapesHeader.phpt
@@ -37,6 +37,7 @@ final class ContactRequestFactory extends FormRequest
 }
 
 function direct(ContactRequestFactory $request): \Illuminate\Http\RedirectResponse {
+    (new \Illuminate\Http\Client\PendingRequest())->get($request->safe()->input('team_email'));
     return redirect()->to($request->safe()->input('team_email'));
 }
 ?>

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestRuleEmailChainEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestRuleEmailChainEscapesHeader.phpt
@@ -30,6 +30,7 @@ final class FluentChainedEmailRequest extends FormRequest
 }
 
 function direct(FluentChainedEmailRequest $request): \Illuminate\Http\RedirectResponse {
+    (new \Illuminate\Http\Client\PendingRequest())->get($request->safe()->input('team_email'));
     return redirect()->to($request->safe()->input('team_email'));
 }
 ?>

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestRuleEmailFluentEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestRuleEmailFluentEscapesHeader.phpt
@@ -11,8 +11,8 @@ use Illuminate\Validation\Rule;
 /**
  * Fluent `Rule::email()` resolves to `Rules\Email` via the Rule facade
  * method map. The resulting class carries the same header/cookie escape
- * as `'email'` and `new Rules\Email()`. redirect()->to() still reports
- * TaintedSSRF because email validation does not constrain resolution.
+ * as `'email'` and `new Rules\Email()`. The http-client sink still
+ * reports TaintedSSRF because email validation does not constrain resolution.
  */
 final class FluentEmailRequest extends FormRequest
 {
@@ -23,6 +23,7 @@ final class FluentEmailRequest extends FormRequest
 }
 
 function direct(FluentEmailRequest $request): \Illuminate\Http\RedirectResponse {
+    (new \Illuminate\Http\Client\PendingRequest())->get($request->safe()->input('team_email'));
     return redirect()->to($request->safe()->input('team_email'));
 }
 ?>

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestRulesEmailInstanceEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestRulesEmailInstanceEscapesHeader.phpt
@@ -10,7 +10,7 @@ use Illuminate\Validation\Rules\Email;
 
 /**
  * `new Rules\Email()` carries the same header/cookie escape as the 'email'
- * string rule. redirect()->to() still reports TaintedSSRF because the email
+ * string rule. The http-client sink still reports TaintedSSRF because the email
  * validator does not prevent SSRF (a valid email domain can resolve to an
  * internal host).
  */
@@ -23,6 +23,7 @@ final class ObjectEmailRequest extends FormRequest
 }
 
 function direct(ObjectEmailRequest $request): \Illuminate\Http\RedirectResponse {
+    (new \Illuminate\Http\Client\PendingRequest())->get($request->safe()->input('team_email'));
     return redirect()->to($request->safe()->input('team_email'));
 }
 ?>

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestStringEmailNoTaintedHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestStringEmailNoTaintedHeader.phpt
@@ -10,7 +10,7 @@ use Illuminate\Foundation\Http\FormRequest;
 /**
  * Rule-based escape extends beyond validated() to safe()->input().
  * The 'email' rule escapes header/cookie taint kinds, so redirect()->to()
- * only fires TaintedSSRF — TaintedHeader is suppressed.
+ * stays silent and only the http-client sink fires TaintedSSRF.
  */
 final class EmailContactRequest extends FormRequest
 {
@@ -21,6 +21,7 @@ final class EmailContactRequest extends FormRequest
 }
 
 function direct(EmailContactRequest $request): \Illuminate\Http\RedirectResponse {
+    (new \Illuminate\Http\Client\PendingRequest())->get($request->safe()->input('team_email'));
     return redirect()->to($request->safe()->input('team_email'));
 }
 ?>

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestWildcardArrayRuleIndexedAccessEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestWildcardArrayRuleIndexedAccessEscapesHeader.phpt
@@ -32,6 +32,7 @@ final class WildcardEmailRequest extends FormRequest
 
 /** @psalm-suppress MixedArgument */
 function storeWildcardFormRequest(WildcardEmailRequest $request): \Illuminate\Http\RedirectResponse {
+    (new \Illuminate\Http\Client\PendingRequest())->get($request->input('emails.0'));
     return redirect()->to($request->input('emails.0'));
 }
 ?>

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestWithInlineValidateMergesEscape.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestWithInlineValidateMergesEscape.phpt
@@ -13,7 +13,7 @@ use Illuminate\Foundation\Http\FormRequest;
  * Here rules() supplies the 'email' string rule (header + cookie escape)
  * and the inline validate() adds a class-level rule that also escapes
  * 'sql'. A subsequent $request->input('email') passes through both paths;
- * redirect()->to() reports only TaintedSSRF, confirming the header/cookie
+ * only the http-client sink's TaintedSSRF fires, confirming the header/cookie
  * escape from rules() survived the OR-merge with the inline path.
  *
  * @psalm-taint-escape sql
@@ -39,6 +39,7 @@ function storeMerge(MergeRequest $request): \Illuminate\Http\RedirectResponse {
         'email' => ['required', new InlineSqlEscapeRule()],
     ]);
 
+    (new \Illuminate\Http\Client\PendingRequest())->get($request->input('email'));
     return redirect()->to($request->input('email'));
 }
 ?>

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateArrayAccessorScalarRuleEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateArrayAccessorScalarRuleEscapesHeader.phpt
@@ -27,6 +27,7 @@ function storeArrayAccessorScalarRule(Request $request): RedirectResponse {
     $request->validate(['email' => 'email']);
 
     foreach ($request->array('email') as $email) {
+        (new \Illuminate\Http\Client\PendingRequest())->get($email);
         return redirect()->to($email);
     }
 

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateArrayAccessorWildcardEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateArrayAccessorWildcardEscapesHeader.phpt
@@ -35,6 +35,7 @@ function storeArrayAccessorWildcard(Request $request): RedirectResponse {
     $request->validate(['email.*' => 'email']);
 
     foreach ($request->array('email') as $email) {
+        (new \Illuminate\Http\Client\PendingRequest())->get($email);
         return redirect()->to($email);
     }
 

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateCaughtValidationExceptionKnownLimitation.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateCaughtValidationExceptionKnownLimitation.phpt
@@ -18,7 +18,7 @@ use Illuminate\Validation\ValidationException;
  * collector's cache was already populated, so the rule's escape still
  * applies.
  *
- * Reproduces as: redirect()->to() only reports TaintedSSRF; TaintedHeader
+ * Reproduces as: only the http-client sink's TaintedSSRF fires; TaintedHeader
  * (which the `email` rule's escape clears) is silently dropped on the
  * thrown path.
  *
@@ -38,6 +38,7 @@ function defensiveValidate(Request $request): RedirectResponse {
         // defensive no-op — validation may have failed, but we proceed
     }
 
+    (new \Illuminate\Http\Client\PendingRequest())->get($request->input('contact_email'));
     return redirect()->to($request->input('contact_email'));
 }
 ?>

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateCoalesceDefaultKnownLimitationViaVariable.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateCoalesceDefaultKnownLimitationViaVariable.phpt
@@ -36,4 +36,3 @@ function coalesceDefaultProbe(Request $request): RedirectResponse {
 ?>
 --EXPECTF--
 TaintedHeader on line %d: Detected tainted header
-TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateConditionalKnownLimitation.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateConditionalKnownLimitation.phpt
@@ -30,6 +30,7 @@ function conditionalProbe(Request $request, bool $trusted): RedirectResponse {
     // The escape applies here even when $trusted === false and no
     // validation ran. Analyzer reports only TaintedSSRF (which the email
     // rule does not escape); TaintedHeader is silently suppressed.
+    (new \Illuminate\Http\Client\PendingRequest())->get($request->input('contact_email'));
     return redirect()->to($request->input('contact_email'));
 }
 ?>

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateConstantKeyKnownLimitationViaVariable.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateConstantKeyKnownLimitationViaVariable.phpt
@@ -13,7 +13,7 @@ use Illuminate\Http\Request;
  * `$request->input(self::KEY)` is not resolved — `beforeExpressionAnalysis`
  * runs before the RHS type inference that the sibling MethodCall path
  * uses to unwrap constants. Fail-safe: the binding keeps the original
- * taint, so both TaintedHeader and TaintedSSRF fire.
+ * taint, so TaintedHeader fires on the redirect sink.
  *
  * The inline form (`$request->input(self::KEY)` used directly in a sink
  * call) still benefits from the rule's escape via the existing
@@ -45,4 +45,3 @@ function constantKeyProbe(Request $request): RedirectResponse {
 ?>
 --EXPECTF--
 TaintedHeader on line %d: Detected tainted header
-TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateCustomRuleEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateCustomRuleEscapesHeader.phpt
@@ -13,7 +13,8 @@ use Illuminate\Http\Request;
  * Inline `$request->validate([...])` with a custom Rule class carrying a
  * class-level @psalm-taint-escape. The subsequent $request->input('field')
  * must honour the same escape as the equivalent FormRequest::rules() form,
- * so redirect()->to() only reports TaintedSSRF — TaintedHeader is removed.
+ * so redirect()->to() stays silent (TaintedHeader is removed) while the
+ * http-client sink's TaintedSSRF proves the value is still tainted.
  *
  * @psalm-taint-escape header
  * @psalm-taint-escape cookie
@@ -30,6 +31,7 @@ function store(Request $request): RedirectResponse {
         'contact_email' => ['required', 'string', new InlineDnsRule()],
     ]);
 
+    (new \Illuminate\Http\Client\PendingRequest())->get($request->input('contact_email'));
     return redirect()->to($request->input('contact_email'));
 }
 ?>

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateCustomRuleEscapesHeaderViaVariable.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateCustomRuleEscapesHeaderViaVariable.phpt
@@ -44,6 +44,7 @@ function storeViaVariable(Request $request): RedirectResponse {
 
     $boundEmail834 = $request->input('contact_email');
 
+    (new \Illuminate\Http\Client\PendingRequest())->get($boundEmail834);
     return redirect()->to($boundEmail834);
 }
 ?>

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateMergeBetweenValidateAndInputKnownLimitation.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateMergeBetweenValidateAndInputKnownLimitation.phpt
@@ -36,6 +36,7 @@ function laundered(Request $request, string $rawAttackerHeader): RedirectRespons
     // the cache still applies the 'email' rule's header escape.
     $request->merge(['contact_email' => $rawAttackerHeader]);
 
+    (new \Illuminate\Http\Client\PendingRequest())->get($request->input('contact_email'));
     return redirect()->to($request->input('contact_email'));
 }
 ?>

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateNestedWildcardKnownLimitation.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateNestedWildcardKnownLimitation.phpt
@@ -31,4 +31,3 @@ function storeNestedWildcard(Request $request): RedirectResponse {
 ?>
 --EXPECTF--
 TaintedHeader on line %d: Detected tainted header
-TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateReassignmentKnownLimitation.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateReassignmentKnownLimitation.phpt
@@ -30,6 +30,7 @@ function reassignProbe(Request $request): RedirectResponse {
     // entry is still keyed under the variable name `$request`. In practice
     // this is a very rare pattern — code that re-creates a Request object
     // by hand is almost exclusively in tests or low-level framework code.
+    (new \Illuminate\Http\Client\PendingRequest())->get($request->input('contact_email'));
     return redirect()->to($request->input('contact_email'));
 }
 ?>

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateReassignmentKnownLimitationViaVariable.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateReassignmentKnownLimitationViaVariable.phpt
@@ -41,6 +41,7 @@ function reassignProbeViaVariable(Request $request): RedirectResponse {
     // 'email' escape is still applied to the bound value.
     $boundReassigned = $request->input('contact_email');
 
+    (new \Illuminate\Http\Client\PendingRequest())->get($boundReassigned);
     return redirect()->to($boundReassigned);
 }
 ?>

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateRuleEmailEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateRuleEmailEscapesHeader.phpt
@@ -18,6 +18,7 @@ function store(Request $request): RedirectResponse {
         'reply_to' => ['required', Rule::email()],
     ]);
 
+    (new \Illuminate\Http\Client\PendingRequest())->get($request->input('reply_to'));
     return redirect()->to($request->input('reply_to'));
 }
 ?>

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateRuleEmailEscapesHeaderViaVariable.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateRuleEmailEscapesHeaderViaVariable.phpt
@@ -29,6 +29,7 @@ function storeRuleEmailViaVariable(Request $request): RedirectResponse {
 
     $boundReplyTo = $request->input('reply_to');
 
+    (new \Illuminate\Http\Client\PendingRequest())->get($boundReplyTo);
     return redirect()->to($boundReplyTo);
 }
 ?>

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateSameKeyOrMergesEscape.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateSameKeyOrMergesEscape.phpt
@@ -25,8 +25,9 @@ use Illuminate\Support\Facades\DB;
  * Both rules must pass for control to reach the input() reads, so the
  * value satisfies both rule sets — OR is the sound merge.
  *
- *   redirect()->to($v) sinks header+ssrf -> only TaintedSSRF fires (A gave us header)
- *   DB::select($v)     sinks sql          -> clean                 (B gave us sql)
+ *   redirect()->to($v)      sinks header -> clean       (A gave us header)
+ *   PendingRequest->get($v) sinks ssrf   -> TaintedSSRF (taint still live)
+ *   DB::select($v)          sinks sql    -> clean       (B gave us sql)
  *
  * A mutation replacing | with & at the merge site would drop one bit and
  * surface a TaintedHeader or TaintedSql; an overwrite-last-wins merge
@@ -56,6 +57,7 @@ function storeMergeSameKey(Request $request): RedirectResponse {
 
     DB::select($request->input('field'));
 
+    (new \Illuminate\Http\Client\PendingRequest())->get($request->input('field'));
     return redirect()->to($request->input('field'));
 }
 ?>

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateWildcardArrayRuleEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateWildcardArrayRuleEscapesHeader.phpt
@@ -32,6 +32,7 @@ function storeWildcardWhole(Request $request): RedirectResponse {
         'email.*' => ['required', Rule::email()],
     ]);
 
+    (new \Illuminate\Http\Client\PendingRequest())->get($request->input('email'));
     return redirect()->to($request->input('email'));
 }
 ?>

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateWildcardArrayRuleEscapesHeaderIndexedAccess.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateWildcardArrayRuleEscapesHeaderIndexedAccess.phpt
@@ -24,6 +24,7 @@ function storeWildcardIndexed(Request $request): RedirectResponse {
         'email.*' => ['required', Rule::email()],
     ]);
 
+    (new \Illuminate\Http\Client\PendingRequest())->get($request->input('email.0'));
     return redirect()->to($request->input('email.0'));
 }
 ?>

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateWildcardArrayRuleEscapesHeaderViaVariable.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateWildcardArrayRuleEscapesHeaderViaVariable.phpt
@@ -37,6 +37,7 @@ function storeWildcardIndexedViaVariable(Request $request): RedirectResponse {
 
     $boundWildcardEmail = $request->input('email.0');
 
+    (new \Illuminate\Http\Client\PendingRequest())->get($boundWildcardEmail);
     return redirect()->to($boundWildcardEmail);
 }
 ?>

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateWithBagEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateWithBagEscapesHeader.phpt
@@ -19,6 +19,7 @@ function storeWithBag(Request $request): RedirectResponse {
         'contact_email' => ['required', 'email'],
     ]);
 
+    (new \Illuminate\Http\Client\PendingRequest())->get($request->input('contact_email'));
     return redirect()->to($request->input('contact_email'));
 }
 ?>

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderControllerValidatesRequestsTraitNotRecognised.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderControllerValidatesRequestsTraitNotRecognised.phpt
@@ -17,7 +17,7 @@ use Illuminate\Http\Request;
  * so a future widening of the caller-type check can't silently extend the
  * escape to Controllers.
  *
- * TaintedHeader and TaintedSSRF must still fire even though the `email`
+ * TaintedHeader must still fire even though the `email`
  * rule would have escaped header/cookie if the call had been on $request.
  */
 final class ContactController
@@ -35,4 +35,3 @@ final class ContactController
 ?>
 --EXPECTF--
 TaintedHeader on line %d: Detected tainted header
-TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderInlineValidateAcrossClosureBoundary.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderInlineValidateAcrossClosureBoundary.phpt
@@ -43,4 +43,3 @@ function store(Request $request): RedirectResponse {
 ?>
 --EXPECTF--
 TaintedHeader on line %d: Detected tainted header
-TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderInlineValidateAfterInput.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderInlineValidateAfterInput.phpt
@@ -36,4 +36,3 @@ function store(Request $request): RedirectResponse {
 ?>
 --EXPECTF--
 TaintedHeader on line %d: Detected tainted header
-TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderInlineValidateChainedCallerNotRecognised.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderInlineValidateChainedCallerNotRecognised.phpt
@@ -37,4 +37,3 @@ function storeChained(RequestFactory $factory, Request $request): RedirectRespon
 ?>
 --EXPECTF--
 TaintedHeader on line %d: Detected tainted header
-TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderInlineValidateDifferentFunction.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderInlineValidateDifferentFunction.phpt
@@ -38,4 +38,3 @@ function read(Request $request): RedirectResponse {
 ?>
 --EXPECTF--
 TaintedHeader on line %d: Detected tainted header
-TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderInlineValidateNonRequestCallerIgnored.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderInlineValidateNonRequestCallerIgnored.phpt
@@ -29,4 +29,3 @@ function storeUnrelatedValidator(OwnValidator $own, Request $request): RedirectR
 ?>
 --EXPECTF--
 TaintedHeader on line %d: Detected tainted header
-TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderRedirect.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderRedirect.phpt
@@ -10,4 +10,3 @@ function loginRedirect(\Illuminate\Http\Request $request) {
 ?>
 --EXPECTF--
 %ATaintedHeader on line %d: Detected tainted header
-%ATaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderRedirectorIntended.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderRedirectorIntended.phpt
@@ -14,4 +14,3 @@ function loginRedirect(\Illuminate\Http\Request $request, \Illuminate\Routing\Re
 ?>
 --EXPECTF--
 %ATaintedHeader on line %d: Detected tainted header
-%ATaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderResponseFactoryRedirect.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderResponseFactoryRedirect.phpt
@@ -24,8 +24,5 @@ function responseRedirectToIntended(\Illuminate\Http\Request $request, \Illumina
 ?>
 --EXPECTF--
 %ATaintedHeader on line %d: Detected tainted header
-%ATaintedSSRF on line %d: Detected tainted network request
 %ATaintedHeader on line %d: Detected tainted header
-%ATaintedSSRF on line %d: Detected tainted network request
 %ATaintedHeader on line %d: Detected tainted header
-%ATaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/TaintedInlineValidateWildcardArrayRuleNonNumericKeyKeepsTaint.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedInlineValidateWildcardArrayRuleNonNumericKeyKeepsTaint.phpt
@@ -33,4 +33,3 @@ function storeWildcardNonNumericKey(Request $request): RedirectResponse {
 ?>
 --EXPECTF--
 TaintedHeader on line %d: Detected tainted header
-TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/UnsafeInlineValidateAssignRefReassignsVariable.phpt
+++ b/tests/Type/tests/TaintAnalysis/UnsafeInlineValidateAssignRefReassignsVariable.phpt
@@ -16,7 +16,7 @@ use Illuminate\Http\Request;
  * the raw reference target. The fix evicts on `AssignRef` in
  * `InlineValidateRulesCollector::beforeExpressionAnalysis`.
  *
- * Both TaintedHeader and TaintedSSRF must fire for the redirect — that
+ * TaintedHeader must fire for the redirect — that
  * proves the rebound slot was evicted before the read-side dispatch.
  *
  * --threads=1: see SafeInlineValidateCustomRuleEscapesHeaderViaVariable
@@ -42,4 +42,3 @@ function assignRefReassignProbe(Request $request): RedirectResponse {
 ?>
 --EXPECTF--
 TaintedHeader on line %d: Detected tainted header
-TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/UnsafeInlineValidateDestructureReassignsVariable.phpt
+++ b/tests/Type/tests/TaintAnalysis/UnsafeInlineValidateDestructureReassignsVariable.phpt
@@ -19,7 +19,7 @@ use Illuminate\Http\Request;
  * pair above) would silently strip header/cookie taint from the raw
  * `$_GET` element on the destructured edge.
  *
- * Both TaintedHeader and TaintedSSRF must fire for the redirect, proving
+ * TaintedHeader must fire for the redirect, proving
  * the destructured slot was evicted before the LHS taint event ran.
  *
  * --threads=1: see SafeInlineValidateCustomRuleEscapesHeaderViaVariable
@@ -43,4 +43,3 @@ function destructureReassignProbe(Request $request): RedirectResponse {
 ?>
 --EXPECTF--
 TaintedHeader on line %d: Detected tainted header
-TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/UnsafeInlineValidateForeachReassignsVariable.phpt
+++ b/tests/Type/tests/TaintAnalysis/UnsafeInlineValidateForeachReassignsVariable.phpt
@@ -16,7 +16,7 @@ use Illuminate\Http\Request;
  * pair above) would silently strip header/cookie taint from the raw
  * `$_GET` element on the loop-variable edge.
  *
- * Both TaintedHeader and TaintedSSRF must fire for the redirect — that
+ * TaintedHeader must fire for the redirect — that
  * proves the loop-variable cache was correctly evicted before
  * `AssignmentAnalyzer` dispatched the LHS taint event for the binding.
  *
@@ -43,4 +43,3 @@ function foreachReassignProbe(Request $request): RedirectResponse {
 ?>
 --EXPECTF--
 TaintedHeader on line %d: Detected tainted header
-TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/UnsafeInlineValidateVariableReassignedToRawInput.phpt
+++ b/tests/Type/tests/TaintAnalysis/UnsafeInlineValidateVariableReassignedToRawInput.phpt
@@ -44,4 +44,3 @@ function reassignToRawInputProbe(Request $request): RedirectResponse {
 ?>
 --EXPECTF--
 TaintedHeader on line %d: Detected tainted header
-TaintedSSRF on line %d: Detected tainted network request


### PR DESCRIPTION
## Issue to Solve

`return redirect($request->url());` reports **two** taint errors: `TaintedSSRF` ("Detected tainted network request") and `TaintedHeader`. Only the header one is correct.

`redirect()` (and the `Redirector` / `ResponseFactory` redirect-family) build an `Illuminate\Http\RedirectResponse` that sets a `Location` response header. The browser follows the redirect; the server makes no outbound request. That is open-redirect / header injection (CWE-601), not SSRF (CWE-918, server-side outbound fetch). The `ssrf` sink was mislabelled, producing the spurious second error.

## Related

Fixes #1313

## Solution Description

Dropped `@psalm-taint-sink ssrf` from the 9 redirect-family positions, kept the `header` sink:

- `stubs/common/Foundation/helpers.phpstub` — `redirect()`
- `stubs/common/Routing/Redirector.phpstub` — `to` / `away` / `secure` / `guest` / `intended`
- `stubs/common/Routing/ResponseFactory.phpstub` — `redirectTo` / `redirectGuest` / `redirectToIntended`

The `header` sink still fires on `redirect($request->url())`, so the genuine open-redirect risk is still reported — just once, correctly.

Test fallout: several validation-escape phpts used a surviving `TaintedSSRF` on a redirect call as their taint-aliveness discriminator (proving the `email` rule escaped `header`/`cookie` but not the value itself). Those now add a real ssrf sink — `(new \Illuminate\Http\Client\PendingRequest())->get($value)` — for the aliveness check, keeping `redirect()->to()` as the header sink whose silence asserts the escape. The 3 dedicated `TaintedSsrf*` redirect tests are renamed to `TaintedHeader*`.

Consistency note: the same reasoning is applied across the helper, `Redirector`, and `ResponseFactory` so `redirect($url)` and `redirect()->to($url)` report identically (the helper stub body is empty, so taint does not flow helper -> Redirector; each needs its own annotation).

Verified: all 333 `tests/Type/tests/TaintAnalysis` type tests green.

A `3.x` backport will follow (stubs are identical on that branch).

## Checklist
- [x] Tests cover the change (type tests in `tests/Type/`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787478020&installation_model_id=424990&pr_number=1315&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1315&signature=4a63294acc182d806c7e1bc49be3151075cdcb52e58c08be71546f3baca91cde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->