### PR TITLE
Cache Psalm between CI runs and parallelise the scan phase

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -89,7 +89,7 @@ jobs:
             "https://github.com/$MONICA_REPO" /tmp/monica
 
       - name: Cache Monica vendor
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /tmp/monica/vendor
           key: monica-vendor-${{ env.MONICA_REF }}-php${{ env.PHP_VERSION }}-v2

--- a/.github/workflows/psalm-delta.yml
+++ b/.github/workflows/psalm-delta.yml
@@ -191,7 +191,7 @@ jobs:
       # RESTORE-ONLY; matching save is a separate non-fork-gated step (see below).
       - name: Restore app source cache
         id: cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/app-cache/${{ matrix.name }}
           key: psalm-delta-app-${{ matrix.name }}-${{ matrix.ref }}-php${{ matrix.php }}-${{ hashFiles('plugin-base/composer.json') }}-v1
@@ -236,7 +236,7 @@ jobs:
       # redundant same-key save.
       - name: Save app source cache
         if: needs.prepare.outputs.is_fork != 'true' && steps.cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/app-cache/${{ matrix.name }}
           key: ${{ steps.cache.outputs.cache-primary-key }}

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -15,19 +15,40 @@ on:
       - 'composer.json'
       - '.github/workflows/psalm.yml'
 
-# Cancel superseded runs on the same branch/PR to save CI minutes on fast pushes.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Pull requests supersede freely, to save CI minutes on fast pushes. Pushes to master do
+  # not: cancelling one loses the Psalm cache generation every later pull request restores.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  PHP_VERSION: '8.4'
+  # Psalm forces a single thread whenever it detects CI, and decides the two phases
+  # separately: --threads covers analysis, --scan-threads covers scanning
+  # (Cli\Psalm::getThreads()). Setting only --threads leaves the whole scan phase serial,
+  # and scanning is the bulk of this job: 187 analysed files against ~13k scanned in vendor.
+  # psalm.xml's threads/scanThreads attributes cannot do this, getThreads() tests for CI
+  # before it reads either. 4 matches ubuntu-latest's core count.
+  PSALM_THREADS: 4
+  PSALM_SCAN_THREADS: 4
 
 jobs:
   psalm:
     name: Psalm
     runs-on: ubuntu-latest
+    # A wedged analysis should fail loudly, not bill six hours against the default limit.
+    timeout-minutes: 15
     steps:
       - name: Harden the runner (Block all outbound calls except allowlist)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
+          # No Actions cache hosts here on purpose: harden-runner resolves the cache blob host
+          # itself in block mode and appends it, and its agent allows the cache endpoints
+          # implicitly when that lookup fails. Listing them by hand would not work anyway, the
+          # blob host comes from a numbered pool that rotates per run.
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
@@ -47,11 +68,67 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
-          php-version: 8.4
+          php-version: ${{ env.PHP_VERSION }}
           coverage: none
+          # Psalm's ForkContext serialises each worker's results back to the parent with
+          # igbinary when present and falls back to PHP's native serializer when absent.
+          # It also selects the cache serializer, which Psalm folds into the hash naming each
+          # cache generation directory, so adding it invalidates existing caches once.
+          extensions: igbinary
 
+      # Left as a plain install on purpose. ramsey/composer-install was measured here and came
+      # out median-neutral (14s either way over five baseline and three cached runs): this
+      # repository does not commit composer.lock, so every run still resolves against Packagist
+      # and the download cache has little left to save.
       - name: Install composer dependencies
         run: composer install -n --prefer-dist
 
+      # Restores the parsed statements and file/class-like storage for vendor, which is where
+      # this job spends most of its time. Deliberately after the install: the key hashes
+      # composer.lock, hashFiles is evaluated when the step runs, and this repository does not
+      # commit a lock file, so the lock only exists once Composer has resolved.
+      #
+      # ~/.cache/psalm is Psalm's default on Linux (XDG home cache); psalm.xml sets no
+      # cacheDirectory. Psalm names each generation directory with a hash covering
+      # composer.lock's contents and psalm.xml, so an entry built from a different lock misses
+      # internally in every subcache while still costing the download. The restore-keys
+      # fallback repeats that hash verbatim and varies only the per-commit part; a bare
+      # 'psalm-cache-' catch-all would fire precisely when the archive is unusable.
+      - name: Restore Psalm's cache
+        id: psalm-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/psalm
+          key: psalm-cache-php${{ env.PHP_VERSION }}-${{ hashFiles('psalm.xml', 'composer.lock') }}-${{ github.sha }}
+          restore-keys: |
+            psalm-cache-php${{ env.PHP_VERSION }}-${{ hashFiles('psalm.xml', 'composer.lock') }}-
+
+      # --shepherd only on push: the type-coverage history it feeds is a master-branch series,
+      # and a pull request run posting into it adds nothing a reviewer reads.
+      #
+      # The thread counts are read as shell variables rather than interpolated as
+      # ${{ env.* }}: octoscan cannot tell a literal workflow-level env from an
+      # attacker-reachable one and flags every ${{ env.* }} reaching a run: block.
       - name: Run Psalm
-        run: ./vendor/bin/psalm --threads=2 --output-format=github --shepherd
+        run: >-
+          ./vendor/bin/psalm
+          --threads="$PSALM_THREADS"
+          --scan-threads="$PSALM_SCAN_THREADS"
+          --output-format=github
+          ${{ github.event_name == 'push' && '--shepherd' || '' }}
+
+      # Split from the restore rather than one combined actions/cache step: a combined step
+      # skips its save on a key hit, so a snapshot whose key does not move never rolls forward.
+      # Only master writes, so pull request runs do not each store a copy under
+      # refs/pull/<n>/merge that nothing else can read; restore-keys already lets them fall
+      # back to the newest master snapshot.
+      #
+      # !cancelled() rather than the implicit success(): Psalm validates every entry against a
+      # per-file content hash on read, so a run that reported issues still leaves a correct
+      # cache, and a red master must not stop refreshing what pull requests restore from.
+      - name: Save Psalm's cache
+        if: ${{ !cancelled() && github.event_name == 'push' && steps.psalm-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/psalm
+          key: ${{ steps.psalm-cache.outputs.cache-primary-key }}

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -43,12 +43,15 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Harden the runner (Block all outbound calls except allowlist)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
-          # No Actions cache hosts here on purpose: harden-runner resolves the cache blob host
-          # itself in block mode and appends it, and its agent allows the cache endpoints
-          # implicitly when that lookup fails. Listing them by hand would not work anyway, the
-          # blob host comes from a numbered pool that rotates per run.
+          # No Actions cache hosts here on purpose: in block mode harden-runner resolves the cache
+          # blob host itself and appends it. Listing it by hand would mean a broad
+          # *.blob.core.windows.net wildcard, since the host rotates per run.
+          #
+          # v2.21.0 is a floor, not a routine bump: up to and including v2.20.0 a failed lookup
+          # downgraded egress-policy from block to audit for the WHOLE job, so a transient
+          # cache-service blip silently disabled egress enforcement for every later step.
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
@@ -99,6 +102,8 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/psalm
+          # Only psalm.xml is hashed because only psalm.xml exists here. Psalm also accepts
+          # psalm.xml.dist and psalm.dist.xml; a project using either must add it to hashFiles.
           key: psalm-cache-php${{ env.PHP_VERSION }}-${{ hashFiles('psalm.xml', 'composer.lock') }}-${{ github.sha }}
           restore-keys: |
             psalm-cache-php${{ env.PHP_VERSION }}-${{ hashFiles('psalm.xml', 'composer.lock') }}-
@@ -119,15 +124,21 @@ jobs:
 
       # Split from the restore rather than one combined actions/cache step: a combined step
       # skips its save on a key hit, so a snapshot whose key does not move never rolls forward.
-      # Only master writes, so pull request runs do not each store a copy under
+      # Only the default branch writes, tested by name rather than by event: the push trigger
+      # above happens to list master alone, but adding 3.x there would otherwise give it a full
+      # second copy per commit. Pull request runs do not store anything under
       # refs/pull/<n>/merge that nothing else can read; restore-keys already lets them fall
       # back to the newest master snapshot.
       #
-      # !cancelled() rather than the implicit success(): Psalm validates every entry against a
-      # per-file content hash on read, so a run that reported issues still leaves a correct
-      # cache, and a red master must not stop refreshing what pull requests restore from.
+      # The implicit success() is load-bearing, do not relax it to !cancelled(). Cache::saveItem()
+      # writes an entry's hash sidecar before the value it describes, and getItem() reads that
+      # value back through an assertion rather than treating a short read as a miss, so a run
+      # killed mid-write (OOM, fatal) leaves an entry that throws on every later read. Keys are
+      # immutable and the cache-hit guard refuses to overwrite, so a re-run at that commit cannot
+      # repair it. Skipping the save on a red master costs a stale snapshot until the next green
+      # one; taking it can cost a wedged snapshot that every pull request then restores.
       - name: Save Psalm's cache
-        if: ${{ !cancelled() && github.event_name == 'push' && steps.psalm-cache.outputs.cache-hit != 'true' }}
+        if: ${{ github.ref_name == github.event.repository.default_branch && steps.psalm-cache.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/psalm


### PR DESCRIPTION
## Issue to Solve

The Psalm job has run half serial and with no cache at all.

`Cli\Psalm::getThreads()` decides the scan phase and the analysis phase separately, and forces a single thread for each whenever it detects CI unless the matching flag is passed. The job passed `--threads=2` and nothing else, so **the entire scan phase has been single-threaded on every run**, and scanning is where this job spends its time: 187 analysed files in `src/` against roughly 13,000 scanned in `vendor/`.

`psalm.xml` cannot fix that. It accepts `threads` and `scanThreads` attributes, but `getThreads()` tests for CI before it reads either, so in CI only the command-line flags have any effect.

## Related

Sibling of #1347, which makes the same corrections to the template shipped by `psalm-laravel add github`. No separate issue.

## Solution Description

**Both thread flags, set to the runner's core count.** `--threads=4 --scan-threads=4`; `ubuntu-latest` has 4 cores. Held in `env:` next to `PHP_VERSION` so there is one place to raise them.

**`igbinary`.** Psalm's `ForkContext` serialises each worker's results back to the parent with it when present and falls back to PHP's native serializer when absent. It also selects the cache serializer, which `Psalm\Internal\Cache` folds into the hash naming each cache generation directory, so installing it invalidates existing caches once. Worth stating because it interacts with the next change.

**A rolling `~/.cache/psalm`.** That is Psalm's default cache directory on Linux (the XDG home cache; `psalm.xml` sets no `cacheDirectory`). Four details are load-bearing:

* **Restore after Composer, not before.** The key hashes `composer.lock`, `hashFiles` is evaluated when the step runs, and this repository gitignores its lock file. The lock only exists once Composer has resolved.
* **Split `actions/cache/restore` from `actions/cache/save`.** A combined step skips its save on a key hit, so a snapshot whose key does not move never rolls forward. The key carries `github.sha`, so every push to `master` writes a fresh generation.
* **A qualified `restore-keys` fallback, not a bare `psalm-cache-` prefix.** Psalm names each generation directory with a hash covering `composer.lock`'s contents and `psalm.xml`, so an entry built from a different lock misses internally in every subcache while still costing the download. A catch-all fires precisely when the archive is unusable, and on `master` that is worse than a plain miss: Psalm writes the new generation beside the restored dead one, never collects stale siblings, and the save archives both. The fallback here repeats the same hash and varies only the per-commit part.
* **Save on the default branch only, and only on success.** The condition tests `github.ref_name` against the repository's default branch rather than `github.event_name == 'push'`, so adding `3.x` under `push:` later cannot give it a second full archive per commit. Pull request entries would land under `refs/pull/<n>/merge` where nothing else can read them, so they are not written at all.

  The implicit `success()` is kept deliberately. `Cache::saveItem()` writes an entry's hash sidecar before the serialized value it describes, and `getItem()` reads that value back through `Assert::notFalse()` rather than treating a short read as a miss, so a run killed mid-write (an OOM, a fatal) leaves an entry that throws on every later read. Cache keys are immutable and the `cache-hit` guard refuses to overwrite, so a re-run at the same commit cannot repair it. An earlier revision of this branch used `!cancelled()` to keep a red `master` refreshing the snapshot; that trades a stale cache for an occasionally wedged one, which is the worse of the two.

No `allowed-endpoints` change is needed: under `egress-policy: block`, `harden-runner` resolves the Actions cache blob host itself and appends it. Listing it by hand would mean a broad `*.blob.core.windows.net:443` wildcard, since the host comes from a rotating numbered pool.

The `harden-runner` pin moves to **v2.21.0**, and that is a floor rather than a routine bump. Up to and including v2.20.0 the lookup's `catch` ran `confg.egress_policy = "audit"`, so a transient cache-service failure silently dropped egress enforcement for every later step in the job. The fix is `93b58ee4` ("never downgrade egress policy"), first tagged in v2.21.0. This fail-open predates the branch, but an earlier revision of this PR added a comment asserting the opposite.

`cancel-in-progress` now applies to pull requests only. Cancelling a `master` run would throw away the cache generation every later pull request restores from.

## Measurements

Baseline is five `master` runs: the Psalm step took 19s, 19s, 19s, 16s, 19s, so a **median 19s** against a very tight spread.

This branch was then measured on real runners with a temporary commit that let pull requests write the cache (since dropped), which also let each of the three cache paths be confirmed in the log rather than assumed:

| run | cache path (from the log) | Run Psalm |
|---|---|---|
| baseline | no cache | 19s (median of 5) |
| A | miss, then `Cache saved with key: psalm-cache-…` | **13s** |
| B | `Cache hit for: psalm-cache-…` (exact key) | **9s** |
| C, new SHA | `Cache hit for restore-key: …` then saved under the new SHA | **8s** |

So the thread flags and igbinary account for 19s to 13s on a cold cache, and the cache for a further 13s to 8-9s. Run C is the one that matters for the steady state: it proves the `restore-keys` fallback fires and that the entry rolls forward to the new commit rather than freezing.

### Measured and not adopted

`ramsey/composer-install` was tried for the Composer download cache and came out **median-neutral**: 14s across five baseline runs of the plain install, and 16s / 9s / 14s across the three cached runs. This repository does not commit `composer.lock`, so every run resolves against Packagist regardless and the download cache has little left to save. Reverted rather than carried on a hunch; the reasoning is recorded in a comment at that step.

### Also in this change

* `permissions: contents: read`, previously unset, so the job ran on the repository default.
* `timeout-minutes: 15`. One earlier run billed 115 minutes before anything stopped it.
* `--shepherd` on `push` only. The type-coverage series it feeds is a `master` one; a pull request posting into it adds nothing a reviewer reads.
* The `actions/cache` pin comments in `benchmark.yml` and `psalm-delta.yml` said `# v5` for a SHA that is in fact `v6.1.0`.

### Review corrections

An external review of the first revision found three real defects, all since fixed and each verified against source rather than taken on trust: the `harden-runner` claim above, the `!cancelled()` save, and `github.event_name == 'push'` standing in for "the default branch". A fourth note, that only `psalm.xml` is hashed while Psalm equally accepts `psalm.xml.dist` and `psalm.dist.xml`, is now recorded as a comment at the key.

## Checklist
- [x] Tests cover the change (CI is the test: `actionlint` and `zizmor` are clean, and every number above comes from a real run with the cache path confirmed in its log)
