### PR TITLE
Also reject a wildcard issue line ending in `%a`

### DIFF
--- a/bin/ci/check-phpt-conventions.sh
+++ b/bin/ci/check-phpt-conventions.sh
@@ -41,17 +41,20 @@ if line_hits="$(grep -rnE 'on line [0-9]' "${TESTS_DIR}")"; then
     status=1
 fi
 
-# Rule 3: `%A` leading an issue line, either "%AFooIssue on line ..." or the
-# bare "%AFooIssue%A" form (no "on line" text at all). Anchor on `%A` directly
-# followed by an issue-type identifier, not `^%A`: a single physical
-# --EXPECTF-- line can pack multiple issues, so the leading `%A` is not
-# always at the start of the line.
+# Rule 3: `%A` leading an issue line, in any of the forms "%AFooIssue on
+# line ...", "%AFooIssue%A", or "%AFooIssue%a". `%A` (`.*?`) and `%a` (`.+?`)
+# both compile to a lazy dotall match (PHPUnit's StringMatchesFormatDescription
+# uses the `/s` modifier), so both can absorb unasserted ISSUE lines across
+# newlines; only they pose the swallowing risk this rule guards against.
+# Anchor on `%A` directly followed by an issue-type identifier, not `^%A`: a
+# single physical --EXPECTF-- line can pack multiple issues, so the leading
+# `%A` is not always at the start of the line.
 wildcard_hits=""
 while IFS= read -r hit; do
     file="${hit%%:*}"
     rel="${file#"${TESTS_DIR}"/}"
     grep -qxF "${rel}" "${WILDCARD_ALLOWLIST}" 2>/dev/null || wildcard_hits="${wildcard_hits}${hit}"$'\n'
-done < <(grep -rnE '%A[A-Za-z]+(%A| on line)' "${TESTS_DIR}" --include='*.phpt' || true)
+done < <(grep -rnE '%A[A-Za-z]+(%A|%a| on line)' "${TESTS_DIR}" --include='*.phpt' || true)
 if [ -n "${wildcard_hits}" ]; then
     echo "ERROR: PHPT expectations must not lead an issue line with '%A':"
     printf '%s' "${wildcard_hits}"


### PR DESCRIPTION
## Issue to Solve

Rule 3, added in #1361, had a false negative: it flagged only **218 of the 221** files that carried the offending shape before the sweep.

It missed `%A<Ident>%a: …`, which was real at the merge base in `TaintedHtmlSanitizeUrlPreservesHtmlTaint.phpt`, `TaintedHtmlUrlEDoesNotEscape.phpt` and `TaintedHtmlUrlMailActionWithoutSanitize.phpt`. A CI rule that misses shapes is worse than no rule, because it certifies.

## Related

Follow-up to #1361. Refs #1359.

## Solution Description

Adds `%a` to the alternation: `%A[A-Za-z]+(%A|%a| on line)`.

### Why `%A` and `%a` are the complete set, not an arbitrary subset

Checked against `StringMatchesFormatDescription.php:200-215`: only `%a` (`.+?`) and `%A` (`.*?`) compile under the `/s` modifier, so only those two can span a newline. `%s` / `%S` compile to `[^\r\n]+` / `[^\r\n]*`, and `%w` / `%i` / `%d` / `%x` / `%f` / `%c` / `%e` / `%0` are fixed-width or single-line tokens. PHPUnit's own `isMultilineMatch()` tests exactly `/%[aA]/` for this reason.

`PsalmTester` emits one issue per line, so a specifier that cannot cross a newline can never swallow a whole issue line. Broadening the rule to "any format specifier" would therefore add false-positive surface (the rules grep the whole phpt, fixture code included) for zero recall gain.

### Recall, measured

The pre-sweep corpus was reconstructed read-only via `git show efb072c3:<path>`, without touching the working tree:

| pattern | pre-sweep corpus | current corpus |
|---|---|---|
| old | 218 / 221 | 0 |
| new | **221 / 221** | 0 (no false positives) |

The rule-3 comment is also corrected: it described `%a` as single-line, which is wrong — it is lazy dotall, like `%A`.

Verification is limited to `bin/ci/check-phpt-conventions.sh` (PASS) plus the recall counts above. No PHPUnit, psalm or php-cs-fixer run: the diff is shell-only.

## Checklist
- [x] Tests cover the change (recall verified against the reconstructed pre-sweep corpus, both directions)
