### PR TITLE
Enforce issue and config documentation policy in tests

### DIFF
--- a/tests/Unit/IssueDocumentationTest.php
+++ b/tests/Unit/IssueDocumentationTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class IssueDocumentationTest extends TestCase
+{
+    /**
+     * @return list<string>
+     */
+    private static function issueClassNames(): array
+    {
+        $root = \dirname(__DIR__, 2);
+        $files = \glob($root . '/src/Issues/*.php');
+        self::assertNotFalse($files);
+
+        $names = [];
+        foreach ($files as $file) {
+            $names[] = \basename($file, '.php');
+        }
+
+        self::assertNotEmpty($names, 'src/Issues/*.php discovery found nothing; the source shape changed');
+
+        \sort($names);
+
+        return $names;
+    }
+
+    #[Test]
+    public function every_issue_class_has_a_matching_doc_page_and_vice_versa(): void
+    {
+        $root = \dirname(__DIR__, 2);
+
+        $docFiles = \glob($root . '/docs/issues/*.md');
+        self::assertNotFalse($docFiles);
+
+        $docNames = [];
+        foreach ($docFiles as $file) {
+            $name = \basename($file, '.md');
+            if ($name === 'index') {
+                continue;
+            }
+            $docNames[] = $name;
+        }
+
+        self::assertEqualsCanonicalizing(
+            self::issueClassNames(),
+            $docNames,
+            'src/Issues/*.php and docs/issues/*.md must name the same set of issues (an orphan page has no source class, a missing page has no docs)',
+        );
+    }
+
+    #[Test]
+    public function every_issue_class_documentation_url_points_to_its_own_page(): void
+    {
+        foreach (self::issueClassNames() as $name) {
+            $fqcn = "Psalm\\LaravelPlugin\\Issues\\{$name}";
+            $expected = "https://psalm.github.io/psalm-plugin-laravel/issues/{$name}/";
+
+            self::assertSame(
+                $expected,
+                \constant("{$fqcn}::DOCUMENTATION_URL"),
+                "{$fqcn}::DOCUMENTATION_URL does not match its own issue page",
+            );
+        }
+    }
+
+    #[Test]
+    public function index_lists_every_issue(): void
+    {
+        $root = \dirname(__DIR__, 2);
+        $index = \file_get_contents($root . '/docs/issues/index.md');
+        self::assertIsString($index);
+
+        foreach (self::issueClassNames() as $name) {
+            self::assertStringContainsString(
+                "[{$name}]({$name}.md)",
+                $index,
+                "docs/issues/index.md has no entry for {$name}",
+            );
+        }
+    }
+
+    #[Test]
+    public function every_config_element_is_documented(): void
+    {
+        $root = \dirname(__DIR__, 2);
+        $source = \file_get_contents($root . '/src/Config/PluginConfig.php');
+        self::assertIsString($source);
+
+        \preg_match_all(
+            "/xml(?:Bool|OptionalBool|String)Attr\(\\\$config\?->\w+,\s*'(\w+)'/",
+            $source,
+            $attrMatches,
+        );
+        $attrElements = $attrMatches[1];
+        self::assertNotEmpty($attrElements, 'the PluginConfig.php source shape changed; xml*Attr regex captured nothing');
+
+        \preg_match_all(
+            "/xmlNameList\(\\\$config,\s*'(\w+)'/",
+            $source,
+            $listMatches,
+        );
+        $listElements = $listMatches[1];
+        self::assertNotEmpty($listElements, 'the PluginConfig.php source shape changed; xmlNameList regex captured nothing');
+
+        $elements = [...$attrElements, ...$listElements];
+        // modelProperties is the element for xmlStringAttr($config?->modelProperties, 'columnFallback', ...):
+        // the regex captures the ATTRIBUTE name ('columnFallback'), not the element name, so no pattern sees it.
+        $elements[] = 'modelProperties';
+
+        $configDocs = \file_get_contents($root . '/docs/config.md');
+        self::assertIsString($configDocs);
+
+        foreach (\array_unique($elements) as $element) {
+            self::assertStringContainsString(
+                $element,
+                $configDocs,
+                "docs/config.md does not mention the '{$element}' config element",
+            );
+        }
+    }
+}

--- a/tests/Unit/IssueDocumentationTest.php
+++ b/tests/Unit/IssueDocumentationTest.php
@@ -14,18 +14,18 @@ final class IssueDocumentationTest extends TestCase
     /**
      * @return list<string>
      */
-    private static function issueClassNames(): array
+    private function issueClassNames(): array
     {
         $root = \dirname(__DIR__, 2);
         $files = \glob($root . '/src/Issues/*.php');
-        self::assertNotFalse($files);
+        $this->assertNotFalse($files);
 
         $names = [];
         foreach ($files as $file) {
             $names[] = \basename($file, '.php');
         }
 
-        self::assertNotEmpty($names, 'src/Issues/*.php discovery found nothing; the source shape changed');
+        $this->assertNotEmpty($names, 'src/Issues/*.php discovery found nothing; the source shape changed');
 
         \sort($names);
 
@@ -38,7 +38,7 @@ final class IssueDocumentationTest extends TestCase
         $root = \dirname(__DIR__, 2);
 
         $docFiles = \glob($root . '/docs/issues/*.md');
-        self::assertNotFalse($docFiles);
+        $this->assertNotFalse($docFiles);
 
         $docNames = [];
         foreach ($docFiles as $file) {
@@ -46,28 +46,21 @@ final class IssueDocumentationTest extends TestCase
             if ($name === 'index') {
                 continue;
             }
+
             $docNames[] = $name;
         }
 
-        self::assertEqualsCanonicalizing(
-            self::issueClassNames(),
-            $docNames,
-            'src/Issues/*.php and docs/issues/*.md must name the same set of issues (an orphan page has no source class, a missing page has no docs)',
-        );
+        $this->assertEqualsCanonicalizing($this->issueClassNames(), $docNames, 'src/Issues/*.php and docs/issues/*.md must name the same set of issues (an orphan page has no source class, a missing page has no docs)');
     }
 
     #[Test]
     public function every_issue_class_documentation_url_points_to_its_own_page(): void
     {
-        foreach (self::issueClassNames() as $name) {
+        foreach ($this->issueClassNames() as $name) {
             $fqcn = "Psalm\\LaravelPlugin\\Issues\\{$name}";
             $expected = "https://psalm.github.io/psalm-plugin-laravel/issues/{$name}/";
 
-            self::assertSame(
-                $expected,
-                \constant("{$fqcn}::DOCUMENTATION_URL"),
-                "{$fqcn}::DOCUMENTATION_URL does not match its own issue page",
-            );
+            $this->assertSame($expected, \constant("{$fqcn}::DOCUMENTATION_URL"), "{$fqcn}::DOCUMENTATION_URL does not match its own issue page");
         }
     }
 
@@ -76,14 +69,10 @@ final class IssueDocumentationTest extends TestCase
     {
         $root = \dirname(__DIR__, 2);
         $index = \file_get_contents($root . '/docs/issues/index.md');
-        self::assertIsString($index);
+        $this->assertIsString($index);
 
-        foreach (self::issueClassNames() as $name) {
-            self::assertStringContainsString(
-                "[{$name}]({$name}.md)",
-                $index,
-                "docs/issues/index.md has no entry for {$name}",
-            );
+        foreach ($this->issueClassNames() as $name) {
+            $this->assertStringContainsString("[{$name}]({$name}.md)", $index, "docs/issues/index.md has no entry for {$name}");
         }
     }
 
@@ -92,7 +81,7 @@ final class IssueDocumentationTest extends TestCase
     {
         $root = \dirname(__DIR__, 2);
         $source = \file_get_contents($root . '/src/Config/PluginConfig.php');
-        self::assertIsString($source);
+        $this->assertIsString($source);
 
         \preg_match_all(
             "/xml(?:Bool|OptionalBool|String)Attr\(\\\$config\?->\w+,\s*'(\w+)'/",
@@ -100,7 +89,7 @@ final class IssueDocumentationTest extends TestCase
             $attrMatches,
         );
         $attrElements = $attrMatches[1];
-        self::assertNotEmpty($attrElements, 'the PluginConfig.php source shape changed; xml*Attr regex captured nothing');
+        $this->assertNotEmpty($attrElements, 'the PluginConfig.php source shape changed; xml*Attr regex captured nothing');
 
         \preg_match_all(
             "/xmlNameList\(\\\$config,\s*'(\w+)'/",
@@ -108,7 +97,7 @@ final class IssueDocumentationTest extends TestCase
             $listMatches,
         );
         $listElements = $listMatches[1];
-        self::assertNotEmpty($listElements, 'the PluginConfig.php source shape changed; xmlNameList regex captured nothing');
+        $this->assertNotEmpty($listElements, 'the PluginConfig.php source shape changed; xmlNameList regex captured nothing');
 
         $elements = [...$attrElements, ...$listElements];
         // modelProperties is the element for xmlStringAttr($config?->modelProperties, 'columnFallback', ...):
@@ -116,14 +105,10 @@ final class IssueDocumentationTest extends TestCase
         $elements[] = 'modelProperties';
 
         $configDocs = \file_get_contents($root . '/docs/config.md');
-        self::assertIsString($configDocs);
+        $this->assertIsString($configDocs);
 
         foreach (\array_unique($elements) as $element) {
-            self::assertStringContainsString(
-                $element,
-                $configDocs,
-                "docs/config.md does not mention the '{$element}' config element",
-            );
+            $this->assertStringContainsString($element, $configDocs, "docs/config.md does not mention the '{$element}' config element");
         }
     }
 }


### PR DESCRIPTION
## Issue to Solve

Two documentation policies are stated in the contributing docs but nothing enforced them:

- every class in `src/Issues/` ships a `docs/issues/<Name>.md` page plus an entry in `docs/issues/index.md`
- every plugin XML config element read by `PluginConfig::fromXml()` is documented in `docs/config.md`

Both are easy to forget in a PR that adds an issue class or a config flag, and neither shows up as a test failure. A stale `DOCUMENTATION_URL` also ships a dead link into user-facing issue output.

## Related

No linked issue.

## Solution Description

`tests/Unit/IssueDocumentationTest.php`, four filesystem-only checks. No Laravel boot, no Psalm run (4 tests / 50 assertions, 0.003s).

1. Bijection `src/Issues/*.php` vs `docs/issues/*.md` minus `index.md`, via `assertEqualsCanonicalizing`, so an orphan page fails as loudly as a missing one.
2. Every class's `DOCUMENTATION_URL` const equals the URL built from its own short name (read via `constant()`).
3. `docs/issues/index.md` contains `[<Name>](<Name>.md)` for every class.
4. Config element names scraped from the `PluginConfig.php` source text (two regexes: the `xml*Attr` family and `xmlNameList`) all appear in `docs/config.md`.

Why source-scraping over reflection for check 4: `fromXml()` reads elements imperatively, so there is no list to reflect over. The regex is the cheapest thing that tracks the real call sites. It captures 11 elements today and misses none.

`modelProperties` stays hardcoded because its `xmlStringAttr` call passes the *attribute* name (`columnFallback`) as arg 2, so no regex sees the element; an inline comment records that.

Every loop asserts its iterand is non-empty first, so no method can pass vacuously if the source layout changes.

### Verification

Each check was proven to go red for the violation it guards, in an isolated mirror of the repo, then restored:

- delete a doc page / add an orphan page → check 1 red
- wrong `DOCUMENTATION_URL` → check 2 red
- drop an `index.md` entry → check 3 red, naming the class
- add an undocumented `xmlBoolAttr` element → check 4 red, naming the element
- add an undocumented `xmlNameList` element → check 4 red, naming the element
- empty `src/Issues/` → checks 1, 2, 3 red instead of silently passing

Also green: `composer cs`, and `psalm --no-cache` on the file (note: `psalm.xml` `projectFiles` is `src` + `bin`, so CI self-analysis does not cover `tests/`).

### Accepted imprecision

- Check 4 matches a bare substring, so deleting the prose section for an element while leaving it in the top full-config XML example still passes. It catches the case that matters (a wholly undocumented element).
- An issue class missing `DOCUMENTATION_URL` entirely raises an `Error` from `constant()` rather than a named assertion failure.
- `glob()` is non-recursive: a future subdirectory under `src/Issues/` would be unchecked, not falsely red.

## Checklist
- [x] Tests cover the change (unit test in `tests/Unit/`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787595184&installation_model_id=424990&pr_number=1319&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1319&signature=aa5518c4ce0447cae618db69307d9aad9ad5b0588d47485b2002c269f67c8fc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->