### PR TITLE
Honour `@psalm-taint-escape` on closure validation rules

### DIFF
--- a/docs/contributing/taint-analysis.md
+++ b/docs/contributing/taint-analysis.md
@@ -555,6 +555,30 @@ final class EmailWithDnsRule implements ValidationRule
 
 **Trust model.** The plugin trusts the developer's assertion, just like any `@psalm-taint-escape`. A mis-annotated rule becomes a **false negative**: the escape removes taint kinds the value still actually carries. Only annotate kinds the rule genuinely prevents, and prefer narrow escapes (such as `header`, `cookie`) over the broad `input` alias unless the rule truly constrains the value to a digit-like or date-like form.
 
+### Closure rules
+
+A closure rule carries the same escape when the docblock sits directly on the closure literal in the rules array. Arrow functions work too, and so do both entry points (inline `$request->validate([...])` and a FormRequest `rules()` array).
+
+```php
+$request->validate([
+    'dataTable' => ['required', 'string',
+        /** @psalm-taint-escape callable */
+        function (string $attribute, mixed $value, Closure $fail): void {
+            if (! is_subclass_of($value, DataTable::class)) {
+                $fail('The selected data table is invalid.');
+            }
+        },
+    ],
+]);
+
+$class = $request->input('dataTable');
+$dataTable = new $class(); // no TaintedCallable
+```
+
+The closure may also be the field's whole rule (`'dataTable' => /** @psalm-taint-escape callable */ function (…) {}`), without the wrapping array.
+
+Tag semantics and the trust model are the class-level ones described above: bare form only (the conditional form is parameter-scoped and is ignored), any `TaintKind` name including the `input` alias, and no annotation means no escape. Placement is what scopes the escape, so a docblock on a neighbouring string rule in the same array does not carry it.
+
 ## Plugin-emitted taint sinks (handler-driven)
 
 Some taint sinks are not expressible as `@psalm-taint-sink` docblocks because they target language constructs (comparison operators) or call shapes that the stub parser cannot annotate. These sinks are registered programmatically by handlers in `src/Handlers/Rules/`.

--- a/src/Handlers/Validation/ValidationRuleAnalyzer.php
+++ b/src/Handlers/Validation/ValidationRuleAnalyzer.php
@@ -42,6 +42,14 @@ final class ValidationRuleAnalyzer
     private const CLASS_SEGMENT_PREFIX = 'class:';
 
     /**
+     * Synthetic segment prefix carrying an already-resolved taint-escape
+     * bitmask, used for closure rules whose `@psalm-taint-escape` docblock has
+     * no addressable class name to look up later. Same collision argument as
+     * {@see CLASS_SEGMENT_PREFIX}: no Laravel rule is named `escape-bits`.
+     */
+    private const ESCAPE_SEGMENT_PREFIX = 'escape-bits:';
+
+    /**
      * Authoritative taint-escape table for first-party Laravel rule classes
      * whose object form carries the same safety guarantees as their string-rule
      * equivalent in {@see ruleToRemovedTaints()}. Consulted before any class
@@ -289,6 +297,24 @@ final class ValidationRuleAnalyzer
                 $removedTaints |= self::classRuleRemovedTaints(\substr($segment, \strlen(self::CLASS_SEGMENT_PREFIX)));
 
                 continue;
+            }
+
+            // Synthetic segment for an annotated closure rule. The bitmask was
+            // already resolved at extraction time — a closure has no name to
+            // look up here.
+            if (\str_starts_with($segment, self::ESCAPE_SEGMENT_PREFIX)) {
+                $bits = \substr($segment, \strlen(self::ESCAPE_SEGMENT_PREFIX));
+
+                // Only a bare non-negative integer is one of ours. A signed or
+                // malformed payload falls through to the normal rule path, so a
+                // userland rule that happens to be named `escape-bits` degrades
+                // to an unknown (no-op) rule instead of a taint mask — `-1`
+                // would otherwise erase every kind via `taints & ~removedTaints`.
+                if ($bits !== '' && \ctype_digit($bits)) {
+                    $removedTaints |= (int) $bits;
+
+                    continue;
+                }
             }
 
             [$ruleName, $ruleParam] = self::splitRule($segment);
@@ -1220,6 +1246,19 @@ final class ValidationRuleAnalyzer
                         continue;
                     }
 
+                    // Closure rule — the body is opaque, so the only escape it
+                    // can contribute is the one the developer asserts in a
+                    // docblock on the literal.
+                    if (self::isClosureLike($ruleItem->value)) {
+                        $escapeBits = self::closureRuleRemovedTaints($ruleItem);
+
+                        if ($escapeBits !== 0) {
+                            $segments[] = self::ESCAPE_SEGMENT_PREFIX . $escapeBits;
+                        }
+
+                        continue;
+                    }
+
                     // Rule::in(...) / Rule::notIn(...) / `new In([...])` / `new NotIn([...])`
                     // with statically-extractable string literals — emit the equivalent
                     // 'in:a,b,c' / 'not_in:a,b,c' segment so resolveRuleSegments narrows
@@ -1258,6 +1297,19 @@ final class ValidationRuleAnalyzer
 
                 if ($segments !== []) {
                     $rules[$fieldName] = $segments;
+                }
+
+                continue;
+            }
+
+            // Value: a bare closure as the whole field rule. Laravel accepts
+            // this alongside the array form, so the annotation has to be read
+            // here too; the escape is then the field's only rule segment.
+            if (self::isClosureLike($item->value)) {
+                $escapeBits = self::closureRuleRemovedTaints($item);
+
+                if ($escapeBits !== 0) {
+                    $rules[$fieldName] = [self::ESCAPE_SEGMENT_PREFIX . $escapeBits];
                 }
 
                 continue;
@@ -1696,18 +1748,7 @@ final class ValidationRuleAnalyzer
      *
      * Psalm stores `removed_taints` on FunctionLikeStorage only — class-level
      * escapes are not part of ClassLikeStorage — so we parse the class's raw
-     * docblock here. Only the bare form (`@psalm-taint-escape header`) is
-     * honoured; the conditional form (`@psalm-taint-escape (...)`) is ignored
-     * because it is defined per-parameter and has no meaning at class scope.
-     *
-     * Unknown kinds map to 0 and are silently dropped. Unlike Psalm's own
-     * `Codebase::getOrRegisterTaint()` (used in FunctionLikeDocblockScanner),
-     * which registers unfamiliar names as custom taint kinds, this lookup
-     * honours only the built-in `TaintKind::TAINT_NAMES` set. A mistyped kind
-     * (e.g. `heder` instead of `header`) contributes no escape and therefore
-     * leaves taint intact, which produces extra reports (the false-positive
-     * direction) — double-check spellings against the kind table in
-     * `docs/contributing/taint-analysis.md`.
+     * docblock here. Tag semantics live in {@see escapeBitsFromDoc()}.
      *
      * The FQN is treated as an opaque string — if the class does not exist in
      * the codebase, the storage lookup below fails and we return 0.
@@ -1766,10 +1807,73 @@ final class ValidationRuleAnalyzer
             return self::$classTaintCache[$cacheKey] = 0;
         }
 
+        return self::$classTaintCache[$cacheKey] = self::escapeBitsFromDoc($docComment);
+    }
+
+    /**
+     * A closure literal usable as a validation rule.
+     *
+     * @psalm-assert-if-true Node\Expr\ArrowFunction|Node\Expr\Closure $expr
+     * @psalm-pure
+     */
+    private static function isClosureLike(Node\Expr $expr): bool
+    {
+        return $expr instanceof Node\Expr\Closure || $expr instanceof Node\Expr\ArrowFunction;
+    }
+
+    /**
+     * Read `@psalm-taint-escape <kind>` annotations from a closure rule literal
+     * in a rules array. Same trust model and tag semantics as
+     * {@see classRuleRemovedTaints()}: the closure body is opaque to static
+     * analysis, so the developer's assertion is all there is.
+     *
+     * PhpParser attaches a comment to whichever node STARTS at the comment's
+     * offset, so the docblock lands on either half of the array item depending
+     * on shape, and both have to be read:
+     *
+     *   - `['rule', /** doc *\/ fn () => …]` — item and value start together,
+     *     so the item carries it.
+     *   - `'field' => /** doc *\/ fn () => …` — the item starts back at the key
+     *     token, so the value carries it. Same for a parenthesized value.
+     *
+     * Psalm's own `ReflectorVisitor` reads the item and `FunctionLikeNodeScanner`
+     * then prefers the closure node's own comment, covering the same two halves.
+     */
+    private static function closureRuleRemovedTaints(Node\ArrayItem $ruleItem): int
+    {
+        $docComment = $ruleItem->getDocComment() ?? $ruleItem->value->getDocComment();
+
+        if (!$docComment instanceof \PhpParser\Comment\Doc) {
+            return 0;
+        }
+
+        return self::escapeBitsFromDoc($docComment);
+    }
+
+    /**
+     * OR together the bits named by every bare `@psalm-taint-escape` tag in a
+     * docblock.
+     *
+     * Only the bare form (`@psalm-taint-escape header`) is honoured; the
+     * conditional form (`@psalm-taint-escape (...)`) is parameter-scoped and
+     * has nothing to bind to on a rule, whose contribution is to a single
+     * validated field rather than to a return value.
+     *
+     * Unknown kinds map to 0 and are silently dropped. Unlike Psalm's own
+     * `Codebase::getOrRegisterTaint()` (used in FunctionLikeDocblockScanner),
+     * which registers unfamiliar names as custom taint kinds, this lookup
+     * honours only the built-in `TaintKind::TAINT_NAMES` set. A mistyped kind
+     * (e.g. `heder` instead of `header`) contributes no escape and therefore
+     * leaves taint intact, which produces extra reports (the false-positive
+     * direction) — double-check spellings against the kind table in
+     * `docs/contributing/taint-analysis.md`.
+     */
+    private static function escapeBitsFromDoc(\PhpParser\Comment\Doc $docComment): int
+    {
         try {
             $parsed = DocComment::parsePreservingLength($docComment, true);
         } catch (DocblockParseException) {
-            return self::$classTaintCache[$cacheKey] = 0;
+            return 0;
         }
 
         $escapeTags = $parsed->tags['psalm-taint-escape'] ?? [];
@@ -1780,7 +1884,6 @@ final class ValidationRuleAnalyzer
             $kind = \trim($tagLine);
 
             if ($kind === '' || $kind[0] === '(') {
-                // Conditional form is parameter-scoped; has no meaning on a class.
                 continue;
             }
 
@@ -1790,7 +1893,7 @@ final class ValidationRuleAnalyzer
             $bits |= TaintKind::TAINT_NAMES[$kind] ?? 0;
         }
 
-        return self::$classTaintCache[$cacheKey] = $bits;
+        return $bits;
     }
 
     /**

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestArrowFunctionRuleEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestArrowFunctionRuleEscapesHeader.phpt
@@ -1,0 +1,36 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis --threads=1
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * FormRequest counterpart of SafeInlineValidateClosureRuleEscapesCallable, using
+ * an arrow function to pin the ArrowFunction node shape alongside Closure.
+ *
+ * The header-sinking redirect()->to() stays silent while the http-client ssrf
+ * sink still fires, proving the value is still tainted and only the annotated
+ * kind was removed.
+ */
+final class ContactArrowRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['team_email' => ['required', 'string',
+            /** @psalm-taint-escape header */
+            fn (string $attribute, mixed $value, \Closure $fail): mixed
+                => $value === $attribute ? $fail('The email is invalid.') : null,
+        ]];
+    }
+}
+
+function direct(ContactArrowRequest $request): \Illuminate\Http\RedirectResponse {
+    (new \Illuminate\Http\Client\PendingRequest())->get($request->safe()->input('team_email'));
+    return redirect()->to($request->safe()->input('team_email'));
+}
+?>
+--EXPECTF--
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateClosureRuleEscapesCallable.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateClosureRuleEscapesCallable.phpt
@@ -1,0 +1,44 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis --threads=1
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+/**
+ * A `@psalm-taint-escape` docblock on a closure rule literal inside an inline
+ * validate() array removes the named kind from the validated field, exactly as
+ * the class-level annotation does for a custom Rule class.
+ *
+ * The input() result is bound to a variable before `new`: the direct form
+ * `new ($request->input('k'))()` is a separate known false negative and would
+ * make this test pass vacuously. No `(string)` cast either — a cast currently
+ * drops the escape for Rule classes too, which would also hide the feature.
+ *
+ * The --threads=1 in --ARGS-- mirrors
+ * SafeInlineValidateCustomRuleEscapesHeaderViaVariable: parallel-worker graph
+ * merges can drop removed_taints on the variable-indirection edge.
+ *
+ * @psalm-suppress MixedAssignment
+ * @psalm-suppress MixedMethodCall
+ */
+function store(Request $request): object {
+    $request->validate([
+        'dataTable' => ['required', 'string',
+            /** @psalm-taint-escape callable */
+            function (string $attribute, mixed $value, \Closure $fail): void {
+                if ($value === $attribute) {
+                    $fail('The selected data table is invalid.');
+                }
+            },
+        ],
+    ]);
+
+    $dataTableClass = $request->input('dataTable');
+
+    return new $dataTableClass();
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeInlineValidateDirectClosureRuleEscapesCallable.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeInlineValidateDirectClosureRuleEscapesCallable.phpt
@@ -1,0 +1,39 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis --threads=1
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+/**
+ * Laravel accepts a bare closure as a field's whole rule, without the wrapping
+ * array. The annotation must be honoured there too.
+ *
+ * This shape also pins the other half of the doc-comment read: PhpParser
+ * attaches a comment to whichever node starts at its offset, and in keyed
+ * position (`'field' => /* doc *\/ closure`) the array item starts back at the
+ * key token, so the comment lands on the closure node rather than on the item.
+ * The list-style fixtures pin the item-node half.
+ *
+ * @psalm-suppress MixedAssignment
+ * @psalm-suppress MixedMethodCall
+ */
+function storeDirectClosure(Request $request): object {
+    $request->validate([
+        'dataTable' =>
+            /** @psalm-taint-escape callable */
+            function (string $attribute, mixed $value, \Closure $fail): void {
+                if ($value === $attribute) {
+                    $fail('The selected data table is invalid.');
+                }
+            },
+    ]);
+
+    $dataTableClass = $request->input('dataTable');
+
+    return new $dataTableClass();
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/TaintedCallableInlineValidateClosureRuleUnannotated.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedCallableInlineValidateClosureRuleUnannotated.phpt
@@ -1,0 +1,35 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis --threads=1
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+/**
+ * Control for SafeInlineValidateClosureRuleEscapesCallable: identical shape with
+ * no docblock on the closure rule. A closure without an annotation contributes
+ * no escape, so the taint reaches the dynamic-class sink.
+ *
+ * @psalm-suppress MixedAssignment
+ * @psalm-suppress MixedMethodCall
+ */
+function storeUnannotated(Request $request): object {
+    $request->validate([
+        'dataTable' => ['required', 'string',
+            function (string $attribute, mixed $value, \Closure $fail): void {
+                if ($value === $attribute) {
+                    $fail('The selected data table is invalid.');
+                }
+            },
+        ],
+    ]);
+
+    $dataTableClass = $request->input('dataTable');
+
+    return new $dataTableClass();
+}
+?>
+--EXPECTF--
+TaintedCallable on line %d: Detected tainted text

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestClosureRuleConditionalIgnored.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestClosureRuleConditionalIgnored.phpt
@@ -1,0 +1,40 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis --threads=1
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Behavior contract: the conditional form of `@psalm-taint-escape` is
+ * parameter-scoped and is ignored on a closure rule, the same as on a Rule
+ * class. The closure must contribute zero escape bits, so HTML taint from the
+ * validated value still flows through the echo sink.
+ *
+ * The conditional is spelled in the well-formed form Psalm accepts on a
+ * function-like, so the only thing under test is the plugin ignoring it.
+ */
+final class ConditionalClosureRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['field' => ['required', 'string',
+            /** @psalm-taint-escape ($value is string ? 'html' : null) */
+            function (string $attribute, mixed $value, \Closure $fail): void {
+                if ($value === $attribute) {
+                    $fail('invalid');
+                }
+            },
+        ]];
+    }
+}
+
+function render(ConditionalClosureRequest $request): void {
+    echo $request->string('field');
+}
+?>
+--EXPECTF--
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Unit/Handlers/Validation/ValidationRuleAnalyzerTest.php
+++ b/tests/Unit/Handlers/Validation/ValidationRuleAnalyzerTest.php
@@ -576,6 +576,84 @@ final class ValidationRuleAnalyzerTest extends TestCase
         );
     }
 
+    // --- Closure rule escape segments (#1351) ---
+
+    #[Test]
+    public function escape_bits_segment_ors_its_mask_into_removed_taints(): void
+    {
+        // The closure branch of extractRulePairsFromArrayNode resolves the
+        // docblock to a bitmask up front, so the segment carries the bits
+        // literally rather than a name to look up here.
+        $rule = ValidationRuleAnalyzer::resolveRuleSegments(
+            ['required', 'string', 'escape-bits:' . TaintKind::INPUT_CALLABLE],
+        );
+
+        $this->assertSame(TaintKind::INPUT_CALLABLE, $rule->removedTaints);
+        $this->assertSame('string', $rule->type->getId());
+        $this->assertTrue($rule->required);
+    }
+
+    #[Test]
+    public function escape_bits_segment_unions_with_string_rule_escapes(): void
+    {
+        $rule = ValidationRuleAnalyzer::resolveRuleSegments(
+            ['required', 'email', 'escape-bits:' . TaintKind::INPUT_CALLABLE],
+        );
+
+        $this->assertSame(
+            TaintKind::INPUT_HEADER | TaintKind::INPUT_COOKIE | TaintKind::INPUT_CALLABLE,
+            $rule->removedTaints,
+        );
+    }
+
+    /**
+     * A negative payload must never be honoured: `removedTaints` is applied as
+     * `taints & ~removedTaints`, so `-1` would erase every kind at once. The
+     * analyzer only ever emits non-negative bitmasks, so anything else reaching
+     * here came from a userland rule string and must degrade to a no-op rule.
+     *
+     * @return iterable<string, array{string}>
+     */
+    public static function provideMalformedEscapeBitsPayloads(): iterable
+    {
+        yield 'negative' => ['escape-bits:-1'];
+        yield 'signed positive' => ['escape-bits:+8'];
+        yield 'trailing junk' => ['escape-bits:123junk'];
+        yield 'leading junk' => ['escape-bits:junk123'];
+        yield 'empty payload' => ['escape-bits:'];
+        yield 'whitespace payload' => ['escape-bits: 8'];
+        yield 'hex' => ['escape-bits:0x10'];
+    }
+
+    #[Test]
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideMalformedEscapeBitsPayloads')]
+    public function malformed_escape_bits_segment_contributes_no_taint_escape(string $segment): void
+    {
+        $rule = ValidationRuleAnalyzer::resolveRuleSegments(['required', 'string', $segment]);
+
+        $this->assertSame(0, $rule->removedTaints);
+        // Falling through to the normal path must leave the other segments alone.
+        $this->assertSame('string', $rule->type->getId());
+        $this->assertTrue($rule->required);
+    }
+
+    #[Test]
+    public function escape_bits_segment_is_not_a_type_bearing_rule(): void
+    {
+        // Guards the segment against the other consumers of a rule name
+        // (splitRule, ruleToType, presence narrowing): a closure's runtime
+        // behavior is opaque, so the segment may only contribute taint bits.
+        $rule = ValidationRuleAnalyzer::resolveRuleSegments(
+            ['escape-bits:' . TaintKind::INPUT_HTML],
+        );
+
+        $this->assertTrue($rule->type->isMixed());
+        $this->assertFalse($rule->required);
+        $this->assertFalse($rule->nullable);
+        $this->assertFalse($rule->sometimes);
+        $this->assertSame(TaintKind::INPUT_HTML, $rule->removedTaints);
+    }
+
     // --- lookupRuleByKey (#838 wildcard-suffix fallback) ---
 
     #[Test]


### PR DESCRIPTION
## Issue to Solve

Closure validation rules contribute no taint escape because static analysis cannot see into the closure body. The only way to assert "this rule makes the value safe" was to extract the check into a dedicated Rule class carrying the class-level `@psalm-taint-escape` annotation, which is heavier than the inline closure Laravel encourages.

## Related

Closes #1351. Prompted by #1335.

## Solution Description

A `@psalm-taint-escape <kind>` docblock on a closure or arrow function rule literal is now honoured, in inline `validate()` arrays, in FormRequest `rules()` arrays, and when the closure is the field's whole rule without a wrapping array. Semantics mirror the class-level annotation on custom Rule classes: bare form only, any `TaintKind` name, conditional form ignored, no annotation means no escape.

Implementation notes:

- `extractRulePairsFromArrayNode()` resolves the docblock to a bitmask at extraction time and carries it as a synthetic `escape-bits:<int>` segment, since a closure has no name to look up later. `resolveRuleSegments()` ORs the mask into the field's removed taints.
- The segment payload is honoured only when it is a bare non-negative integer. A signed or malformed payload falls through to the normal rule path as an unknown rule, so a userland rule that happens to be named `escape-bits` cannot grant itself an arbitrary mask (`-1` would otherwise erase every taint kind).
- PhpParser attaches a doc comment to whichever node starts at the comment's offset, so the comment lands on the `ArrayItem` in list position but on the closure node in keyed or parenthesized position. Both halves are read. Psalm's own `ReflectorVisitor` plus `FunctionLikeNodeScanner` handle the same two halves, verified against a nine-shape parser probe.
- Tag parsing is shared with the class-level path via a new `escapeBitsFromDoc()` helper, no duplication.

Verified by five type tests (safe inline closure, unannotated control, FormRequest arrow function, conditional form ignored, keyed direct closure) and ten unit tests covering the segment contract and malformed payloads. Each safe test was confirmed red before the fix. Full type suite, unit suite, self-analysis, Rector, and code style all pass.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)
- [x] Documentation is updated (new "Closure rules" subsection in `docs/contributing/taint-analysis.md`)
