### PR TITLE
Sink view names as `include` only, not `file`

### DIFF
--- a/stubs/common/Contracts/Routing/ResponseFactory.phpstub
+++ b/stubs/common/Contracts/Routing/ResponseFactory.phpstub
@@ -28,8 +28,8 @@ interface ResponseFactory
      * Create a new response for a given view.
      *
      * Forwards the view name to `Factory::make()` (or `Factory::first()` for the array
-     * form), so it resolves to an arbitrary blade path. `$data` stays un-sunk: Blade
-     * auto-escapes `{{ }}`.
+     * form), so it selects which blade template executes — include only, it cannot escape
+     * to an arbitrary file. `$data` stays un-sunk: Blade auto-escapes `{{ }}`.
      *
      * @param  string|array  $view
      * @param  array  $data
@@ -37,7 +37,9 @@ interface ResponseFactory
      * @param  array  $headers
      * @return \Illuminate\Http\Response
      *
-     * @psalm-taint-sink file $view
+     * The finder maps every `.` in the name to `/` and appends a fixed extension, so a
+     * tainted name selects a template rather than reaching an arbitrary file.
+     *
      * @psalm-taint-sink include $view
      */
     public function view($view, $data = [], $status = 200, array $headers = []);

--- a/stubs/common/Contracts/View/Factory.phpstub
+++ b/stubs/common/Contracts/View/Factory.phpstub
@@ -24,15 +24,15 @@ interface Factory
     /**
      * Get the evaluated view contents for the given view.
      *
-     * A user-controlled view name resolves to an arbitrary blade path, same as
-     * `Factory::file()`.
+     * A user-controlled view name selects which blade template gets compiled and executed;
+     * unlike `Factory::file()`'s path argument, it cannot escape to an arbitrary file —
+     * include only.
      *
      * @param  string  $view
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
      * @param  array  $mergeData
      * @return \Illuminate\Contracts\View\View
      *
-     * @psalm-taint-sink file $view
      * @psalm-taint-sink include $view
      */
     public function make($view, $data = [], $mergeData = []);

--- a/stubs/common/Foundation/helpers.phpstub
+++ b/stubs/common/Foundation/helpers.phpstub
@@ -395,14 +395,16 @@ function validator(array $data = [], array $rules = [], array $messages = [], ar
  * argument-supplied form to `\Illuminate\View\View`, the latter only when that
  * resolved factory is the stock `\Illuminate\View\Factory`.
  *
- * A user-controlled view name resolves to an arbitrary blade path, same as `Factory::file()`.
+ * A user-controlled view name selects which blade template gets compiled and executed.
+ * FileViewFinder normalizes the name (dots become path separators, a known extension is
+ * appended) before joining it onto a configured view path, so it cannot escape to an
+ * arbitrary file the way `Factory::file()`'s path argument can — include only.
  *
  * @param  string|null  $view
  * @param  \Illuminate\Contracts\Support\Arrayable<string, mixed>|array<string, mixed>  $data
  * @param  array<string, mixed>  $mergeData
  * @return (func_num_args() is 0 ? \Illuminate\Contracts\View\Factory : \Illuminate\Contracts\View\View)
  *
- * @psalm-taint-sink file $view
  * @psalm-taint-sink include $view
  */
 function view($view = null, $data = [], $mergeData = []) {}

--- a/stubs/common/Routing/ResponseFactory.phpstub
+++ b/stubs/common/Routing/ResponseFactory.phpstub
@@ -51,7 +51,8 @@ class ResponseFactory implements FactoryContract
     // View data ($data) is intentionally NOT marked as @psalm-taint-sink html.
     // Blade auto-escapes all {{ $var }} output — see Factory.phpstub for full rationale.
     // The view NAME is a different matter: this forwards it to Factory::make() (or
-    // Factory::first() for the array form), so it resolves to an arbitrary blade path.
+    // Factory::first() for the array form), so it selects which blade template executes —
+    // include only, it cannot escape to an arbitrary file.
     /**
      * Create a new response for a given view.
      *
@@ -61,7 +62,6 @@ class ResponseFactory implements FactoryContract
      * @param  array  $headers
      * @return \Illuminate\Http\Response
      *
-     * @psalm-taint-sink file $view
      * @psalm-taint-sink include $view
      */
     public function view($view, $data = [], $status = 200, array $headers = []) {}

--- a/stubs/common/View/Factory.phpstub
+++ b/stubs/common/View/Factory.phpstub
@@ -13,9 +13,10 @@ class Factory implements \Illuminate\Contracts\View\Factory
     // See: https://github.com/psalm/psalm-plugin-laravel/issues/684
 
     /**
-     * A user-controlled view name resolves to an arbitrary blade path, same as `file()`.
+     * A user-controlled view name selects which blade template gets compiled and executed.
+     * FileViewFinder normalizes it before joining a configured view path, so unlike
+     * `file()`'s path argument it cannot escape to an arbitrary file — include only.
      *
-     * @psalm-taint-sink file $view
      * @psalm-taint-sink include $view
      */
     public function make($view, $data = [], $mergeData = []) {}
@@ -27,22 +28,19 @@ class Factory implements \Illuminate\Contracts\View\Factory
     public function file($path, $data = [], $mergeData = []) {}
 
     // Everything below forwards its view name to make(), so each name param carries the
-    // same file + include sinks. Verified against Illuminate\View\Factory.
+    // same include sink. Verified against Illuminate\View\Factory.
 
     /**
-     * @psalm-taint-sink file $views
      * @psalm-taint-sink include $views
      */
     public function first(array $views, $data = [], $mergeData = []) {}
 
     /**
-     * @psalm-taint-sink file $view
      * @psalm-taint-sink include $view
      */
     public function renderWhen($condition, $view, $data = [], $mergeData = []) {}
 
     /**
-     * @psalm-taint-sink file $view
      * @psalm-taint-sink include $view
      */
     public function renderUnless($condition, $view, $data = [], $mergeData = []) {}
@@ -51,9 +49,7 @@ class Factory implements \Illuminate\Contracts\View\Factory
      * $empty is a view name too, unless it is the `raw|` literal form: the else-branch
      * calls make($empty).
      *
-     * @psalm-taint-sink file $view
      * @psalm-taint-sink include $view
-     * @psalm-taint-sink file $empty
      * @psalm-taint-sink include $empty
      */
     public function renderEach($view, $data, $iterator, $empty = 'raw|') {}

--- a/tests/Type/tests/TaintAnalysis/TaintedIncludeResponseViewName.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedIncludeResponseViewName.phpt
@@ -8,7 +8,8 @@ use Illuminate\Routing\ResponseFactory;
 
 /**
  * `ResponseFactory::view()` forwards its view name to `Factory::make()` (or `first()` for
- * the array form), so a user-controlled name resolves to an arbitrary blade path.
+ * the array form), so a user-controlled name selects which blade template executes —
+ * include only, it cannot escape to an arbitrary file.
  *
  * Both receivers are pinned: the zero-argument `response()` helper, typed as the
  * `Illuminate\Contracts\Routing\ResponseFactory` contract, and the concrete class. Sinks do
@@ -28,7 +29,5 @@ function responseConcreteViewNameIsTainted(Request $request, ResponseFactory $re
 }
 ?>
 --EXPECTF--
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedInclude on line %d: Detected tainted code passed to include or similar
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedInclude on line %d: Detected tainted code passed to include or similar
+TaintedInclude on line %d: Detected tainted code passed to include or similar
+TaintedInclude on line %d: Detected tainted code passed to include or similar

--- a/tests/Type/tests/TaintAnalysis/TaintedIncludeViewFactoryForwardingNames.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedIncludeViewFactoryForwardingNames.phpt
@@ -8,9 +8,10 @@ use Illuminate\View\Factory;
 
 /**
  * Every `Factory` method that resolves a view name forwards it to `make()`, so each name
- * param carries the same file + include sinks. Verified against Illuminate\View\Factory:
- * `first()` picks from `$views`, `renderWhen()` calls `make()`, `renderUnless()` delegates
- * to `renderWhen()`, and `renderEach()` calls `make($view)` per row.
+ * param carries the same include sink — no TaintedFile, the finder cannot be steered to an
+ * arbitrary file. Verified against Illuminate\View\Factory: `first()` picks from `$views`,
+ * `renderWhen()` calls `make()`, `renderUnless()` delegates to `renderWhen()`, and
+ * `renderEach()` calls `make($view)` per row.
  *
  * `renderEach()`'s `$empty` is a view name too: the no-rows branch calls `make($empty)`
  * unless the value uses the literal `raw|` form.
@@ -45,13 +46,8 @@ function renderEachEmptyViewIsTainted(Request $request, Factory $factory): void
 }
 ?>
 --EXPECTF--
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedInclude on line %d: Detected tainted code passed to include or similar
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedInclude on line %d: Detected tainted code passed to include or similar
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedInclude on line %d: Detected tainted code passed to include or similar
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedInclude on line %d: Detected tainted code passed to include or similar
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedInclude on line %d: Detected tainted code passed to include or similar
+TaintedInclude on line %d: Detected tainted code passed to include or similar
+TaintedInclude on line %d: Detected tainted code passed to include or similar
+TaintedInclude on line %d: Detected tainted code passed to include or similar
+TaintedInclude on line %d: Detected tainted code passed to include or similar
+TaintedInclude on line %d: Detected tainted code passed to include or similar

--- a/tests/Type/tests/TaintAnalysis/TaintedIncludeViewName.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedIncludeViewName.phpt
@@ -8,10 +8,11 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\View;
 
 /**
- * A user-controlled view *name* resolves to an arbitrary blade path, so it carries the
- * same file + include sinks as `Factory::file()` (see TaintedIncludeViewFactory.phpt).
- * View *data* remains deliberately un-sunk — Blade escapes `{{ }}` (see
- * SafeViewFactoryUserInput.phpt).
+ * A user-controlled view *name* selects which blade template gets compiled and executed,
+ * but FileViewFinder normalizes it before joining a configured view path, so it cannot
+ * escape to an arbitrary file the way `Factory::file()`'s path argument can (see
+ * TaintedIncludeViewFactory.phpt) — include only, no TaintedFile. View *data* remains
+ * deliberately un-sunk — Blade escapes `{{ }}` (see SafeViewFactoryUserInput.phpt).
  *
  * Three call shapes, each with its own sink source. Verified by deleting each in turn:
  * every one is load-bearing for exactly one case, and none covers another.
@@ -43,9 +44,6 @@ function viewContractNameIsTainted(Request $request, ViewFactoryContract $factor
 }
 ?>
 --EXPECTF--
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedInclude on line %d: Detected tainted code passed to include or similar
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedInclude on line %d: Detected tainted code passed to include or similar
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedInclude on line %d: Detected tainted code passed to include or similar
+TaintedInclude on line %d: Detected tainted code passed to include or similar
+TaintedInclude on line %d: Detected tainted code passed to include or similar
+TaintedInclude on line %d: Detected tainted code passed to include or similar

--- a/tests/Unit/Stubs/ContractStubSinkParityTest.php
+++ b/tests/Unit/Stubs/ContractStubSinkParityTest.php
@@ -111,9 +111,10 @@ final class ContractStubSinkParityTest extends TestCase
         // every parity assertion above trivially true.
         $this->assertSame(['@psalm-taint-sink html $content'], $sinks['make'] ?? []);
 
-        // The view NAME is sunk (it resolves to a blade path); the view DATA is not.
+        // The view NAME is sunk (it selects which blade template executes); the view DATA
+        // is not.
         $this->assertSame(
-            ['@psalm-taint-sink file $view', '@psalm-taint-sink include $view'],
+            ['@psalm-taint-sink include $view'],
             $sinks['view'] ?? [],
         );
 


### PR DESCRIPTION
## Issue to Solve

A tainted view **name** was reported twice on a single `view()` / `View::make()` call, as both `TaintedFile` and `TaintedInclude`. Only `include` is accurate.

`Illuminate\View\FileViewFinder::getPossibleViewFiles()` builds the candidate path as `str_replace('.', '/', $name) . '.' . $extension`, so every `.` in the name becomes `/` (destroying `../` traversal), a fixed extension is always appended, and the result is only ever joined onto a configured view path. A tainted name therefore selects **which template executes**, which is `include`; it cannot reach an arbitrary file, which is what `file` means.

Introduced by #1318, which added view-name sinks and copied the `file` kind from `Factory::file()`, where it is correct. Observed in the wild on `filamentphp/filament` (`packages/support/src/Components/ViewComponent.php:149`), where one call produced both issues.

## Related

Fixes #1353

## Solution Description

Dropped `@psalm-taint-sink file` on the view **name** parameter only, keeping `include`, at 10 sites:

- `view()` helper (`$view`)
- `View\Factory::make()`, `first()` (`$views`), `renderWhen()`, `renderUnless()`, `renderEach()` (`$view` and `$empty`)
- `Contracts\View\Factory::make()`
- `Routing\ResponseFactory::view()` and `Contracts\Routing\ResponseFactory::view()`

Deliberately unchanged: `Factory::file()` and `Contracts\View\Factory::file()` (real filesystem path, keep both kinds) and the `download()` / `file()` response methods.

Why the annotations and not a handler: the semantics are per parameter and docblock expressible, and the facade static form (`View::make()`) inherits the parameter sink bitmask through `FacadeTaintForwardingHandler`, so the stub is the single source of truth for both call shapes.

No detection is lost. Every taint source in `stubs/` is either `input` (which expands to `TaintKindGroup::ALL_INPUT`, carrying both `INPUT_FILE` and `INPUT_INCLUDE`), `user_secret` (reaches neither), or `UploadedFile`'s explicit kind list, which already carries `include` and deliberately omits `file` (#1134). `INPUT_FILE` and `INPUT_INCLUDE` appear nowhere in `src/`, so no handler can separate the two kinds either.

The reasoning lives as a two-line comment next to the annotation in `Contracts\Routing\ResponseFactory`, not in `docs/security.md`.

Verification:

- Three type tests renamed and re-pinned: `TaintedIncludeViewName.phpt` (3 cases), `TaintedIncludeViewFactoryForwardingNames.phpt` (5 cases), `TaintedIncludeResponseViewName.phpt` (2 cases). All 10 changed sites are covered.
- Negative pin `TaintedIncludeViewFactory.phpt` keeps `Factory::file()` at both kinds, unchanged.
- `ContractStubSinkParityTest` enforces concrete/contract parity, so both halves of each pair moved in the same commit.
- Full suites green on Psalm 7.0.0-beta19: `test:type` 650 tests, `test:unit` 1096 tests, self-analysis with the CI invocation reports no errors at 100% type coverage.

While re-pinning, the three type tests turned out to have **no teeth**: their `--EXPECTF--` blocks used a leading `%A`, which absorbed interleaved findings, so the pre-fix `TaintedFile` output still matched. The wildcard is now stripped, and the pins were verified by reintroducing the regression and confirming they fail.

### Accepted imprecision

A userland `ViewFinderInterface` installed via `Factory::setFinder()` could reintroduce a genuine file sink on a view name. Stubs model the framework's default finder; this follows the project convention of not modelling replaced framework internals.

### Reviewer notes

- `TaintedIncludeViewFactory.phpt` still uses a leading `%A` in its `--EXPECTF--`, so it cannot assert the absence of a spurious kind. Now inconsistent with its three cleaned siblings; worth a follow-up sweep across the taint test suite.
- The issue text says `download()` / `file()` carry `file` plus `include` today. They carry `file` only; nothing was added there.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)
