### PR TITLE
Add agent guide, contributor code-pattern docs, and a docs path lint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Active majors:
 - `master` is 4.x (PHP 8.2+, Laravel `^12.14 || ^13.3`, Psalm 7 beta)
 - `3.x` is the Psalm 6 line (Laravel `^11.35+`), backports only
 
-Taint: Psalm 6 reports it only in a separate `--taint-analysis` run (type issues suppressed there); Psalm 7 emits type and taint issues together in one run, on a rewritten engine with different internals. Psalm core defaults taint off, but `psalm-laravel init` writes `runTaintAnalysis="true"`, so initialized user projects run it by default; this repo's own self-analysis keeps it off.
+Taint: Psalm 6 keeps taint off by default and reports it only in a separate `--taint-analysis` run (type issues suppressed there). Psalm 7 runs taint BY DEFAULT and emits type and taint issues together in one run, on a rewritten engine with different internals; `psalm-laravel init` additionally writes `runTaintAnalysis="true"` to make that explicit.
 
 ## Read before re-deriving
 
@@ -49,8 +49,8 @@ composer rector -- --no-progress-bar --no-ansi                         # rector 
 Gotchas:
 
 - The final pre-commit psalm gate must DROP `--no-suggestions` to match CI, which runs bare `psalm` (`.github/workflows/psalm.yml`) and reports what the flag hides locally. Keep the flag for iteration only.
-- Full local `composer test:type` can flake with mass class-not-found fatals (parallel batch runner). An isolated `--filter` run passing is the local signal; CI validates the full suite.
 - `composer test:type` runs a phpt convention check BEFORE PHPUnit and aborts the whole suite on any `--EXPECT--` section or hardcoded `on line N` under `tests/Type/tests`. Use `--EXPECTF--` with `on line %d`.
+- Before citing Psalm source or defaults, confirm `vendor/composer/installed.json` carries the Psalm major that composer.json requires: a stale vendor from an interrupted install answers every source read and probe with the PREVIOUS major's behavior, convincingly.
 
 ## Git and PRs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Active majors:
 - `master` is 4.x (PHP 8.2+, Laravel `^12.14 || ^13.3`, Psalm 7 beta)
 - `3.x` is the Psalm 6 line (Laravel `^11.35+`), backports only
 
-Taint: Psalm 6 reports it only in a separate `--taint-analysis` run (type issues suppressed there); Psalm 7 emits both in one run when enabled (`runTaintAnalysis="true"` or `--taint-analysis`, default off, including self-analysis here) on a rewritten engine with different internals.
+Taint: Psalm 6 reports it only in a separate `--taint-analysis` run (type issues suppressed there); Psalm 7 emits type and taint issues together in one run, on a rewritten engine with different internals. Psalm core defaults taint off, but `psalm-laravel init` writes `runTaintAnalysis="true"`, so initialized user projects run it by default; this repo's own self-analysis keeps it off.
 
 ## Read before re-deriving
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Active majors:
 - `master` is 4.x (PHP 8.2+, Laravel `^12.14 || ^13.3`, Psalm 7 beta)
 - `3.x` is the Psalm 6 line (Laravel `^11.35+`), backports only
 
-Taint: Psalm 6 keeps taint off by default and reports it only in a separate `--taint-analysis` run (type issues suppressed there). Psalm 7 runs taint BY DEFAULT and emits type and taint issues together in one run, on a rewritten engine with different internals; `psalm-laravel init` additionally writes `runTaintAnalysis="true"` to make that explicit.
+Taint: Psalm 6 runs in exactly one mode per invocation: plain `psalm` reports type issues only, `psalm --taint-analysis` reports taint issues only, so full coverage takes two runs. Psalm 7 runs taint BY DEFAULT and emits type and taint issues together in one run, on a rewritten engine with different internals; `psalm-laravel init` additionally writes `runTaintAnalysis="true"` to make that explicit.
 
 ## Read before re-deriving
 
@@ -49,7 +49,6 @@ composer rector -- --no-progress-bar --no-ansi                         # rector 
 Gotchas:
 
 - The final pre-commit psalm gate must DROP `--no-suggestions` to match CI, which runs bare `psalm` (`.github/workflows/psalm.yml`) and reports what the flag hides locally. Keep the flag for iteration only.
-- `composer test:type` runs a phpt convention check BEFORE PHPUnit and aborts the whole suite on any `--EXPECT--` section or hardcoded `on line N` under `tests/Type/tests`. Use `--EXPECTF--` with `on line %d`.
 - Before citing Psalm source or defaults, confirm `vendor/composer/installed.json` carries the Psalm major that composer.json requires: a stale vendor from an interrupted install answers every source read and probe with the PREVIOUS major's behavior, convincingly.
 
 ## Git and PRs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,130 @@
+# psalm-plugin-laravel
+
+Psalm plugin for Laravel. It boots a real Laravel application (the analyzed project's own `bootstrap/app.php`, with Orchestra Testbench as the package fallback), then hooks Psalm's event system and registers stubs to type Laravel's magic. It also ships taint sources, sinks, and escapes for security analysis.
+
+Active majors:
+- `master` is 4.x (PHP 8.2+, Laravel `^12.14 || ^13.3`, Psalm 7 beta)
+- `3.x` is the Psalm 6 line (Laravel `^11.35+`), backports only
+
+Taint: Psalm 6 reports it only in a separate `--taint-analysis` run (type issues suppressed there); Psalm 7 emits both in one run when enabled (`runTaintAnalysis="true"` or `--taint-analysis`, default off, including self-analysis here) on a rewritten engine with different internals.
+
+## Read before re-deriving
+
+These documents are maintained and source-verified. Consult them before exploring source; prefer them over re-deriving from code.
+
+| Topic | Where |
+|---|---|
+| How to add a stub or handler; boot flow, hook phases, stub layout/merging, version dirs, SKIPIF gating, experimental issue lifecycle | `docs/contributing/README.md` |
+| Design rationale: handler loading, producer narrowing, suppression, version policy, taint philosophy, performance budget | `docs/contributing/decisions.md` |
+| How Laravel `__call` / `__callStatic` / macros / forwarding resolve, and the handlers modeling them | `docs/contributing/laravel-magic-call-patterns.md` |
+| Taint annotation authoring | `docs/contributing/taint-analysis.md` |
+| Psalm annotation syntax reference | `docs/contributing/types.md` |
+| Keeping self-analysis at 100% type coverage | `docs/contributing/type-coverage.md` |
+| Handler, stub, and test authoring patterns (mined from this codebase, with evidence) | `docs/contributing/code-patterns.md` |
+| Type test (.phpt) format and assertions | `tests/Type/README.md` |
+| Application fixture and archetype models (reuse before adding) | `tests/Application/README.md` |
+| Custom issue documentation, one page per `src/Issues/` class | `docs/issues/<Name>.md` + `docs/issues/index.md` |
+| Plugin XML config flags (opt-in issues, `columnFallback`, ...) | `docs/config.md` |
+| Step-debugging a handler | `docs/contributing/xdebug.md` |
+
+Ground truth for stub signatures is Laravel source in `vendor/laravel/framework/`, never Laravel's own PHPDoc and never another tool's stubs.
+
+## Commands
+
+Use these forms by default (verbose output only when debugging):
+
+```bash
+composer test:unit -- --no-progress --colors=never --display-errors --display-warnings  # PHPUnit unit tests
+composer test:type -- --no-progress                                    # type tests (psalm-tester)
+composer test:app                                                      # plugin on a fresh Laravel app
+composer psalm -- --no-progress --no-suggestions --output-format=compact  # self-analysis
+composer cs                                                            # auto-fix code style (quiet flags baked in)
+composer rector -- --no-progress-bar --no-ansi                         # rector refactoring
+
+# single test file, cheaper than the suite
+./vendor/bin/phpunit tests/Unit/PluginConfigTest.php
+./vendor/bin/phpunit --filter=AuthTest tests/Type/
+```
+
+Gotchas:
+
+- The final pre-commit psalm gate must DROP `--no-suggestions` to match CI, which runs bare `psalm` (`.github/workflows/psalm.yml`) and reports what the flag hides locally. Keep the flag for iteration only.
+- Full local `composer test:type` can flake with mass class-not-found fatals (parallel batch runner). An isolated `--filter` run passing is the local signal; CI validates the full suite.
+- `composer test:type` runs a phpt convention check BEFORE PHPUnit and aborts the whole suite on any `--EXPECT--` section or hardcoded `on line N` under `tests/Type/tests`. Use `--EXPECTF--` with `on line %d`.
+
+## Git and PRs
+
+- Base PRs on `master`. Psalm-6-only bugs base on `3.x`.
+- The `style: auto-fix` workflow commits style fixes back to pushed branches. Run `composer rector` and `composer cs` locally BEFORE pushing, and `git pull --ff-only` before any further local edits after a push.
+- Worktrees: the symlinked `vendor/` PSR-4 autoloader points at the primary checkout's `src/` and `stubs/`. Edits in a worktree are invisible to Psalm until `composer install` runs inside that worktree. Write and Edit tools must target worktree-absolute paths, never the primary root.
+- Commits follow Conventional Commits. The subject describes the change, not the issue it closes; issue ref is required in PR body and optional in commit message body.
+
+## Hard rules
+
+Each rule exists because violating it shipped a bug. The pointer holds the full story.
+
+1. Every handler in `Plugin::registerHandlers()` keeps its paired `require_once`. Rationale: decisions.md, "Class Loading and Discovery".
+2. A stub that re-declares a class must copy the `extends` / `implements` / `use` header verbatim from Laravel source. Psalm wipes the reflected interface list on re-declaration. See "Stub merging" in the contributing README.
+3. In template positions of relation stubs (the declaring-model argument of `HasRelationships` factory returns, the chainable branch of conditional returns), write `static`, never `$this`: Psalm does not late-static-substitute `$this` there. Plain fluent `@return $this` on non-generic methods is fine. Keep `TDeclaringModel` covariant (`@template-covariant`); do not make it invariant to match other tools. Full rationale: docblock of `stubs/common/Database/Eloquent/Relations/Relation.phpstub` and psalm/psalm-plugin-laravel#913.
+4. Across stub files, type annotations replace (last loaded wins) while taint annotations accumulate. Keep both kinds for one method in the SAME file.
+5. A regression test must fail before the fix. For trivial stub syncs a write-then-delete throwaway test suffices; commit a type test for the fragile cases (conditional returns, template tricks, version-gated behavior). New narrowing handlers need positive AND negative coverage (handler declines, fallback stays intact).
+6. Plugin self-analysis has no baseline and must never gain one. The only baseline is the Application-fixture snapshot `tests/Application/laravel-test-psalm-baseline.xml` (refresh via `tests/Application/laravel-test.sh -u`). Never `@psalm-suppress` before trying hard to fix the issue at its source.
+7. Grep the diff for `CLAUDE` before committing. Comments and docs state facts directly and never cite agent instruction files.
+
+## Writing code
+
+Pattern catalog with evidence: `docs/contributing/code-patterns.md`. Non-negotiables:
+
+- Pick the mechanism by failure shape, stubs first: docblock-expressible semantics = stub; newer-Laravel-only behavior = `stubs/<version>/`; call-site or flow context = handler; whole-codebase per-model facts = `ModelMetadataRegistry`. Record probed dead ends in decisions.md.
+- Handlers decline with `null`, never a guessed type: a non-null answer permanently overrides Psalm's own inference and issues.
+- Method providers register per CLASS: gate on the method name first, order bails cheapest first, touch `$codebase` last. Taint handlers bail when `$source->taint_flow_graph` is absent.
+- Narrow only a receiver resolved to exactly one known class; unions and userland subclasses turn narrowing into false positives. Taint strips and sinks gate on the receiver, not the argument shape.
+- A facade `@method` pseudo-method answer pairs the return-type AND params providers on one `methodExists()` lookup, or Psalm fatals in `getMethodParams()`.
+- Static state carrying booted-app or per-run facts gets `reset()` registered in `Plugin::resetInvocationState()`; storage lookups that can fire pre-population sit in `catch (InvalidArgumentException|UnpopulatedClasslikeException)` treated as "not proven"; custom issues always pass the suppressed-issues list to `IssueBuffer::accepts()`.
+- After fixing one family member, sweep the siblings (Builder, Collection, relations; facade and static forms) by reusing the same resolver, not a copy.
+
+## Layout
+
+- `src/Plugin.php`: entry point (parse config, boot app, build migration schema, register handlers, register stubs).
+- `src/Handlers/<Feature>/`: Psalm hook handlers, one directory per feature area.
+- `src/Handlers/Eloquent/Metadata/`: `ModelMetadataRegistry`, the per-model metadata store; completeness-gating semantics are in code-patterns.md.
+- `src/Bootstrap/`: Laravel app boot. `ApplicationProvider::doGetApp()` holds the resolution logic.
+- `src/Stubs/` providers plus `stubs/` files. Layout and merging rules: contributing README.
+- `src/Cli/`: the `psalm-laravel` binary (init, add GitHub, diagnose, analyze). `<ignoreFiles>` skips analysis, not scanning: a dir listed in `<projectFiles>` under an ignored parent gets scanned but never analyzed and silently reports zero issues.
+- `src/Issues/`: custom issue classes, each paired with `docs/issues/<Name>.md` via `DOCUMENTATION_URL`.
+- `tests/Type/` phpt type tests, `tests/Unit/` PHPUnit, `tests/Application/` integration against a real app.
+
+## Tests: where a regression goes
+
+| Bug kind | Home |
+|---|---|
+| Wrong inferred type, stub or handler regression | `tests/Type/tests/*.phpt` |
+| Internal logic (config parsing, schema aggregation, registries) | `tests/Unit/` |
+| CLI command behavior and output | `tests/Unit/Cli/` |
+| Boot behavior, fresh-app integration, whole-project scans | `tests/Application/` |
+
+Prefer Type over Unit when both fit (suite overview: `tests/README.md`). A test asserting a `stubs/<version>/` override needs a `--SKIPIF--` section with `LaravelVersion::skipBelow()` (worked example in the contributing README).
+
+Regression phpts use minimal abstracted fixtures (house style), but reduce toward them FROM the reported shape while the test stays red: simplifying before the first honest failure can delete the trigger (a trait, a docblock, a magic `__get` is often load-bearing).
+
+- Taint and opt-in-rule phpts need an `--ARGS--` section (`--taint-analysis` or an alternate `tests/Type/psalm-*.xml` config), or they pass vacuously under plain defaults.
+- Unit tests gate version-dependent behavior on capability probes (`class_exists` + `markTestSkipped`), never version numbers; phpts use `--SKIPIF--`.
+- A deliberately accepted soundness gap gets a `*KnownLimitation.phpt` test pointing at the source caveat docblock.
+
+## Debugging
+
+- `/** @psalm-trace $var */` above a line dumps the inferred type of `$var` during analysis.
+- Runtime-debugging a handler: plant `var_dump()` and run `vendor/bin/psalm --threads=1 --no-cache` on a small fixture (forked workers swallow output).
+
+## Policies
+
+- Upstream first: when plugin work reveals a bug in vimeo/psalm, laravel/framework, or another dependency, say so and name the correct layer BEFORE attempting a plugin-level workaround.
+- Doc pairing: any change to `Plugin::registerHandlers()`, `Plugin::registerStubs()`, or the stub directory layout updates `docs/contributing/README.md` in the same PR.
+- Every new class in `src/Issues/` ships its `docs/issues/<Name>.md` page plus an entry in `docs/issues/index.md` in the same PR. Opt-in issues also document their `PluginConfig` flag in `docs/config.md`; severity defaults go through the experimental lifecycle (contributing README).
+- Taint source/sink/escape changes update the detection table in `docs/security.md` in the same PR.
+- Code style is delegated to tooling: `composer rector` + `composer cs`.
+  - When Rector strips a `@var` needed for type coverage, use `@psalm-var` (Rector ignores `@psalm-` prefixed annotations).
+  - Unit test method names are exempt from camelCase.
+- Comments state the non-obvious WHY that a reader cannot get from the code, keep them concise (written for senior engineers).
+- PR bodies and docs use short engineering bullets over prose.
+- "I do not understand why X is needed" from a reviewer or user is a request to investigate whether X is still needed, not to defend it.

--- a/bin/ci/check-phpt-conventions.sh
+++ b/bin/ci/check-phpt-conventions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Enforce PHPT authoring conventions for the type-test suite (tests/Type/tests).
-# See tests/Type/CLAUDE.local.md for the rationale.
+# See the Conventions section of tests/Type/README.md for the rationale.
 #
 # Rules:
 #   1. Use the `--EXPECTF--` section, never `--EXPECT--`. EXPECTF supports the

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -67,7 +67,7 @@ composer test:app      # creates a fresh Laravel project, scaffolds common class
 LARAVEL_INSTALLER_VERSION=12.12.2 composer test:app # run over a specific Laravel version
 
 # single test file
-./vendor/bin/phpunit tests/Unit/Handlers/Auth/AuthHandlerTest.php
+./vendor/bin/phpunit tests/Unit/PluginConfigTest.php
 ./vendor/bin/phpunit --filter=AuthTest tests/Type/
 ```
 

--- a/docs/contributing/code-patterns.md
+++ b/docs/contributing/code-patterns.md
@@ -1,0 +1,55 @@
+---
+title: Code Patterns
+parent: Contributing
+nav_order: 7
+---
+
+# Code patterns
+
+Recurring practices mined from this codebase (handlers, stubs, tests) in 2026-07, each with the evidence that makes it a practice rather than an anecdote. Evidence cites files and symbols, not line numbers, so grep for the named method when a reference feels stale. Read this before writing a handler, stub, or test. The rationale behind many of these lives in [Architecture Decisions](decisions.md).
+
+## Choosing the mechanism
+
+Pick by failure shape, not by escalation. Stubs are the default: prefer one wherever a docblock can express the semantics, since a stub carries zero lifecycle surface (see the principle in decisions.md):
+
+| Failure shape | Mechanism |
+|---|---|
+| Static semantics, expressible in a docblock | stub in `stubs/common/` |
+| Behavior valid only on newer Laravel | stub in `stubs/<version>/` (widening `common` is a silent false negative on the older floor, see the `SortDirection` note in `stubs/13.8.0/Database/Query/Builder.phpstub`) |
+| Needs call-site context, argument flow, or config | handler |
+| Whole-codebase per-model facts (schema, casts, relations) | `ModelMetadataRegistry` via `AfterCodebasePopulated` |
+
+When every stub shape you can write is blocked by an upstream Psalm limitation, stop and record the probed alternatives plus the chosen trade-off in `decisions.md`, and pin a regression test to that decision. Without the record, later contributors re-probe the same dead ends or "fix" a working workaround.
+
+## Handlers
+
+- **Decline with `null`; never emit a guessed type.** A non-null answer permanently overrides Psalm's own inference and its own issues; declining is the only way a typo still reaches `UndefinedMagicMethod` and a stub still wins. (`CacheManagerReturnTypeHandler::getMethodReturnType()`; 35 declines in `ValidatedTypeHandler` alone.)
+- **Gate a per-class method provider on the method name before anything else.** Registration is per class, so Psalm offers the provider every method on that receiver; un-gated providers rewrite unrelated methods (the #1075 `ContainerHandler` regression).
+- **Order per-expression bails cheapest first**: AST `instanceof`, then `Identifier` name, then a `strtolower` compare against a const map, and only then any `$codebase` lookup. Taint handlers additionally bail when `$source->taint_flow_graph` is absent so non-taint runs pay nothing. (`OctaneIncompatibleBindingHandler`, `ImplicitQueryBuilderCallHandler`.)
+- **Resolve the receiver to exactly one known class or bail.** Union receivers, mixed atomics, and userland subclasses turn a helpful narrowing into a false positive on correct code, the plugin's dominant failure mode. Taint strips and sinks gate on the actual receiver, never just the argument shape (#1306). (`ImplicitQueryBuilderCallHandler`, `WhereColumnTaintHandler`.)
+- **Answering for a facade `@method` pseudo-method requires implementing BOTH the return-type and params providers, gated on the same `methodExists()` lookup** (`with_pseudo: false` discriminates real from pseudo). A return without params drives Psalm into `getMethodParams()` and fatals. (`CacheManagerReturnTypeHandler` and the other dual-interface handlers.)
+- **Static state that carries booted-app or per-run facts gets `public static function reset(): void`, registered in `Plugin::resetInvocationState()`**, which runs before boot on every invocation. The plugin can be re-invoked in one process (language server, tests); without the reset a previous app's aliases and config leak into the next run. Process-invariant caches need no reset, and per-file scratch state may instead clear inside its own hook. (39 `reset()` definitions repo-wide.)
+- **Storage lookups that can fire before a class is scanned or populated (`classlike_storage_provider->get()`, `classExtends()`, `getDeclaringMethodId()`) sit in `catch (\InvalidArgumentException|UnpopulatedClasslikeException)`** with the failure treated as "not proven". Storage can be missing or unpopulated depending on scan order, and an uncaught throw aborts the whole Psalm run; a lookup guaranteed to run post-population may skip the catch. (38 files catch the first, 10 also the second.)
+- **Register facade receivers three ways**: the service class, the hardcoded canonical facade, and `FacadeMapProvider::getFacadeClasses()` for the app's configured root aliases. Psalm dispatches providers by exact FQCN, and apps that trim `Facade::defaultAliases()` would otherwise lose the handler. (`CacheManagerReturnTypeHandler::getClassLikeNames()`; 8 handlers.)
+- **Every `IssueBuffer::accepts()` passes the suppressed-issues list** (`$source->getSuppressedIssues()` in statement hooks, `$storage->suppressed_issues` in class-visit hooks), or the custom issue is unsuppressable by `@psalm-suppress`. (13 of 13 call sites.)
+- **Gate definitive negative judgments on `ModelMetadata::isComplete(SECTION_*)`.** Emitting an issue ("this attribute does not exist") requires the relevant section to be complete; positive enrichment may consume partial metadata. A set section bit is authoritative even when the section is empty, and issue-emitting consumers additionally bail on an empty schema map because dynamic migrations can hide columns. (`UnknownModelAttributeHandler` gates; `BuilderScopeHandler` reads partial data.)
+- **Precompute lookup tables as `array<lowercase-string, true>` class constants and memoize per-class results in a `reset()`-cleared static.** Hooks fire once per expression across the project. Mark pure helpers `@psalm-pure` / `@psalm-external-mutation-free` or raw CI psalm fails on `MissingPureAnnotation`. (`TimingUnsafeComparisonHandler`.)
+- **The class docblock answers "why is this a handler and not a stub"**, cites the issue number, and cross-references hand-duplicated twin code with a "keep in sync" note. It is the most-repeated review question. (45 handler files cite an issue.)
+
+## Stubs
+
+- **Declare deliberately weak types rather than inventing precision.** `Query\Builder` leaves `min()`/`max()` unstubbed (reflected `mixed`) and `Relation.phpstub` mirrors that with an explicit `@return mixed` so `BuilderAggregateHandler` can narrow known columns later; the carbon stubs leave methods entirely undeclared so reflection of the real class fills them. A confident-but-wrong docblock is worse than `mixed`.
+- **Fluent accumulators get fresh template parameters plus `@psalm-this-out`**, not the class's own invariant templates: `collect()->push($x)` starts at `Collection<never, never>` and must widen per call. (`Collection.phpstub` `merge`/`push`/`put`.)
+- **Before generalizing a template return, instrument a dump of what Psalm's Populator actually stores** (`template_extended_params` on a real fixture) instead of assuming the ancestry shape; plausible-looking code silently no-ops on the wrong storage keys. (Verified pattern in the #1287/#1295 fix chain.)
+- **After fixing one member of a family, sweep the siblings by reusing the same resolver method**, never by duplicating logic: the #1287 Builder gap repeated in Collections (#1295) and relations (#1294), each fixed by pointing at the shared resolver.
+
+## Tests
+
+- **A phpt exercising taint or an opt-in rule needs an `--ARGS--` section before `--FILE--`** (`--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis`, or one of the alternate configs `psalm-with-optin-custom-issues.xml`, `psalm-experimental-issues.xml`, `psalm-sealed.xml`, `psalm-no-dynamic-where.xml`). Without it the test runs under plain defaults and a "Safe*" negative test passes vacuously.
+- **Write one comprehensive "must stay silent" phpt per rule** enumerating every syntax shape that should defer, each line commented with the reason. A regression then names the exact shape that broke. (`tests/Type/tests/Relation/UndefinedModelRelationNoFalsePositivesTest.phpt`.)
+- **Name taint tests by outcome** (`Safe*`, `Tainted*`) and suffix a deliberately accepted soundness gap with `KnownLimitation`, its docblock pointing at the source class's caveats section. Distinguishes reviewed trade-offs from untested holes. (`tests/Type/tests/TaintAnalysis/SafeInlineValidateReassignmentKnownLimitation.phpt`.)
+- **Unit tests gate version-dependent behavior on a capability probe** (`class_exists(...)` or a behavioral check, then `markTestSkipped()`), never a hardcoded version number; phpt files use `--SKIPIF--` with `LaravelVersion` instead. (13+ gates in `ModelMetadataRegistryTest` alone.)
+- **Anything unobservable in-process (issue emission, STDERR writes, whole-project rules) forks a real `vendor/bin/psalm` via Symfony Process** against a self-contained fixture: `run()` not `mustRun()` (Psalm exits non-zero on findings), `--output-format=json --threads=1 --no-cache`, and the fixture ships a private-namespace `spl_autoload_register`, never the package's own autoloader. Embed the captured output in assertion failure messages so CI logs are self-sufficient. (`UnknownModelAttributeEmissionTest`, `tests/Unit/Handlers/Fixtures/*/autoload.php`.)
+- **Reset handler statics via `ReflectionProperty` in `setUp()` / `tearDown()`, all interdependent statics together**, or tests become order-dependent flakes. (`CustomBuilderDetectionTest`.)
+- **Pair every positive branch assertion with a negative one proving the other branch's output is absent**; a regressed detector can satisfy a lone "contains" via its fallback path. (`InitCommandTest`.)
+- **Coverage is organized by testing layer, not by mirroring `src/`**: pure type-inference handlers (Cache, Collections, Config, ...) have no `tests/Unit/Handlers/<Dir>` and are covered by feature-named phpt files instead; PHPUnit dirs exist only for handlers with stateful internal logic.

--- a/docs/contributing/type-coverage.md
+++ b/docs/contributing/type-coverage.md
@@ -1,0 +1,71 @@
+---
+title: Type Coverage
+parent: Contributing
+nav_order: 6
+---
+
+# Keeping self-analysis at 100% type coverage
+
+Plugin self-analysis must report `Psalm was able to infer types for 100% of the codebase`. Verify with:
+
+```bash
+composer psalm -- --no-progress --no-suggestions --stats 2>&1 | grep -E "mixed\)" | grep -vE '\b0 mixed'
+```
+
+Empty output means 100%. Any printed line names a file with mixed expressions. An empty result also appears when psalm itself failed, so confirm the run succeeded before trusting it.
+
+Psalm's coverage counter fires on mixed expressions, mostly assignments to locals. Closure and function parameters do not count. The patterns below remove the counter honestly, without suppressing anything.
+
+## 1. Inline mixed-returning calls
+
+Do not bind a mixed value to a local variable when it is consumed once:
+
+```php
+// BAD: counts as 1 mixed (assignment)
+$value = $repo->get($key);
+return Reflector::reflect($value);
+
+// GOOD: no local, no counter
+return Reflector::reflect($repo->get($key));
+```
+
+## 2. Iterate mixed values via `array_map`, not `foreach`
+
+A `foreach` over `array<array-key, mixed>` produces a mixed assignment per element variable. A closure parameter typed `mixed` does not count:
+
+```php
+// BAD: $sub_value foreach assignment counts as mixed
+foreach ($value as $key => $sub_value) {
+    $properties[$key] = self::reflectInternal($sub_value, ...);
+}
+
+// GOOD: closure parameter, no counter
+$properties = array_map(
+    static function (mixed $sub_value) use ($depth, &$budget): Union {
+        return self::reflectInternal($sub_value, $depth + 1, $budget);
+    },
+    $value,
+);
+```
+
+Gotcha: arrow functions (`static fn(mixed $x) => ...`) capture `use` variables by value only.
+If by-reference state matters (for example a `&$budget` counter threaded through recursion), keep the long form `function () use (&$budget)`.
+Switching to `fn()` silently breaks mutation propagation across iterations. Cover the budget or limit path with a unit test.
+
+## 3. `@psalm-var mixed` does not help coverage
+
+It suppresses the `MixedAssignment` issue, but the variable stays typed mixed, so the coverage counter still fires.
+Use it only when restructuring is impossible, and take the coverage hit deliberately.
+
+## 4. `@psalm-suppress MixedAssignment` is banned
+
+Restructure the code instead. Plugin self-analysis has no baseline file, and none may be introduced (the only baseline in the repo is the Application-fixture snapshot).
+
+## Trade-off: try/catch boundaries
+
+Storing a `try`-captured value in a local for use after the catch always produces a mixed assignment when the value is mixed. Two options:
+
+1. Restructure so the mixed value is consumed inline inside the `try`. Preferred when the inner call is pure and will not throw. Document that purity in a comment.
+2. Add an `@psalm-var` when restructuring would obscure intent (see pattern 3).
+
+`src/Handlers/Config/ConfigKeyResolver.php::warm()` is the worked example: `ConfigValueReflector::reflect()` is pure, so wrapping it under the same `Throwable` catch as `Repository::has()` and `get()` is acceptable and removes the mixed local.

--- a/src/Handlers/Collections/CollectionFilterHandler.php
+++ b/src/Handlers/Collections/CollectionFilterHandler.php
@@ -376,8 +376,8 @@ final class CollectionFilterHandler implements MethodReturnTypeProviderInterface
      * (Psalm's SimpleNameResolver stores it as a string via `.toString()`) and falls
      * back to the source spelling.
      *
-     * `@psalm-var` (not `@var`) so Rector preserves it (CLAUDE.md). Declaring the local
-     * as `string|null` rather than letting it default to mixed avoids the coverage hit
+     * `@psalm-var` (not `@var`) so Rector preserves it (Rector ignores `@psalm-` prefixed annotations).
+     * Declaring the local as `string|null` rather than letting it default to mixed avoids the coverage hit
      * that a bare `mixed` assignment would cause.
      */
     private static function resolveClassName(Name $name): string

--- a/stubs/common/Database/Eloquent/HigherOrderBuilderProxy.phpstub
+++ b/stubs/common/Database/Eloquent/HigherOrderBuilderProxy.phpstub
@@ -17,7 +17,7 @@ namespace Illuminate\Database\Eloquent;
  * (`__call`'s return), so when the receiver is `Builder<Model&static>` on a non-final
  * model, the inferred `Builder<Model&static>` must satisfy a call-site `Builder<self>` —
  * covariance accepts it, invariance would reject. Mirrors Builder's own variance and the
- * relation-stub rule in CLAUDE.md.
+ * covariance rationale in Relations/Relation.phpstub.
  *
  * Do NOT drop the `@template` and type the property as `@property-read static`/`$this`
  * (Larastan's form): Psalm 7 collapses both to `Builder&static` in a property-read and

--- a/stubs/integrations/carbon/pre-3.12/CarbonInterface.phpstub
+++ b/stubs/integrations/carbon/pre-3.12/CarbonInterface.phpstub
@@ -19,7 +19,7 @@ use JsonSerializable;
  * down to trait method definitions, so the conditional return must be repeated
  * at both layers.
  *
- * Class redeclaration wipes `class_implements` / `parent_interfaces` (CLAUDE.md),
+ * Class redeclaration wipes `class_implements` / `parent_interfaces` (see "Stub merging" in docs/contributing/README.md),
  * so the full `extends` clause is copied verbatim from
  * vendor/nesbot/carbon/src/Carbon/CarbonInterface.php:858. Methods not
  * redeclared here continue to come from reflection of the real interface.

--- a/stubs/integrations/carbon/shared/CarbonPeriod.phpstub
+++ b/stubs/integrations/carbon/shared/CarbonPeriod.phpstub
@@ -30,7 +30,7 @@ use JsonSerializable;
  * and silently rejects the template binding with `InvalidDocblock` if the
  * interface is not already listed.
  *
- * Class declaration redeclaration wipes `class_implements` (CLAUDE.md), so
+ * Class redeclaration wipes `class_implements` (see "Stub merging" in docs/contributing/README.md), so
  * the `extends` / `implements` / `use` clauses are copied verbatim from
  * Carbon source. Methods not redeclared here continue to come from
  * reflection of the real class.

--- a/tests/Type/README.md
+++ b/tests/Type/README.md
@@ -10,6 +10,10 @@ To go deeper with PHPT syntax, please check [PHPT](https://qa.php.net/phpt_detai
 
 - When asserting error output, use `--EXPECTF--` (not `--EXPECT--`) with `%d` for line numbers (e.g., `ErrorType on line %d: message`).
   This prevents tests from breaking when lines shift due to unrelated edits.
+- A test that needs taint analysis or a non-default config declares an `--ARGS--` section before `--FILE--`,
+  e.g. `--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis`, or one of the alternate
+  `tests/Type/psalm-*.xml` configs. Without it the test runs under plain defaults, where a negative
+  (empty-`--EXPECTF--`) taint or opt-in-rule test passes vacuously.
 
 ### `--EXPECTF--` format specifiers
 

--- a/tests/Unit/DocumentationPathsTest.php
+++ b/tests/Unit/DocumentationPathsTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Agent-facing docs route by file path; a dangling path silently sends every
+ * future session exploring from scratch. This lint keeps the routing honest.
+ */
+#[CoversNothing]
+final class DocumentationPathsTest extends TestCase
+{
+    private const DOCS = [
+        'CLAUDE.md',
+        'docs/contributing/code-patterns.md',
+        'docs/contributing/type-coverage.md',
+    ];
+
+    #[Test]
+    public function every_backtick_path_reference_exists(): void
+    {
+        $root = \dirname(__DIR__, 2);
+        $checked = 0;
+
+        foreach (self::DOCS as $doc) {
+            $content = \file_get_contents($root . '/' . $doc);
+            $this->assertIsString($content, "unreadable: {$doc}");
+
+            // Match path-shaped substrings directly instead of pairing backticks: code
+            // fences (```) contain an odd backtick run that scrambles pair alignment and
+            // silently drops tokens, and fence bodies carry real paths worth checking.
+            \preg_match_all('~(?<![A-Za-z0-9_-])(?:src|docs|tests|stubs|bin|vendor|\.github)/[A-Za-z0-9_\-./*<>]*~', $content, $matches);
+
+            foreach ($matches[0] as $token) {
+                $path = $this->normalize($token);
+                if ($path === null) {
+                    continue;
+                }
+
+                ++$checked;
+                $this->assertFileExists("{$root}/{$path}", "{$doc} references `{$token}` but {$path} does not exist");
+            }
+        }
+
+        // A regex or doc-shape drift that stops matching paths would otherwise pass vacuously.
+        $this->assertGreaterThan(15, $checked, "extractor matched only {$checked} paths; the doc shape or regex drifted");
+    }
+
+    /**
+     * Reduce a matched token to a checkable repo-relative path, or null for
+     * placeholders (`stubs/<version>/`) and globs (`tests/Type/psalm-*.xml`).
+     */
+    private function normalize(string $token): ?string
+    {
+        if (\preg_match('/[<>*]/', $token) === 1) {
+            return null;
+        }
+
+        // Trailing sentence punctuation and dir slashes are not part of the path.
+        $path = \rtrim($token, './');
+
+        return $path === '' ? null : $path;
+    }
+}


### PR DESCRIPTION
## Issue to Solve

New contributors and AI coding agents re-derive the same repository knowledge every session (architecture, stub rules, test conventions), and that knowledge rots silently: this branch alone found a dead example test path copied across two docs, four committed files citing agent instruction files instead of stating facts, and an undocumented `--ARGS--` phpt convention used by 351 tests.

## Related

Follows the enforcement approach of #1319.

## Solution Description

- `CLAUDE.md`: instruction file for AI coding agents. Routes to existing docs instead of duplicating them; inlines only non-derivable facts (command forms, CI gotchas, hard rules with pointers to full rationale).
- `docs/contributing/code-patterns.md`: practice catalog mined from the codebase (handler lifecycle, stub authoring, test idioms), evidence cited by file and symbol.
- `docs/contributing/type-coverage.md`: the restructuring patterns that keep self-analysis at 100% type inference.
- `tests/Unit/DocumentationPathsTest.php`: lints every path reference in the new docs against the filesystem, so routing cannot dangle. Verified red on a planted fake path before landing.
- Fixes: stale `AuthHandlerTest` example path in two docs, `--ARGS--` section documented in `tests/Type/README.md`, `check-phpt-conventions.sh` comment repointed at the public README, and four docblocks now state facts directly instead of citing instruction files.

Verification: `tests/Unit/DocumentationPathsTest.php` + `tests/Unit/IssueDocumentationTest.php` green (109 assertions); `composer cs` and rector clean; psalm self-analysis output identical to master.

## Checklist
- [x] Tests cover the change (`tests/Unit/DocumentationPathsTest.php`)
- [x] Documentation is updated

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787597951&installation_model_id=424990&pr_number=1320&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1320&signature=fe4f4184efe255751830bec9dbb865fcdb01facf9463b469bf64a83f3639b121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->