### PR TITLE
Suppress cross-class taint flow in `Dispatchable` traits

### DIFF
--- a/src/Handlers/Jobs/DispatchableHandler.php
+++ b/src/Handlers/Jobs/DispatchableHandler.php
@@ -94,8 +94,8 @@ final class DispatchableHandler implements AfterExpressionAnalysisInterface
             return null;
         }
 
-        $className = $expr->class->getAttribute('resolvedName');
-        if (!\is_string($className)) {
+        $className = self::resolveClassName($expr->class, $event);
+        if ($className === null) {
             return null;
         }
 
@@ -156,6 +156,33 @@ final class DispatchableHandler implements AfterExpressionAnalysisInterface
         );
 
         return null;
+    }
+
+    /**
+     * Resolve a `StaticCall`'s class `Name` to an FQCN, or `null` when it cannot be pinned to one class.
+     *
+     * `resolvedName` is only set for ordinary names — PhpParser's name resolver deliberately leaves
+     * `self`/`static`/`parent` alone because they are context-sensitive. Without this substitution the
+     * handler declines, and since the Dispatchable stubs are bodyless it is the only producer of the
+     * constructor argument and taint edges, so declining silently drops both.
+     *
+     * All three keywords map to the enclosing class: the trait bodies build `new static(...$arguments)`,
+     * so late static binding sends even `parent::dispatch()` to the caller's own class — never
+     * `$context->parent`.
+     */
+    private static function resolveClassName(Name $class, AfterExpressionAnalysisEvent $event): ?string
+    {
+        if ($class->isSpecialClassName()) {
+            return match ($class->toLowerString()) {
+                'self', 'static', 'parent' => $event->getContext()->self,
+                default => null,
+            };
+        }
+
+        /** @psalm-var ?string $resolved */
+        $resolved = $class->getAttribute('resolvedName');
+
+        return \is_string($resolved) ? $resolved : null;
     }
 
     /**

--- a/stubs/13/Foundation/Events/Dispatchable.phpstub
+++ b/stubs/13/Foundation/Events/Dispatchable.phpstub
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Foundation\Events;
+
+use Illuminate\Broadcasting\PendingBroadcast;
+
+trait Dispatchable
+{
+    public static function dispatch(mixed ...$arguments): mixed {}
+
+    public static function dispatchIf(bool $boolean, mixed ...$arguments): mixed {}
+
+    public static function dispatchUnless(bool $boolean, mixed ...$arguments): mixed {}
+
+    public static function broadcast(mixed ...$arguments): PendingBroadcast {}
+}

--- a/stubs/common/Foundation/Bus/Dispatchable.phpstub
+++ b/stubs/common/Foundation/Bus/Dispatchable.phpstub
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Foundation\Bus;
+
+use Closure;
+use Illuminate\Support\Fluent;
+
+trait Dispatchable
+{
+    public static function dispatch(mixed ...$arguments): PendingDispatch {}
+
+    public static function dispatchIf(bool|Closure $boolean, mixed ...$arguments): PendingDispatch|Fluent {}
+
+    public static function dispatchUnless(bool|Closure $boolean, mixed ...$arguments): PendingDispatch|Fluent {}
+
+    public static function dispatchSync(mixed ...$arguments): mixed {}
+
+    public static function dispatchAfterResponse(mixed ...$arguments): mixed {}
+}

--- a/stubs/common/Foundation/Events/Dispatchable.phpstub
+++ b/stubs/common/Foundation/Events/Dispatchable.phpstub
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Foundation\Events;
+
+use Illuminate\Broadcasting\PendingBroadcast;
+
+trait Dispatchable
+{
+    /** @psalm-variadic */
+    public static function dispatch(): mixed {}
+
+    public static function dispatchIf(bool $boolean, mixed ...$arguments): mixed {}
+
+    public static function dispatchUnless(bool $boolean, mixed ...$arguments): mixed {}
+
+    /** @psalm-variadic */
+    public static function broadcast(): PendingBroadcast {}
+}

--- a/tests/Type/tests/DispatchableTest.phpt
+++ b/tests/Type/tests/DispatchableTest.phpt
@@ -139,6 +139,12 @@ function test_events_dispatchable(User $user): void
     // Error — missing $orderId (condition excluded)
     OrderShipped::dispatchIf(true, $user);
 
+    // OK — condition + correct args
+    OrderShipped::dispatchUnless(false, $user, 1);
+
+    // Error — missing $orderId (condition excluded)
+    OrderShipped::dispatchUnless(false, $user);
+
     // OK — broadcast all args
     OrderShipped::broadcast($user, 1);
 
@@ -156,6 +162,7 @@ TooManyArguments on line %d: Too many arguments for App\Jobs\SendEmail::__constr
 TooFewArguments on line %d: Too few arguments for App\Jobs\SendEmail::__construct - expecting subject to be passed
 TooFewArguments on line %d: Too few arguments for App\Jobs\SendEmail::__construct - expecting subject to be passed
 TooFewArguments on line %d: Too few arguments for App\Jobs\SendEmail::__construct - expecting subject to be passed
+TooFewArguments on line %d: Too few arguments for App\Jobs\OrderShipped::__construct - expecting orderId to be passed
 TooFewArguments on line %d: Too few arguments for App\Jobs\OrderShipped::__construct - expecting orderId to be passed
 TooFewArguments on line %d: Too few arguments for App\Jobs\OrderShipped::__construct - expecting orderId to be passed
 TooFewArguments on line %d: Too few arguments for App\Jobs\OrderShipped::__construct - expecting orderId to be passed

--- a/tests/Type/tests/DispatchableTest.phpt
+++ b/tests/Type/tests/DispatchableTest.phpt
@@ -151,6 +151,33 @@ function test_events_dispatchable(User $user): void
     // Error — missing $orderId
     OrderShipped::broadcast($user);
 }
+
+/** self/static receivers carry no `resolvedName` — they resolve against the enclosing class */
+class SelfDispatchJob
+{
+    use BusDispatchable;
+
+    public function __construct(private User $user, private string $subject) {}
+
+    public static function requeue(User $user): void
+    {
+        // OK
+        self::dispatch($user, 'Hello');
+
+        // Error — missing $subject
+        static::dispatch($user);
+    }
+}
+
+/** `parent::dispatch()` still builds `new static(...)`, so it validates against the child */
+final class ChildDispatchJob extends SelfDispatchJob
+{
+    public static function requeueFromChild(User $user): void
+    {
+        // Error — missing $subject
+        parent::dispatch($user);
+    }
+}
 ?>
 --EXPECTF--
 TooFewArguments on line %d: Too few arguments for App\Jobs\SendEmail::__construct - expecting subject to be passed
@@ -166,3 +193,5 @@ TooFewArguments on line %d: Too few arguments for App\Jobs\OrderShipped::__const
 TooFewArguments on line %d: Too few arguments for App\Jobs\OrderShipped::__construct - expecting orderId to be passed
 TooFewArguments on line %d: Too few arguments for App\Jobs\OrderShipped::__construct - expecting orderId to be passed
 TooFewArguments on line %d: Too few arguments for App\Jobs\OrderShipped::__construct - expecting orderId to be passed
+TooFewArguments on line %d: Too few arguments for App\Jobs\SelfDispatchJob::__construct - expecting subject to be passed
+TooFewArguments on line %d: Too few arguments for App\Jobs\ChildDispatchJob::__construct - expecting subject to be passed

--- a/tests/Type/tests/TaintAnalysis/DispatchableEventsNamedArgumentL12.phpt
+++ b/tests/Type/tests/TaintAnalysis/DispatchableEventsNamedArgumentL12.phpt
@@ -1,0 +1,27 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+\Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipFrom('13.0.0');
+--FILE--
+<?php declare(strict_types=1);
+
+namespace DispatchableEventsNamedArgumentL12;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+final class Event
+{
+    use Dispatchable;
+
+    public function __construct(mixed $arguments) {}
+}
+
+function eventDispatchDoesNotAcceptNamedArguments(): void
+{
+    Event::dispatch(arguments: 'event');
+    Event::broadcast(arguments: 'event');
+}
+?>
+--EXPECTF--
+InvalidNamedArgument on line %d: Parameter $arguments does not exist on function DispatchableEventsNamedArgumentL12\Event::dispatch
+InvalidNamedArgument on line %d: Parameter $arguments does not exist on function DispatchableEventsNamedArgumentL12\Event::broadcast

--- a/tests/Type/tests/TaintAnalysis/TaintedShellDispatchableSelfStatic.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedShellDispatchableSelfStatic.phpt
@@ -1,0 +1,67 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace TaintedShellDispatchableSelfStatic;
+
+use Illuminate\Foundation\Bus\Dispatchable as BusDispatchable;
+use Illuminate\Foundation\Events\Dispatchable as EventsDispatchable;
+use Illuminate\Http\Request;
+
+final class SelfRequeueJob
+{
+    use BusDispatchable;
+
+    /** @psalm-taint-sink shell $command */
+    public function __construct(mixed $command) {}
+
+    public static function requeue(Request $request): void
+    {
+        self::dispatch($request->input('bus-command'));
+    }
+
+    public static function requeueClean(): void
+    {
+        self::dispatch('echo clean-self');
+    }
+}
+
+final class StaticConditionalEvent
+{
+    use EventsDispatchable;
+
+    /** @psalm-taint-sink shell $command */
+    public function __construct(mixed $command) {}
+
+    public static function fire(Request $request): void
+    {
+        static::dispatchIf(true, $request->input('event-command'));
+    }
+
+    public static function fireClean(): void
+    {
+        static::dispatchIf(true, 'echo clean-static');
+    }
+}
+
+class BaseParentJob
+{
+    use BusDispatchable;
+
+    /** @psalm-taint-sink shell $command */
+    public function __construct(mixed $command) {}
+}
+
+final class ChildParentJob extends BaseParentJob
+{
+    public static function requeue(Request $request): void
+    {
+        parent::dispatch($request->input('parent-command'));
+    }
+}
+?>
+--EXPECTF--
+TaintedShell on line %d: Detected tainted shell code
+TaintedShell on line %d: Detected tainted shell code
+TaintedShell on line %d: Detected tainted shell code

--- a/tests/Type/tests/TaintAnalysis/TaintedShellDispatchableTraitIsolation.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedShellDispatchableTraitIsolation.phpt
@@ -1,0 +1,54 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace TaintedShellDispatchableTraitIsolation;
+
+use Illuminate\Foundation\Bus\Dispatchable as BusDispatchable;
+use Illuminate\Foundation\Events\Dispatchable as EventsDispatchable;
+use Illuminate\Http\Request;
+
+final class TaintedBusJob
+{
+    use BusDispatchable;
+
+    /** @psalm-taint-sink shell $command */
+    public function __construct(mixed $command) {}
+}
+
+final class CleanBusJob
+{
+    use BusDispatchable;
+
+    /** @psalm-taint-sink shell $command */
+    public function __construct(mixed $command) {}
+}
+
+final class TaintedEvent
+{
+    use EventsDispatchable;
+
+    /** @psalm-taint-sink shell $command */
+    public function __construct(mixed $command) {}
+}
+
+final class CleanEvent
+{
+    use EventsDispatchable;
+
+    /** @psalm-taint-sink shell $command */
+    public function __construct(mixed $command) {}
+}
+
+function dispatchesRemainIsolated(Request $request): void
+{
+    TaintedBusJob::dispatch($request->input('bus-command'));
+    CleanBusJob::dispatch('echo clean-bus');
+    TaintedEvent::dispatch($request->input('event-command'));
+    CleanEvent::dispatch('echo clean-event');
+}
+?>
+--EXPECTF--
+TaintedShell on line %d: Detected tainted shell code
+TaintedShell on line %d: Detected tainted shell code


### PR DESCRIPTION
## Issue to Solve

Psalm can conflate taint-flow nodes from Laravel's shared `Dispatchable` trait bodies across unrelated jobs and events. A tainted argument dispatched to one class can therefore appear to reach another class's constructor sink.

T2 — dispatch taint false-positive suppression; source budget ≤300 lines; one reviewer; real-app delta required.

## Related

Fixes #1333

Upstream root cause: vimeo/psalm#11913.

## Solution Description

- Add non-forwarding partial stubs for the Bus and Events `Dispatchable` traits so Psalm does not analyze the shared framework bodies.
- Preserve all nine dispatch-family return contracts while leaving `DispatchableHandler` as the sole source of class-specific constructor argument and taint edges.
- Keep Laravel 12's zero-parameter Event API plus `@psalm-variadic`, and overlay Laravel 13's explicit variadic signatures so named-argument behavior remains version-correct.
- Add regressions proving real Bus/Event taint is still reported, unrelated clean dispatches stay clean, and Laravel 12 continues rejecting named variadic arguments.

Verification passed: RED reproduced four taint findings; the final exact oracle reports only the two genuine findings. Type tests, unit tests, Psalm with `--no-cache`, PHPT conventions, code style, and Rector dry-run passed. The final read-only review gate scored 96/100 with no must-fix findings.

### Accepted imprecision

- Dynamic class-string dispatch through named literal static-call shapes is not expanded by this change.
- Closure-condition object flow beyond constructor argument flow is not preserved.

### Reviewer notes

- Reordered named arguments for conditional dispatch remain a pre-existing handler-offset limitation.
- A focused analyzer probe covers Laravel 13 named dispatch arguments; a dedicated committed PHPT is optional future coverage.

## Checklist

- [x] Tests cover the change (type tests in `tests/Type/`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/psalm/codesmith/psalm-plugin-laravel/pr/1334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787915546&installation_model_id=424990&pr_number=1334&repository=psalm%2Fpsalm-plugin-laravel&return_to=https%3A%2F%2Fgithub.com%2Fpsalm%2Fpsalm-plugin-laravel%2Fpull%2F1334&signature=c5c6e6069a22a0314ef73adae07a622a1e050055ed9ea8f2d181075b0a571d78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->