### PR TITLE
Fix: bump rector to 2.5.8 for phpstan 2.2.6 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,10 +47,9 @@
         "alies-dev/psalm-tester": "dev-feature/parallel-batch",
         "friendsofphp/php-cs-fixer": "^3.94",
         "laravel/framework": "^12.14 || ^13.3",
-        "phpstan/phpstan": ">=2.2.2 <2.2.6",
         "phpunit/phpunit": "^11.5 || ^12.5 || ^13.0",
         "ramsey/collection": "^1.3",
-        "rector/rector": "^2.3",
+        "rector/rector": "^2.5.8",
         "symfony/http-foundation": "^7.1 || ^8.0",
         "symfony/process": "^7.1 || ^8.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         "alies-dev/psalm-tester": "dev-feature/parallel-batch",
         "friendsofphp/php-cs-fixer": "^3.94",
         "laravel/framework": "^12.14 || ^13.3",
+        "phpstan/phpstan": ">=2.2.2 <2.2.6",
         "phpunit/phpunit": "^11.5 || ^12.5 || ^13.0",
         "ramsey/collection": "^1.3",
         "rector/rector": "^2.3",

--- a/rector.php
+++ b/rector.php
@@ -5,6 +5,7 @@ use Rector\CodingStyle\Rector\Assign\SplitDoubleAssignRector;
 use Rector\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector;
 use Rector\CodingStyle\Rector\If_\NullableCompareToNullRector;
 use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\PHPUnit\CodeQuality\Rector\FuncCall\AssertFuncCallToPHPUnitAssertRector;
@@ -50,4 +51,11 @@ return RectorConfig::configure()
         // `assertX()` call is part of the test's observable expectations — it counts towards the
         // assertion tally and turns a broken fixture into a plain test failure instead of an error.
         AssertFuncCallToPHPUnitAssertRector::class,
+        // GetKeyOverrideModel's getKey() is a trivial parent delegation ON PURPOSE:
+        // GetKeyReturnTypeTest.phpt asserts the plugin stops narrowing getKey() past a
+        // user override of the method it narrows. Removing the "redundant" delegation
+        // removes the override itself, so the test would stop exercising that path.
+        RemoveParentDelegatingClassMethodRector::class => [
+            __DIR__ . '/tests/Application/app/Models/GetKeyOverrideModel.php',
+        ],
     ]);

--- a/tests/Application/app/Models/GetKeyOverrideModel.php
+++ b/tests/Application/app/Models/GetKeyOverrideModel.php
@@ -10,4 +10,10 @@ use Illuminate\Database\Eloquent\Model;
  * Overrides getKey() so callers must fall back to the stub's `int|string` — the plugin
  * must not narrow past a user override of the method it is narrowing.
  */
-final class GetKeyOverrideModel extends Model {}
+final class GetKeyOverrideModel extends Model
+{
+    public function getKey()
+    {
+        return parent::getKey();
+    }
+}

--- a/tests/Application/app/Models/GetKeyOverrideModel.php
+++ b/tests/Application/app/Models/GetKeyOverrideModel.php
@@ -10,10 +10,4 @@ use Illuminate\Database\Eloquent\Model;
  * Overrides getKey() so callers must fall back to the stub's `int|string` — the plugin
  * must not narrow past a user override of the method it is narrowing.
  */
-final class GetKeyOverrideModel extends Model
-{
-    public function getKey()
-    {
-        return parent::getKey();
-    }
-}
+final class GetKeyOverrideModel extends Model {}


### PR DESCRIPTION
## Issue to Solve
The Code Style CI job fatals on every branch, including master's next run. Rector 2.5.7 reaches into `PHPStan\Parser\RichParser`'s private `container` property via reflection (`Rector\Util\Reflection\PrivatesAccessor` → `PHPStanContainerMemento` → `RectorParser::__construct()`), and phpstan 2.2.6 removed that property.

Because `composer.lock` is gitignored, every CI run resolves dependencies fresh, so all branches pick up phpstan 2.2.6 at once as soon as it's published, regardless of what each branch actually touches.

## Related
No tracked issue. Found investigating CI run 30222731832; every run was green before 2026-07-26T21:18Z and red from 21:35Z onward, across unrelated branches.

## Solution Description
Rector 2.5.8 fixes this incompatibility upstream ("Bump to PHPStan ^2.2.6 and Fix its Container compatibility in RichParser") and now requires `phpstan/phpstan ^2.2.6` itself. Raised the `rector/rector` floor from `^2.3` to `^2.5.8` so a fresh resolve pulls in the fix instead of landing on the broken 2.5.7. No constraint on `phpstan/phpstan` directly; it's a transitive dependency of rector and rector now expresses the correct requirement itself.

The bump also brings `RemoveParentDelegatingClassMethodRector` into scope, which flags `GetKeyOverrideModel::getKey()` as a redundant parent delegation. That method is deliberately a trivial delegation: `GetKeyReturnTypeTest.phpt` asserts the plugin stops narrowing `getKey()` past a user override of the method it narrows, and removing the delegation removes the override under test. Added a file-scoped skip for that one rule on that one file in `rector.php`, with a comment explaining why. (The style auto-fix workflow already ran once on this branch and deleted the method before the skip landed; restored it in the same commit as the skip.)

Verified:
- `composer update rector/rector phpstan/phpstan --with-all-dependencies` resolves `rector/rector` 2.5.8 and `phpstan/phpstan` 2.2.6, the exact combination that used to fatal.
- `composer rector -- --dry-run --no-progress-bar --no-ansi` completes with no changes and exit 0.
- `GetKeyReturnTypeTest.phpt` still passes.

Net diff vs master is 1 line in `composer.json` plus the scoped skip in `rector.php`.
