### PR TITLE
Fingerprint the migration schema cache on file contents, not mtimes

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -198,7 +198,7 @@ The plugin stores generated files (alias stubs) and cached migration schemas in 
 
 When `columnFallback="migrations"` is active, the plugin caches the parsed migration schema to disk so subsequent Psalm runs skip re-parsing unchanged migrations.
 
-The cache key is a fingerprint of sorted migration and SQL dump file paths, their modification times, and the plugin version. Any file change or plugin upgrade automatically invalidates the cache.
+The cache key is a fingerprint of sorted migration and SQL dump file paths, hashes of their contents, and the plugin version. Any file change or plugin upgrade automatically invalidates the cache. Content hashes (rather than modification times) keep the cache usable on CI, where a fresh checkout stamps every file with the checkout time.
 
 **Cache invalidation**: run `--clear-cache` to remove all plugin caches (including migration schema). The plugin also cleans up stale cache files automatically on each cache miss.
 

--- a/src/Handlers/Eloquent/Schema/MigrationCache.php
+++ b/src/Handlers/Eloquent/Schema/MigrationCache.php
@@ -102,11 +102,11 @@ final class MigrationCache
         $entries = [];
 
         foreach ($migrationFiles as $file) {
-            $entries[] = 'M:' . $file . ':' . self::hashFileContents($file);
+            $entries[] = 'M:' . $file . ':' . $this->hashFileContents($file);
         }
 
         foreach ($sqlDumpFiles as $file) {
-            $entries[] = 'S:' . $file . ':' . self::hashFileContents($file);
+            $entries[] = 'S:' . $file . ':' . $this->hashFileContents($file);
         }
 
         \sort($entries);
@@ -128,7 +128,7 @@ final class MigrationCache
      * acceptable: the file list itself is part of the fingerprint, so an
      * appearing or disappearing file still invalidates the cache.
      */
-    private static function hashFileContents(string $file): string
+    private function hashFileContents(string $file): string
     {
         $hash = @\hash_file('xxh128', $file);
 

--- a/src/Handlers/Eloquent/Schema/MigrationCache.php
+++ b/src/Handlers/Eloquent/Schema/MigrationCache.php
@@ -10,7 +10,7 @@ use Composer\InstalledVersions;
  * Fingerprint-based disk cache for parsed migration schema.
  *
  * Avoids re-parsing all migration files on every Psalm run when they haven't changed.
- * The cache key is a hash of sorted file paths + modification times + plugin version,
+ * The cache key is a hash of sorted file paths + file content hashes + plugin version,
  * so any file change or plugin upgrade automatically invalidates the cache.
  *
  * Inspired by Larastan's MigrationCache (src/Properties/MigrationCache.php).
@@ -84,12 +84,15 @@ final class MigrationCache
     }
 
     /**
-     * Generate a fingerprint from file metadata and plugin version.
+     * Generate a fingerprint from file contents and plugin version.
      *
-     * Uses sorted file paths + modification times so file discovery order
-     * does not affect the fingerprint. The plugin version is included so
-     * a plugin upgrade (which may change schema parsing logic) automatically
-     * invalidates the cache.
+     * Uses sorted file paths + content hashes so file discovery order does not
+     * affect the fingerprint. Content hashing (rather than modification times)
+     * keeps the cache usable on machines that do not preserve mtimes, most
+     * notably CI runners, where a fresh checkout stamps every file with the
+     * checkout time. Psalm core fingerprints its own caches the same way.
+     * The plugin version is included so a plugin upgrade (which may change
+     * schema parsing logic) automatically invalidates the cache.
      *
      * @param list<string> $migrationFiles
      * @param list<string> $sqlDumpFiles
@@ -99,13 +102,11 @@ final class MigrationCache
         $entries = [];
 
         foreach ($migrationFiles as $file) {
-            $mtime = @\filemtime($file);
-            $entries[] = 'M:' . $file . ':' . ($mtime !== false ? $mtime : '0');
+            $entries[] = 'M:' . $file . ':' . self::hashFileContents($file);
         }
 
         foreach ($sqlDumpFiles as $file) {
-            $mtime = @\filemtime($file);
-            $entries[] = 'S:' . $file . ':' . ($mtime !== false ? $mtime : '0');
+            $entries[] = 'S:' . $file . ':' . self::hashFileContents($file);
         }
 
         \sort($entries);
@@ -118,6 +119,20 @@ final class MigrationCache
         $data .= '|V:' . $pluginVersion;
 
         return \hash('xxh128', $data);
+    }
+
+    /**
+     * Hash a file's contents, falling back to a constant when it cannot be read.
+     *
+     * An unreadable file yields the same value as an empty one, which is
+     * acceptable: the file list itself is part of the fingerprint, so an
+     * appearing or disappearing file still invalidates the cache.
+     */
+    private static function hashFileContents(string $file): string
+    {
+        $hash = @\hash_file('xxh128', $file);
+
+        return $hash !== false ? $hash : '0';
     }
 
     /** @psalm-mutation-free */

--- a/tests/Unit/Handlers/Eloquent/Schema/DefaultValuesTest.php
+++ b/tests/Unit/Handlers/Eloquent/Schema/DefaultValuesTest.php
@@ -7,7 +7,7 @@ namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Eloquent\Schema;
 use PHPUnit\Framework\Attributes\Test;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaAggregator;
 
-/** @covers \Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaAggregator */
+#[\PHPUnit\Framework\Attributes\CoversClass(\Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaAggregator::class)]
 final class DefaultValuesTest extends AbstractSchemaAggregatorTestCase
 {
     private SchemaAggregator $schemaAggregator;

--- a/tests/Unit/Handlers/Eloquent/Schema/MigrationCacheTest.php
+++ b/tests/Unit/Handlers/Eloquent/Schema/MigrationCacheTest.php
@@ -90,8 +90,6 @@ final class MigrationCacheTest extends TestCase
     {
         $migrationFile = $this->cacheDir . '/migration.php';
         \file_put_contents($migrationFile, '<?php // v1');
-        // Ensure mtime is older for reliable invalidation
-        \touch($migrationFile, \time() - 10);
 
         $cache = new MigrationCache($this->cacheDir);
         $callCount = 0;
@@ -106,15 +104,41 @@ final class MigrationCacheTest extends TestCase
         $cache->remember([$migrationFile], [], $compute);
         $this->assertSame(1, $callCount);
 
-        // Same file, same mtime — hit
+        // Same file, same contents — hit
         $cache->remember([$migrationFile], [], $compute);
         $this->assertSame(1, $callCount);
 
-        // Touch the file to change mtime — miss
-        \touch($migrationFile, \time());
+        // Different contents — miss
+        \file_put_contents($migrationFile, '<?php // v2');
         \clearstatcache(true, $migrationFile);
         $cache->remember([$migrationFile], [], $compute);
         $this->assertSame(2, $callCount);
+    }
+
+    #[Test]
+    public function cache_survives_modification_time_changes(): void
+    {
+        $migrationFile = $this->cacheDir . '/migration.php';
+        \file_put_contents($migrationFile, '<?php // v1');
+        \touch($migrationFile, \time() - 3600);
+
+        $cache = new MigrationCache($this->cacheDir);
+        $callCount = 0;
+
+        $compute = function () use (&$callCount): array {
+            $callCount++;
+
+            return ['users' => new SchemaTable()];
+        };
+
+        $cache->remember([$migrationFile], [], $compute);
+        $this->assertSame(1, $callCount);
+
+        // A fresh checkout rewrites mtimes without changing contents — still a hit
+        \touch($migrationFile, \time());
+        \clearstatcache(true, $migrationFile);
+        $cache->remember([$migrationFile], [], $compute);
+        $this->assertSame(1, $callCount);
     }
 
     #[Test]

--- a/tests/Unit/Handlers/Translations/TranslationKeyHandlerTest.php
+++ b/tests/Unit/Handlers/Translations/TranslationKeyHandlerTest.php
@@ -22,6 +22,7 @@ use Psalm\StatementsSource;
 use Psalm\Type\Union;
 
 #[CoversClass(TranslationKeyHandler::class)]
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class TranslationKeyHandlerTest extends TestCase
 {
     /** @var array<string, string|array<string, string>> Translation values used by the stub translator */


### PR DESCRIPTION
## Issue to Solve

The migration schema cache builds its fingerprint from `filemtime()` of every migration file plus the SQL schema dump (`MigrationCache::generateFingerprint()`). Modification times are not content, and they are not stable across machines.

The practical consequence is on CI. A `git clone` stamps every checked-out file with the checkout time, so the fingerprint differs on every run and the cache never hits, even when the cached schema is still valid and the Psalm cache directory was restored intact. The usual workaround is a full-history checkout (`fetch-depth: 0`) plus `git-restore-mtime`, which on a repository with a long history costs more than the cache saves. On one of our projects that pair added roughly 70 seconds to every static-analysis job and intermittently hung.

Psalm core does not have this problem: `FileStorageCacheProvider` and `ParserCacheProvider` key their entries on `hash('xxh128', $file_contents)`.

## Related

No filed issue; found while profiling a CI job.

## Solution Description

Fingerprint on `hash_file('xxh128', ...)` of each file instead of its modification time. Everything else about the key stays the same: sorted `path:hash` entries so discovery order does not matter, plus the plugin version so a plugin upgrade still invalidates.

This is strictly more accurate than mtime. `touch` no longer invalidates a cache that is still valid, and a rewrite that preserves mtime (rare, but possible with `touch -r` or some rsync modes) now does invalidate.

Cost: hashing 245 migration files totalling ~600 KB takes about 6 ms against 0.2 ms for the equivalent `filemtime()` calls, measured on the project that prompted this. That is negligible next to the migration parse the cache exists to avoid.

An unreadable file hashes to `'0'`, the same value an empty file would produce. That is acceptable because the file list itself is part of the fingerprint, so a file appearing or disappearing still invalidates.

Verified with the existing unit suite (`tests/Unit/Handlers/Eloquent/Schema/MigrationCacheTest.php`, 16 tests). `cache_invalidates_when_migration_file_changes` now rewrites the file contents rather than touching it, and a new `cache_survives_modification_time_changes` asserts the CI case: same contents, new mtime, still a hit.

## Checklist
- [x] Tests cover the change (unit test in `tests/Unit/`)
- [x] Documentation is updated (`docs/config.md`)
