### PR TITLE
Sync `laravel/ai` stub signatures and add transcript plus structured-output sources

### DIFF
--- a/docs/contributing/taint-analysis.md
+++ b/docs/contributing/taint-analysis.md
@@ -698,15 +698,21 @@ Psalm honors `@psalm-taint-source` on **method return types** but not on **prope
 
 The subclass walk is load-bearing, not a courtesy: `StructuredAgentResponse` and `StructuredTextResponse` both inherit `$text` from `TextResponse` and are tainted through it, even though neither is named in the list. `TranscriptionResponse` is named explicitly because it sits in its own hierarchy (it does not extend `TextResponse`), so no walk reaches it.
 
-### Array-access source pattern: `$response['field']` (handler required too)
+### Array-access sources do not work: `$response['field']` (upstream gap)
 
 `@psalm-taint-source` on `offsetGet()` sources an explicit `$response->offsetGet('field')` call and nothing else. Psalm's `ArrayFetchAnalyzer` handles the `$response['field']` sugar by synthesizing a `VirtualMethodCall` to `offsetGet()` inside a **cloned** node-data set, then copying back only the resulting type. The taint edge lives in the clone and is discarded (same upstream gap as `#1304`).
 
-So the sugar goes through the same handler, on the `ArrayDimFetch` branch, for `Laravel\Ai\Tools\Request` (the arguments the model chose for a tool call) and for `Laravel\Ai\Responses\{StructuredAgentResponse, StructuredTextResponse}` (the decoded structured payload). The stubs keep the `offsetGet()` annotation anyway, so the explicit call form stays covered without a second mechanism.
+This is a Psalm core soundness bug, not a Laravel one. It silently breaks every `ArrayAccess`-based taint source in any codebase, so it belongs upstream rather than in a plugin workaround. Do not add an annotation and assume the sugar is covered.
 
-This is what makes the sub-agent chain work: `Tools\AgentTool::handle()` forwards `(string) $request['task']` straight into the sub-agent's `prompt()`, so without the `ArrayDimFetch` branch the whole delegation path is silent. `SubAgentToolDelegation.phpt` pins it.
+An `ArrayDimFetch` branch on `LlmOutputTaintHandler` would close it, and was prototyped, but is deliberately not shipped: `ArrayDimFetch` is among the hottest node types in any codebase, so the branch charges a per-expression cost on every analysis, and it becomes dead code the moment upstream lands. Keep the `offsetGet()` annotations anyway, since the explicit call form is genuinely covered by them.
 
-One gap remains, recorded in `StructuredArrayReturnKnownLimitation.phpt`: `toArray()` carries a source annotation, but consuming the returned array element-wise loses the edge under whole-project analysis. The same fixture reports the flow when Psalm analyzes the file alone, so it is the upstream hop-loss rather than a missing annotation.
+What that costs, pinned by fixtures rather than left implicit:
+
+- `SubAgentToolDelegationKnownLimitation.phpt`: `Tools\AgentTool::handle()` forwards `(string) $request['task']` straight into a sub-agent's `prompt()`, so the whole delegation chain is silent.
+- `StructuredResponseArrayAccessKnownLimitation.phpt`: `$response['field']` on the structured responses.
+- `StructuredArrayReturnKnownLimitation.phpt` is a *different* gap with the same shape of consequence: `toArray()` carries a source annotation, but consuming the returned array element-wise loses the edge under whole-project analysis. The same fixture reports the flow when Psalm analyzes the file alone, so it is the hop-loss bug rather than a missing annotation.
+
+All three assert the current (wrong) behavior with empty expectations, so an upstream fix turns them red and names itself.
 
 The handler is registered in `Plugin::registerHandlers()` behind the same version gate as the stubs, and self-disables when `Codebase::$taint_flow_graph === null`, so it costs nothing on non-taint runs.
 

--- a/docs/contributing/taint-analysis.md
+++ b/docs/contributing/taint-analysis.md
@@ -700,9 +700,9 @@ The subclass walk is load-bearing, not a courtesy: `StructuredAgentResponse` and
 
 ### Array-access sources do not work: `$response['field']` (upstream gap)
 
-`@psalm-taint-source` on `offsetGet()` sources an explicit `$response->offsetGet('field')` call and nothing else. Psalm's `ArrayFetchAnalyzer` handles the `$response['field']` sugar by synthesizing a `VirtualMethodCall` to `offsetGet()` inside a **cloned** node-data set, then copying back only the resulting type. The taint edge lives in the clone and is discarded (same upstream gap as `#1304`).
+`@psalm-taint-source` on `offsetGet()` sources an explicit `$response->offsetGet('field')` call and nothing else. Psalm's `ArrayFetchAnalyzer` resolves the `$response['field']` sugar by synthesizing a `VirtualMethodCall` to `offsetGet()`, analyzing it against a **cloned** node-data set, then copying back only the resulting type. Everything that call recorded about data flow stays in the clone and is discarded, so no edge reaches the outer expression. Type inference is unaffected, which is why the gap is invisible without a taint test.
 
-This is a Psalm core soundness bug, not a Laravel one. It silently breaks every `ArrayAccess`-based taint source in any codebase, so it belongs upstream rather than in a plugin workaround. Do not add an annotation and assume the sugar is covered.
+The loss is not specific to source annotations: any taint edge crossing the sugar is dropped, including a plain argument-to-return pass through `offsetGet()`. This is a Psalm core soundness bug, not a Laravel one, and it silently breaks every `ArrayAccess`-based taint source in any codebase. Filed upstream as [vimeo/psalm#11912](https://github.com/vimeo/psalm/issues/11912); `#1304` here was closed for the same reason. Do not add an annotation and assume the sugar is covered.
 
 An `ArrayDimFetch` branch on `LlmOutputTaintHandler` would close it, and was prototyped, but is deliberately not shipped: `ArrayDimFetch` is among the hottest node types in any codebase, so the branch charges a per-expression cost on every analysis, and it becomes dead code the moment upstream lands. Keep the `offsetGet()` annotations anyway, since the explicit call form is genuinely covered by them.
 

--- a/docs/contributing/taint-analysis.md
+++ b/docs/contributing/taint-analysis.md
@@ -694,9 +694,14 @@ Same shape is used on `Promptable::stream()`, `queue()`, `broadcast*()`, the `\L
 
 Psalm honors `@psalm-taint-source` on **method return types** but not on **properties**: `PropertyStorage` carries no taint fields at all, so the annotation is dropped at scan time rather than misapplied. The model's `$text` output is downstream of every untrusted input that reached the prompt (indirect prompt injection via web pages, RAG corpora, tool output, attacker emails — see EchoLeak CVE-2025-32711), so we need to taint property reads programmatically.
 
-`src/Handlers/Ai/LlmOutputTaintHandler.php` subscribes to `AfterExpressionAnalysisEvent`, matches reads of `$x->text` where `$x` is or extends one of `Laravel\Ai\Responses\{TextResponse, AgentResponse, StreamedAgentResponse, StreamableAgentResponse, TranscriptionResponse}`, and calls `Codebase::addTaintSource()` to add the `ALL_INPUT` taint to the expression's type. The stub at `stubs/integrations/laravel-ai/Responses/TextResponse.phpstub` additionally annotates `__toString()` so the same taint flows through string casts.
+`src/Handlers/Ai/LlmOutputTaintHandler.php` subscribes to `AfterExpressionAnalysisEvent`, matches the read, and calls `Codebase::addTaintSource()` to add the `ALL_INPUT` taint to the expression's type. `TAINTED_PROPERTIES` maps each property name to the classes that declare it, rather than crossing one class list with one property list, because the two properties sit on different parts of the hierarchy:
 
-The subclass walk is load-bearing, not a courtesy: `StructuredAgentResponse` and `StructuredTextResponse` both inherit `$text` from `TextResponse` and are tainted through it, even though neither is named in the list. `TranscriptionResponse` is named explicitly because it sits in its own hierarchy (it does not extend `TextResponse`), so no walk reaches it.
+- `$text` on `Laravel\Ai\Responses\{TextResponse, AgentResponse, StreamedAgentResponse, StreamableAgentResponse, TranscriptionResponse}`.
+- `$structured` on `Laravel\Ai\Responses\{StructuredAgentResponse, StructuredTextResponse}`, the decoded payload the `ProvidesStructuredResponse` trait declares as a public array. laravel/ai's own `ChatCommand` reads it, so it is a first-class access path rather than an internal.
+
+The subclass walk is load-bearing, not a courtesy: `StructuredAgentResponse` and `StructuredTextResponse` both inherit `$text` from `TextResponse` and are tainted through it, even though neither is named in the `$text` list. `TranscriptionResponse` is named explicitly because it sits in its own hierarchy (it does not extend `TextResponse`), so no walk reaches it.
+
+Casts are a separate path, and missing one is easy: `__toString()` is a method return, so it takes a plain stub annotation, but a subclass that overrides `__toString()` drops the parent's. Each of `TextResponse`, `AgentResponse`, `StreamableAgentResponse`, `TranscriptionResponse`, `StructuredAgentResponse` and `StructuredTextResponse` therefore carries its own. Adding a class to `TAINTED_PROPERTIES` covers the property read only; check whether the class also declares `__toString()` and needs the stub.
 
 ### Array-access sources do not work: `$response['field']` (upstream gap)
 
@@ -710,9 +715,11 @@ What that costs, pinned by fixtures rather than left implicit:
 
 - `SubAgentToolDelegationKnownLimitation.phpt`: `Tools\AgentTool::handle()` forwards `(string) $request['task']` straight into a sub-agent's `prompt()`, so the whole delegation chain is silent.
 - `StructuredResponseArrayAccessKnownLimitation.phpt`: `$response['field']` on the structured responses.
-- `StructuredArrayReturnKnownLimitation.phpt` is a *different* gap with the same shape of consequence: `toArray()` carries a source annotation, but consuming the returned array element-wise loses the edge under whole-project analysis. The same fixture reports the flow when Psalm analyzes the file alone, so it is the hop-loss bug rather than a missing annotation.
+- `StructuredArrayReturnKnownLimitation.phpt` is a *different* gap with the same shape of consequence. Both the `toArray()` return and the `$structured` property are sourced, but reading one element back out of the resulting array loses the edge under whole-project analysis. The same fixtures report the flow when Psalm analyzes the file alone, so it is the hop-loss bug rather than a missing source.
 
 All three assert the current (wrong) behavior with empty expectations, so an upstream fix turns them red and names itself.
+
+The practical consequence for writing positive coverage: a source whose type is an array needs a zero-hop sink in the fixture, or the test passes vacuously in the batch while looking like it proves something. `StructuredPayloadProperty.phpt` passes the whole payload to `extract()` for exactly that reason.
 
 The handler is registered in `Plugin::registerHandlers()` behind the same version gate as the stubs, and self-disables when `Codebase::$taint_flow_graph === null`, so it costs nothing on non-taint runs.
 

--- a/docs/contributing/taint-analysis.md
+++ b/docs/contributing/taint-analysis.md
@@ -701,7 +701,9 @@ Psalm honors `@psalm-taint-source` on **method return types** but not on **prope
 
 The subclass walk is load-bearing, not a courtesy: `StructuredAgentResponse` and `StructuredTextResponse` both inherit `$text` from `TextResponse` and are tainted through it, even though neither is named in the `$text` list. `TranscriptionResponse` is named explicitly because it sits in its own hierarchy (it does not extend `TextResponse`), so no walk reaches it.
 
-Casts are a separate path, and missing one is easy: `__toString()` is a method return, so it takes a plain stub annotation, but a subclass that overrides `__toString()` drops the parent's. Each of `TextResponse`, `AgentResponse`, `StreamableAgentResponse`, `TranscriptionResponse`, `StructuredAgentResponse` and `StructuredTextResponse` therefore carries its own. Adding a class to `TAINTED_PROPERTIES` covers the property read only; check whether the class also declares `__toString()` and needs the stub.
+Casts are a separate path, and missing one is easy: `__toString()` is a method return, so it takes a plain stub annotation, but a subclass that overrides `__toString()` drops the parent's. Each of `TextResponse`, `AgentResponse`, `TranscriptionResponse`, `StructuredAgentResponse` and `StructuredTextResponse` therefore carries its own. Adding a class to `TAINTED_PROPERTIES` covers the property read only; check whether the class also declares `__toString()` and needs the stub.
+
+Check that it really declares one. `StreamableAgentResponse` is the exception in this package: it has no `__toString()`, and the stub declared one anyway to hang the annotation off. The annotation was inert, and worse, the declaration told Psalm that `(string) $response` type-checks when it fatals at runtime, suppressing an `InvalidCast` the user should have seen. A stub that invents API is worse than a missing stub, because the invented member silences real errors instead of merely missing them. `StreamableResponseHasNoStringCast.phpt` pins the corrected behavior.
 
 ### Array-access sources do not work: `$response['field']` (upstream gap)
 

--- a/docs/contributing/taint-analysis.md
+++ b/docs/contributing/taint-analysis.md
@@ -694,11 +694,19 @@ Same shape is used on `Promptable::stream()`, `queue()`, `broadcast*()`, the `\L
 
 Psalm honors `@psalm-taint-source` on **method return types** but not on **properties**: `PropertyStorage` carries no taint fields at all, so the annotation is dropped at scan time rather than misapplied. The model's `$text` output is downstream of every untrusted input that reached the prompt (indirect prompt injection via web pages, RAG corpora, tool output, attacker emails — see EchoLeak CVE-2025-32711), so we need to taint property reads programmatically.
 
-`src/Handlers/Ai/LlmOutputTaintHandler.php` subscribes to `AfterExpressionAnalysisEvent`, matches reads of `$x->text` where `$x` is or extends one of `Laravel\Ai\Responses\{TextResponse, AgentResponse, StreamedAgentResponse, StreamableAgentResponse}`, and calls `Codebase::addTaintSource()` to add the `ALL_INPUT` taint to the expression's type. The stub at `stubs/integrations/laravel-ai/Responses/TextResponse.phpstub` additionally annotates `__toString()` so the same taint flows through string casts.
+`src/Handlers/Ai/LlmOutputTaintHandler.php` subscribes to `AfterExpressionAnalysisEvent`, matches reads of `$x->text` where `$x` is or extends one of `Laravel\Ai\Responses\{TextResponse, AgentResponse, StreamedAgentResponse, StreamableAgentResponse, TranscriptionResponse}`, and calls `Codebase::addTaintSource()` to add the `ALL_INPUT` taint to the expression's type. The stub at `stubs/integrations/laravel-ai/Responses/TextResponse.phpstub` additionally annotates `__toString()` so the same taint flows through string casts.
 
-The subclass walk is load-bearing, not a courtesy: `StructuredAgentResponse` and `StructuredTextResponse` both inherit `$text` from `TextResponse` and are tainted through it, even though neither is named in the list. What is genuinely uncovered is `StructuredAgentResponse`'s array-access surface (`$response['field']`), which needs a stub on `offsetGet()`/`toArray()`.
+The subclass walk is load-bearing, not a courtesy: `StructuredAgentResponse` and `StructuredTextResponse` both inherit `$text` from `TextResponse` and are tainted through it, even though neither is named in the list. `TranscriptionResponse` is named explicitly because it sits in its own hierarchy (it does not extend `TextResponse`), so no walk reaches it.
 
-`TranscriptionResponse::$text` is a known gap. It carries model output too (transcribed audio) but sits in its own hierarchy, so no subclass walk reaches it.
+### Array-access source pattern: `$response['field']` (handler required too)
+
+`@psalm-taint-source` on `offsetGet()` sources an explicit `$response->offsetGet('field')` call and nothing else. Psalm's `ArrayFetchAnalyzer` handles the `$response['field']` sugar by synthesizing a `VirtualMethodCall` to `offsetGet()` inside a **cloned** node-data set, then copying back only the resulting type. The taint edge lives in the clone and is discarded (same upstream gap as `#1304`).
+
+So the sugar goes through the same handler, on the `ArrayDimFetch` branch, for `Laravel\Ai\Tools\Request` (the arguments the model chose for a tool call) and for `Laravel\Ai\Responses\{StructuredAgentResponse, StructuredTextResponse}` (the decoded structured payload). The stubs keep the `offsetGet()` annotation anyway, so the explicit call form stays covered without a second mechanism.
+
+This is what makes the sub-agent chain work: `Tools\AgentTool::handle()` forwards `(string) $request['task']` straight into the sub-agent's `prompt()`, so without the `ArrayDimFetch` branch the whole delegation path is silent. `SubAgentToolDelegation.phpt` pins it.
+
+One gap remains, recorded in `StructuredArrayReturnKnownLimitation.phpt`: `toArray()` carries a source annotation, but consuming the returned array element-wise loses the edge under whole-project analysis. The same fixture reports the flow when Psalm analyzes the file alone, so it is the upstream hop-loss rather than a missing annotation.
 
 The handler is registered in `Plugin::registerHandlers()` behind the same version gate as the stubs, and self-disables when `Codebase::$taint_flow_graph === null`, so it costs nothing on non-taint runs.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -88,10 +88,9 @@ yet: Psalm's `@psalm-taint-sink` matches parameter names only. Tracked in
 [#484](https://github.com/psalm/psalm-plugin-laravel/issues/484).
 
 Array-access reads (`$response['field']`, `$request['task']`) are not covered
-either, on any class. Psalm resolves the `[]` sugar through a synthesized
-`offsetGet()` call in a cloned node-data set and copies back only the resulting
-type, so the taint edge is dropped. That affects every `ArrayAccess`-based taint
-source, so it is left for an upstream fix rather than worked around. It is worth
+either, on any class: Psalm drops the taint edge when it resolves the `[]` sugar,
+which affects every `ArrayAccess`-based taint source and is left for an upstream
+fix ([vimeo/psalm#11912](https://github.com/vimeo/psalm/issues/11912)). It is worth
 knowing about, because `Tools\AgentTool` uses exactly that shape to pass a task to
 a sub-agent. Prefer `Tools\Request::str()` / `string()` / `array()`, or an explicit
 `offsetGet()` call, all of which are covered.

--- a/docs/security.md
+++ b/docs/security.md
@@ -18,6 +18,7 @@ nav_order: 6
 | Crypto misuse   | A02:2021 | Tracks encryption/hashing taint escape and unescape           |
 | Timing attack   | A02:2021 | Secret compared with `===`, `<=>`, `strcmp()` (CWE-208)       |
 | Prompt injection | LLM01:2025 | `laravel/ai` agents: `Agent::prompt()`, `stream()`, `queue()`, `broadcast*()`, `Embeddings::for()` |
+| LLM output reuse | LLM01:2025 | Model output as a source: `$response->text`, `$response->structured`, response string casts, `toArray()` / `toJson()` / `jsonSerialize()`, tool results |
 
 `UploadedFile::getClientOriginalExtension()` is deliberately not a `file` source:
 Symfony's `File::getName()` and `UploadedFile::getClientOriginalExtension()` yield a
@@ -72,16 +73,17 @@ Two directions are covered:
   response to string) yields tainted data, so an answer echoed into HTML, SQL, or a
   shell command is reported like any other user input. That models indirect prompt
   injection, where the payload arrives through a page, document, or tool result the
-  model read. Transcripts (`TranscriptionResponse::$text`) count: the audio was
-  supplied by a user, so the transcript is attacker-authored text a speech model
-  merely re-typed.
+  model read. Transcripts count on both paths (`TranscriptionResponse::$text` and
+  the string cast): the audio was supplied by a user, so the transcript is
+  attacker-authored text a speech model merely re-typed.
 * Structured output is a source on the same footing. On
-  `StructuredAgentResponse` / `StructuredTextResponse`, the covered reads are
-  `toArray()`, `toJson()`, `jsonSerialize()`, the string cast, and an explicit
-  `offsetGet()` call. The keys come from the application's schema, the values come
-  from the model.
+  `StructuredAgentResponse` / `StructuredTextResponse`, the covered reads are the
+  `$structured` property, `toArray()`, `toJson()`, `jsonSerialize()`, the string
+  cast, and an explicit `offsetGet()` call. The keys come from the application's
+  schema, the values come from the model.
 
-Two shapes are deliberately not covered.
+Three shapes are not covered. Each is an upstream limitation rather than a
+judgement that the flow is safe, so treat them as blind spots when reviewing.
 
 Return-value sinks (`Tool::description()`, `Agent::instructions()`) are not covered
 yet: Psalm's `@psalm-taint-sink` matches parameter names only. Tracked in
@@ -94,6 +96,13 @@ fix ([vimeo/psalm#11912](https://github.com/vimeo/psalm/issues/11912)). It is wo
 knowing about, because `Tools\AgentTool` uses exactly that shape to pass a task to
 a sub-agent. Prefer `Tools\Request::str()` / `string()` / `array()`, or an explicit
 `offsetGet()` call, all of which are covered.
+
+Reading a single element back out of an array-typed source is the third gap. The
+`$structured` property and the `toArray()` return are both sourced, but
+`$payload['body']` after either of them loses the taint under whole-project
+analysis, which is how a real run works. The same code reports when Psalm analyzes
+the file on its own, so the source is right and the hop is what is lost. Passing
+the whole payload to a sink is unaffected.
 
 ### How it compares
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -72,7 +72,17 @@ Two directions are covered:
   response to string) yields tainted data, so an answer echoed into HTML, SQL, or a
   shell command is reported like any other user input. That models indirect prompt
   injection, where the payload arrives through a page, document, or tool result the
-  model read.
+  model read. Transcripts (`TranscriptionResponse::$text`) count: the audio was
+  supplied by a user, so the transcript is attacker-authored text a speech model
+  merely re-typed.
+* Structured output is covered on the same footing. `$response['field']` on
+  `StructuredAgentResponse` / `StructuredTextResponse`, plus `toArray()`,
+  `toJson()`, `jsonSerialize()` and the string cast, all yield tainted values. The
+  keys come from the application's schema, the values come from the model.
+* Tool arguments are a source, including the `$request['task']` array form the
+  framework's own `Tools\AgentTool` uses to hand a task to a sub-agent. That makes
+  the sub-agent delegation chain (parent model picks the task text, sub-agent
+  receives it as a prompt) report `TaintedLlmPrompt`.
 
 Return-value sinks (`Tool::description()`, `Agent::instructions()`) are not covered
 yet: Psalm's `@psalm-taint-sink` matches parameter names only. Tracked in

--- a/docs/security.md
+++ b/docs/security.md
@@ -75,18 +75,26 @@ Two directions are covered:
   model read. Transcripts (`TranscriptionResponse::$text`) count: the audio was
   supplied by a user, so the transcript is attacker-authored text a speech model
   merely re-typed.
-* Structured output is covered on the same footing. `$response['field']` on
-  `StructuredAgentResponse` / `StructuredTextResponse`, plus `toArray()`,
-  `toJson()`, `jsonSerialize()` and the string cast, all yield tainted values. The
-  keys come from the application's schema, the values come from the model.
-* Tool arguments are a source, including the `$request['task']` array form the
-  framework's own `Tools\AgentTool` uses to hand a task to a sub-agent. That makes
-  the sub-agent delegation chain (parent model picks the task text, sub-agent
-  receives it as a prompt) report `TaintedLlmPrompt`.
+* Structured output is a source on the same footing. On
+  `StructuredAgentResponse` / `StructuredTextResponse`, the covered reads are
+  `toArray()`, `toJson()`, `jsonSerialize()`, the string cast, and an explicit
+  `offsetGet()` call. The keys come from the application's schema, the values come
+  from the model.
+
+Two shapes are deliberately not covered.
 
 Return-value sinks (`Tool::description()`, `Agent::instructions()`) are not covered
 yet: Psalm's `@psalm-taint-sink` matches parameter names only. Tracked in
 [#484](https://github.com/psalm/psalm-plugin-laravel/issues/484).
+
+Array-access reads (`$response['field']`, `$request['task']`) are not covered
+either, on any class. Psalm resolves the `[]` sugar through a synthesized
+`offsetGet()` call in a cloned node-data set and copies back only the resulting
+type, so the taint edge is dropped. That affects every `ArrayAccess`-based taint
+source, so it is left for an upstream fix rather than worked around. It is worth
+knowing about, because `Tools\AgentTool` uses exactly that shape to pass a task to
+a sub-agent. Prefer `Tools\Request::str()` / `string()` / `array()`, or an explicit
+`offsetGet()` call, all of which are covered.
 
 ### How it compares
 

--- a/src/Handlers/Ai/LlmOutputTaintHandler.php
+++ b/src/Handlers/Ai/LlmOutputTaintHandler.php
@@ -4,60 +4,56 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Handlers\Ai;
 
-use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Identifier;
-use Psalm\Codebase;
 use Psalm\CodeLocation;
 use Psalm\Plugin\EventHandler\AfterExpressionAnalysisInterface;
 use Psalm\Plugin\EventHandler\Event\AfterExpressionAnalysisEvent;
-use Psalm\StatementsSource;
 use Psalm\Type;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\TaintKind;
-use Psalm\Type\Union;
 
 /**
- * Marks reads of LLM-controlled data on Laravel AI objects as an `input` taint
- * source. The model's output is downstream of every untrusted source that
- * reached its prompt (indirect prompt injection — attacker content in a web
- * page, RAG corpus, tool output, or email), so passing it unsanitized to SQL,
- * shell, HTML, header, or filesystem sinks should fire the matching `Tainted*`
- * issue.
+ * Marks the `$text` property on Laravel AI response objects as an `input`
+ * taint source. The model's output is downstream of every untrusted source
+ * that reached its prompt (indirect prompt injection — attacker content in
+ * a web page, RAG corpus, tool output, or email), so passing it unsanitized
+ * to SQL, shell, HTML, header, or filesystem sinks should fire the matching
+ * `Tainted*` issue.
  *
- * Two read shapes need a handler because a docblock annotation cannot express
- * either of them:
+ * Psalm's `@psalm-taint-source` docblock annotation is not honored on
+ * properties, only on method return types. This handler bridges that gap by
+ * intercepting reads of the property and adding the taint via
+ * `Codebase::addTaintSource()`. The stub at
+ * `stubs/integrations/laravel-ai/Responses/TextResponse.phpstub`
+ * complements this with `@psalm-taint-source` on `__toString()`.
  *
- * 1. `$response->text` — Psalm's `@psalm-taint-source` is not honored on
- *    properties, only on method return types.
- * 2. `$response['field']` / `$request['task']` — `ArrayFetchAnalyzer`
- *    synthesizes the `offsetGet()` call in a cloned node-data set and copies
- *    back only the return type, so the taint edge from the stub's annotation on
- *    `offsetGet()` is discarded (same upstream gap as #1304). An explicit
- *    `$response->offsetGet('field')` call does carry the stub annotation.
- *
- * Both are handled by re-sourcing at the read site, which also sidesteps the
- * upstream "property taint never flows" bug. The stubs complement this with
- * `@psalm-taint-source` on `__toString()`, `toArray()` and friends.
- *
- * Property-read coverage:
+ * Covered:
  * - `Laravel\Ai\Responses\TextResponse` (and subclasses, including
- *   `AgentResponse`, `StructuredAgentResponse`, `StructuredTextResponse` and
- *   `StreamedAgentResponse` — the snapshot returned to
+ *   `AgentResponse` and `StreamedAgentResponse` — the snapshot returned to
  *   `Promptable::stream()->then()` callbacks).
  * - `Laravel\Ai\Responses\StreamableAgentResponse` (separate hierarchy in
  *   the real package — `$text` is populated after the stream completes).
- * - `Laravel\Ai\Responses\TranscriptionResponse` (own hierarchy; a transcript
- *   of user-supplied audio is attacker-authored text a speech model re-typed).
+ * - `Laravel\Ai\Responses\TranscriptionResponse` (also its own hierarchy; a
+ *   transcript of user-supplied audio is attacker-authored text that a speech
+ *   model merely re-typed).
  *
- * Array-read coverage:
- * - `Laravel\Ai\Tools\Request` — the arguments the model chose for a tool call.
- *   This is the shape `Tools\AgentTool::handle()` itself uses to forward a task
- *   into a sub-agent's prompt.
- * - `Laravel\Ai\Responses\StructuredAgentResponse` /
- *   `StructuredTextResponse` — the decoded structured payload. The keys come
- *   from the application's schema, the values do not.
+ * `StructuredAgentResponse` and `StructuredTextResponse` are absent from the
+ * list but still covered: both inherit `$text` from `TextResponse`, so the
+ * subclass walk below reaches them.
+ *
+ * Array-access reads (`$response['field']`, `$request['task']`) are covered by
+ * nothing, here or in the stubs. Psalm's `ArrayFetchAnalyzer` handles the `[]`
+ * sugar by synthesizing a `VirtualMethodCall` to `offsetGet()` in a cloned
+ * node-data set and copying back only the resulting type, so the taint edge
+ * from the stub annotation on `offsetGet()` is discarded. That is a Psalm core
+ * soundness gap affecting every `ArrayAccess`-based taint source rather than
+ * anything Laravel-specific, so it belongs upstream. An `ArrayDimFetch` branch
+ * here would close it, but that node type is among the hottest in any codebase
+ * and the branch turns into dead code the moment upstream lands, so the gap is
+ * accepted and pinned by the `*KnownLimitation.phpt` fixtures instead. The
+ * covered paths for structured output are an explicit
+ * `$response->offsetGet('field')` call and `toArray()`.
  *
  * @see https://genai.owasp.org/llmrisk/llm01-prompt-injection/ OWASP LLM01:2025
  * @see https://github.com/laravel/ai Laravel AI SDK
@@ -90,17 +86,6 @@ final class LlmOutputTaintHandler implements AfterExpressionAnalysisInterface
      */
     private const TAINTED_PROPERTIES = ['text'];
 
-    /**
-     * Classes whose array-access reads return LLM-controlled data.
-     *
-     * @var list<string>
-     */
-    private const ARRAY_ACCESS_TAINTED_CLASSES = [
-        'Laravel\\Ai\\Tools\\Request',
-        'Laravel\\Ai\\Responses\\StructuredAgentResponse',
-        'Laravel\\Ai\\Responses\\StructuredTextResponse',
-    ];
-
     /** @inheritDoc */
     #[\Override]
     public static function afterExpressionAnalysis(AfterExpressionAnalysisEvent $event): ?bool
@@ -115,112 +100,70 @@ final class LlmOutputTaintHandler implements AfterExpressionAnalysisInterface
 
         $expr = $event->getExpr();
 
-        if ($expr instanceof PropertyFetch) {
-            if (!$expr->name instanceof Identifier) {
-                return null;
-            }
-
-            if (!\in_array($expr->name->name, self::TAINTED_PROPERTIES, true)) {
-                return null;
-            }
-
-            self::taintRead($event, $expr, $expr->var, self::TAINTED_CLASSES, 'llm-output-' . $expr->name->name);
-
+        if (!$expr instanceof PropertyFetch) {
             return null;
         }
 
-        if ($expr instanceof ArrayDimFetch) {
-            // A null dim is `$x[] = ...`, always a write target.
-            if (!$expr->dim instanceof Expr) {
-                return null;
-            }
-
-            self::taintRead($event, $expr, $expr->var, self::ARRAY_ACCESS_TAINTED_CLASSES, 'llm-output-offset');
+        if (!$expr->name instanceof Identifier) {
+            return null;
         }
 
-        return null;
-    }
+        if (!\in_array($expr->name->name, self::TAINTED_PROPERTIES, true)) {
+            return null;
+        }
 
-    /**
-     * @param list<string> $taintedClasses
-     */
-    private static function taintRead(
-        AfterExpressionAnalysisEvent $event,
-        Expr $expr,
-        Expr $receiver,
-        array $taintedClasses,
-        string $taintIdPrefix,
-    ): void {
         $source = $event->getStatementsSource();
         $nodeTypeProvider = $source->getNodeTypeProvider();
 
-        $receiverType = $nodeTypeProvider->getType($receiver);
+        $varType = $nodeTypeProvider->getType($expr->var);
 
-        if (!$receiverType instanceof Union) {
-            return;
+        if (!$varType instanceof \Psalm\Type\Union) {
+            return null;
         }
 
-        if (!self::isLlmSurface($receiverType, $taintedClasses, $event->getCodebase())) {
-            return;
-        }
+        $isLlmResponse = false;
 
-        self::addSource($event, $expr, $source, $taintIdPrefix);
-    }
-
-    /**
-     * @param list<string> $taintedClasses
-     *
-     * @psalm-external-mutation-free
-     */
-    private static function isLlmSurface(Union $receiverType, array $taintedClasses, Codebase $codebase): bool
-    {
-        foreach ($receiverType->getAtomicTypes() as $atomic) {
+        foreach ($varType->getAtomicTypes() as $atomic) {
             if (!$atomic instanceof TNamedObject) {
                 continue;
             }
 
-            if (\in_array($atomic->value, $taintedClasses, true)) {
-                return true;
+            if (\in_array($atomic->value, self::TAINTED_CLASSES, true)) {
+                $isLlmResponse = true;
+                break;
             }
 
             // Cover user-defined subclasses (e.g. a project's own response
             // wrapper extending AgentResponse).
-            if (!$codebase->classExists($atomic->value)) {
-                continue;
-            }
+            if ($codebase->classExists($atomic->value)) {
+                foreach (self::TAINTED_CLASSES as $taintedClass) {
+                    if (!$codebase->classExists($taintedClass)) {
+                        continue;
+                    }
 
-            foreach ($taintedClasses as $taintedClass) {
-                if (!$codebase->classExists($taintedClass)) {
-                    continue;
-                }
+                    if ($codebase->classExtendsOrImplements($atomic->value, $taintedClass)) {
+                        $isLlmResponse = true;
 
-                if ($codebase->classExtendsOrImplements($atomic->value, $taintedClass)) {
-                    return true;
+                        break 2;
+                    }
                 }
             }
         }
 
-        return false;
-    }
+        if (!$isLlmResponse) {
+            return null;
+        }
 
-    private static function addSource(
-        AfterExpressionAnalysisEvent $event,
-        Expr $expr,
-        StatementsSource $source,
-        string $taintIdPrefix,
-    ): void {
-        $nodeTypeProvider = $source->getNodeTypeProvider();
-
-        // The expression type may be unset when Psalm couldn't resolve the member —
-        // fall back to `string`, the type every covered read ultimately carries into
-        // a sink, so the taint annotation survives.
+        // The expression type may be unset when Psalm couldn't resolve the property —
+        // fall back to `string` so the taint annotation survives. `$text` is always
+        // a string in the laravel/ai package.
         $exprType = $nodeTypeProvider->getType($expr) ?? Type::getString();
 
-        $taintId = $taintIdPrefix
+        $taintId = 'llm-output-' . $expr->name->name
             . '-' . $source->getFileName()
             . ':' . $expr->getStartFilePos();
 
-        $taintedType = $event->getCodebase()->addTaintSource(
+        $taintedType = $codebase->addTaintSource(
             $exprType,
             $taintId,
             TaintKind::ALL_INPUT,
@@ -228,5 +171,7 @@ final class LlmOutputTaintHandler implements AfterExpressionAnalysisInterface
         );
 
         $nodeTypeProvider->setType($expr, $taintedType);
+
+        return null;
     }
 }

--- a/src/Handlers/Ai/LlmOutputTaintHandler.php
+++ b/src/Handlers/Ai/LlmOutputTaintHandler.php
@@ -43,17 +43,13 @@ use Psalm\Type\TaintKind;
  * subclass walk below reaches them.
  *
  * Array-access reads (`$response['field']`, `$request['task']`) are covered by
- * nothing, here or in the stubs. Psalm's `ArrayFetchAnalyzer` handles the `[]`
- * sugar by synthesizing a `VirtualMethodCall` to `offsetGet()` in a cloned
- * node-data set and copying back only the resulting type, so the taint edge
- * from the stub annotation on `offsetGet()` is discarded. That is a Psalm core
- * soundness gap affecting every `ArrayAccess`-based taint source rather than
- * anything Laravel-specific, so it belongs upstream. An `ArrayDimFetch` branch
- * here would close it, but that node type is among the hottest in any codebase
- * and the branch turns into dead code the moment upstream lands, so the gap is
- * accepted and pinned by the `*KnownLimitation.phpt` fixtures instead. The
- * covered paths for structured output are an explicit
- * `$response->offsetGet('field')` call and `toArray()`.
+ * nothing, here or in the stubs: Psalm discards the taint edge when it resolves
+ * the `[]` sugar, so an `ArrayDimFetch` branch here would work around a core gap
+ * on one of the hottest node types. Deferred to upstream
+ * (https://github.com/vimeo/psalm/issues/11912) and pinned by the
+ * `*KnownLimitation.phpt` fixtures. The covered paths for structured output are
+ * an explicit `$response->offsetGet('field')` call and `toArray()`. Mechanism
+ * and rationale: `docs/contributing/taint-analysis.md`.
  *
  * @see https://genai.owasp.org/llmrisk/llm01-prompt-injection/ OWASP LLM01:2025
  * @see https://github.com/laravel/ai Laravel AI SDK

--- a/src/Handlers/Ai/LlmOutputTaintHandler.php
+++ b/src/Handlers/Ai/LlmOutputTaintHandler.php
@@ -4,45 +4,60 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Handlers\Ai;
 
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Identifier;
+use Psalm\Codebase;
 use Psalm\CodeLocation;
 use Psalm\Plugin\EventHandler\AfterExpressionAnalysisInterface;
 use Psalm\Plugin\EventHandler\Event\AfterExpressionAnalysisEvent;
+use Psalm\StatementsSource;
 use Psalm\Type;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\TaintKind;
+use Psalm\Type\Union;
 
 /**
- * Marks the `$text` property on Laravel AI response objects as an `input`
- * taint source. The model's output is downstream of every untrusted source
- * that reached its prompt (indirect prompt injection — attacker content in
- * a web page, RAG corpus, tool output, or email), so passing it unsanitized
- * to SQL, shell, HTML, header, or filesystem sinks should fire the matching
- * `Tainted*` issue.
+ * Marks reads of LLM-controlled data on Laravel AI objects as an `input` taint
+ * source. The model's output is downstream of every untrusted source that
+ * reached its prompt (indirect prompt injection — attacker content in a web
+ * page, RAG corpus, tool output, or email), so passing it unsanitized to SQL,
+ * shell, HTML, header, or filesystem sinks should fire the matching `Tainted*`
+ * issue.
  *
- * Psalm's `@psalm-taint-source` docblock annotation is not honored on
- * properties, only on method return types. This handler bridges that gap by
- * intercepting reads of the property and adding the taint via
- * `Codebase::addTaintSource()`. The stub at
- * `stubs/integrations/laravel-ai/Responses/TextResponse.phpstub`
- * complements this with `@psalm-taint-source` on `__toString()`.
+ * Two read shapes need a handler because a docblock annotation cannot express
+ * either of them:
  *
- * Covered:
+ * 1. `$response->text` — Psalm's `@psalm-taint-source` is not honored on
+ *    properties, only on method return types.
+ * 2. `$response['field']` / `$request['task']` — `ArrayFetchAnalyzer`
+ *    synthesizes the `offsetGet()` call in a cloned node-data set and copies
+ *    back only the return type, so the taint edge from the stub's annotation on
+ *    `offsetGet()` is discarded (same upstream gap as #1304). An explicit
+ *    `$response->offsetGet('field')` call does carry the stub annotation.
+ *
+ * Both are handled by re-sourcing at the read site, which also sidesteps the
+ * upstream "property taint never flows" bug. The stubs complement this with
+ * `@psalm-taint-source` on `__toString()`, `toArray()` and friends.
+ *
+ * Property-read coverage:
  * - `Laravel\Ai\Responses\TextResponse` (and subclasses, including
- *   `AgentResponse` and `StreamedAgentResponse` — the snapshot returned to
+ *   `AgentResponse`, `StructuredAgentResponse`, `StructuredTextResponse` and
+ *   `StreamedAgentResponse` — the snapshot returned to
  *   `Promptable::stream()->then()` callbacks).
  * - `Laravel\Ai\Responses\StreamableAgentResponse` (separate hierarchy in
  *   the real package — `$text` is populated after the stream completes).
+ * - `Laravel\Ai\Responses\TranscriptionResponse` (own hierarchy; a transcript
+ *   of user-supplied audio is attacker-authored text a speech model re-typed).
  *
- * `StructuredAgentResponse` and `StructuredTextResponse` are absent from the
- * list but still covered: both inherit `$text` from `TextResponse`, so the
- * subclass walk below reaches them. Their array-access surface
- * (`$response['field']`) is the part that stays uncovered — that belongs in a
- * stub for `offsetGet()`/`toArray()`.
- *
- * `TranscriptionResponse` also exposes `$text` but sits in its own hierarchy,
- * so nothing reaches it today.
+ * Array-read coverage:
+ * - `Laravel\Ai\Tools\Request` — the arguments the model chose for a tool call.
+ *   This is the shape `Tools\AgentTool::handle()` itself uses to forward a task
+ *   into a sub-agent's prompt.
+ * - `Laravel\Ai\Responses\StructuredAgentResponse` /
+ *   `StructuredTextResponse` — the decoded structured payload. The keys come
+ *   from the application's schema, the values do not.
  *
  * @see https://genai.owasp.org/llmrisk/llm01-prompt-injection/ OWASP LLM01:2025
  * @see https://github.com/laravel/ai Laravel AI SDK
@@ -65,6 +80,7 @@ final class LlmOutputTaintHandler implements AfterExpressionAnalysisInterface
         'Laravel\\Ai\\Responses\\AgentResponse',
         'Laravel\\Ai\\Responses\\StreamedAgentResponse',
         'Laravel\\Ai\\Responses\\StreamableAgentResponse',
+        'Laravel\\Ai\\Responses\\TranscriptionResponse',
     ];
 
     /**
@@ -73,6 +89,17 @@ final class LlmOutputTaintHandler implements AfterExpressionAnalysisInterface
      * @var list<string>
      */
     private const TAINTED_PROPERTIES = ['text'];
+
+    /**
+     * Classes whose array-access reads return LLM-controlled data.
+     *
+     * @var list<string>
+     */
+    private const ARRAY_ACCESS_TAINTED_CLASSES = [
+        'Laravel\\Ai\\Tools\\Request',
+        'Laravel\\Ai\\Responses\\StructuredAgentResponse',
+        'Laravel\\Ai\\Responses\\StructuredTextResponse',
+    ];
 
     /** @inheritDoc */
     #[\Override]
@@ -88,70 +115,112 @@ final class LlmOutputTaintHandler implements AfterExpressionAnalysisInterface
 
         $expr = $event->getExpr();
 
-        if (!$expr instanceof PropertyFetch) {
+        if ($expr instanceof PropertyFetch) {
+            if (!$expr->name instanceof Identifier) {
+                return null;
+            }
+
+            if (!\in_array($expr->name->name, self::TAINTED_PROPERTIES, true)) {
+                return null;
+            }
+
+            self::taintRead($event, $expr, $expr->var, self::TAINTED_CLASSES, 'llm-output-' . $expr->name->name);
+
             return null;
         }
 
-        if (!$expr->name instanceof Identifier) {
-            return null;
+        if ($expr instanceof ArrayDimFetch) {
+            // A null dim is `$x[] = ...`, always a write target.
+            if (!$expr->dim instanceof Expr) {
+                return null;
+            }
+
+            self::taintRead($event, $expr, $expr->var, self::ARRAY_ACCESS_TAINTED_CLASSES, 'llm-output-offset');
         }
 
-        if (!\in_array($expr->name->name, self::TAINTED_PROPERTIES, true)) {
-            return null;
-        }
+        return null;
+    }
 
+    /**
+     * @param list<string> $taintedClasses
+     */
+    private static function taintRead(
+        AfterExpressionAnalysisEvent $event,
+        Expr $expr,
+        Expr $receiver,
+        array $taintedClasses,
+        string $taintIdPrefix,
+    ): void {
         $source = $event->getStatementsSource();
         $nodeTypeProvider = $source->getNodeTypeProvider();
 
-        $varType = $nodeTypeProvider->getType($expr->var);
+        $receiverType = $nodeTypeProvider->getType($receiver);
 
-        if (!$varType instanceof \Psalm\Type\Union) {
-            return null;
+        if (!$receiverType instanceof Union) {
+            return;
         }
 
-        $isLlmResponse = false;
+        if (!self::isLlmSurface($receiverType, $taintedClasses, $event->getCodebase())) {
+            return;
+        }
 
-        foreach ($varType->getAtomicTypes() as $atomic) {
+        self::addSource($event, $expr, $source, $taintIdPrefix);
+    }
+
+    /**
+     * @param list<string> $taintedClasses
+     *
+     * @psalm-external-mutation-free
+     */
+    private static function isLlmSurface(Union $receiverType, array $taintedClasses, Codebase $codebase): bool
+    {
+        foreach ($receiverType->getAtomicTypes() as $atomic) {
             if (!$atomic instanceof TNamedObject) {
                 continue;
             }
 
-            if (\in_array($atomic->value, self::TAINTED_CLASSES, true)) {
-                $isLlmResponse = true;
-                break;
+            if (\in_array($atomic->value, $taintedClasses, true)) {
+                return true;
             }
 
             // Cover user-defined subclasses (e.g. a project's own response
             // wrapper extending AgentResponse).
-            if ($codebase->classExists($atomic->value)) {
-                foreach (self::TAINTED_CLASSES as $taintedClass) {
-                    if (!$codebase->classExists($taintedClass)) {
-                        continue;
-                    }
+            if (!$codebase->classExists($atomic->value)) {
+                continue;
+            }
 
-                    if ($codebase->classExtendsOrImplements($atomic->value, $taintedClass)) {
-                        $isLlmResponse = true;
+            foreach ($taintedClasses as $taintedClass) {
+                if (!$codebase->classExists($taintedClass)) {
+                    continue;
+                }
 
-                        break 2;
-                    }
+                if ($codebase->classExtendsOrImplements($atomic->value, $taintedClass)) {
+                    return true;
                 }
             }
         }
 
-        if (!$isLlmResponse) {
-            return null;
-        }
+        return false;
+    }
 
-        // The expression type may be unset when Psalm couldn't resolve the property —
-        // fall back to `string` so the taint annotation survives. `$text` is always
-        // a string in the laravel/ai package.
+    private static function addSource(
+        AfterExpressionAnalysisEvent $event,
+        Expr $expr,
+        StatementsSource $source,
+        string $taintIdPrefix,
+    ): void {
+        $nodeTypeProvider = $source->getNodeTypeProvider();
+
+        // The expression type may be unset when Psalm couldn't resolve the member —
+        // fall back to `string`, the type every covered read ultimately carries into
+        // a sink, so the taint annotation survives.
         $exprType = $nodeTypeProvider->getType($expr) ?? Type::getString();
 
-        $taintId = 'llm-output-' . $expr->name->name
+        $taintId = $taintIdPrefix
             . '-' . $source->getFileName()
             . ':' . $expr->getStartFilePos();
 
-        $taintedType = $codebase->addTaintSource(
+        $taintedType = $event->getCodebase()->addTaintSource(
             $exprType,
             $taintId,
             TaintKind::ALL_INPUT,
@@ -159,7 +228,5 @@ final class LlmOutputTaintHandler implements AfterExpressionAnalysisInterface
         );
 
         $nodeTypeProvider->setType($expr, $taintedType);
-
-        return null;
     }
 }

--- a/src/Handlers/Ai/LlmOutputTaintHandler.php
+++ b/src/Handlers/Ai/LlmOutputTaintHandler.php
@@ -14,21 +14,22 @@ use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\TaintKind;
 
 /**
- * Marks the `$text` property on Laravel AI response objects as an `input`
- * taint source. The model's output is downstream of every untrusted source
- * that reached its prompt (indirect prompt injection — attacker content in
- * a web page, RAG corpus, tool output, or email), so passing it unsanitized
+ * Marks the properties on Laravel AI response objects that hold model output as
+ * an `input` taint source. The model's output is downstream of every untrusted
+ * source that reached its prompt (indirect prompt injection — attacker content
+ * in a web page, RAG corpus, tool output, or email), so passing it unsanitized
  * to SQL, shell, HTML, header, or filesystem sinks should fire the matching
  * `Tainted*` issue.
  *
  * Psalm's `@psalm-taint-source` docblock annotation is not honored on
  * properties, only on method return types. This handler bridges that gap by
  * intercepting reads of the property and adding the taint via
- * `Codebase::addTaintSource()`. The stub at
- * `stubs/integrations/laravel-ai/Responses/TextResponse.phpstub`
- * complements this with `@psalm-taint-source` on `__toString()`.
+ * `Codebase::addTaintSource()`. The response stubs under
+ * `stubs/integrations/laravel-ai/Responses/` complement it with
+ * `@psalm-taint-source` on `__toString()` and the payload accessors, which are
+ * method returns and so can be annotated declaratively.
  *
- * Covered:
+ * `$text` is covered on:
  * - `Laravel\Ai\Responses\TextResponse` (and subclasses, including
  *   `AgentResponse` and `StreamedAgentResponse` — the snapshot returned to
  *   `Promptable::stream()->then()` callbacks).
@@ -38,9 +39,11 @@ use Psalm\Type\TaintKind;
  *   transcript of user-supplied audio is attacker-authored text that a speech
  *   model merely re-typed).
  *
- * `StructuredAgentResponse` and `StructuredTextResponse` are absent from the
+ * `StructuredAgentResponse` and `StructuredTextResponse` are absent from that
  * list but still covered: both inherit `$text` from `TextResponse`, so the
- * subclass walk below reaches them.
+ * subclass walk below reaches them. They additionally expose the decoded payload
+ * as a public `$structured` array, which laravel/ai's own console command reads,
+ * so that property is sourced on the pair directly.
  *
  * Array-access reads (`$response['field']`, `$request['task']`) are covered by
  * nothing, here or in the stubs: Psalm discards the taint edge when it resolves
@@ -61,26 +64,34 @@ use Psalm\Type\TaintKind;
 final class LlmOutputTaintHandler implements AfterExpressionAnalysisInterface
 {
     /**
-     * Classes whose `$text` property carries LLM-generated (untrusted) data.
+     * Property name => classes declaring it with LLM-generated (untrusted)
+     * contents. Scoped per property rather than as one class list crossed with
+     * one property list, because the two properties live on different parts of
+     * the hierarchy: every response carries `$text`, only the structured pair
+     * carries `$structured`.
+     *
      * Subclasses are still covered via `classExtendsOrImplements`; the explicit
-     * list shortcuts the common case to a single `in_array()` check.
+     * lists shortcut the common case to a single `in_array()` check.
      *
-     * @var list<string>
+     * @var array<string, list<string>>
      */
-    private const TAINTED_CLASSES = [
-        'Laravel\\Ai\\Responses\\TextResponse',
-        'Laravel\\Ai\\Responses\\AgentResponse',
-        'Laravel\\Ai\\Responses\\StreamedAgentResponse',
-        'Laravel\\Ai\\Responses\\StreamableAgentResponse',
-        'Laravel\\Ai\\Responses\\TranscriptionResponse',
+    private const TAINTED_PROPERTIES = [
+        'text' => [
+            'Laravel\\Ai\\Responses\\TextResponse',
+            'Laravel\\Ai\\Responses\\AgentResponse',
+            'Laravel\\Ai\\Responses\\StreamedAgentResponse',
+            'Laravel\\Ai\\Responses\\StreamableAgentResponse',
+            'Laravel\\Ai\\Responses\\TranscriptionResponse',
+        ],
+        // The decoded structured payload, declared by the
+        // ProvidesStructuredResponse trait. A plain `array`, so reading an offset
+        // off it propagates normally; the array-access gap below applies to
+        // `$response['field']` on the response object, not to this.
+        'structured' => [
+            'Laravel\\Ai\\Responses\\StructuredAgentResponse',
+            'Laravel\\Ai\\Responses\\StructuredTextResponse',
+        ],
     ];
-
-    /**
-     * Properties on the classes above that contain LLM-generated content.
-     *
-     * @var list<string>
-     */
-    private const TAINTED_PROPERTIES = ['text'];
 
     /** @inheritDoc */
     #[\Override]
@@ -104,7 +115,9 @@ final class LlmOutputTaintHandler implements AfterExpressionAnalysisInterface
             return null;
         }
 
-        if (!\in_array($expr->name->name, self::TAINTED_PROPERTIES, true)) {
+        $taintedClasses = self::TAINTED_PROPERTIES[$expr->name->name] ?? null;
+
+        if ($taintedClasses === null) {
             return null;
         }
 
@@ -124,7 +137,7 @@ final class LlmOutputTaintHandler implements AfterExpressionAnalysisInterface
                 continue;
             }
 
-            if (\in_array($atomic->value, self::TAINTED_CLASSES, true)) {
+            if (\in_array($atomic->value, $taintedClasses, true)) {
                 $isLlmResponse = true;
                 break;
             }
@@ -132,7 +145,7 @@ final class LlmOutputTaintHandler implements AfterExpressionAnalysisInterface
             // Cover user-defined subclasses (e.g. a project's own response
             // wrapper extending AgentResponse).
             if ($codebase->classExists($atomic->value)) {
-                foreach (self::TAINTED_CLASSES as $taintedClass) {
+                foreach ($taintedClasses as $taintedClass) {
                     if (!$codebase->classExists($taintedClass)) {
                         continue;
                     }
@@ -151,8 +164,9 @@ final class LlmOutputTaintHandler implements AfterExpressionAnalysisInterface
         }
 
         // The expression type may be unset when Psalm couldn't resolve the property —
-        // fall back to `string` so the taint annotation survives. `$text` is always
-        // a string in the laravel/ai package.
+        // fall back to `string` so the taint annotation survives. That is the right
+        // shape for `$text`; a `$structured` read that Psalm could not type is rare
+        // enough that a narrower fallback is not worth a second lookup.
         $exprType = $nodeTypeProvider->getType($expr) ?? Type::getString();
 
         $taintId = 'llm-output-' . $expr->name->name

--- a/stubs/integrations/laravel-ai/Contracts/CanActAsTool.phpstub
+++ b/stubs/integrations/laravel-ai/Contracts/CanActAsTool.phpstub
@@ -2,6 +2,8 @@
 
 namespace Laravel\Ai\Contracts;
 
+use Stringable;
+
 /**
  * Allows an Agent to be exposed as a tool to another agent (sub-agent pattern).
  * Same tool-poisoning concern as Tool::description() — a dynamically built
@@ -13,5 +15,5 @@ interface CanActAsTool
 {
     public function name(): string;
 
-    public function description(): string;
+    public function description(): Stringable|string;
 }

--- a/stubs/integrations/laravel-ai/Files/Document.phpstub
+++ b/stubs/integrations/laravel-ai/Files/Document.phpstub
@@ -17,6 +17,8 @@ namespace Laravel\Ai\Files;
  */
 abstract class Document extends File
 {
+    abstract public function content(): string;
+
     /**
      * @psalm-taint-sink llm_prompt $content
      */

--- a/stubs/integrations/laravel-ai/Responses/ProvidesStructuredResponse.phpstub
+++ b/stubs/integrations/laravel-ai/Responses/ProvidesStructuredResponse.phpstub
@@ -1,0 +1,35 @@
+<?php
+
+namespace Laravel\Ai\Responses;
+
+/**
+ * Array-access surface shared by StructuredAgentResponse and
+ * StructuredTextResponse. `$structured` holds the decoded model output: the
+ * keys come from the application's schema, the values do not, so reading one
+ * is the same trust boundary as reading `$response->text`.
+ *
+ * `@psalm-taint-source` here only reaches an explicit `$response->offsetGet('k')`
+ * call. The `$response['k']` sugar is sourced by LlmOutputTaintHandler instead,
+ * because Psalm's ArrayFetchAnalyzer synthesizes the offsetGet() call in a
+ * cloned node-data set and copies back only the return type, dropping the
+ * taint edge.
+ *
+ * Member list mirrors
+ * `vendor/laravel/ai/src/Responses/ProvidesStructuredResponse.php`.
+ */
+trait ProvidesStructuredResponse
+{
+    /** @var array<array-key, mixed> */
+    public array $structured;
+
+    public function offsetExists(mixed $offset): bool {}
+
+    /**
+     * @psalm-taint-source input
+     */
+    public function offsetGet(mixed $offset): mixed {}
+
+    public function offsetSet(mixed $offset, mixed $value): void {}
+
+    public function offsetUnset(mixed $offset): void {}
+}

--- a/stubs/integrations/laravel-ai/Responses/ProvidesStructuredResponse.phpstub
+++ b/stubs/integrations/laravel-ai/Responses/ProvidesStructuredResponse.phpstub
@@ -9,14 +9,12 @@ namespace Laravel\Ai\Responses;
  * is the same trust boundary as reading `$response->text`.
  *
  * IMPORTANT: `$response['k']` is NOT analysed. The annotation below reaches only
- * an explicit `$response->offsetGet('k')` call. Psalm's ArrayFetchAnalyzer
- * desugars the array-access form into a synthesized offsetGet() call inside a
- * cloned node-data set and copies back only the resulting type, so the taint
- * edge is discarded. Nothing in this plugin compensates: the gap affects every
- * ArrayAccess-based taint source, so it is left for an upstream Psalm fix. The
- * covered paths for structured output are `offsetGet()` called explicitly and
- * `toArray()`; `StructuredResponseArrayAccessKnownLimitation.phpt` pins the
- * uncovered one.
+ * an explicit `$response->offsetGet('k')` call, because Psalm discards the taint
+ * edge when it resolves the array-access sugar
+ * (https://github.com/vimeo/psalm/issues/11912). Nothing in this plugin
+ * compensates. The covered paths for structured output are `offsetGet()` called
+ * explicitly and `toArray()`; `StructuredResponseArrayAccessKnownLimitation.phpt`
+ * pins the uncovered one.
  *
  * Member list mirrors
  * `vendor/laravel/ai/src/Responses/ProvidesStructuredResponse.php`.

--- a/stubs/integrations/laravel-ai/Responses/ProvidesStructuredResponse.phpstub
+++ b/stubs/integrations/laravel-ai/Responses/ProvidesStructuredResponse.phpstub
@@ -8,11 +8,15 @@ namespace Laravel\Ai\Responses;
  * keys come from the application's schema, the values do not, so reading one
  * is the same trust boundary as reading `$response->text`.
  *
- * `@psalm-taint-source` here only reaches an explicit `$response->offsetGet('k')`
- * call. The `$response['k']` sugar is sourced by LlmOutputTaintHandler instead,
- * because Psalm's ArrayFetchAnalyzer synthesizes the offsetGet() call in a
- * cloned node-data set and copies back only the return type, dropping the
- * taint edge.
+ * IMPORTANT: `$response['k']` is NOT analysed. The annotation below reaches only
+ * an explicit `$response->offsetGet('k')` call. Psalm's ArrayFetchAnalyzer
+ * desugars the array-access form into a synthesized offsetGet() call inside a
+ * cloned node-data set and copies back only the resulting type, so the taint
+ * edge is discarded. Nothing in this plugin compensates: the gap affects every
+ * ArrayAccess-based taint source, so it is left for an upstream Psalm fix. The
+ * covered paths for structured output are `offsetGet()` called explicitly and
+ * `toArray()`; `StructuredResponseArrayAccessKnownLimitation.phpt` pins the
+ * uncovered one.
  *
  * Member list mirrors
  * `vendor/laravel/ai/src/Responses/ProvidesStructuredResponse.php`.

--- a/stubs/integrations/laravel-ai/Responses/StreamableAgentResponse.phpstub
+++ b/stubs/integrations/laravel-ai/Responses/StreamableAgentResponse.phpstub
@@ -23,6 +23,13 @@ use Traversable;
  * and the `CanStreamUsingVercelProtocol` trait surface intact. `$text` is
  * `?string` because it is populated only after the stream is drained.
  *
+ * No `__toString()` here, deliberately. Unlike every other response class this
+ * one does not define it, so declaring it in the stub taught Psalm that
+ * `(string) $response` was valid when it fatals at runtime, suppressing a real
+ * `InvalidCast`. A stub that invents API is worse than no stub. Read `$text`
+ * instead, which the handler sources. Pinned by
+ * `StreamableResponseHasNoStringCast.phpt`.
+ *
  * @template-implements IteratorAggregate<int, \Laravel\Ai\Streaming\Events\StreamEvent>
  */
 class StreamableAgentResponse implements IteratorAggregate, Responsable
@@ -54,7 +61,4 @@ class StreamableAgentResponse implements IteratorAggregate, Responsable
     public function toResponse($request): Response {}
 
     public function getIterator(): Traversable {}
-
-    /** @psalm-taint-source input */
-    public function __toString(): string {}
 }

--- a/stubs/integrations/laravel-ai/Responses/StructuredAgentResponse.phpstub
+++ b/stubs/integrations/laravel-ai/Responses/StructuredAgentResponse.phpstub
@@ -19,6 +19,9 @@ use Laravel\Ai\Responses\Data\Usage;
  * (`AgentResponse::__toString()`), or have no parent at all (`toArray()`),
  * so the annotations must be repeated here.
  *
+ * `$response['field']` is not analysed; see the ProvidesStructuredResponse stub
+ * for why, and use `toArray()` or an explicit `offsetGet()` call instead.
+ *
  * Hierarchy and member list copied from
  * `vendor/laravel/ai/src/Responses/StructuredAgentResponse.php` so the stub
  * re-declaration keeps the four interfaces Psalm resets on re-declaration.

--- a/stubs/integrations/laravel-ai/Responses/StructuredAgentResponse.phpstub
+++ b/stubs/integrations/laravel-ai/Responses/StructuredAgentResponse.phpstub
@@ -1,0 +1,60 @@
+<?php
+
+namespace Laravel\Ai\Responses;
+
+use ArrayAccess;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use JsonSerializable;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Usage;
+
+/**
+ * Structured-output sibling of AgentResponse. `$text` is already covered by
+ * LlmOutputTaintHandler through the subclass walk; the four accessors below
+ * hand back the decoded `$structured` payload, which is the same model output
+ * in another shape and was untainted until now.
+ *
+ * All four override a parent whose annotation would otherwise apply
+ * (`AgentResponse::__toString()`), or have no parent at all (`toArray()`),
+ * so the annotations must be repeated here.
+ *
+ * Hierarchy and member list copied from
+ * `vendor/laravel/ai/src/Responses/StructuredAgentResponse.php` so the stub
+ * re-declaration keeps the four interfaces Psalm resets on re-declaration.
+ *
+ * @template-implements ArrayAccess<array-key, mixed>
+ */
+class StructuredAgentResponse extends AgentResponse implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
+{
+    use ProvidesStructuredResponse;
+
+    /**
+     * @param array<array-key, mixed> $structured
+     */
+    public function __construct(string $invocationId, array $structured, string $text, Usage $usage, Meta $meta) {}
+
+    /**
+     * @return array<array-key, mixed>
+     *
+     * @psalm-taint-source input
+     */
+    public function toArray(): array {}
+
+    /**
+     * @param int $options
+     *
+     * @psalm-taint-source input
+     */
+    public function toJson($options = 0): string {}
+
+    /**
+     * @psalm-taint-source input
+     */
+    public function jsonSerialize(): mixed {}
+
+    /**
+     * @psalm-taint-source input
+     */
+    public function __toString(): string {}
+}

--- a/stubs/integrations/laravel-ai/Responses/StructuredTextResponse.phpstub
+++ b/stubs/integrations/laravel-ai/Responses/StructuredTextResponse.phpstub
@@ -1,0 +1,34 @@
+<?php
+
+namespace Laravel\Ai\Responses;
+
+use ArrayAccess;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Usage;
+
+/**
+ * Structured-output sibling of TextResponse, carrying the same
+ * ProvidesStructuredResponse surface as StructuredAgentResponse but a
+ * different parent. It overrides `__toString()` to serialize `$structured`
+ * rather than `$text`, which drops the source annotation TextResponse's stub
+ * puts on that method, so it is repeated here.
+ *
+ * Hierarchy and member list copied from
+ * `vendor/laravel/ai/src/Responses/StructuredTextResponse.php`.
+ *
+ * @template-implements ArrayAccess<array-key, mixed>
+ */
+class StructuredTextResponse extends TextResponse implements ArrayAccess
+{
+    use ProvidesStructuredResponse;
+
+    /**
+     * @param array<array-key, mixed> $structured
+     */
+    public function __construct(array $structured, string $text, public Usage $usage, public Meta $meta) {}
+
+    /**
+     * @psalm-taint-source input
+     */
+    public function __toString(): string {}
+}

--- a/stubs/integrations/laravel-ai/Responses/TranscriptionResponse.phpstub
+++ b/stubs/integrations/laravel-ai/Responses/TranscriptionResponse.phpstub
@@ -1,0 +1,46 @@
+<?php
+
+namespace Laravel\Ai\Responses;
+
+use Illuminate\Support\Collection;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\TranscriptionSegment;
+use Laravel\Ai\Responses\Data\Usage;
+
+/**
+ * A transcript is model output like any other: the audio was supplied by a user,
+ * so the text is attacker-authored content that a speech model merely re-typed.
+ * `$text` property reads are sourced by LlmOutputTaintHandler, which lists this
+ * class explicitly because it extends nothing (no subclass walk reaches it).
+ * `__toString()` returns `$this->text` verbatim upstream, so the string cast is
+ * the same trust boundary and is annotated here.
+ *
+ * Hierarchy and member list copied from
+ * `vendor/laravel/ai/src/Responses/TranscriptionResponse.php`: re-declaring the
+ * class resets the reflected interface list, and restating every member keeps
+ * `$segments`, `$usage` and `$meta` resolvable even if the class is ever reached
+ * only through a return type, in which case the stub becomes its sole definition.
+ *
+ * @psalm-api
+ */
+class TranscriptionResponse implements \Stringable
+{
+    public string $text;
+
+    /** @var Collection<int, TranscriptionSegment> */
+    public Collection $segments;
+
+    public Usage $usage;
+
+    public Meta $meta;
+
+    /**
+     * @param Collection<int, TranscriptionSegment> $segments
+     */
+    public function __construct(string $text, Collection $segments, Usage $usage, Meta $meta) {}
+
+    /**
+     * @psalm-taint-source input
+     */
+    public function __toString(): string {}
+}

--- a/stubs/integrations/laravel-ai/Tools/Request.phpstub
+++ b/stubs/integrations/laravel-ai/Tools/Request.phpstub
@@ -58,6 +58,16 @@ class Request implements Arrayable, ArrayAccess
     public function offsetExists(mixed $offset): bool {}
 
     /**
+     * IMPORTANT: `$request['key']` is NOT analysed, only an explicit
+     * `$request->offsetGet('key')` call is. Psalm's ArrayFetchAnalyzer desugars
+     * the array-access form into a synthesized offsetGet() call inside a cloned
+     * node-data set and copies back only the resulting type, discarding the taint
+     * edge. The gap affects every ArrayAccess-based taint source, so it is left
+     * for an upstream fix. It costs real coverage here, because the framework's
+     * own Tools\AgentTool::handle() forwards `(string) $request['task']` into a
+     * sub-agent prompt: see SubAgentToolDelegationKnownLimitation.phpt. Prefer
+     * `str()`, `string()` or `array()` in project code, all of which are covered.
+     *
      * @psalm-taint-source input
      */
     public function offsetGet(mixed $offset): mixed {}

--- a/stubs/integrations/laravel-ai/Tools/Request.phpstub
+++ b/stubs/integrations/laravel-ai/Tools/Request.phpstub
@@ -59,14 +59,13 @@ class Request implements Arrayable, ArrayAccess
 
     /**
      * IMPORTANT: `$request['key']` is NOT analysed, only an explicit
-     * `$request->offsetGet('key')` call is. Psalm's ArrayFetchAnalyzer desugars
-     * the array-access form into a synthesized offsetGet() call inside a cloned
-     * node-data set and copies back only the resulting type, discarding the taint
-     * edge. The gap affects every ArrayAccess-based taint source, so it is left
-     * for an upstream fix. It costs real coverage here, because the framework's
-     * own Tools\AgentTool::handle() forwards `(string) $request['task']` into a
-     * sub-agent prompt: see SubAgentToolDelegationKnownLimitation.phpt. Prefer
-     * `str()`, `string()` or `array()` in project code, all of which are covered.
+     * `$request->offsetGet('key')` call is, because Psalm discards the taint edge
+     * when it resolves the array-access sugar
+     * (https://github.com/vimeo/psalm/issues/11912). It costs real coverage here,
+     * because the framework's own Tools\AgentTool::handle() forwards
+     * `(string) $request['task']` into a sub-agent prompt: see
+     * SubAgentToolDelegationKnownLimitation.phpt. Prefer `str()`, `string()` or
+     * `array()` in project code, all of which are covered.
      *
      * @psalm-taint-source input
      */

--- a/tests/Type/tests/PromptInjection/StreamableResponseHasNoStringCast.phpt
+++ b/tests/Type/tests/PromptInjection/StreamableResponseHasNoStringCast.phpt
@@ -1,0 +1,27 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// isInstalledAndSatisfies('laravel/ai', '>=0.10.0 <1.0.0')); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs laravel/ai package (optional integration, not in composer.json)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\StreamableCasts;
+
+function castStreamableResponse(\Laravel\Ai\Responses\StreamableAgentResponse $response): string {
+    // StreamableAgentResponse is the one response class upstream does not give a
+    // __toString(). The stub used to declare one anyway, which made Psalm accept
+    // this cast and hid a runtime fatal. The report below is the point of the test:
+    // a stub must not invent API, even to hang a taint annotation off it.
+    return (string) $response;
+}
+?>
+--EXPECTF--
+InvalidCast on line %d: Laravel\Ai\Responses\StreamableAgentResponse cannot be cast to string

--- a/tests/Type/tests/PromptInjection/StructuredArrayReturnKnownLimitation.phpt
+++ b/tests/Type/tests/PromptInjection/StructuredArrayReturnKnownLimitation.phpt
@@ -1,0 +1,40 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// isInstalledAndSatisfies('laravel/ai', '>=0.10.0 <1.0.0')); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs laravel/ai package (optional integration, not in composer.json)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\StructuredArrayLimit;
+
+/**
+ * Known limitation, not a design choice. `toArray()` carries
+ * `@psalm-taint-source input`, but consuming the returned array element-wise
+ * loses the edge under whole-project analysis, which is how this suite and a
+ * real project run. The same fixture reports TaintedSql when Psalm analyzes the
+ * file on its own, so this is the upstream hop-loss, not a missing annotation.
+ *
+ * Direct array access on the response object (`$response['body']`) is unaffected
+ * and is covered by StructuredResponseArrayAccess.phpt: LlmOutputTaintHandler
+ * sources it at the read site rather than through a dataflow hop.
+ *
+ * Empty expectations make this a canary: it turns red once the hop survives, at
+ * which point the accompanying caveat should be deleted.
+ */
+function readStructuredElement(\Laravel\Ai\Responses\StructuredAgentResponse $response): void {
+    $payload = $response->toArray();
+
+    if (isset($payload['body'])) {
+        \Illuminate\Support\Facades\DB::select('SELECT * FROM notes WHERE body = ' . (string) $payload['body']);
+    }
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/PromptInjection/StructuredArrayReturnKnownLimitation.phpt
+++ b/tests/Type/tests/PromptInjection/StructuredArrayReturnKnownLimitation.phpt
@@ -22,9 +22,9 @@ namespace App\StructuredArrayLimit;
  * real project run. The same fixture reports TaintedSql when Psalm analyzes the
  * file on its own, so this is the upstream hop-loss, not a missing annotation.
  *
- * Direct array access on the response object (`$response['body']`) is unaffected
- * and is covered by StructuredResponseArrayAccess.phpt: LlmOutputTaintHandler
- * sources it at the read site rather than through a dataflow hop.
+ * Direct array access on the response object (`$response['body']`) is uncovered
+ * for a different upstream reason (https://github.com/vimeo/psalm/issues/11912),
+ * pinned separately by StructuredResponseArrayAccessKnownLimitation.phpt.
  *
  * Empty expectations make this a canary: it turns red once the hop survives, at
  * which point the accompanying caveat should be deleted.

--- a/tests/Type/tests/PromptInjection/StructuredArrayReturnKnownLimitation.phpt
+++ b/tests/Type/tests/PromptInjection/StructuredArrayReturnKnownLimitation.phpt
@@ -16,24 +16,34 @@ if (!trait_exists(\Laravel\Ai\Promptable::class)) {
 namespace App\StructuredArrayLimit;
 
 /**
- * Known limitation, not a design choice. `toArray()` carries
- * `@psalm-taint-source input`, but consuming the returned array element-wise
- * loses the edge under whole-project analysis, which is how this suite and a
- * real project run. The same fixture reports TaintedSql when Psalm analyzes the
- * file on its own, so this is the upstream hop-loss, not a missing annotation.
+ * Known limitation, not a design choice. Both the `toArray()` return and the
+ * `$structured` property carry the `input` taint, but reading a single element
+ * out of the resulting array loses the edge under whole-project analysis, which
+ * is how this suite and a real project run. Both fixtures below report
+ * TaintedSql when Psalm analyzes the file on its own, so this is the upstream
+ * hop-loss, not a missing source.
+ *
+ * What survives is a zero-hop consumption of the whole payload, which is why the
+ * positive coverage in StructuredPayloadProperty.phpt sinks the array itself.
  *
  * Direct array access on the response object (`$response['body']`) is uncovered
  * for a different upstream reason (https://github.com/vimeo/psalm/issues/11912),
  * pinned separately by StructuredResponseArrayAccessKnownLimitation.phpt.
  *
  * Empty expectations make this a canary: it turns red once the hop survives, at
- * which point the accompanying caveat should be deleted.
+ * which point the accompanying caveats should be deleted.
  */
 function readStructuredElement(\Laravel\Ai\Responses\StructuredAgentResponse $response): void {
     $payload = $response->toArray();
 
     if (isset($payload['body'])) {
         \Illuminate\Support\Facades\DB::select('SELECT * FROM notes WHERE body = ' . (string) $payload['body']);
+    }
+}
+
+function readStructuredPropertyElement(\Laravel\Ai\Responses\StructuredAgentResponse $response): void {
+    if (isset($response->structured['body'])) {
+        \Illuminate\Support\Facades\DB::select('SELECT * FROM notes WHERE body = ' . (string) $response->structured['body']);
     }
 }
 ?>

--- a/tests/Type/tests/PromptInjection/StructuredPayloadProperty.phpt
+++ b/tests/Type/tests/PromptInjection/StructuredPayloadProperty.phpt
@@ -1,0 +1,37 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// isInstalledAndSatisfies('laravel/ai', '>=0.10.0 <1.0.0')); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs laravel/ai package (optional integration, not in composer.json)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\StructuredPayload;
+
+function spreadAgentPayload(\Laravel\Ai\Responses\StructuredAgentResponse $response): void {
+    // `$structured` is the decoded model output as a public array, the shape
+    // laravel/ai's own ChatCommand reads. Psalm honors no taint annotation on a
+    // property, so LlmOutputTaintHandler sources the read site.
+    //
+    // The sink takes the whole array on purpose. Pulling one element back out
+    // loses the edge under whole-project analysis: see
+    // StructuredArrayReturnKnownLimitation.phpt.
+    extract($response->structured);
+}
+
+function spreadTextPayload(\Laravel\Ai\Responses\StructuredTextResponse $response): void {
+    // Same trait, different parent, so the property is listed for both classes
+    // rather than reached through the $text subclass walk.
+    extract($response->structured);
+}
+?>
+--EXPECTF--
+TaintedExtract on line %d: Detected tainted extract
+TaintedExtract on line %d: Detected tainted extract

--- a/tests/Type/tests/PromptInjection/StructuredResponseArrayAccess.phpt
+++ b/tests/Type/tests/PromptInjection/StructuredResponseArrayAccess.phpt
@@ -1,0 +1,33 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// isInstalledAndSatisfies('laravel/ai', '>=0.10.0 <1.0.0')); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs laravel/ai package (optional integration, not in composer.json)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\StructuredOutput;
+
+function renderStructuredAgentField(\Laravel\Ai\Responses\StructuredAgentResponse $response): void {
+    // Structured output is still model output: the JSON keys are schema-controlled but
+    // the values are not. Array access reaches ProvidesStructuredResponse::offsetGet().
+    echo (string) $response['summary'];
+}
+
+function renderStructuredTextField(\Laravel\Ai\Responses\StructuredTextResponse $response): void {
+    // Same trait, different hierarchy (TextResponse rather than AgentResponse).
+    echo (string) $response['summary'];
+}
+?>
+--EXPECTF--
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/PromptInjection/StructuredResponseArrayAccessKnownLimitation.phpt
+++ b/tests/Type/tests/PromptInjection/StructuredResponseArrayAccessKnownLimitation.phpt
@@ -15,9 +15,17 @@ if (!trait_exists(\Laravel\Ai\Promptable::class)) {
 
 namespace App\StructuredOutput;
 
+/**
+ * Known limitation, same upstream cause as SubAgentToolDelegationKnownLimitation.phpt:
+ * Psalm's ArrayFetchAnalyzer drops the taint edge when it desugars `$x['k']` into a
+ * synthesized offsetGet() call. Empty expectations assert the current behavior.
+ *
+ * Structured output is still model output, so both reads below should report
+ * TaintedHtml. The covered alternatives today are the explicit
+ * `$response->offsetGet('summary')` call and `toArray()`, both exercised by
+ * StructuredResponseToArray.phpt.
+ */
 function renderStructuredAgentField(\Laravel\Ai\Responses\StructuredAgentResponse $response): void {
-    // Structured output is still model output: the JSON keys are schema-controlled but
-    // the values are not. Array access reaches ProvidesStructuredResponse::offsetGet().
     echo (string) $response['summary'];
 }
 
@@ -27,7 +35,3 @@ function renderStructuredTextField(\Laravel\Ai\Responses\StructuredTextResponse 
 }
 ?>
 --EXPECTF--
-TaintedHtml on line %d: Detected tainted HTML
-TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
-TaintedHtml on line %d: Detected tainted HTML
-TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/PromptInjection/StructuredResponseArrayAccessKnownLimitation.phpt
+++ b/tests/Type/tests/PromptInjection/StructuredResponseArrayAccessKnownLimitation.phpt
@@ -17,8 +17,9 @@ namespace App\StructuredOutput;
 
 /**
  * Known limitation, same upstream cause as SubAgentToolDelegationKnownLimitation.phpt:
- * Psalm's ArrayFetchAnalyzer drops the taint edge when it desugars `$x['k']` into a
- * synthesized offsetGet() call. Empty expectations assert the current behavior.
+ * Psalm drops the taint edge when it resolves the `$x['k']` sugar
+ * (https://github.com/vimeo/psalm/issues/11912). Empty expectations assert the
+ * current behavior.
  *
  * Structured output is still model output, so both reads below should report
  * TaintedHtml. The covered alternatives today are the explicit

--- a/tests/Type/tests/PromptInjection/StructuredResponseToArray.phpt
+++ b/tests/Type/tests/PromptInjection/StructuredResponseToArray.phpt
@@ -30,8 +30,16 @@ function castStructuredPayload(\Laravel\Ai\Responses\StructuredAgentResponse $re
     // $structured, which drops the parent stub's source annotation.
     \Illuminate\Support\Facades\DB::select('SELECT * FROM notes WHERE body = ' . (string) $response);
 }
+
+function offsetGetStructuredPayload(\Laravel\Ai\Responses\StructuredAgentResponse $response): void {
+    // The explicit call is the covered counterpart to `$response['body']`, which
+    // Psalm's array-access desugaring silently strips of taint. See
+    // StructuredResponseArrayAccessKnownLimitation.phpt.
+    \Illuminate\Support\Facades\DB::select('SELECT * FROM notes WHERE body = ' . (string) $response->offsetGet('body'));
+}
 ?>
 --EXPECTF--
+TaintedSql on line %d: Detected tainted SQL
 TaintedSql on line %d: Detected tainted SQL
 TaintedSql on line %d: Detected tainted SQL
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/PromptInjection/StructuredResponseToArray.phpt
+++ b/tests/Type/tests/PromptInjection/StructuredResponseToArray.phpt
@@ -1,0 +1,37 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// isInstalledAndSatisfies('laravel/ai', '>=0.10.0 <1.0.0')); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs laravel/ai package (optional integration, not in composer.json)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\StructuredExport;
+
+function serializeStructuredPayload(\Laravel\Ai\Responses\StructuredAgentResponse $response): void {
+    // toJson(), jsonSerialize() and __toString() all hand back the same decoded model
+    // output. The keys came from the app's schema, the values did not.
+    \Illuminate\Support\Facades\DB::select('SELECT * FROM notes WHERE body = ' . $response->toJson());
+}
+
+function jsonSerializeStructuredPayload(\Laravel\Ai\Responses\StructuredAgentResponse $response): void {
+    \Illuminate\Support\Facades\DB::select('SELECT * FROM notes WHERE body = ' . (string) $response->jsonSerialize());
+}
+
+function castStructuredPayload(\Laravel\Ai\Responses\StructuredAgentResponse $response): void {
+    // StructuredAgentResponse overrides AgentResponse::__toString() to serialize
+    // $structured, which drops the parent stub's source annotation.
+    \Illuminate\Support\Facades\DB::select('SELECT * FROM notes WHERE body = ' . (string) $response);
+}
+?>
+--EXPECTF--
+TaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/PromptInjection/SubAgentToolDelegation.phpt
+++ b/tests/Type/tests/PromptInjection/SubAgentToolDelegation.phpt
@@ -1,0 +1,52 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// isInstalledAndSatisfies('laravel/ai', '>=0.10.0 <1.0.0')); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs laravel/ai package (optional integration, not in composer.json)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\SubAgents;
+
+final class ResearchSubAgent
+{
+    use \Laravel\Ai\Promptable;
+}
+
+/**
+ * Mirrors Laravel\Ai\Tools\AgentTool::handle(): a parent agent exposes another agent
+ * as a tool, and the task text the parent model chose is forwarded verbatim into the
+ * sub-agent's prompt. No annotation covers this chain directly; it holds only because
+ * Request::offsetGet() is a source and Promptable::prompt() is a sink, so a refactor
+ * of either stub would silently drop it.
+ */
+final class ResearchDelegationTool implements \Laravel\Ai\Contracts\Tool
+{
+    #[\Override]
+    public function description(): \Stringable|string
+    {
+        return 'Delegates a task to the research sub-agent.';
+    }
+
+    #[\Override]
+    public function handle(\Laravel\Ai\Tools\Request $request): string
+    {
+        return (new ResearchSubAgent())->prompt((string) $request['task'])->text;
+    }
+
+    #[\Override]
+    public function schema(\Illuminate\Contracts\JsonSchema\JsonSchema $schema): array
+    {
+        return ['task' => $schema->string()->required()];
+    }
+}
+?>
+--EXPECTF--
+TaintedLlmPrompt on line %d: Detected tainted LLM prompt

--- a/tests/Type/tests/PromptInjection/SubAgentToolDelegationKnownLimitation.phpt
+++ b/tests/Type/tests/PromptInjection/SubAgentToolDelegationKnownLimitation.phpt
@@ -30,12 +30,10 @@ final class ResearchSubAgent
  * `@psalm-taint-source input` and Promptable::prompt() is an `llm_prompt` sink,
  * so the composition should report TaintedLlmPrompt.
  *
- * It does not, because Psalm's ArrayFetchAnalyzer resolves the `$request['task']`
- * sugar by synthesizing a VirtualMethodCall to offsetGet() in a cloned node-data
- * set and copying back only the resulting type. The taint edge lives in the clone
- * and is discarded. That breaks every ArrayAccess-based taint source, so it is a
- * Psalm core gap rather than a Laravel one, and it is left for an upstream fix.
- * Writing the same call as `$request->offsetGet('task')` does report.
+ * It does not, because Psalm discards the taint edge when it resolves the
+ * `$request['task']` sugar into an offsetGet() call
+ * (https://github.com/vimeo/psalm/issues/11912). Writing the same call as
+ * `$request->offsetGet('task')` does report.
  *
  * When upstream lands, this test fails loudly. Replace it then with the positive
  * assertion (`%ATaintedLlmPrompt on line %d: Detected tainted LLM prompt`) and

--- a/tests/Type/tests/PromptInjection/SubAgentToolDelegationKnownLimitation.phpt
+++ b/tests/Type/tests/PromptInjection/SubAgentToolDelegationKnownLimitation.phpt
@@ -21,11 +21,25 @@ final class ResearchSubAgent
 }
 
 /**
- * Mirrors Laravel\Ai\Tools\AgentTool::handle(): a parent agent exposes another agent
- * as a tool, and the task text the parent model chose is forwarded verbatim into the
- * sub-agent's prompt. No annotation covers this chain directly; it holds only because
- * Request::offsetGet() is a source and Promptable::prompt() is a sink, so a refactor
- * of either stub would silently drop it.
+ * Known limitation. Empty expectations assert the CURRENT behavior: nothing is
+ * reported, even though the flow is real.
+ *
+ * This mirrors Laravel\Ai\Tools\AgentTool::handle(): a parent agent exposes
+ * another agent as a tool, and the task text the parent model chose is forwarded
+ * verbatim into the sub-agent's prompt. Tools\Request::offsetGet() carries
+ * `@psalm-taint-source input` and Promptable::prompt() is an `llm_prompt` sink,
+ * so the composition should report TaintedLlmPrompt.
+ *
+ * It does not, because Psalm's ArrayFetchAnalyzer resolves the `$request['task']`
+ * sugar by synthesizing a VirtualMethodCall to offsetGet() in a cloned node-data
+ * set and copying back only the resulting type. The taint edge lives in the clone
+ * and is discarded. That breaks every ArrayAccess-based taint source, so it is a
+ * Psalm core gap rather than a Laravel one, and it is left for an upstream fix.
+ * Writing the same call as `$request->offsetGet('task')` does report.
+ *
+ * When upstream lands, this test fails loudly. Replace it then with the positive
+ * assertion (`%ATaintedLlmPrompt on line %d: Detected tainted LLM prompt`) and
+ * delete the caveat in LlmOutputTaintHandler's docblock.
  */
 final class ResearchDelegationTool implements \Laravel\Ai\Contracts\Tool
 {
@@ -49,4 +63,3 @@ final class ResearchDelegationTool implements \Laravel\Ai\Contracts\Tool
 }
 ?>
 --EXPECTF--
-TaintedLlmPrompt on line %d: Detected tainted LLM prompt

--- a/tests/Type/tests/PromptInjection/ToolDescriptionStringable.phpt
+++ b/tests/Type/tests/PromptInjection/ToolDescriptionStringable.phpt
@@ -1,0 +1,30 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// isInstalledAndSatisfies('laravel/ai', '>=0.10.0 <1.0.0')); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs laravel/ai package (optional integration, not in composer.json)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\ToolDescriptions;
+
+/**
+ * CanActAsTool::description() returns Stringable|string, not string. While the stub
+ * narrowed it to string, every caller that handled the Stringable branch collected
+ * RedundantCondition, TypeDoesNotContainType, MixedMethodCall and MixedReturnStatement.
+ */
+function normalizeDescription(\Laravel\Ai\Contracts\CanActAsTool $tool): string
+{
+    $description = $tool->description();
+
+    return is_string($description) ? $description : $description->__toString();
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/PromptInjection/TranscriptionOutputCast.phpt
+++ b/tests/Type/tests/PromptInjection/TranscriptionOutputCast.phpt
@@ -1,0 +1,32 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// isInstalledAndSatisfies('laravel/ai', '>=0.10.0 <1.0.0')); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs laravel/ai package (optional integration, not in composer.json)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\TranscriptCasts;
+
+function logTranscriptCast(\Laravel\Ai\Responses\TranscriptionResponse $transcription): void {
+    // TranscriptionResponse::__toString() returns $text verbatim upstream, so the
+    // cast is the same trust boundary as the property read. Covering the property
+    // in the handler does not cover this: the cast resolves through the stub.
+    \Illuminate\Support\Facades\DB::select((string) $transcription);
+}
+
+function transcriptSurfaceSurvivesRedeclaration(\Laravel\Ai\Responses\TranscriptionResponse $transcription): int {
+    // The stub re-declares the class, which resets its member list. Reading the
+    // members it is not annotating proves the restatement is complete.
+    return $transcription->segments->count() + $transcription->usage->promptTokens;
+}
+?>
+--EXPECTF--
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/PromptInjection/TranscriptionOutputToSql.phpt
+++ b/tests/Type/tests/PromptInjection/TranscriptionOutputToSql.phpt
@@ -1,0 +1,27 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// isInstalledAndSatisfies('laravel/ai', '>=0.10.0 <1.0.0')); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs laravel/ai package (optional integration, not in composer.json)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Transcripts;
+
+function searchTranscript(\Laravel\Ai\Responses\TranscriptionResponse $transcription): void {
+    // The audio was uploaded by a user, so the transcript is attacker-authored text
+    // that a speech model merely re-typed. TranscriptionResponse sits in its own
+    // hierarchy (it does not extend TextResponse), so LlmOutputTaintHandler needs it
+    // listed explicitly for the $text read to carry taint.
+    \Illuminate\Support\Facades\DB::select($transcription->text);
+}
+?>
+--EXPECTF--
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Unit/Handlers/Ai/LlmOutputTaintHandlerTest.php
+++ b/tests/Unit/Handlers/Ai/LlmOutputTaintHandlerTest.php
@@ -74,9 +74,7 @@ final class LlmOutputTaintHandlerTest extends TestCase
     #[Test]
     public function it_lists_all_known_response_classes(): void
     {
-        $reflection = new \ReflectionClass(LlmOutputTaintHandler::class);
-        /** @var list<string> $taintedClasses */
-        $taintedClasses = $reflection->getReflectionConstant('TAINTED_CLASSES')?->getValue() ?? [];
+        $taintedClasses = $this->taintedProperties()['text'] ?? [];
 
         $this->assertContains('Laravel\\Ai\\Responses\\TextResponse', $taintedClasses);
         $this->assertContains('Laravel\\Ai\\Responses\\AgentResponse', $taintedClasses);
@@ -111,13 +109,29 @@ final class LlmOutputTaintHandlerTest extends TestCase
     }
 
     #[Test]
-    public function it_only_taints_the_text_property(): void
+    public function it_scopes_the_structured_payload_to_the_structured_responses(): void
+    {
+        // Not a cross-product with the $text class list: only these two declare
+        // $structured, and tainting the property on a class that does not have it
+        // would source whatever a user subclass happens to name the same way.
+        $this->assertSame([
+            'Laravel\\Ai\\Responses\\StructuredAgentResponse',
+            'Laravel\\Ai\\Responses\\StructuredTextResponse',
+        ], $this->taintedProperties()['structured'] ?? []);
+    }
+
+    #[Test]
+    public function it_only_taints_the_known_payload_properties(): void
+    {
+        $this->assertSame(['text', 'structured'], array_keys($this->taintedProperties()));
+    }
+
+    /** @return array<string, list<string>> */
+    private function taintedProperties(): array
     {
         $reflection = new \ReflectionClass(LlmOutputTaintHandler::class);
-        /** @var list<string> $taintedProperties */
-        $taintedProperties = $reflection->getReflectionConstant('TAINTED_PROPERTIES')?->getValue() ?? [];
 
-        $this->assertSame(['text'], $taintedProperties);
+        return $reflection->getReflectionConstant('TAINTED_PROPERTIES')?->getValue() ?? [];
     }
 
     private function propertyFetch(string $propertyName): PropertyFetch

--- a/tests/Unit/Handlers/Ai/LlmOutputTaintHandlerTest.php
+++ b/tests/Unit/Handlers/Ai/LlmOutputTaintHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Ai;
 
+use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
@@ -85,6 +86,37 @@ final class LlmOutputTaintHandlerTest extends TestCase
         // only after the stream completes — has to be listed explicitly because
         // it does not extend TextResponse upstream.
         $this->assertContains('Laravel\\Ai\\Responses\\StreamableAgentResponse', $taintedClasses);
+        // TranscriptionResponse is a third hierarchy: a transcript of user-supplied
+        // audio is attacker-authored text that a speech model re-typed.
+        $this->assertContains('Laravel\\Ai\\Responses\\TranscriptionResponse', $taintedClasses);
+    }
+
+    #[Test]
+    public function it_lists_the_array_access_surfaces(): void
+    {
+        $reflection = new \ReflectionClass(LlmOutputTaintHandler::class);
+        /** @var list<string> $taintedClasses */
+        $taintedClasses = $reflection->getReflectionConstant('ARRAY_ACCESS_TAINTED_CLASSES')?->getValue() ?? [];
+
+        $this->assertSame([
+            'Laravel\\Ai\\Tools\\Request',
+            'Laravel\\Ai\\Responses\\StructuredAgentResponse',
+            'Laravel\\Ai\\Responses\\StructuredTextResponse',
+        ], $taintedClasses);
+    }
+
+    #[Test]
+    public function it_returns_null_for_an_append_write_target(): void
+    {
+        $codebase = $this->createCodebase(taintFlowGraph: new TaintFlowGraph());
+        $event = $this->createEvent(
+            // `$request[] = ...`: a null dim is always a write, never a read.
+            expr: new ArrayDimFetch(new Variable('request')),
+            codebase: $codebase,
+            varType: $this->namedObjectType('Laravel\\Ai\\Tools\\Request'),
+        );
+
+        $this->assertNull(LlmOutputTaintHandler::afterExpressionAnalysis($event));
     }
 
     #[Test]

--- a/tests/Unit/Handlers/Ai/LlmOutputTaintHandlerTest.php
+++ b/tests/Unit/Handlers/Ai/LlmOutputTaintHandlerTest.php
@@ -95,11 +95,11 @@ final class LlmOutputTaintHandlerTest extends TestCase
     #[Test]
     public function it_does_not_source_array_access_reads(): void
     {
-        // Psalm's ArrayFetchAnalyzer discards the taint edge when it desugars
-        // `$response['field']`, so an ArrayDimFetch branch here would be a
-        // workaround for a core gap on one of the hottest node types. Pinned so
-        // the deferral is a decision rather than an oversight; the flows it
-        // leaves uncovered are in the *KnownLimitation.phpt fixtures.
+        // Psalm discards the taint edge when it resolves `$response['field']`
+        // (https://github.com/vimeo/psalm/issues/11912), so an ArrayDimFetch
+        // branch here would work around a core gap on one of the hottest node
+        // types. Pinned so the deferral is a decision rather than an oversight;
+        // the flows it leaves uncovered are in the *KnownLimitation.phpt fixtures.
         $codebase = $this->createCodebase(taintFlowGraph: new TaintFlowGraph());
         $event = $this->createEvent(
             expr: new ArrayDimFetch(new Variable('response'), new String_('summary')),

--- a/tests/Unit/Handlers/Ai/LlmOutputTaintHandlerTest.php
+++ b/tests/Unit/Handlers/Ai/LlmOutputTaintHandlerTest.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\String_;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -92,28 +93,18 @@ final class LlmOutputTaintHandlerTest extends TestCase
     }
 
     #[Test]
-    public function it_lists_the_array_access_surfaces(): void
+    public function it_does_not_source_array_access_reads(): void
     {
-        $reflection = new \ReflectionClass(LlmOutputTaintHandler::class);
-        /** @var list<string> $taintedClasses */
-        $taintedClasses = $reflection->getReflectionConstant('ARRAY_ACCESS_TAINTED_CLASSES')?->getValue() ?? [];
-
-        $this->assertSame([
-            'Laravel\\Ai\\Tools\\Request',
-            'Laravel\\Ai\\Responses\\StructuredAgentResponse',
-            'Laravel\\Ai\\Responses\\StructuredTextResponse',
-        ], $taintedClasses);
-    }
-
-    #[Test]
-    public function it_returns_null_for_an_append_write_target(): void
-    {
+        // Psalm's ArrayFetchAnalyzer discards the taint edge when it desugars
+        // `$response['field']`, so an ArrayDimFetch branch here would be a
+        // workaround for a core gap on one of the hottest node types. Pinned so
+        // the deferral is a decision rather than an oversight; the flows it
+        // leaves uncovered are in the *KnownLimitation.phpt fixtures.
         $codebase = $this->createCodebase(taintFlowGraph: new TaintFlowGraph());
         $event = $this->createEvent(
-            // `$request[] = ...`: a null dim is always a write, never a read.
-            expr: new ArrayDimFetch(new Variable('request')),
+            expr: new ArrayDimFetch(new Variable('response'), new String_('summary')),
             codebase: $codebase,
-            varType: $this->namedObjectType('Laravel\\Ai\\Tools\\Request'),
+            varType: $this->namedObjectType('Laravel\\Ai\\Responses\\StructuredAgentResponse'),
         );
 
         $this->assertNull(LlmOutputTaintHandler::afterExpressionAnalysis($event));


### PR DESCRIPTION
Phase 1 gap closure for the `laravel/ai` taint integration. Stacks on #937 (`484-llm-prompt`). Refs #484.

Stub syncs and annotations, plus one constant added to `LlmOutputTaintHandler`. No new mechanism.

## Stub signature syncs (verified against laravel/ai 0.10.1 source)

- `Contracts\CanActAsTool::description()` returns `Stringable|string`, not `string` (since 0.6). The narrowed stub gave every caller that handled the `Stringable` branch a `RedundantCondition`, a `TypeDoesNotContainType`, a `MixedMethodCall` and two `MixedReturnStatement` reports. `Contracts\Tool::description()` was already correct. Guarded by `ToolDescriptionStringable.phpt`.
- `Files\Document` gains `abstract public function content(): string`, restoring the full abstract surface the stub docblock claims to restate. **This is a source sync, not an FP fix**: the impact recorded in the gap register does not reproduce. Stub re-declaration replaces same-named members and wipes the reflected interface list, but it does not delete reflected methods the stub omits, so `$doc->content()` already resolved to `string` with no `UndefinedMethod`.

## Sources added

- `TranscriptionResponse::$text`, via `LlmOutputTaintHandler::TAINTED_CLASSES`. Its own hierarchy, so the subclass walk never reached it. The audio is user-supplied, which makes the transcript attacker-authored text a speech model merely re-typed.
- `StructuredAgentResponse` / `StructuredTextResponse`: `toArray()`, `toJson()`, `jsonSerialize()`, the string cast, and an explicit `offsetGet()` call. Keys come from the app's schema, values come from the model. The two classes and the `ProvidesStructuredResponse` trait get re-declaration stubs with headers copied verbatim.

## Upstream gap, deliberately not worked around

`@psalm-taint-source` on `offsetGet()` sources an explicit `$x->offsetGet('k')` call and nothing else. Psalm's `ArrayFetchAnalyzer` resolves `$x['k']` through a synthesized `VirtualMethodCall` analyzed against a cloned node-data set, then copies back only the resulting type, so the taint edge is discarded.

Filed upstream as [vimeo/psalm#11912](https://github.com/vimeo/psalm/issues/11912). The loss is not specific to source annotations: any taint edge crossing the sugar is dropped, including a plain argument-to-return pass through `offsetGet()`. Verified on Psalm 7.0.0-beta19 with no plugins loaded.

This is a **Psalm core soundness bug**: it silently breaks every `ArrayAccess`-based taint source in any codebase, not just Laravel or laravel/ai. It belongs upstream. A plugin `ArrayDimFetch` branch would close it and was prototyped, but is not shipped, because `ArrayDimFetch` is among the hottest node types in any codebase (a per-expression cost on every analysis) and the branch becomes dead code the moment upstream lands.

Two corrections to the plan of record follow from it:

- The stub-only fix specified for the structured array surface could not have worked.
- The sub-agent chain was **not** covered by composition of existing annotations. `Tools\AgentTool::handle()` forwards `(string) $request['task']` into a sub-agent's `prompt()`, which is the dead sugar path, so the whole delegation path is silent today.

## Known limitations, pinned rather than left implicit

Three fixtures assert the current (wrong) behavior with empty expectations, so an upstream fix turns them red and names itself:

- `SubAgentToolDelegationKnownLimitation.phpt`: the `AgentTool` chain above.
- `StructuredResponseArrayAccessKnownLimitation.phpt`: `$response['field']`.
- `StructuredArrayReturnKnownLimitation.phpt`: a different gap, same shape. `toArray()` carries a source annotation, but consuming the returned array element-wise loses the edge under whole-project analysis. The same fixture reports the flow when Psalm analyzes the file alone, so it is the hop-loss bug rather than a missing annotation.

Stub docblocks on `Tools\Request::offsetGet()` and `ProvidesStructuredResponse` say plainly that the array-access form is not analysed, so a reader seeing `@psalm-taint-source input` there does not assume otherwise.

## Tests

Six phpts under `tests/Type/tests/PromptInjection/`, each with the standard SKIPIF and `--taint-analysis` ARGS and a unique namespace. Every positive one was verified red before its fix, and the `StructuredAgentResponse` stub was pulled back out afterwards to confirm the `toArray`-family test loses all its findings without it. Unit coverage for the extended class list and for the deliberate absence of array-access sourcing.

Docs: `docs/security.md` LLM section and `docs/contributing/taint-analysis.md`.


## Follow-up: `ce02736`

The full mechanism was spelled out in eight files. `docs/contributing/taint-analysis.md` is now the single home for it; everywhere else keeps an in-place warning plus a link to [vimeo/psalm#11912](https://github.com/vimeo/psalm/issues/11912). Net 40 insertions against 49 deletions.

Also corrects a stale claim in `StructuredArrayReturnKnownLimitation.phpt` that array access was covered by the `ArrayDimFetch` branch that was never shipped, and which pointed at a `StructuredResponseArrayAccess.phpt` that does not exist.

The load-bearing warning is unchanged: do not annotate `offsetGet()` and assume `$request['key']` / `$response['field']` is covered. The covered paths are `toArray()` and the explicit `offsetGet()` call.