### PR TITLE
Fix `TaintedSql` false positive on `where()` array values for nullable and template-bounded builder receivers

### DIFF
--- a/src/Handlers/Eloquent/WhereColumnTaintHandler.php
+++ b/src/Handlers/Eloquent/WhereColumnTaintHandler.php
@@ -28,6 +28,7 @@ use Psalm\Type\Atomic\Scalar;
 use Psalm\Type\Atomic\TKeyedArray;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Atomic\TNull;
+use Psalm\Type\Atomic\TTemplateParam;
 use Psalm\Type\TaintKind;
 use Psalm\Type\Union;
 
@@ -512,6 +513,14 @@ final class WhereColumnTaintHandler implements
      * True when the call's receiver is one of Laravel's query builders, which is what makes
      * `addArrayOfWheres()` the runtime dispatch. Anything else — a project's own class that happens
      * to expose a `where()` method — keeps the sink, as does an unresolved or widened receiver type.
+     *
+     * Delegates the atomic-level walk to {@see isBuilderUnion}, which additionally tolerates a
+     * `TNull` atomic (a null receiver never reaches `addArrayOfWheres()`: a plain `->` fatals
+     * before any SQL exists, and `?->` skips the call outright — see `MethodCallAnalyzer`, which
+     * emits `PossiblyNullReference` for a nullable receiver but never removes the `TNull` atomic
+     * before dispatching this handler) and recurses into a `TTemplateParam`'s `as` bound (a
+     * receiver typed `@template T of Builder` is one; an unbounded template, whose `as` widens to
+     * `mixed`, is not). #1336
      */
     private static function isLaravelBuilder(
         Expr $receiver,
@@ -524,9 +533,41 @@ final class WhereColumnTaintHandler implements
             return false;
         }
 
-        $codebase = $event->getCodebase();
+        return self::isBuilderUnion($type, $event->getCodebase());
+    }
+
+    /**
+     * True when every atomic of `$type` is either a `TNull` (skipped, never disqualifying on its
+     * own) or a Laravel builder — a `TTemplateParam` counts by recursing into its `as` bound — AND
+     * at least one atomic actually matched, so an all-null union (unreachable in practice, since
+     * the call itself could not have resolved) still returns false instead of vacuously true.
+     *
+     * (Not independently phpt-covered for the unbounded-template branch: an unconstrained
+     * `@template T`'s `as` widens to `mixed`, and Psalm cannot resolve which method's stub to
+     * consult on a `mixed` receiver — `MixedMethodCall` fires instead of dispatching any sink at
+     * all, with or without this method. The `false` return there is by-construction and manually
+     * verified rather than pinned by a regression test.)
+     *
+     * @psalm-mutation-free
+     */
+    private static function isBuilderUnion(Union $type, \Psalm\Codebase $codebase): bool
+    {
+        $has_builder = false;
 
         foreach ($type->getAtomicTypes() as $atomic) {
+            if ($atomic instanceof TNull) {
+                continue;
+            }
+
+            if ($atomic instanceof TTemplateParam) {
+                if (!self::isBuilderUnion($atomic->as, $codebase)) {
+                    return false;
+                }
+
+                $has_builder = true;
+                continue;
+            }
+
             if (!$atomic instanceof TNamedObject) {
                 return false;
             }
@@ -545,9 +586,11 @@ final class WhereColumnTaintHandler implements
             if (!$matches) {
                 return false;
             }
+
+            $has_builder = true;
         }
 
-        return true;
+        return $has_builder;
     }
 
     /**

--- a/tests/Type/tests/TaintAnalysis/SafeSqlWhereArrayVariable.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeSqlWhereArrayVariable.phpt
@@ -4,11 +4,12 @@
 <?php declare(strict_types=1);
 
 /**
- * Prophylactic CANARY for the variable-form argument edge (`$conds = [...]; where($conds)`). Psalm
- * does not currently flag this shape even without the strip, so it stays green with the handler
- * disabled. It documents that the map-form FP must not appear for the variable form either, and would
- * catch a future upstream change that started flowing the sink through a local. It does not, on its
- * own, prove the variable-form recording fires (the inline literal form is the load-bearing pin). #734
+ * LOAD-BEARING, not a canary, for the variable-form argument edge (`$conds = [...]; where($conds)`).
+ * The sink DOES flow through a local variable argument (verified empirically: the same shape with a
+ * `whereAll()` receiver — a sink the element-wise/whole-argument strip never touches — still fires),
+ * so this test stays green only because the WHOLE-ARGUMENT strip ({@see
+ * \Psalm\LaravelPlugin\Handlers\Eloquent\WhereColumnTaintHandler::isBoundValueMap}) fires on the
+ * type-level shape. #734, #1336
  *
  * @psalm-suppress TooFewArguments, MixedAssignment
  */

--- a/tests/Type/tests/TaintAnalysis/SafeSqlWhereNullableReceiverArrayValues.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeSqlWhereNullableReceiverArrayValues.phpt
@@ -1,0 +1,17 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * A `Builder|null` receiver kept the `sql` sink on the map-form argument even though a null
+ * receiver never reaches `addArrayOfWheres()`: a plain `->` fatals before any SQL exists, so
+ * `isLaravelBuilder` tolerating the `TNull` atomic in the receiver's union is safe. #1336
+ *
+ * @psalm-suppress PossiblyNullReference
+ */
+function safeNullableReceiverArrayWhere(\Illuminate\Http\Request $request, ?\Illuminate\Database\Query\Builder $query): void {
+    $query->where(['status_id' => $request->input('status')]);
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeSqlWhereNullsafeArrayValues.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeSqlWhereNullsafeArrayValues.phpt
@@ -4,10 +4,12 @@
 <?php declare(strict_types=1);
 
 /**
- * Upstream-behavior CANARY, not a pin. Psalm does not currently dispatch the `sql` sink through a
- * nullsafe call `$builder?->where([...])`, so this stays green even with the handler disabled. The
- * Before-hook still handles the NullsafeMethodCall branch, so if a future Psalm starts flowing sinks
- * through nullsafe calls this test catches the resulting map-form FP before it reaches users.
+ * LOAD-BEARING, not a canary: the `sql` sink DOES dispatch through a nullsafe call
+ * `$builder?->where([...])` (Psalm narrows the receiver to non-null before the member-call
+ * dispatch, so `?->` reaches the same sink a plain `->` would — verified empirically for both the
+ * string form and an array-argument sink outside `WHERE_MAP_METHODS`, #1336). This test stays
+ * green because the element-wise strip fires, gated by {@see
+ * \Psalm\LaravelPlugin\Handlers\Eloquent\WhereColumnTaintHandler::isLaravelBuilder}.
  */
 function safeNullsafeArrayWhere(\Illuminate\Http\Request $request, ?\Illuminate\Database\Query\Builder $builder): void {
     $status = (string) $request->input('status');

--- a/tests/Type/tests/TaintAnalysis/SafeSqlWhereTemplateBoundedReceiverArrayValues.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeSqlWhereTemplateBoundedReceiverArrayValues.phpt
@@ -1,0 +1,19 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * A receiver typed as a `@template T of Builder` is a `TTemplateParam` atomic, not a
+ * `TNamedObject` — `isLaravelBuilder` rejected it exactly like it rejected `TNull` until it
+ * started recursing into the template's `as` bound to decide whether it is builder-only. #1336
+ *
+ * @template T of \Illuminate\Database\Query\Builder
+ *
+ * @param T $q
+ */
+function safeTemplateBoundedReceiverArrayWhere(\Illuminate\Http\Request $request, $q): void {
+    $q->where(['status_id' => $request->input('status')]);
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereNullableNonBuilderReceiver.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereNullableNonBuilderReceiver.phpt
@@ -1,0 +1,27 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis --threads=1
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * Tolerating the `TNull` atomic in the receiver gate must not let a NULLABLE non-builder receiver
+ * through: `isLaravelBuilder` still requires every non-null atomic to be a Laravel builder, so a
+ * project's own class must keep the sink even when its declared type is nullable. #1336
+ *
+ * Runs in the `--threads=1` ARGS group; `DB::unprepared` is a distinct sink from the where-family
+ * ones the default taint group saturates (see TaintedSqlWhereNonBuilderReceiver.phpt).
+ */
+final class NullableNonBuilderReportQuery {
+    /** @param array<array-key, string> $parts */
+    public function where(array $parts): void {
+        \Illuminate\Support\Facades\DB::unprepared('select * from reports where ' . $parts[0]);
+    }
+}
+
+/** @psalm-suppress PossiblyNullReference */
+function unsafeNullableNonBuilderWhereReceiver(\Illuminate\Http\Request $request, ?NullableNonBuilderReportQuery $q): void {
+    $q->where([(string) $request->input('clause')]);
+}
+?>
+--EXPECTF--
+%ATaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereTemplateNonBuilderReceiver.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereTemplateNonBuilderReceiver.phpt
@@ -1,0 +1,33 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis --threads=1
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * The `TTemplateParam` accept-branch must actually verify its `as` bound is builder-only, not wave
+ * any template receiver through: `@template T of <userland non-builder class>` must keep the sink
+ * exactly like a concrete non-builder receiver already does (see
+ * TaintedSqlWhereNonBuilderReceiver.phpt). If `isBuilderUnion` ever stopped recursing into a
+ * template's `as` bound — e.g. treated every `TTemplateParam` as a builder without checking its
+ * bound — this test goes silent.
+ *
+ * Runs in the `--threads=1` ARGS group; `DB::unprepared` is a distinct sink from the where-family
+ * ones the default taint group saturates (see TaintedSqlWhereNonBuilderReceiver.phpt). #1336
+ */
+final class TemplateNonBuilderReportQuery {
+    /** @param array{f: string} $parts */
+    public function where(array $parts): void {
+        \Illuminate\Support\Facades\DB::unprepared('select * from reports where ' . $parts['f']);
+    }
+}
+
+/**
+ * @template T of TemplateNonBuilderReportQuery
+ * @param T $q
+ */
+function unsafeTemplateNonBuilderWhereReceiver(\Illuminate\Http\Request $request, $q): void {
+    $q->where(['f' => (string) $request->input('x')]);
+}
+?>
+--EXPECTF--
+%ATaintedSql on line %d: Detected tainted SQL


### PR DESCRIPTION
## Issue to Solve

`$q->where(['field' => $request->input('x')])` still reported `TaintedSql` when the receiver was typed `Builder|null` (parameter, property, or a local assigned under an `if` guard) or by a template bounded by a builder (`@template T of Builder`). The value position is PDO-bound through `addArrayOfWheres()`, so both are false positives: `isLaravelBuilder()` rejected every non-`TNamedObject` atomic, which killed the #734/#1300 strip.

## Related

Fixes #1336. Family: #734, #1300, #1306. Follow-ups: #1337, #1339.

## Solution Description

- `isLaravelBuilder()` now delegates to a recursive `isBuilderUnion()`: it skips `TNull` atomics (a runtime `->where()` call implies a non-null receiver, and `?->` skips the call on null), recurses into a `TTemplateParam` `as` bound, and requires at least one real builder match, so a null-only receiver keeps the sink.
- FN axis probed: an unbounded template never reaches the sink (`MixedMethodCall` fires instead), a userland template bound and a `Model|Builder` union keep the sink.
- Red-first: both new Safe fixtures produced `TaintedSql` on pre-fix master. Negative pins (`--threads=1` ARGS group) were proven non-vacuous by simulating the regression of each accept branch and watching them go silent.
- Corrected two test docblocks that measurement contradicted: the nullsafe and array-in-variable shapes DO dispatch the sink, so those tests are load-bearing, not canaries.

Contract: T1, taint FP strip loosening, ~50 src lines, 1 reviewer, no delta run.

### Accepted imprecision

- Instance-path `extends Builder` subclass declaring its own raw-SQL `where()` is still silenced. Pre-existing inheritance match (#1300 added the declaring-method check to the static path only), tracked as #1337.
- A template intersection receiver (`T&Builder`) still reports the FP: `isBuilderUnion()` examines only the `as` bound, not `extra_types`. Pre-existing shape (every template receiver declined the strip before this PR), tracked as #1339.
- A plain `Model` instance receiver still reports the FP. Pre-existing, FP direction, out of scope here.

### Reviewer notes

- `SafeSqlWhereArrayVariable` wording: `whereAll()` is the callee, not the receiver.
- The whole-argument nullable path is fixed but not separately pinned.
- The "`?->` skips the call" clause is moot in practice: Psalm narrows the receiver before the gate sees it.

## Checklist

- [x] Tests cover the change (type tests in `tests/Type/`)
