### PR TITLE
Narrow `UploadedFile::getClientOriginalExtension()` file taint

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -18,6 +18,10 @@ nav_order: 6
 | Crypto misuse   | A02:2021 | Tracks encryption/hashing taint escape and unescape           |
 | Timing attack   | A02:2021 | Secret compared with `===`, `<=>`, `strcmp()` (CWE-208)       |
 
+`UploadedFile::getClientOriginalExtension()` is deliberately not a `file` source:
+Symfony's `File::getName()` and `UploadedFile::getClientOriginalExtension()` yield a
+slash-, backslash-, and dot-free extension, which cannot form a traversal segment.
+
 Security scanning runs automatically alongside type analysis, no extra configuration needed.
 
 ### Timing-unsafe secret comparison (CWE-208)

--- a/stubs/common/Http/UploadedFile.phpstub
+++ b/stubs/common/Http/UploadedFile.phpstub
@@ -34,10 +34,28 @@ class UploadedFile
 
     /**
      * Returns the original file extension supplied by the client.
+     * Symfony File::getName() makes the original name a basename and
+     * UploadedFile::getClientOriginalExtension() returns its dot-free extension.
+     * The result has no /, \\, or . and cannot form a traversal segment.
      *
      * @return string
      *
-     * @psalm-taint-source input
+     * @psalm-taint-source callable
+     * @psalm-taint-source unserialize
+     * @psalm-taint-source include
+     * @psalm-taint-source eval
+     * @psalm-taint-source ldap
+     * @psalm-taint-source sql
+     * @psalm-taint-source html
+     * @psalm-taint-source has_quotes
+     * @psalm-taint-source shell
+     * @psalm-taint-source ssrf
+     * @psalm-taint-source cookie
+     * @psalm-taint-source header
+     * @psalm-taint-source xpath
+     * @psalm-taint-source sleep
+     * @psalm-taint-source extract
+     * @psalm-taint-source llm_prompt
      */
     public function getClientOriginalExtension(): string {}
 

--- a/tests/Type/tests/TaintAnalysis/SafeFileUploadedFileOriginalExtension.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFileUploadedFileOriginalExtension.phpt
@@ -1,0 +1,15 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Symfony UploadedFile::getClientOriginalExtension() returns an extension
+ * without path separators or dots, so appending it cannot traverse a path.
+ */
+function readByClientExtension(\Illuminate\Http\UploadedFile $file): void {
+    file_get_contents('uploads/file.' . $file->getClientOriginalExtension());
+}
+?>
+--EXPECTF--
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeFileUploadedFileOriginalExtensionStoragePutFileAs.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFileUploadedFileOriginalExtensionStoragePutFileAs.phpt
@@ -1,0 +1,15 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+function storeByClientExtension(UploadedFile $file): void {
+    $name = Str::ulid()->toString() . '.' . $file->getClientOriginalExtension();
+    Storage::putFileAs('attendance-proofs', $file, $name);
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderUploadedFileOriginalExtension.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderUploadedFileOriginalExtension.phpt
@@ -1,0 +1,11 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+function setHeaderByClientExtension(\Illuminate\Http\UploadedFile $file): void {
+    response('OK')->header('X-Extension', $file->getClientOriginalExtension());
+}
+?>
+--EXPECTF--
+TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedIncludeUploadedFileOriginalExtension.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedIncludeUploadedFileOriginalExtension.phpt
@@ -1,0 +1,12 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+function includeByClientExtension(\Illuminate\Http\UploadedFile $file): void {
+    /** @psalm-suppress UnresolvableInclude */
+    include $file->getClientOriginalExtension() . '.php';
+}
+?>
+--EXPECTF--
+TaintedInclude on line %d: Detected tainted code passed to include or similar


### PR DESCRIPTION
## Issue to Solve

`UploadedFile::getClientOriginalExtension()` is currently a broad `input` taint source. That includes `file`, so safe upload names such as `<ULID>.<client-extension>` produce `TaintedFile` when passed to `Storage::putFileAs()`.

Symfony first normalizes the client name to a basename in `File::getName()`, then `UploadedFile::getClientOriginalExtension()` returns the tail after the final dot. The result therefore contains no slash, backslash, or dot and cannot introduce a path-traversal segment.

Scope contract: T1 value-shape false-positive suppression, implemented in the stub without a handler.

## Related

Fixes #1322

#1323 separately tracks whether MIME-map-derived `clientExtension()` should be a taint source at all.

## Solution Description

- Replace the broad `input` annotation with every individual input kind except `file`.
- Keep `include`: include taint covers attacker-controlled code selection, not only traversal, so a value such as `evil` can still select `evil.php`.
- Add type tests for the original `file_get_contents()` shape and the reported `Str::ulid()` plus `Storage::putFileAs()` shape.
- Add negative coverage proving `include` and `header` taint remain, and document the deliberate `file` omission.

An attacker-controlled `.php` or `.phtml` extension can still be dangerous when uploads are served or executed by the deployment. That is a content-type and execution-policy risk rather than path traversal, and all non-`file` taint kinds remain intact.

A 3.x backport is possible if maintainers want it; the affected stub is identical at this method.

Reviewer gate: 98/100, SHIP, no must-fix findings. The external IxDF smoke was not rerun because that checkout has unrelated dirty dependency state; the committed PHPT reproduces the exact facade sink shape instead.

Verification:

- `composer test:type` — 635 tests, 634 assertions, 1 skipped
- `composer test:unit` — 1085 tests, 2931 assertions, 1 skipped
- Psalm self-analysis — 0 errors, 100% inferred
- `composer cs:check`
- `composer rector:dry`
- PHPT conventions and `git diff --check`
- focused post-sync UploadedFile PHPT batch

## Checklist
- [x] Tests cover the change (type tests in `tests/Type/`)
- [x] Documentation is updated

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787613932&installation_model_id=424990&pr_number=1324&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1324&signature=3eef60d72009422fa1d123b736ce85a00bcd61aca222f264b6cabce9e18dbacf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->