### PR TITLE
Detect undefined relations in model eager-load defaults (`$with`, `$withCount`)

### DIFF
--- a/docs/issues/UndefinedModelRelation.md
+++ b/docs/issues/UndefinedModelRelation.md
@@ -6,11 +6,21 @@ nav_order: 11
 
 # UndefinedModelRelation
 
-A relation name passed to an eager-loading or relationship-query method does not resolve to a method on the model. See [Reporting level](#reporting-level).
+A relation name passed to an eager-loading or relationship-query method, or configured in a model's `$with` / `$withCount` defaults, does not resolve to a method on the model. See [Reporting level](#reporting-level).
 
 ## Why it matters
 
 Passing a non-existent relation name is one of the most common sources of runtime errors in Laravel apps. A typo such as `User::with('pots')` (for `posts`) is silently accepted by Psalm, then throws `RelationNotFoundException` at runtime. This rule reports it during analysis.
+
+The same typo in a model default is evaluated when Laravel builds or hydrates a query:
+
+```php
+final class Post extends Model
+{
+    protected $with = ['authr'];
+    protected $withCount = ['coments'];
+}
+```
 
 ## What is checked
 
@@ -21,6 +31,8 @@ The relation name in the first argument of these methods is validated against th
 * Lazy eager loading: `load()`, `loadMissing()`, `loadCount()`, `loadSum()`, `loadAvg()`, `loadMax()`, `loadMin()`, `loadExists()`.
 
 The model is resolved from the receiver: a `Builder<TModel>` or `Relation<TModel, ...>` generic parameter, a `Model` instance, or the class of a static call (`User::with(...)`).
+
+Effective string entries from concrete, user-owned models' `$with` and `$withCount` defaults are also checked. `$with` supports dot notation and `:columns`; `$withCount` accepts a direct relation name and a case-insensitive ` as alias` suffix. Keyed configuration maps are not checked.
 
 Supported name syntaxes:
 
@@ -60,7 +72,7 @@ To keep false positives near zero, the rule reports only when no method (real or
 * Relations registered at runtime via `Model::resolveRelationUsing()` or package macros, which static analysis cannot see.
 * Deeper dot-notation segments after a polymorphic `morphTo`, whose related model is not statically known.
 
-The `withCount()` / `withSum()` aggregate family is not covered by this first pass.
+Keyed `$with` / `$withCount` configuration maps are not checked.
 
 ## Reporting level
 

--- a/docs/issues/UndefinedModelRelation.md
+++ b/docs/issues/UndefinedModelRelation.md
@@ -18,7 +18,7 @@ The same typo in a model default is evaluated when Laravel builds or hydrates a 
 final class Post extends Model
 {
     protected $with = ['authr'];
-    protected $withCount = ['coments'];
+    protected $withCount = ['nmae'];
 }
 ```
 

--- a/src/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php
+++ b/src/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php
@@ -1662,8 +1662,14 @@ final class ModelMetadataRegistryBuilder
             return [];
         }
 
-        if (!\is_array($value) || !\array_is_list($value)) {
+        if (!\is_array($value)) {
             return [];
+        }
+
+        foreach (\array_keys($value) as $key) {
+            if (\is_string($key)) {
+                return [];
+            }
         }
 
         return self::filterStringList($value);

--- a/src/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php
+++ b/src/Handlers/Eloquent/Metadata/ModelMetadataRegistryBuilder.php
@@ -1647,6 +1647,10 @@ final class ModelMetadataRegistryBuilder
      * shadowed it). Any other throwable is handled by the runtime-configuration section,
      * which reports the failure and leaves that section incomplete.
      *
+     * Keyed eager-load maps carry callbacks or nested constraints rather than a relation-name list.
+     * They are deliberately excluded: ModelMetadata stores only values, so retaining them would lose the
+     * relation key and make a later consumer validate the wrong string.
+     *
      * @return list<string>
      */
     private static function readStringList(Model $instance, string $propertyName): array
@@ -1658,7 +1662,7 @@ final class ModelMetadataRegistryBuilder
             return [];
         }
 
-        if (!\is_array($value)) {
+        if (!\is_array($value) || !\array_is_list($value)) {
             return [];
         }
 

--- a/src/Handlers/Rules/UndefinedModelRelationHandler.php
+++ b/src/Handlers/Rules/UndefinedModelRelationHandler.php
@@ -27,6 +27,7 @@ use Psalm\Plugin\EventHandler\Event\AfterCodebasePopulatedEvent;
 use Psalm\Plugin\EventHandler\Event\AfterExpressionAnalysisEvent;
 use Psalm\StatementsSource;
 use Psalm\Storage\ClassLikeStorage;
+use Psalm\Storage\PropertyStorage;
 use Psalm\Type\Atomic;
 use Psalm\Type\Atomic\TGenericObject;
 use Psalm\Type\Atomic\TKeyedArray;
@@ -164,9 +165,15 @@ final class UndefinedModelRelationHandler implements AfterCodebasePopulatedInter
             }
 
             foreach (['with' => $metadata->with, 'withCount' => $metadata->withCount] as $property => $relations) {
-                $location = self::defaultRelationLocation($storage, $modelFqcn, $property);
+                $propertyStorage = self::ownDefaultProperty($storage, $modelFqcn, $property);
+                $location = $propertyStorage?->location ?? $storage->location;
                 if (!$location instanceof CodeLocation) {
                     continue;
+                }
+
+                $suppressedIssues = $storage->suppressed_issues;
+                if ($propertyStorage instanceof \Psalm\Storage\PropertyStorage) {
+                    $suppressedIssues = [...$suppressedIssues, ...$propertyStorage->suppressed_issues];
                 }
 
                 foreach ($relations as $relation) {
@@ -175,7 +182,7 @@ final class UndefinedModelRelationHandler implements AfterCodebasePopulatedInter
                         $modelFqcn,
                         $relation,
                         $location,
-                        $storage->suppressed_issues,
+                        $suppressedIssues,
                         allowsAlias: $property === 'withCount',
                         allowsPaths: $property === 'with',
                         allowsColumns: $property === 'with',
@@ -499,7 +506,10 @@ final class UndefinedModelRelationHandler implements AfterCodebasePopulatedInter
             // relation maps to a PHP method, which never contains a space, so this can
             // only ever remove alias syntax, never mask a typo.
             if ($allowsAlias) {
-                $name = \preg_replace('/\s+as\s+.+$/i', '', $name) ?? $name;
+                $aliasParts = \explode(' ', $name);
+                if (\count($aliasParts) === 3 && \strtolower($aliasParts[1]) === 'as') {
+                    $name = $aliasParts[0];
+                }
             }
 
             if ($name === '') {
@@ -540,12 +550,12 @@ final class UndefinedModelRelationHandler implements AfterCodebasePopulatedInter
     }
 
     /**
-     * Use the property's own location only when the concrete model declares it. A parent or trait
-     * default is evaluated in the child context, so its diagnostic belongs on that affected child.
+     * A parent or trait default is evaluated in the child context, so only a property declared by the
+     * concrete model supplies a property-local location or suppression; inherited defaults stay on the child.
      *
      * @psalm-mutation-free
      */
-    private static function defaultRelationLocation(ClassLikeStorage $storage, string $modelFqcn, string $property): ?CodeLocation
+    private static function ownDefaultProperty(ClassLikeStorage $storage, string $modelFqcn, string $property): ?PropertyStorage
     {
         $declaringClass = $storage->declaring_property_ids[$property] ?? null;
         $propertyStorage = $storage->properties[$property] ?? null;
@@ -556,9 +566,9 @@ final class UndefinedModelRelationHandler implements AfterCodebasePopulatedInter
             && $propertyStorage !== null
             && $propertyStorage->location instanceof CodeLocation
         ) {
-            return $propertyStorage->location;
+            return $propertyStorage;
         }
 
-        return $storage->location;
+        return null;
     }
 }

--- a/src/Handlers/Rules/UndefinedModelRelationHandler.php
+++ b/src/Handlers/Rules/UndefinedModelRelationHandler.php
@@ -16,12 +16,17 @@ use Psalm\Codebase;
 use Psalm\CodeLocation;
 use Psalm\Exception\UnpopulatedClasslikeException;
 use Psalm\IssueBuffer;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadata;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadataRegistry;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Support\ModelPropertyResolver;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Support\RelationResolver;
 use Psalm\LaravelPlugin\Issues\UndefinedModelRelation;
+use Psalm\Plugin\EventHandler\AfterCodebasePopulatedInterface;
 use Psalm\Plugin\EventHandler\AfterExpressionAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterCodebasePopulatedEvent;
 use Psalm\Plugin\EventHandler\Event\AfterExpressionAnalysisEvent;
 use Psalm\StatementsSource;
+use Psalm\Storage\ClassLikeStorage;
 use Psalm\Type\Atomic;
 use Psalm\Type\Atomic\TGenericObject;
 use Psalm\Type\Atomic\TKeyedArray;
@@ -74,7 +79,7 @@ use Psalm\Type\Union;
  * @see https://github.com/psalm/psalm-plugin-laravel/issues/643
  * @see https://github.com/larastan/larastan RelationExistenceRule — Larastan's analogue
  */
-final class UndefinedModelRelationHandler implements AfterExpressionAnalysisInterface
+final class UndefinedModelRelationHandler implements AfterCodebasePopulatedInterface, AfterExpressionAnalysisInterface
 {
     /**
      * Methods whose relation name(s) come from the FIRST argument. That is the
@@ -133,6 +138,54 @@ final class UndefinedModelRelationHandler implements AfterExpressionAnalysisInte
         'loadexists' => true,
     ];
 
+    /**
+     * Validate effective `$with` / `$withCount` defaults after ModelRegistrationHandler has warmed
+     * ModelMetadataRegistry. Metadata is intentionally read from the concrete model: a child can
+     * supply a relation that makes an inherited default valid, while a sibling cannot.
+     */
+    #[\Override]
+    public static function afterCodebasePopulated(AfterCodebasePopulatedEvent $event): void
+    {
+        $codebase = $event->getCodebase();
+        $provider = $codebase->classlike_storage_provider;
+
+        foreach (ModelMetadataRegistry::all() as $modelFqcn => $metadata) {
+            if (
+                ($metadata->with === [] && $metadata->withCount === [])
+                || !$metadata->isComplete(ModelMetadata::SECTION_RUNTIME_CONFIGURATION)
+                || !$provider->has($modelFqcn)
+            ) {
+                continue;
+            }
+
+            $storage = $provider->get($modelFqcn);
+            if (!$storage->user_defined || $storage->abstract) {
+                continue;
+            }
+
+            foreach (['with' => $metadata->with, 'withCount' => $metadata->withCount] as $property => $relations) {
+                $location = self::defaultRelationLocation($storage, $modelFqcn, $property);
+                if (!$location instanceof CodeLocation) {
+                    continue;
+                }
+
+                foreach ($relations as $relation) {
+                    self::validateRelationPath(
+                        $codebase,
+                        $modelFqcn,
+                        $relation,
+                        $location,
+                        $storage->suppressed_issues,
+                        allowsAlias: $property === 'withCount',
+                        allowsPaths: $property === 'with',
+                        allowsColumns: $property === 'with',
+                        property: $property,
+                    );
+                }
+            }
+        }
+    }
+
     /** @inheritDoc */
     #[\Override]
     public static function afterExpressionAnalysis(AfterExpressionAnalysisEvent $event): ?bool
@@ -175,7 +228,16 @@ final class UndefinedModelRelationHandler implements AfterExpressionAnalysisInte
         $allowsAlias = isset(self::AGGREGATE_METHODS[$methodNameLc]);
 
         foreach (self::extractRelationNames($source, $args[0]) as $relationName) {
-            self::validateRelationPath($codebase, $source, $modelFqcn, $relationName, $args[0], $allowsAlias);
+            self::validateRelationPath(
+                $codebase,
+                $modelFqcn,
+                $relationName,
+                new CodeLocation($source, $args[0]->value),
+                $source->getSuppressedIssues(),
+                allowsAlias: $allowsAlias,
+                allowsPaths: true,
+                allowsColumns: true,
+            );
         }
 
         return null;
@@ -409,29 +471,35 @@ final class UndefinedModelRelationHandler implements AfterExpressionAnalysisInte
      * @param bool $allowsAlias whether the calling method accepts a `relation as alias`
      *                          clause (the aggregate `load*` family) that must be
      *                          stripped before the relation lookup
+     * @param bool $allowsPaths whether dot notation is meaningful for this declaration surface
+     * @param bool $allowsColumns whether eager-load `:columns` syntax is meaningful
+     * @param array<array-key, string> $suppressedIssues
      */
     private static function validateRelationPath(
         Codebase $codebase,
-        StatementsSource $source,
         string $modelFqcn,
         string $relationName,
-        Arg $arg,
+        CodeLocation $location,
+        array $suppressedIssues,
         bool $allowsAlias,
+        bool $allowsPaths,
+        bool $allowsColumns,
+        ?string $property = null,
     ): void {
-        $segments = \explode('.', $relationName);
+        $segments = $allowsPaths ? \explode('.', $relationName) : [$relationName];
         $lastIndex = \count($segments) - 1;
         $current = $modelFqcn;
 
         foreach ($segments as $index => $segment) {
             // Strip the `:col1,col2` select syntax (with()/load() eager-load columns).
-            $name = \trim(\explode(':', $segment, 2)[0]);
+            $name = \trim($allowsColumns ? \explode(':', $segment, 2)[0] : $segment);
 
             // Strip the ` as <alias>` aggregate clause (loadCount/loadSum/...): the
             // alias names the sub-select column, not part of the relation name. A real
             // relation maps to a PHP method, which never contains a space, so this can
             // only ever remove alias syntax, never mask a typo.
             if ($allowsAlias) {
-                $name = \explode(' ', $name, 2)[0];
+                $name = \preg_replace('/\s+as\s+.+$/i', '', $name) ?? $name;
             }
 
             if ($name === '') {
@@ -439,12 +507,13 @@ final class UndefinedModelRelationHandler implements AfterExpressionAnalysisInte
             }
 
             if (!RelationResolver::relationMethodExists($codebase, $current, $name)) {
+                $context = $property === null ? '' : " from {$modelFqcn}::\${$property}";
                 IssueBuffer::accepts(
                     new UndefinedModelRelation(
-                        "Relation '{$name}' is not defined on {$current}.",
-                        new CodeLocation($source, $arg->value),
+                        "Relation '{$name}'{$context} is not defined on {$current}.",
+                        $location,
                     ),
-                    $source->getSuppressedIssues(),
+                    $suppressedIssues,
                 );
 
                 return;
@@ -468,5 +537,28 @@ final class UndefinedModelRelationHandler implements AfterExpressionAnalysisInte
                 return;
             }
         }
+    }
+
+    /**
+     * Use the property's own location only when the concrete model declares it. A parent or trait
+     * default is evaluated in the child context, so its diagnostic belongs on that affected child.
+     *
+     * @psalm-mutation-free
+     */
+    private static function defaultRelationLocation(ClassLikeStorage $storage, string $modelFqcn, string $property): ?CodeLocation
+    {
+        $declaringClass = $storage->declaring_property_ids[$property] ?? null;
+        $propertyStorage = $storage->properties[$property] ?? null;
+
+        if (
+            $declaringClass !== null
+            && \strtolower($declaringClass) === \strtolower($modelFqcn)
+            && $propertyStorage !== null
+            && $propertyStorage->location instanceof CodeLocation
+        ) {
+            return $propertyStorage->location;
+        }
+
+        return $storage->location;
     }
 }

--- a/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/app/Concerns/HasTraitRelation.php
+++ b/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/app/Concerns/HasTraitRelation.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RelationDefaultsFixture\Concerns;
+
+use RelationDefaultsFixture\Models\RelatedModel;
+
+trait HasTraitRelation
+{
+    public function traitRelation()
+    {
+        return $this->hasMany(RelatedModel::class);
+    }
+}

--- a/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/app/Models/AbstractDefaultsModel.php
+++ b/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/app/Models/AbstractDefaultsModel.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RelationDefaultsFixture\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+abstract class AbstractDefaultsModel extends Model
+{
+    protected $with = ['childRelation'];
+}

--- a/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/app/Models/BadDefaultsModel.php
+++ b/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/app/Models/BadDefaultsModel.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RelationDefaultsFixture\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+final class BadDefaultsModel extends Model
+{
+    protected $with = ['misspelledRelation'];
+
+    protected $withCount = ['misspelledCount'];
+}

--- a/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/app/Models/ChildWithInheritedRelation.php
+++ b/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/app/Models/ChildWithInheritedRelation.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RelationDefaultsFixture\Models;
+
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+final class ChildWithInheritedRelation extends AbstractDefaultsModel
+{
+    /** @return HasMany<RelatedModel, $this> */
+    public function childRelation(): HasMany
+    {
+        return $this->hasMany(RelatedModel::class);
+    }
+}

--- a/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/app/Models/KeyedDefaultsModel.php
+++ b/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/app/Models/KeyedDefaultsModel.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RelationDefaultsFixture\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+final class KeyedDefaultsModel extends Model
+{
+    /** @var array<string, string> */
+    protected $with = ['missingRelation' => 'ignored'];
+}

--- a/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/app/Models/MalformedAliasModel.php
+++ b/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/app/Models/MalformedAliasModel.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RelationDefaultsFixture\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+final class MalformedAliasModel extends Model
+{
+    protected $withCount = ['comments  AS  total'];
+
+    /** @return HasMany<RelatedModel, $this> */
+    public function comments(): HasMany
+    {
+        return $this->hasMany(RelatedModel::class);
+    }
+}

--- a/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/app/Models/NestedAndAliasModel.php
+++ b/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/app/Models/NestedAndAliasModel.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RelationDefaultsFixture\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+final class NestedAndAliasModel extends Model
+{
+    protected $with = ['related:nestedRelation', 'related.nestedRelation'];
+
+    protected $withCount = ['related AS related_total'];
+
+    /** @return HasMany<RelatedModel, $this> */
+    public function related(): HasMany
+    {
+        return $this->hasMany(RelatedModel::class);
+    }
+}

--- a/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/app/Models/NumericKeyedDefaultsModel.php
+++ b/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/app/Models/NumericKeyedDefaultsModel.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RelationDefaultsFixture\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+final class NumericKeyedDefaultsModel extends Model
+{
+    protected $with = [2 => 'numericMissing'];
+}

--- a/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/app/Models/PropertySuppressedDefaultsModel.php
+++ b/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/app/Models/PropertySuppressedDefaultsModel.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RelationDefaultsFixture\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+final class PropertySuppressedDefaultsModel extends Model
+{
+    /** @psalm-suppress UndefinedModelRelation Runtime relation registration. */
+    protected $with = ['suppressedMissing'];
+}

--- a/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/app/Models/RelatedModel.php
+++ b/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/app/Models/RelatedModel.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RelationDefaultsFixture\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+final class RelatedModel extends Model
+{
+    public function nestedRelation(): void {}
+}

--- a/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/app/Models/SiblingWithoutInheritedRelation.php
+++ b/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/app/Models/SiblingWithoutInheritedRelation.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RelationDefaultsFixture\Models;
+
+final class SiblingWithoutInheritedRelation extends AbstractDefaultsModel {}

--- a/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/app/Models/TraitAndPseudoModel.php
+++ b/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/app/Models/TraitAndPseudoModel.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RelationDefaultsFixture\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use RelationDefaultsFixture\Concerns\HasTraitRelation;
+
+/** @method static pseudoRelation() */
+final class TraitAndPseudoModel extends Model
+{
+    use HasTraitRelation;
+
+    protected $with = ['traitRelation', 'pseudoRelation'];
+}

--- a/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/app/Models/TraitRelationModel.php
+++ b/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/app/Models/TraitRelationModel.php
@@ -7,10 +7,9 @@ namespace RelationDefaultsFixture\Models;
 use Illuminate\Database\Eloquent\Model;
 use RelationDefaultsFixture\Concerns\HasTraitRelation;
 
-/** @method static pseudoRelation() */
-final class TraitAndPseudoModel extends Model
+final class TraitRelationModel extends Model
 {
     use HasTraitRelation;
 
-    protected $with = ['traitRelation', 'pseudoRelation'];
+    protected $with = ['traitRelation'];
 }

--- a/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/autoload.php
+++ b/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/autoload.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+\spl_autoload_register(static function (string $class): void {
+    $prefix = 'RelationDefaultsFixture\\';
+
+    if (!\str_starts_with($class, $prefix)) {
+        return;
+    }
+
+    $file = __DIR__ . '/app/' . \str_replace('\\', '/', \substr($class, \strlen($prefix))) . '.php';
+
+    if (\is_file($file)) {
+        require_once $file;
+    }
+});

--- a/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/psalm.xml
+++ b/tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/psalm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="1"
+    autoloader="autoload.php"
+    xmlns="https://getpsalm.org/schema/config"
+>
+    <projectFiles>
+        <directory name="app" />
+    </projectFiles>
+    <plugins>
+        <pluginClass class="Psalm\LaravelPlugin\Plugin">
+            <experimental value="true" />
+        </pluginClass>
+    </plugins>
+</psalm>

--- a/tests/Unit/Handlers/UndefinedModelRelationDefaultsEmissionTest.php
+++ b/tests/Unit/Handlers/UndefinedModelRelationDefaultsEmissionTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Handlers\Rules\UndefinedModelRelationHandler;
+use Symfony\Component\Process\Process;
+
+/**
+ * Metadata warm-up requires autoloadable models, so this exercises the full plugin lifecycle in a
+ * dedicated fixture project rather than a PHPT source file.
+ */
+#[CoversClass(UndefinedModelRelationHandler::class)]
+final class UndefinedModelRelationDefaultsEmissionTest extends TestCase
+{
+    #[Test]
+    public function it_reports_invalid_default_relations_and_accepts_inherited_and_trait_methods(): void
+    {
+        $findings = $this->runPsalmAndCollectFindings();
+        $messages = \array_column($findings, 'message');
+
+        $this->assertCount(3, $findings, \implode("\n", $messages));
+        $this->assertContains(
+            "Relation 'misspelledRelation' from " . \RelationDefaultsFixture\Models\BadDefaultsModel::class . '::$with is not defined on ' . \RelationDefaultsFixture\Models\BadDefaultsModel::class . '.',
+            $messages,
+        );
+        $this->assertContains(
+            "Relation 'misspelledCount' from " . \RelationDefaultsFixture\Models\BadDefaultsModel::class . '::$withCount is not defined on ' . \RelationDefaultsFixture\Models\BadDefaultsModel::class . '.',
+            $messages,
+        );
+        $this->assertContains(
+            "Relation 'childRelation' from " . \RelationDefaultsFixture\Models\SiblingWithoutInheritedRelation::class . '::$with is not defined on ' . \RelationDefaultsFixture\Models\SiblingWithoutInheritedRelation::class . '.',
+            $messages,
+        );
+    }
+
+    /** @return list<array{type: string, message: string}> */
+    private function runPsalmAndCollectFindings(): array
+    {
+        $projectRoot = \dirname(__DIR__, 3);
+        $fixtureDir = __DIR__ . '/Fixtures/UndefinedModelRelationDefaults';
+        $process = new Process(
+            [\PHP_BINARY, $projectRoot . '/vendor/bin/psalm', '-c', 'psalm.xml', '--no-cache', '--threads=1', '--no-progress', '--output-format=json'],
+            $fixtureDir,
+        );
+        $process->setTimeout(300);
+        $process->run();
+
+        $decoded = \json_decode($process->getOutput(), true);
+        $this->assertIsArray($decoded, $process->getErrorOutput());
+
+        $findings = [];
+        foreach ($decoded as $finding) {
+            if (\is_array($finding) && ($finding['type'] ?? null) === 'UndefinedModelRelation') {
+                $findings[] = ['type' => $finding['type'], 'message' => (string) $finding['message']];
+            }
+        }
+
+        return $findings;
+    }
+}

--- a/tests/Unit/Handlers/UndefinedModelRelationDefaultsEmissionTest.php
+++ b/tests/Unit/Handlers/UndefinedModelRelationDefaultsEmissionTest.php
@@ -23,7 +23,7 @@ final class UndefinedModelRelationDefaultsEmissionTest extends TestCase
         $findings = $this->runPsalmAndCollectFindings();
         $messages = \array_column($findings, 'message');
 
-        $this->assertCount(3, $findings, \implode("\n", $messages));
+        $this->assertCount(5, $findings, \implode("\n", $messages));
         $this->assertContains(
             "Relation 'misspelledRelation' from " . \RelationDefaultsFixture\Models\BadDefaultsModel::class . '::$with is not defined on ' . \RelationDefaultsFixture\Models\BadDefaultsModel::class . '.',
             $messages,
@@ -34,6 +34,14 @@ final class UndefinedModelRelationDefaultsEmissionTest extends TestCase
         );
         $this->assertContains(
             "Relation 'childRelation' from " . \RelationDefaultsFixture\Models\SiblingWithoutInheritedRelation::class . '::$with is not defined on ' . \RelationDefaultsFixture\Models\SiblingWithoutInheritedRelation::class . '.',
+            $messages,
+        );
+        $this->assertContains(
+            "Relation 'numericMissing' from " . \RelationDefaultsFixture\Models\NumericKeyedDefaultsModel::class . '::$with is not defined on ' . \RelationDefaultsFixture\Models\NumericKeyedDefaultsModel::class . '.',
+            $messages,
+        );
+        $this->assertContains(
+            "Relation 'comments  AS  total' from " . \RelationDefaultsFixture\Models\MalformedAliasModel::class . '::$withCount is not defined on ' . \RelationDefaultsFixture\Models\MalformedAliasModel::class . '.',
             $messages,
         );
     }


### PR DESCRIPTION
## Issue to Solve

`UndefinedModelRelation` validates relation names passed to eager-loading calls, but it did not inspect the effective `$with` and `$withCount` defaults declared by Eloquent models. Typos in those defaults therefore survived analysis and failed when Laravel built or hydrated a query.

The metadata registry already records both defaults, but its `relations()` map contains only methods parsed from the concrete class body and cannot safely prove absence for inherited or trait-hosted relations.

## Related

No linked issue.

## Solution Description

- Validate effective `$with` and `$withCount` metadata for complete, concrete, user-owned models after the codebase is populated.
- Reuse the inheritance-, trait-, and pseudo-method-aware relation resolver instead of treating the own-class relation map as authoritative.
- Support dotted `$with` paths, eager-load column selectors, and Laravel's `$withCount` alias grammar while deferring when an intermediate related model cannot be resolved.
- Emit the existing `UndefinedModelRelation` issue with property context, property-level suppressions, and concrete-child locations for inherited defaults.
- Preserve integer-keyed relation lists while deliberately excluding associative keyed maps whose relation names would otherwise be lost by metadata normalization.
- Document the new declaration surface and its conservative, open-world limits.

Accepted imprecision:

- Runtime relations registered through `resolveRelationUsing()` or macros remain outside static visibility.
- A same-named real or pseudo method is accepted without requiring proof that it returns `Relation`.
- Associative keyed configuration maps and unresolved nested intermediates are not reported.

Verification:

- Dedicated subprocess fixture: 1 test, 7 assertions, exactly five expected diagnostics
- Unit suite
- Type suite: 631 tests, 630 assertions, 1 skipped
- Uncached Psalm self-analysis
- Rector, code-style, and `git diff --check`

## Checklist

- [x] Tests cover the change (unit fixture exercising the full plugin lifecycle)
- [x] Documentation is updated

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787610144&installation_model_id=424990&pr_number=1321&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1321&signature=e33dce8ceb61f59e3db7b8f0d187346051634ec31e06c23b92a42aacc08e3bd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->