### PR TITLE
Backport: reject a leading `%A` in `--EXPECTF--` and enumerate swallowed issues

### DIFF
--- a/bin/ci/check-phpt-conventions.sh
+++ b/bin/ci/check-phpt-conventions.sh
@@ -10,6 +10,10 @@
 #      drift.
 #   2. Never hardcode `on line <number>`. Line numbers shift whenever the
 #      fixture above the expectation changes; use `on line %d` instead.
+#   3. Never lead an issue line with `%A`. PsalmTester::formatErrors() has no
+#      preamble or trailer, so a leading `%A` can only absorb unasserted ISSUE
+#      lines, silently under-checking the test (#1359). Allowlist a file only
+#      for provably version-variable output.
 #
 # Exits non-zero (and prints file:line) on the first kind of violation found.
 
@@ -17,6 +21,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 TESTS_DIR="${ROOT}/tests/Type/tests"
+WILDCARD_ALLOWLIST="${ROOT}/bin/ci/phpt-leading-wildcard-allowlist.txt"
 
 status=0
 
@@ -32,6 +37,26 @@ fi
 if line_hits="$(grep -rnE 'on line [0-9]' "${TESTS_DIR}")"; then
     echo "ERROR: PHPT expectations must use 'on line %d', not a hardcoded number:"
     echo "${line_hits}"
+    echo
+    status=1
+fi
+
+# Rule 3: `%A` leading an issue line, either "%AFooIssue on line ..." or the
+# bare "%AFooIssue%A" form (no "on line" text at all). Anchor on `%A` directly
+# followed by an issue-type identifier, not `^%A`: a single physical
+# --EXPECTF-- line can pack multiple issues, so the leading `%A` is not
+# always at the start of the line.
+wildcard_hits=""
+while IFS= read -r hit; do
+    file="${hit%%:*}"
+    rel="${file#"${TESTS_DIR}"/}"
+    grep -qxF "${rel}" "${WILDCARD_ALLOWLIST}" 2>/dev/null || wildcard_hits="${wildcard_hits}${hit}"$'\n'
+done < <(grep -rnE '%A[A-Za-z]+(%A| on line)' "${TESTS_DIR}" --include='*.phpt' || true)
+if [ -n "${wildcard_hits}" ]; then
+    echo "ERROR: PHPT expectations must not lead an issue line with '%A':"
+    printf '%s' "${wildcard_hits}"
+    echo "Enumerate the issue explicitly, or add the file to ${WILDCARD_ALLOWLIST}"
+    echo "only for provably version-variable output."
     echo
     status=1
 fi

--- a/bin/ci/check-phpt-conventions.sh
+++ b/bin/ci/check-phpt-conventions.sh
@@ -41,17 +41,20 @@ if line_hits="$(grep -rnE 'on line [0-9]' "${TESTS_DIR}")"; then
     status=1
 fi
 
-# Rule 3: `%A` leading an issue line, either "%AFooIssue on line ..." or the
-# bare "%AFooIssue%A" form (no "on line" text at all). Anchor on `%A` directly
-# followed by an issue-type identifier, not `^%A`: a single physical
-# --EXPECTF-- line can pack multiple issues, so the leading `%A` is not
-# always at the start of the line.
+# Rule 3: `%A` leading an issue line, in any of the forms "%AFooIssue on
+# line ...", "%AFooIssue%A", or "%AFooIssue%a". `%A` (`.*?`) and `%a` (`.+?`)
+# both compile to a lazy dotall match (PHPUnit's StringMatchesFormatDescription
+# uses the `/s` modifier), so both can absorb unasserted ISSUE lines across
+# newlines; only they pose the swallowing risk this rule guards against.
+# Anchor on `%A` directly followed by an issue-type identifier, not `^%A`: a
+# single physical --EXPECTF-- line can pack multiple issues, so the leading
+# `%A` is not always at the start of the line.
 wildcard_hits=""
 while IFS= read -r hit; do
     file="${hit%%:*}"
     rel="${file#"${TESTS_DIR}"/}"
     grep -qxF "${rel}" "${WILDCARD_ALLOWLIST}" 2>/dev/null || wildcard_hits="${wildcard_hits}${hit}"$'\n'
-done < <(grep -rnE '%A[A-Za-z]+(%A| on line)' "${TESTS_DIR}" --include='*.phpt' || true)
+done < <(grep -rnE '%A[A-Za-z]+(%A|%a| on line)' "${TESTS_DIR}" --include='*.phpt' || true)
 if [ -n "${wildcard_hits}" ]; then
     echo "ERROR: PHPT expectations must not lead an issue line with '%A':"
     printf '%s' "${wildcard_hits}"

--- a/bin/ci/phpt-leading-wildcard-allowlist.txt
+++ b/bin/ci/phpt-leading-wildcard-allowlist.txt
@@ -1,0 +1,4 @@
+# Files exempted from rule 3 in check-phpt-conventions.sh (no %A leading an
+# issue line — it silently absorbs unasserted findings). One path per line,
+# relative to tests/Type/tests. Entries only for provably version-variable
+# output; keep this list as small as possible. See #1359.

--- a/tests/Type/README.md
+++ b/tests/Type/README.md
@@ -45,7 +45,11 @@ Hard-won rules. Each of these has silently produced a test that passes while ass
 2. **`%A` in `--EXPECTF--` is a lower bound, not an exact match.** It expands to a lazy `.*` (with `/s`),
    so it absorbs any extra findings. A test using `%A` cannot pin an exact error count and cannot assert
    that something is NOT reported. To assert the absence of errors, write a separate test with an empty
-   `--EXPECTF--` block (empty means "no Psalm output at all").
+   `--EXPECTF--` block (empty means "no Psalm output at all"). `PsalmTester::formatErrors()` produces no
+   preamble or trailer — the whole matched string is issue lines, nothing else — so a `%A` leading an
+   issue line only ever absorbs unasserted findings, never structural noise. `bin/ci/check-phpt-conventions.sh`
+   rejects this (allowlist: `bin/ci/phpt-leading-wildcard-allowlist.txt`, for provably version-variable
+   output only); enumerate every emitted line instead (#1359).
 
 3. **Version-gated stubs need `--SKIPIF--`.** A test asserting a `stubs/<version>/` override fails on
    the lower cells of the CI matrix, where the override does not load. Gate it:

--- a/tests/Type/tests/Builder/OrderBySortDirectionL13Test.phpt
+++ b/tests/Type/tests/Builder/OrderBySortDirectionL13Test.phpt
@@ -31,4 +31,4 @@ function test_order_by(): void {
 }
 ?>
 --EXPECTF--
-%AInvalidArgument on line %d: Argument 2 of Illuminate\Database\Query\Builder::orderBy expects 'asc'|'desc'|SortDirection, but 'DESC' provided%A
+InvalidArgument on line %d: Argument 2 of Illuminate\Database\Query\Builder::orderBy expects 'asc'|'desc'|SortDirection, but 'DESC' provided

--- a/tests/Type/tests/ContractMethodBridgeParamCheckTest.phpt
+++ b/tests/Type/tests/ContractMethodBridgeParamCheckTest.phpt
@@ -13,7 +13,7 @@ use Illuminate\Contracts\Foundation\Application;
  *
  * Psalm double-reports TooFewArguments for any interface call (contract receiver +
  * resolved declarer) — native behaviour, not a bridge artifact (setLocale() does
- * the same). %A absorbs the contract-named line; we pin only the concrete one. #1108.
+ * the same). Both lines are pinned below. #1108.
  */
 function param_check(Application $app): void
 {
@@ -21,4 +21,5 @@ function param_check(Application $app): void
 }
 ?>
 --EXPECTF--
-%ATooFewArguments on line %d: Too few arguments for method Illuminate\Foundation\Application::useenvironmentpath saw 0%A
+TooFewArguments on line %d: Too few arguments for Illuminate\Contracts\Foundation\Application::useEnvironmentPath - expecting path to be passed
+TooFewArguments on line %d: Too few arguments for method Illuminate\Foundation\Application::useenvironmentpath saw 0

--- a/tests/Type/tests/TaintAnalysis/CWE470/TaintedCallableContainerResolution.phpt
+++ b/tests/Type/tests/TaintAnalysis/CWE470/TaintedCallableContainerResolution.phpt
@@ -43,4 +43,11 @@ function unsafeConcreteMakeWith(\Illuminate\Http\Request $request, \Illuminate\C
 }
 ?>
 --EXPECTF--
-%ATaintedCallable on line %d: Detected tainted text%ATaintedCallable on line %d: Detected tainted text%ATaintedCallable on line %d: Detected tainted text%ATaintedCallable on line %d: Detected tainted text%A
+MixedArgument on line %d: Argument 1 of app cannot be mixed, expecting null|string
+TaintedCallable on line %d: Detected tainted text
+MixedArgument on line %d: Argument 1 of resolve cannot be mixed, expecting string
+TaintedCallable on line %d: Detected tainted text
+MixedArgument on line %d: Argument 1 of Illuminate\Contracts\Foundation\Application::make cannot be mixed, expecting string
+TaintedCallable on line %d: Detected tainted text
+MixedArgument on line %d: Argument 1 of Illuminate\Container\Container::makeWith cannot be mixed, expecting string
+TaintedCallable on line %d: Detected tainted text

--- a/tests/Type/tests/TaintAnalysis/CWE470/TaintedCallableContainerResolution.phpt
+++ b/tests/Type/tests/TaintAnalysis/CWE470/TaintedCallableContainerResolution.phpt
@@ -43,11 +43,7 @@ function unsafeConcreteMakeWith(\Illuminate\Http\Request $request, \Illuminate\C
 }
 ?>
 --EXPECTF--
-MixedArgument on line %d: Argument 1 of app cannot be mixed, expecting null|string
 TaintedCallable on line %d: Detected tainted text
-MixedArgument on line %d: Argument 1 of resolve cannot be mixed, expecting string
 TaintedCallable on line %d: Detected tainted text
-MixedArgument on line %d: Argument 1 of Illuminate\Contracts\Foundation\Application::make cannot be mixed, expecting string
 TaintedCallable on line %d: Detected tainted text
-MixedArgument on line %d: Argument 1 of Illuminate\Container\Container::makeWith cannot be mixed, expecting string
 TaintedCallable on line %d: Detected tainted text

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestRuleEmailChainEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestRuleEmailChainEscapesHeader.phpt
@@ -35,4 +35,4 @@ function direct(FluentChainedEmailRequest $request): \Illuminate\Http\RedirectRe
 }
 ?>
 --EXPECTF--
-%ATaintedSSRF on line %d: Detected tainted network request
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestRuleEmailFluentEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestRuleEmailFluentEscapesHeader.phpt
@@ -28,4 +28,4 @@ function direct(FluentEmailRequest $request): \Illuminate\Http\RedirectResponse 
 }
 ?>
 --EXPECTF--
-%ATaintedSSRF on line %d: Detected tainted network request
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestRulesEmailInstanceEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestRulesEmailInstanceEscapesHeader.phpt
@@ -28,4 +28,4 @@ function direct(ObjectEmailRequest $request): \Illuminate\Http\RedirectResponse 
 }
 ?>
 --EXPECTF--
-%ATaintedSSRF on line %d: Detected tainted network request
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestStringEmailNoTaintedHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestStringEmailNoTaintedHeader.phpt
@@ -26,4 +26,4 @@ function direct(EmailContactRequest $request): \Illuminate\Http\RedirectResponse
 }
 ?>
 --EXPECTF--
-%ATaintedSSRF on line %d: Detected tainted network request
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeFormRequestWildcardArrayRuleIndexedAccessEscapesHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeFormRequestWildcardArrayRuleIndexedAccessEscapesHeader.phpt
@@ -20,7 +20,9 @@ use Illuminate\Validation\Rule;
  * `$request->validate([...])` tests in `SafeInlineValidateWildcardArrayRule*`.
  *
  * TaintedSSRF still fires: a valid email's domain may still resolve to an
- * internal host.
+ * internal host. It fires TWICE for this single sink call — same type, line,
+ * and message — a suspected duplicate-report bug distinct from this test's
+ * subject, pinned as observed rather than silently absorbed. #1359.
  */
 final class WildcardEmailRequest extends FormRequest
 {
@@ -37,4 +39,5 @@ function storeWildcardFormRequest(WildcardEmailRequest $request): \Illuminate\Ht
 }
 ?>
 --EXPECTF--
-%ATaintedSSRF on line %d: Detected tainted network request
+TaintedSSRF on line %d: Detected tainted network request
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/SafeStorageFacadeUrlNoTaint.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeStorageFacadeUrlNoTaint.phpt
@@ -12,8 +12,8 @@ use Illuminate\Support\Facades\Storage;
  * even though `Storage::disk()` now returns the concrete `FilesystemAdapter`.
  *
  * The empty `--EXPECTF--` makes this load-bearing: ANY finding fails the match
- * (unlike the `%A`-prefixed positive sinks in `TaintedFileStorageFacade.phpt`,
- * which only assert a lower bound). The sibling `SafeStorageUrlNoTaint.phpt`
+ * (unlike the exact-pinned positive sinks in `TaintedFileStorageFacade.phpt`).
+ * The sibling `SafeStorageUrlNoTaint.phpt`
  * proves the same on a directly-typed adapter; this proves it through the facade
  * routing that `StorageHandler` introduces.
  */

--- a/tests/Type/tests/TaintAnalysis/TaintedEvalRedisEval.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedEvalRedisEval.phpt
@@ -11,4 +11,7 @@ function runUserScript(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedEval on line %d: Detected tainted code passed to eval or similar
+UnnecessaryVarAnnotation on line %d: The @var Illuminate\Redis\Connections\PhpRedisConnection annotation for $redis is unnecessary
+MixedAssignment on line %d: Unable to determine the type that $script is being assigned to
+MixedArgument on line %d: Argument 1 of Illuminate\Redis\Connections\PhpRedisConnection::eval cannot be mixed, expecting string
+TaintedEval on line %d: Detected tainted code passed to eval or similar

--- a/tests/Type/tests/TaintAnalysis/TaintedEvalRedisEval.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedEvalRedisEval.phpt
@@ -11,7 +11,4 @@ function runUserScript(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-UnnecessaryVarAnnotation on line %d: The @var Illuminate\Redis\Connections\PhpRedisConnection annotation for $redis is unnecessary
-MixedAssignment on line %d: Unable to determine the type that $script is being assigned to
-MixedArgument on line %d: Argument 1 of Illuminate\Redis\Connections\PhpRedisConnection::eval cannot be mixed, expecting string
 TaintedEval on line %d: Detected tainted code passed to eval or similar

--- a/tests/Type/tests/TaintAnalysis/TaintedEvalRedisEvalSha.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedEvalRedisEvalSha.phpt
@@ -11,4 +11,7 @@ function runUserScript(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedEval on line %d: Detected tainted code passed to eval or similar
+UnnecessaryVarAnnotation on line %d: The @var Illuminate\Redis\Connections\PhpRedisConnection annotation for $redis is unnecessary
+MixedAssignment on line %d: Unable to determine the type that $scriptSha is being assigned to
+MixedArgument on line %d: Argument 1 of Illuminate\Redis\Connections\PhpRedisConnection::evalsha cannot be mixed, expecting string
+TaintedEval on line %d: Detected tainted code passed to eval or similar

--- a/tests/Type/tests/TaintAnalysis/TaintedEvalRedisEvalSha.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedEvalRedisEvalSha.phpt
@@ -11,7 +11,4 @@ function runUserScript(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-UnnecessaryVarAnnotation on line %d: The @var Illuminate\Redis\Connections\PhpRedisConnection annotation for $redis is unnecessary
-MixedAssignment on line %d: Unable to determine the type that $scriptSha is being assigned to
-MixedArgument on line %d: Argument 1 of Illuminate\Redis\Connections\PhpRedisConnection::evalsha cannot be mixed, expecting string
 TaintedEval on line %d: Detected tainted code passed to eval or similar

--- a/tests/Type/tests/TaintAnalysis/TaintedEvalRedisExecuteRaw.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedEvalRedisExecuteRaw.phpt
@@ -11,4 +11,6 @@ function runRawCommand(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedEval on line %d: Detected tainted code passed to eval or similar
+UnnecessaryVarAnnotation on line %d: The @var Illuminate\Redis\Connections\PhpRedisConnection annotation for $redis is unnecessary
+MixedAssignment on line %d: Unable to determine the type that $command is being assigned to
+TaintedEval on line %d: Detected tainted code passed to eval or similar

--- a/tests/Type/tests/TaintAnalysis/TaintedEvalRedisExecuteRaw.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedEvalRedisExecuteRaw.phpt
@@ -11,6 +11,4 @@ function runRawCommand(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-UnnecessaryVarAnnotation on line %d: The @var Illuminate\Redis\Connections\PhpRedisConnection annotation for $redis is unnecessary
-MixedAssignment on line %d: Unable to determine the type that $command is being assigned to
 TaintedEval on line %d: Detected tainted code passed to eval or similar

--- a/tests/Type/tests/TaintAnalysis/TaintedFileFileFacadeStatic.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedFileFileFacadeStatic.phpt
@@ -18,4 +18,4 @@ function facadeStaticDeleteIsTainted(Request $request): void
 }
 ?>
 --EXPECTF--
-%ATaintedFile on line %d: Detected tainted file handling
+TaintedFile on line %d: Detected tainted file handling

--- a/tests/Type/tests/TaintAnalysis/TaintedFileFilesystem.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedFileFilesystem.phpt
@@ -82,49 +82,25 @@ function fsCleanDirectory(\Illuminate\Http\Request $request, \Illuminate\Filesys
 }
 ?>
 --EXPECTF--
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::get cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::relativeLink cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 2 of Illuminate\Filesystem\Filesystem::relativeLink cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::type cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::mimeType cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::guessExtension cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::hasSameHash cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 2 of Illuminate\Filesystem\Filesystem::hasSameHash cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::size cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::lastModified cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::glob cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::files cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::allFiles cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::directories cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::allDirectories cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::ensureDirectoryExists cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::moveDirectory cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 2 of Illuminate\Filesystem\Filesystem::moveDirectory cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::copyDirectory cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 2 of Illuminate\Filesystem\Filesystem::copyDirectory cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::deleteDirectory cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::deleteDirectories cannot be mixed, expecting string
-TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::cleanDirectory cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling

--- a/tests/Type/tests/TaintAnalysis/TaintedFileFilesystem.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedFileFilesystem.phpt
@@ -86,26 +86,49 @@ function fsCleanDirectory(\Illuminate\Http\Request $request, \Illuminate\Filesys
 }
 ?>
 --EXPECTF--
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::get cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::relativeLink cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 2 of Illuminate\Filesystem\Filesystem::relativeLink cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::type cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::mimeType cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::guessExtension cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::hasSameHash cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 2 of Illuminate\Filesystem\Filesystem::hasSameHash cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::size cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::lastModified cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::glob cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::files cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::allFiles cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::directories cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::allDirectories cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::ensureDirectoryExists cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::moveDirectory cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 2 of Illuminate\Filesystem\Filesystem::moveDirectory cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::copyDirectory cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 2 of Illuminate\Filesystem\Filesystem::copyDirectory cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::deleteDirectory cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::deleteDirectories cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\Filesystem::cleanDirectory cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling

--- a/tests/Type/tests/TaintAnalysis/TaintedFileFilesystemAdapter.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedFileFilesystemAdapter.phpt
@@ -124,33 +124,65 @@ function storageAllDirectories(\Illuminate\Http\Request $request, \Illuminate\Fi
 }
 ?>
 --EXPECTF--
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::get cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::put cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::download cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::delete cannot be mixed, expecting array<array-key, mixed>|string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::copy cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 2 of Illuminate\Filesystem\FilesystemAdapter::copy cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::move cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 2 of Illuminate\Filesystem\FilesystemAdapter::move cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::makeDirectory cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::deleteDirectory cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::json cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::response cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 2 of Illuminate\Filesystem\FilesystemAdapter::serve cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::putFile cannot be mixed, expecting Illuminate\Http\File|Illuminate\Http\UploadedFile|string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::putFileAs cannot be mixed, expecting Illuminate\Http\File|Illuminate\Http\UploadedFile|string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 3 of Illuminate\Filesystem\FilesystemAdapter::putFileAs cannot be mixed, expecting array<array-key, mixed>|null|string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::prepend cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::append cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::readStream cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::writeStream cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::temporaryUploadUrl cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::getVisibility cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::setVisibility cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::size cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::checksum cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::mimeType cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::lastModified cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::files cannot be mixed, expecting null|string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::allFiles cannot be mixed, expecting null|string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::directories cannot be mixed, expecting null|string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::allDirectories cannot be mixed, expecting null|string
+TaintedFile on line %d: Detected tainted file handling

--- a/tests/Type/tests/TaintAnalysis/TaintedFileFilesystemAdapter.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedFileFilesystemAdapter.phpt
@@ -124,65 +124,34 @@ function storageAllDirectories(\Illuminate\Http\Request $request, \Illuminate\Fi
 }
 ?>
 --EXPECTF--
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::get cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::put cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::download cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::delete cannot be mixed, expecting array<array-key, mixed>|string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::copy cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 2 of Illuminate\Filesystem\FilesystemAdapter::copy cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::move cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 2 of Illuminate\Filesystem\FilesystemAdapter::move cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::makeDirectory cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::deleteDirectory cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::json cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::response cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 2 of Illuminate\Filesystem\FilesystemAdapter::serve cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::putFile cannot be mixed, expecting Illuminate\Http\File|Illuminate\Http\UploadedFile|string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::putFileAs cannot be mixed, expecting Illuminate\Http\File|Illuminate\Http\UploadedFile|string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 3 of Illuminate\Filesystem\FilesystemAdapter::putFileAs cannot be mixed, expecting array<array-key, mixed>|null|string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::prepend cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::append cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::readStream cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::writeStream cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::temporaryUploadUrl cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::getVisibility cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::setVisibility cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::size cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::checksum cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::mimeType cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::lastModified cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::files cannot be mixed, expecting null|string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::allFiles cannot be mixed, expecting null|string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::directories cannot be mixed, expecting null|string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\FilesystemAdapter::allDirectories cannot be mixed, expecting null|string
 TaintedFile on line %d: Detected tainted file handling

--- a/tests/Type/tests/TaintAnalysis/TaintedFileLockableFile.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedFileLockableFile.phpt
@@ -8,5 +8,4 @@ function openLockableFile(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\LockableFile::__construct cannot be mixed, expecting string
 TaintedFile on line %d: Detected tainted file handling

--- a/tests/Type/tests/TaintAnalysis/TaintedFileLockableFile.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedFileLockableFile.phpt
@@ -8,4 +8,5 @@ function openLockableFile(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Filesystem\LockableFile::__construct cannot be mixed, expecting string
+TaintedFile on line %d: Detected tainted file handling

--- a/tests/Type/tests/TaintAnalysis/TaintedFileResponseFactory.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedFileResponseFactory.phpt
@@ -17,5 +17,7 @@ function responseFile(\Illuminate\Http\Request $request, \Illuminate\Routing\Res
 }
 ?>
 --EXPECTF--
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Routing\ResponseFactory::download cannot be mixed, expecting SplFileInfo|string
+TaintedFile on line %d: Detected tainted file handling
+MixedArgument on line %d: Argument 1 of Illuminate\Routing\ResponseFactory::file cannot be mixed, expecting SplFileInfo|string
+TaintedFile on line %d: Detected tainted file handling

--- a/tests/Type/tests/TaintAnalysis/TaintedFileResponseFactory.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedFileResponseFactory.phpt
@@ -17,7 +17,5 @@ function responseFile(\Illuminate\Http\Request $request, \Illuminate\Routing\Res
 }
 ?>
 --EXPECTF--
-MixedArgument on line %d: Argument 1 of Illuminate\Routing\ResponseFactory::download cannot be mixed, expecting SplFileInfo|string
 TaintedFile on line %d: Detected tainted file handling
-MixedArgument on line %d: Argument 1 of Illuminate\Routing\ResponseFactory::file cannot be mixed, expecting SplFileInfo|string
 TaintedFile on line %d: Detected tainted file handling

--- a/tests/Type/tests/TaintAnalysis/TaintedFileStorageFacade.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedFileStorageFacade.phpt
@@ -24,9 +24,7 @@ use Illuminate\Support\Facades\Storage;
  *
  * The safe counterpart — `url()` must NOT taint through the same facade path —
  * lives in `SafeStorageFacadeUrlNoTaint.phpt`, which uses an empty `--EXPECTF--`
- * so any spurious finding fails. (A negative cannot be asserted here: the
- * `%A`-prefixed positive lines below are a lower bound — an extra `TaintedFile`
- * would be absorbed by a `%A` segment, not rejected.)
+ * so any spurious finding fails.
  */
 
 function facadeDiskPutIsTainted(Request $request): void
@@ -51,6 +49,6 @@ function managerDiskDeleteIsTainted(Request $request, FilesystemManager $manager
 }
 ?>
 --EXPECTF--
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
+TaintedFile on line %d: Detected tainted file handling
+TaintedFile on line %d: Detected tainted file handling
+TaintedFile on line %d: Detected tainted file handling

--- a/tests/Type/tests/TaintAnalysis/TaintedFileStorageFacadeStatic.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedFileStorageFacadeStatic.phpt
@@ -35,6 +35,6 @@ function facadeDiskChainStillTainted(Request $request): void
 }
 ?>
 --EXPECTF--
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedFile on line %d: Detected tainted file handling
+TaintedFile on line %d: Detected tainted file handling
+TaintedFile on line %d: Detected tainted file handling
+TaintedFile on line %d: Detected tainted file handling

--- a/tests/Type/tests/TaintAnalysis/TaintedFileUploadedFileClientNameViaRequestFile.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedFileUploadedFileClientNameViaRequestFile.phpt
@@ -19,5 +19,5 @@ function readByClientName(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedSSRF on line %d: Detected tainted network request
+TaintedFile on line %d: Detected tainted file handling
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieHelper.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieHelper.phpt
@@ -10,4 +10,4 @@ function taintedCookieHelper(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHeader on line %d: Detected tainted header
+TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieHelperName.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieHelperName.phpt
@@ -10,5 +10,4 @@ function taintedCookieHelperName(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-ArgumentTypeCoercion on line %d: Argument 1 of cookie expects non-empty-string|null, but parent type string provided
 TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieHelperName.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieHelperName.phpt
@@ -10,4 +10,5 @@ function taintedCookieHelperName(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHeader on line %d: Detected tainted header
+ArgumentTypeCoercion on line %d: Argument 1 of cookie expects non-empty-string|null, but parent type string provided
+TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieJarExpire.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieJarExpire.phpt
@@ -10,4 +10,4 @@ function taintedExpireCookie(\Illuminate\Http\Request $request, \Illuminate\Cook
 }
 ?>
 --EXPECTF--
-%ATaintedHeader on line %d: Detected tainted header
+TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieJarExpireDomain.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieJarExpireDomain.phpt
@@ -10,4 +10,4 @@ function taintedExpireDomain(\Illuminate\Http\Request $request, \Illuminate\Cook
 }
 ?>
 --EXPECTF--
-%ATaintedHeader on line %d: Detected tainted header
+TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieJarExpirePath.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieJarExpirePath.phpt
@@ -10,4 +10,4 @@ function taintedExpirePath(\Illuminate\Http\Request $request, \Illuminate\Cookie
 }
 ?>
 --EXPECTF--
-%ATaintedHeader on line %d: Detected tainted header
+TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieJarForever.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieJarForever.phpt
@@ -10,4 +10,4 @@ function taintedForeverCookie(\Illuminate\Http\Request $request, \Illuminate\Coo
 }
 ?>
 --EXPECTF--
-%ATaintedHeader on line %d: Detected tainted header
+TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieJarForeverName.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieJarForeverName.phpt
@@ -10,4 +10,4 @@ function taintedForeverCookieName(\Illuminate\Http\Request $request, \Illuminate
 }
 ?>
 --EXPECTF--
-%ATaintedHeader on line %d: Detected tainted header
+TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieJarForget.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieJarForget.phpt
@@ -10,4 +10,4 @@ function taintedForgetCookie(\Illuminate\Http\Request $request, \Illuminate\Cook
 }
 ?>
 --EXPECTF--
-%ATaintedHeader on line %d: Detected tainted header
+TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieJarForgetDomain.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieJarForgetDomain.phpt
@@ -10,4 +10,4 @@ function taintedForgetDomain(\Illuminate\Http\Request $request, \Illuminate\Cook
 }
 ?>
 --EXPECTF--
-%ATaintedHeader on line %d: Detected tainted header
+TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieJarForgetPath.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieJarForgetPath.phpt
@@ -10,4 +10,4 @@ function taintedForgetPath(\Illuminate\Http\Request $request, \Illuminate\Cookie
 }
 ?>
 --EXPECTF--
-%ATaintedHeader on line %d: Detected tainted header
+TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieJarMakeDomain.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieJarMakeDomain.phpt
@@ -10,4 +10,4 @@ function taintedCookieDomain(\Illuminate\Http\Request $request, \Illuminate\Cook
 }
 ?>
 --EXPECTF--
-%ATaintedHeader on line %d: Detected tainted header
+TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieJarMakeName.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieJarMakeName.phpt
@@ -10,4 +10,4 @@ function taintedCookieName(\Illuminate\Http\Request $request, \Illuminate\Cookie
 }
 ?>
 --EXPECTF--
-%ATaintedHeader on line %d: Detected tainted header
+TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieJarMakePath.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieJarMakePath.phpt
@@ -10,4 +10,4 @@ function taintedCookiePath(\Illuminate\Http\Request $request, \Illuminate\Cookie
 }
 ?>
 --EXPECTF--
-%ATaintedHeader on line %d: Detected tainted header
+TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieJarMakeValue.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieJarMakeValue.phpt
@@ -10,4 +10,4 @@ function taintedCookieValue(\Illuminate\Http\Request $request, \Illuminate\Cooki
 }
 ?>
 --EXPECTF--
-%ATaintedHeader on line %d: Detected tainted header
+TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieJarQueue.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieJarQueue.phpt
@@ -10,4 +10,4 @@ function taintedQueueCookie(\Illuminate\Http\Request $request, \Illuminate\Cooki
 }
 ?>
 --EXPECTF--
-%ATaintedHeader on line %d: Detected tainted header
+TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieJarQueueName.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderCookieJarQueueName.phpt
@@ -10,4 +10,4 @@ function taintedQueueCookieName(\Illuminate\Http\Request $request, \Illuminate\C
 }
 ?>
 --EXPECTF--
-%ATaintedHeader on line %d: Detected tainted header
+TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderMailMessageFrom.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderMailMessageFrom.phpt
@@ -9,6 +9,4 @@ function notifyUser(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method notifyUser does not have a return type, expecting void
-MixedArgument on line %d: Argument 1 of Illuminate\Notifications\Messages\MailMessage::from cannot be mixed, expecting string
 TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderMailMessageFrom.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderMailMessageFrom.phpt
@@ -9,4 +9,6 @@ function notifyUser(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedHeader on line %d: Detected tainted header
+MissingReturnType on line %d: Method notifyUser does not have a return type, expecting void
+MixedArgument on line %d: Argument 1 of Illuminate\Notifications\Messages\MailMessage::from cannot be mixed, expecting string
+TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderMailableRecipients.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderMailableRecipients.phpt
@@ -50,11 +50,19 @@ function mailableReplyToName(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHeader on line %d: Detected tainted header
-%ATaintedHeader on line %d: Detected tainted header
-%ATaintedHeader on line %d: Detected tainted header
-%ATaintedHeader on line %d: Detected tainted header
-%ATaintedHeader on line %d: Detected tainted header
-%ATaintedHeader on line %d: Detected tainted header
-%ATaintedHeader on line %d: Detected tainted header
-%ATaintedHeader on line %d: Detected tainted header
+MixedArgument on line %d: Argument 1 of Illuminate\Mail\Mailable::from cannot be mixed, expecting array<array-key, mixed>|object|string
+TaintedHeader on line %d: Detected tainted header
+MixedArgument on line %d: Argument 1 of Illuminate\Mail\Mailable::cc cannot be mixed, expecting array<array-key, mixed>|object|string
+TaintedHeader on line %d: Detected tainted header
+MixedArgument on line %d: Argument 1 of Illuminate\Mail\Mailable::bcc cannot be mixed, expecting array<array-key, mixed>|object|string
+TaintedHeader on line %d: Detected tainted header
+MixedArgument on line %d: Argument 1 of Illuminate\Mail\Mailable::replyTo cannot be mixed, expecting array<array-key, mixed>|object|string
+TaintedHeader on line %d: Detected tainted header
+MixedArgument on line %d: Argument 2 of Illuminate\Mail\Mailable::from cannot be mixed, expecting null|string
+TaintedHeader on line %d: Detected tainted header
+MixedArgument on line %d: Argument 2 of Illuminate\Mail\Mailable::cc cannot be mixed, expecting null|string
+TaintedHeader on line %d: Detected tainted header
+MixedArgument on line %d: Argument 2 of Illuminate\Mail\Mailable::bcc cannot be mixed, expecting null|string
+TaintedHeader on line %d: Detected tainted header
+MixedArgument on line %d: Argument 2 of Illuminate\Mail\Mailable::replyTo cannot be mixed, expecting null|string
+TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderMailableRecipients.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderMailableRecipients.phpt
@@ -50,19 +50,11 @@ function mailableReplyToName(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-MixedArgument on line %d: Argument 1 of Illuminate\Mail\Mailable::from cannot be mixed, expecting array<array-key, mixed>|object|string
 TaintedHeader on line %d: Detected tainted header
-MixedArgument on line %d: Argument 1 of Illuminate\Mail\Mailable::cc cannot be mixed, expecting array<array-key, mixed>|object|string
 TaintedHeader on line %d: Detected tainted header
-MixedArgument on line %d: Argument 1 of Illuminate\Mail\Mailable::bcc cannot be mixed, expecting array<array-key, mixed>|object|string
 TaintedHeader on line %d: Detected tainted header
-MixedArgument on line %d: Argument 1 of Illuminate\Mail\Mailable::replyTo cannot be mixed, expecting array<array-key, mixed>|object|string
 TaintedHeader on line %d: Detected tainted header
-MixedArgument on line %d: Argument 2 of Illuminate\Mail\Mailable::from cannot be mixed, expecting null|string
 TaintedHeader on line %d: Detected tainted header
-MixedArgument on line %d: Argument 2 of Illuminate\Mail\Mailable::cc cannot be mixed, expecting null|string
 TaintedHeader on line %d: Detected tainted header
-MixedArgument on line %d: Argument 2 of Illuminate\Mail\Mailable::bcc cannot be mixed, expecting null|string
 TaintedHeader on line %d: Detected tainted header
-MixedArgument on line %d: Argument 2 of Illuminate\Mail\Mailable::replyTo cannot be mixed, expecting null|string
 TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderMailableSubject.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderMailableSubject.phpt
@@ -9,4 +9,6 @@ function sendFeedback(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedHeader on line %d: Detected tainted header
+MissingReturnType on line %d: Method sendFeedback does not have a return type, expecting void
+MixedArgument on line %d: Argument 1 of Illuminate\Mail\Mailable::subject cannot be mixed, expecting string
+TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderMailableSubject.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderMailableSubject.phpt
@@ -9,6 +9,4 @@ function sendFeedback(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method sendFeedback does not have a return type, expecting void
-MixedArgument on line %d: Argument 1 of Illuminate\Mail\Mailable::subject cannot be mixed, expecting string
 TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderMailableTo.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderMailableTo.phpt
@@ -9,4 +9,6 @@ function sendWelcome(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedHeader on line %d: Detected tainted header
+MissingReturnType on line %d: Method sendWelcome does not have a return type, expecting void
+MixedArgument on line %d: Argument 1 of Illuminate\Mail\Mailable::to cannot be mixed, expecting array<array-key, mixed>|object|string
+TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderMailableTo.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderMailableTo.phpt
@@ -9,6 +9,4 @@ function sendWelcome(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method sendWelcome does not have a return type, expecting void
-MixedArgument on line %d: Argument 1 of Illuminate\Mail\Mailable::to cannot be mixed, expecting array<array-key, mixed>|object|string
 TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderRedirect.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderRedirect.phpt
@@ -9,4 +9,7 @@ function loginRedirect(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedHeader on line %d: Detected tainted header
+MissingReturnType on line %d: Method loginRedirect does not have a return type, expecting void
+MixedAssignment on line %d: Unable to determine the type that $returnUrl is being assigned to
+MixedArgument on line %d: Argument 1 of redirect cannot be mixed, expecting null|string
+TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderRedirect.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderRedirect.phpt
@@ -9,7 +9,4 @@ function loginRedirect(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method loginRedirect does not have a return type, expecting void
-MixedAssignment on line %d: Unable to determine the type that $returnUrl is being assigned to
-MixedArgument on line %d: Argument 1 of redirect cannot be mixed, expecting null|string
 TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderRedirectFacadeStatic.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderRedirectFacadeStatic.phpt
@@ -18,4 +18,4 @@ function facadeStaticToIsTainted(Request $request): void
 }
 ?>
 --EXPECTF--
-%ATaintedHeader on line %d: Detected tainted header
+TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderRedirectorIntended.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderRedirectorIntended.phpt
@@ -13,4 +13,4 @@ function loginRedirect(\Illuminate\Http\Request $request, \Illuminate\Routing\Re
 }
 ?>
 --EXPECTF--
-%ATaintedHeader on line %d: Detected tainted header
+TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderResponseFactoryRedirect.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderResponseFactoryRedirect.phpt
@@ -23,6 +23,6 @@ function responseRedirectToIntended(\Illuminate\Http\Request $request, \Illumina
 }
 ?>
 --EXPECTF--
-%ATaintedHeader on line %d: Detected tainted header
-%ATaintedHeader on line %d: Detected tainted header
-%ATaintedHeader on line %d: Detected tainted header
+TaintedHeader on line %d: Detected tainted header
+TaintedHeader on line %d: Detected tainted header
+TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderResponseHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderResponseHeader.phpt
@@ -9,7 +9,4 @@ function setHeader(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method setHeader does not have a return type, expecting Illuminate\Http\Response&static
-MixedAssignment on line %d: Unable to determine the type that $value is being assigned to
-MixedArgument on line %d: Argument 2 of Illuminate\Http\Response::header cannot be mixed, expecting array<array-key, mixed>|string
 TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderResponseHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderResponseHeader.phpt
@@ -9,4 +9,7 @@ function setHeader(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedHeader on line %d: Detected tainted header
+MissingReturnType on line %d: Method setHeader does not have a return type, expecting Illuminate\Http\Response&static
+MixedAssignment on line %d: Unable to determine the type that $value is being assigned to
+MixedArgument on line %d: Argument 2 of Illuminate\Http\Response::header cannot be mixed, expecting array<array-key, mixed>|string
+TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderResponseHeaderKey.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderResponseHeaderKey.phpt
@@ -9,7 +9,4 @@ function setHeaderKey(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method setHeaderKey does not have a return type, expecting Illuminate\Http\Response&static
-MixedAssignment on line %d: Unable to determine the type that $key is being assigned to
-MixedArgument on line %d: Argument 1 of Illuminate\Http\Response::header cannot be mixed, expecting string
 TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderResponseHeaderKey.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderResponseHeaderKey.phpt
@@ -9,4 +9,7 @@ function setHeaderKey(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedHeader on line %d: Detected tainted header
+MissingReturnType on line %d: Method setHeaderKey does not have a return type, expecting Illuminate\Http\Response&static
+MixedAssignment on line %d: Unable to determine the type that $key is being assigned to
+MixedArgument on line %d: Argument 1 of Illuminate\Http\Response::header cannot be mixed, expecting string
+TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderResponseWithHeaders.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderResponseWithHeaders.phpt
@@ -9,5 +9,4 @@ function setHeaders(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method setHeaders does not have a return type, expecting Illuminate\Http\Response&static
 TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHeaderResponseWithHeaders.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHeaderResponseWithHeaders.phpt
@@ -9,4 +9,5 @@ function setHeaders(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedHeader on line %d: Detected tainted header
+MissingReturnType on line %d: Method setHeaders does not have a return type, expecting Illuminate\Http\Response&static
+TaintedHeader on line %d: Detected tainted header

--- a/tests/Type/tests/TaintAnalysis/TaintedHtml.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtml.phpt
@@ -10,4 +10,6 @@ function renderComment(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
+MissingReturnType on line %d: Method renderComment does not have a return type, expecting Illuminate\Http\Response
+MixedAssignment on line %d: Unable to determine the type that $comment is being assigned to
+TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtml.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtml.phpt
@@ -10,6 +10,4 @@ function renderComment(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method renderComment does not have a return type, expecting Illuminate\Http\Response
-MixedAssignment on line %d: Unable to determine the type that $comment is being assigned to
 TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlClientResponseBody.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlClientResponseBody.phpt
@@ -12,5 +12,5 @@ function renderApiBody(\Illuminate\Http\Client\Response $response): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlClientResponseCollect.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlClientResponseCollect.phpt
@@ -12,5 +12,5 @@ function renderApiCollect(\Illuminate\Http\Client\Response $response): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlClientResponseFluent.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlClientResponseFluent.phpt
@@ -12,5 +12,5 @@ function renderApiFluent(\Illuminate\Http\Client\Response $response): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlClientResponseHeader.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlClientResponseHeader.phpt
@@ -12,5 +12,5 @@ function renderApiHeader(\Illuminate\Http\Client\Response $response): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlClientResponseHeaders.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlClientResponseHeaders.phpt
@@ -12,5 +12,7 @@ function renderApiHeaders(\Illuminate\Http\Client\Response $response): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
+PossiblyUndefinedStringArrayOffset on line %d: Possibly undefined array offset ''Content-Type'' is risky given expected type 'array-key'. Consider using isset beforehand.
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlClientResponseHeaders.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlClientResponseHeaders.phpt
@@ -12,7 +12,5 @@ function renderApiHeaders(\Illuminate\Http\Client\Response $response): void {
 }
 ?>
 --EXPECTF--
-MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
-PossiblyUndefinedStringArrayOffset on line %d: Possibly undefined array offset ''Content-Type'' is risky given expected type 'array-key'. Consider using isset beforehand.
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlClientResponseJson.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlClientResponseJson.phpt
@@ -12,5 +12,6 @@ function renderApiJson(\Illuminate\Http\Client\Response $response): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlClientResponseJson.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlClientResponseJson.phpt
@@ -12,6 +12,5 @@ function renderApiJson(\Illuminate\Http\Client\Response $response): void {
 }
 ?>
 --EXPECTF--
-MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlClientResponseObject.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlClientResponseObject.phpt
@@ -12,5 +12,5 @@ function renderApiObject(\Illuminate\Http\Client\Response $response): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlClientResponseToString.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlClientResponseToString.phpt
@@ -12,5 +12,5 @@ function renderApiResponse(\Illuminate\Http\Client\Response $response): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlCollectionFirstDefault.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlCollectionFirstDefault.phpt
@@ -10,5 +10,6 @@ function renderCollectionFirstDefault(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MixedArgument on line %d: Argument 1 of echo cannot be mixed|string, expecting string
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlCollectionFirstDefault.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlCollectionFirstDefault.phpt
@@ -10,6 +10,5 @@ function renderCollectionFirstDefault(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-MixedArgument on line %d: Argument 1 of echo cannot be mixed|string, expecting string
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlCollectionGetDefault.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlCollectionGetDefault.phpt
@@ -10,5 +10,6 @@ function renderCollectionGetDefault(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MixedArgument on line %d: Argument 1 of echo cannot be mixed|string, expecting string
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlCollectionGetDefault.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlCollectionGetDefault.phpt
@@ -10,6 +10,5 @@ function renderCollectionGetDefault(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-MixedArgument on line %d: Argument 1 of echo cannot be mixed|string, expecting string
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlCollectionPullDefault.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlCollectionPullDefault.phpt
@@ -10,5 +10,6 @@ function renderCollectionPullDefault(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MixedArgument on line %d: Argument 1 of echo cannot be mixed|string, expecting string
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlCollectionPullDefault.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlCollectionPullDefault.phpt
@@ -10,6 +10,5 @@ function renderCollectionPullDefault(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-MixedArgument on line %d: Argument 1 of echo cannot be mixed|string, expecting string
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlCollectionValueDefault.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlCollectionValueDefault.phpt
@@ -10,6 +10,5 @@ function renderCollectionValueDefault(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlCollectionValueDefault.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlCollectionValueDefault.phpt
@@ -10,5 +10,6 @@ function renderCollectionValueDefault(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlCookieInput.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlCookieInput.phpt
@@ -8,5 +8,7 @@ function showGreeting(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MissingReturnType on line %d: Method showGreeting does not have a return type, expecting void
+MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlCookieInput.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlCookieInput.phpt
@@ -8,7 +8,5 @@ function showGreeting(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method showGreeting does not have a return type, expecting void
-MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlDecryptRestoresTaint.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlDecryptRestoresTaint.phpt
@@ -20,9 +20,9 @@ function renderDecryptedInput(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedSystemSecret on line %d: Detected tainted system secret leaking
-%ATaintedSystemSecret on line %d: Detected tainted system secret leaking
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
-%ATaintedUserSecret on line %d: Detected tainted user secret leaking
-%ATaintedUserSecret on line %d: Detected tainted user secret leaking
+TaintedHtml on line %d: Detected tainted HTML
+TaintedSystemSecret on line %d: Detected tainted system secret leaking
+TaintedSystemSecret on line %d: Detected tainted system secret leaking
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedUserSecret on line %d: Detected tainted user secret leaking
+TaintedUserSecret on line %d: Detected tainted user secret leaking

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlEncrypterDecryptString.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlEncrypterDecryptString.phpt
@@ -20,9 +20,9 @@ function renderDecryptedToken(\Illuminate\Http\Request $request, \Illuminate\Enc
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedSystemSecret on line %d: Detected tainted system secret leaking
-%ATaintedSystemSecret on line %d: Detected tainted system secret leaking
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
-%ATaintedUserSecret on line %d: Detected tainted user secret leaking
-%ATaintedUserSecret on line %d: Detected tainted user secret leaking
+TaintedHtml on line %d: Detected tainted HTML
+TaintedSystemSecret on line %d: Detected tainted system secret leaking
+TaintedSystemSecret on line %d: Detected tainted system secret leaking
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedUserSecret on line %d: Detected tainted user secret leaking
+TaintedUserSecret on line %d: Detected tainted user secret leaking

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestOnly.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestOnly.phpt
@@ -30,5 +30,7 @@ function render(OnlyAccessorRequest $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
+PossiblyUndefinedStringArrayOffset on line %d: Possibly undefined array offset ''body'' is risky given expected type 'array-key'. Consider using isset beforehand.
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestOnly.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestOnly.phpt
@@ -30,7 +30,5 @@ function render(OnlyAccessorRequest $request): void {
 }
 ?>
 --EXPECTF--
-MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
-PossiblyUndefinedStringArrayOffset on line %d: Possibly undefined array offset ''body'' is risky given expected type 'array-key'. Consider using isset beforehand.
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestRuleNotInNoEscape.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestRuleNotInNoEscape.phpt
@@ -27,5 +27,5 @@ function render(FluentNotInRequest $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestRuleNotInVariadicNoEscape.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestRuleNotInVariadicNoEscape.phpt
@@ -30,5 +30,5 @@ function render(FluentVariadicNotInRequest $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestRuleUniqueNoEscape.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestRuleUniqueNoEscape.phpt
@@ -28,5 +28,5 @@ function render(FluentUniqueRequest $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestString.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlFormRequestString.phpt
@@ -29,5 +29,5 @@ function render(BodyStringRequest $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlInputWithTaintedDefault.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlInputWithTaintedDefault.phpt
@@ -15,6 +15,10 @@ use Illuminate\Foundation\Http\FormRequest;
  * Here 'age' is constrained to integer (would normally escape ALL_INPUT), but
  * the tainted $default comes from an unvalidated source ('fallback'), so the
  * echo sink must still fire TaintedHtml.
+ *
+ * Each finding fires TWICE for this single echo — same type, line, and
+ * message — a suspected duplicate-report bug distinct from this test's
+ * subject, pinned as observed rather than silently absorbed. #1359.
  */
 final class InputWithDefaultRequest extends FormRequest
 {
@@ -30,5 +34,7 @@ function render(InputWithDefaultRequest $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlMailMessageAction.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlMailMessageAction.phpt
@@ -9,4 +9,8 @@ function notifyWithAction(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
+MissingReturnType on line %d: Method notifyWithAction does not have a return type, expecting void
+MixedArgument on line %d: Argument 1 of Illuminate\Notifications\Messages\MailMessage::action cannot be mixed, expecting string
+TaintedHtml on line %d: Detected tainted HTML
+MixedArgument on line %d: Argument 2 of Illuminate\Notifications\Messages\MailMessage::action cannot be mixed, expecting string
+TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlMailMessageAction.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlMailMessageAction.phpt
@@ -9,8 +9,5 @@ function notifyWithAction(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method notifyWithAction does not have a return type, expecting void
-MixedArgument on line %d: Argument 1 of Illuminate\Notifications\Messages\MailMessage::action cannot be mixed, expecting string
 TaintedHtml on line %d: Detected tainted HTML
-MixedArgument on line %d: Argument 2 of Illuminate\Notifications\Messages\MailMessage::action cannot be mixed, expecting string
 TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlMailMessageLine.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlMailMessageLine.phpt
@@ -9,4 +9,5 @@ function notifyWithContent(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
+MissingReturnType on line %d: Method notifyWithContent does not have a return type, expecting void
+TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlMailMessageLine.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlMailMessageLine.phpt
@@ -9,5 +9,4 @@ function notifyWithContent(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method notifyWithContent does not have a return type, expecting void
 TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlMailableBody.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlMailableBody.phpt
@@ -9,6 +9,4 @@ function sendCustomHtml(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method sendCustomHtml does not have a return type, expecting void
-MixedArgument on line %d: Argument 1 of Illuminate\Mail\Mailable::html cannot be mixed, expecting string
 TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlMailableBody.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlMailableBody.phpt
@@ -9,4 +9,6 @@ function sendCustomHtml(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
+MissingReturnType on line %d: Method sendCustomHtml does not have a return type, expecting void
+MixedArgument on line %d: Argument 1 of Illuminate\Mail\Mailable::html cannot be mixed, expecting string
+TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlOldHelper.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlOldHelper.phpt
@@ -8,5 +8,7 @@ function renderOldInput() {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MissingReturnType on line %d: Method renderOldInput does not have a return type, expecting void
+PossiblyInvalidArgument on line %d: Argument 1 of echo expects string, but possibly different type array<array-key, mixed>|null|string provided
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlOldHelper.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlOldHelper.phpt
@@ -8,7 +8,5 @@ function renderOldInput() {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method renderOldInput does not have a return type, expecting void
-PossiblyInvalidArgument on line %d: Argument 1 of echo expects string, but possibly different type array<array-key, mixed>|null|string provided
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlQueryInput.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlQueryInput.phpt
@@ -8,5 +8,7 @@ function showSearchResults(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MissingReturnType on line %d: Method showSearchResults does not have a return type, expecting void
+PossiblyInvalidArgument on line %d: Argument 1 of echo expects string, but possibly different type array<array-key, mixed>|null|string provided
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlQueryInput.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlQueryInput.phpt
@@ -8,7 +8,5 @@ function showSearchResults(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method showSearchResults does not have a return type, expecting void
-PossiblyInvalidArgument on line %d: Argument 1 of echo expects string, but possibly different type array<array-key, mixed>|null|string provided
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestArray.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestArray.phpt
@@ -13,7 +13,5 @@ function showData(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-MixedAssignment on line %d: Unable to determine the type that $item is being assigned to
-MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestArray.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestArray.phpt
@@ -13,5 +13,7 @@ function showData(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MixedAssignment on line %d: Unable to determine the type that $item is being assigned to
+MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestCollect.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestCollect.phpt
@@ -14,6 +14,5 @@ function renderCollectRequestData(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-MixedArgument on line %d: Argument 1 of echo cannot be mixed|null, expecting string
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestCollect.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestCollect.phpt
@@ -14,5 +14,6 @@ function renderCollectRequestData(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MixedArgument on line %d: Argument 1 of echo cannot be mixed|null, expecting string
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestExcept.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestExcept.phpt
@@ -16,7 +16,5 @@ function renderExceptRequestData(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
-PossiblyUndefinedStringArrayOffset on line %d: Possibly undefined array offset ''name'' is risky given expected type 'array-key'. Consider using isset beforehand.
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestExcept.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestExcept.phpt
@@ -16,5 +16,7 @@ function renderExceptRequestData(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
+PossiblyUndefinedStringArrayOffset on line %d: Possibly undefined array offset ''name'' is risky given expected type 'array-key'. Consider using isset beforehand.
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestFluent.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestFluent.phpt
@@ -9,5 +9,6 @@ function showName(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestFluent.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestFluent.phpt
@@ -9,6 +9,5 @@ function showName(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestFullUrlWithQuery.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestFullUrlWithQuery.phpt
@@ -8,5 +8,5 @@ function showUrl(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestFullUrlWithoutQuery.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestFullUrlWithoutQuery.phpt
@@ -8,5 +8,5 @@ function showUrlWithoutQuery(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestHelper.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestHelper.phpt
@@ -8,5 +8,7 @@ function renderTitle() {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MissingReturnType on line %d: Method renderTitle does not have a return type, expecting void
+MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestHelper.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestHelper.phpt
@@ -8,7 +8,5 @@ function renderTitle() {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method renderTitle does not have a return type, expecting void
-MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestMagicProperty.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestMagicProperty.phpt
@@ -8,5 +8,6 @@ function renderBreadcrumb(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MissingReturnType on line %d: Method renderBreadcrumb does not have a return type, expecting void
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestMagicProperty.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestMagicProperty.phpt
@@ -8,6 +8,5 @@ function renderBreadcrumb(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method renderBreadcrumb does not have a return type, expecting void
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestOld.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestOld.phpt
@@ -15,5 +15,6 @@ function renderOldRequestData(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestOld.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestOld.phpt
@@ -15,6 +15,5 @@ function renderOldRequestData(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestOnly.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestOnly.phpt
@@ -18,7 +18,5 @@ function renderOnlyRequestData(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
-PossiblyUndefinedStringArrayOffset on line %d: Possibly undefined array offset ''name'' is risky given expected type 'array-key'. Consider using isset beforehand.
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestOnly.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestOnly.phpt
@@ -18,5 +18,7 @@ function renderOnlyRequestData(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
+PossiblyUndefinedStringArrayOffset on line %d: Possibly undefined array offset ''name'' is risky given expected type 'array-key'. Consider using isset beforehand.
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestPath.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestPath.phpt
@@ -8,5 +8,6 @@ function renderBreadcrumb(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MissingReturnType on line %d: Method renderBreadcrumb does not have a return type, expecting void
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestPath.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestPath.phpt
@@ -8,6 +8,5 @@ function renderBreadcrumb(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method renderBreadcrumb does not have a return type, expecting void
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestSchemeAndHttpHost.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRequestSchemeAndHttpHost.phpt
@@ -8,5 +8,5 @@ function showHost(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlResponse.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlResponse.phpt
@@ -9,4 +9,7 @@ function showAuthor(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
+MissingReturnType on line %d: Method showAuthor does not have a return type, expecting Illuminate\Http\Response
+MixedAssignment on line %d: Unable to determine the type that $authorName is being assigned to
+MixedArgument on line %d: Argument 1 of response cannot be mixed, expecting Illuminate\Contracts\View\View|array<array-key, mixed>|null|string
+TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlResponse.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlResponse.phpt
@@ -9,7 +9,4 @@ function showAuthor(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method showAuthor does not have a return type, expecting Illuminate\Http\Response
-MixedAssignment on line %d: Unable to determine the type that $authorName is being assigned to
-MixedArgument on line %d: Argument 1 of response cannot be mixed, expecting Illuminate\Contracts\View\View|array<array-key, mixed>|null|string
 TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFacadeStatic.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFacadeStatic.phpt
@@ -18,4 +18,4 @@ function facadeStaticMakeIsTainted(Request $request): void
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
+TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactory.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactory.phpt
@@ -25,6 +25,5 @@ function responseJsonp(\Illuminate\Http\Request $request, \Illuminate\Routing\Re
 ?>
 --EXPECTF--
 TaintedHtml on line %d: Detected tainted HTML
-MixedArgument on line %d: Argument 1 of Illuminate\Routing\ResponseFactory::jsonp cannot be mixed, expecting string
 TaintedHtml on line %d: Detected tainted HTML
 TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactory.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactory.phpt
@@ -24,6 +24,7 @@ function responseJsonp(\Illuminate\Http\Request $request, \Illuminate\Routing\Re
 
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedHtml on line %d: Detected tainted HTML
+TaintedHtml on line %d: Detected tainted HTML
+MixedArgument on line %d: Argument 1 of Illuminate\Routing\ResponseFactory::jsonp cannot be mixed, expecting string
+TaintedHtml on line %d: Detected tainted HTML
+TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseHelperContract.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseHelperContract.phpt
@@ -12,8 +12,7 @@ use Illuminate\Http\Request;
  * mirrored onto the contract stub (Contracts/Routing/ResponseFactory.phpstub).
  *
  * `json()` deliberately does NOT sink through this path; its clean counterpart is pinned
- * in SafeResponseFactoryJsonNoHtmlTaint.phpt (a negative cannot be asserted here, since
- * the `%A` segments below are a lower bound).
+ * in SafeResponseFactoryJsonNoHtmlTaint.phpt.
  */
 
 function responseHelperMakeIsTainted(Request $request): void
@@ -22,4 +21,5 @@ function responseHelperMakeIsTainted(Request $request): void
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
+MixedArgument on line %d: Argument 1 of Illuminate\Contracts\Routing\ResponseFactory::make cannot be mixed, expecting array<array-key, mixed>|string
+TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseHelperContract.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseHelperContract.phpt
@@ -21,5 +21,4 @@ function responseHelperMakeIsTainted(Request $request): void
 }
 ?>
 --EXPECTF--
-MixedArgument on line %d: Argument 1 of Illuminate\Contracts\Routing\ResponseFactory::make cannot be mixed, expecting array<array-key, mixed>|string
 TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRouteOriginalParameter.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRouteOriginalParameter.phpt
@@ -8,5 +8,6 @@ function showOriginalParam(\Illuminate\Routing\Route $route) {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MissingReturnType on line %d: Method showOriginalParam does not have a return type, expecting void
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRouteOriginalParameter.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRouteOriginalParameter.phpt
@@ -8,6 +8,5 @@ function showOriginalParam(\Illuminate\Routing\Route $route) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method showOriginalParam does not have a return type, expecting void
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRouteOriginalParameters.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRouteOriginalParameters.phpt
@@ -9,5 +9,7 @@ function showOriginalParams(\Illuminate\Routing\Route $route): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
+PossiblyUndefinedStringArrayOffset on line %d: Possibly undefined array offset ''id'' is risky given expected type 'array-key'. Consider using isset beforehand.
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRouteOriginalParameters.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRouteOriginalParameters.phpt
@@ -9,7 +9,5 @@ function showOriginalParams(\Illuminate\Routing\Route $route): void {
 }
 ?>
 --EXPECTF--
-MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
-PossiblyUndefinedStringArrayOffset on line %d: Possibly undefined array offset ''id'' is risky given expected type 'array-key'. Consider using isset beforehand.
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRouteParameter.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRouteParameter.phpt
@@ -8,7 +8,5 @@ function showRouteParam(\Illuminate\Routing\Route $route) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method showRouteParam does not have a return type, expecting void
-PossiblyInvalidCast on line %d: object cannot be cast to string
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRouteParameter.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRouteParameter.phpt
@@ -8,5 +8,7 @@ function showRouteParam(\Illuminate\Routing\Route $route) {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MissingReturnType on line %d: Method showRouteParam does not have a return type, expecting void
+PossiblyInvalidCast on line %d: object cannot be cast to string
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRouteParameters.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRouteParameters.phpt
@@ -9,7 +9,5 @@ function showRouteParams(\Illuminate\Routing\Route $route): void {
 }
 ?>
 --EXPECTF--
-MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
-PossiblyUndefinedStringArrayOffset on line %d: Possibly undefined array offset ''id'' is risky given expected type 'array-key'. Consider using isset beforehand.
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRouteParameters.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRouteParameters.phpt
@@ -9,5 +9,7 @@ function showRouteParams(\Illuminate\Routing\Route $route): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
+PossiblyUndefinedStringArrayOffset on line %d: Possibly undefined array offset ''id'' is risky given expected type 'array-key'. Consider using isset beforehand.
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRouteParametersWithoutNulls.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRouteParametersWithoutNulls.phpt
@@ -9,7 +9,5 @@ function showRouteParams(\Illuminate\Routing\Route $route): void {
 }
 ?>
 --EXPECTF--
-MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
-PossiblyUndefinedStringArrayOffset on line %d: Possibly undefined array offset ''id'' is risky given expected type 'array-key'. Consider using isset beforehand.
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlRouteParametersWithoutNulls.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlRouteParametersWithoutNulls.phpt
@@ -9,5 +9,7 @@ function showRouteParams(\Illuminate\Routing\Route $route): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
+PossiblyUndefinedStringArrayOffset on line %d: Possibly undefined array offset ''id'' is risky given expected type 'array-key'. Consider using isset beforehand.
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSafeInput.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSafeInput.phpt
@@ -25,5 +25,5 @@ function renderSafeInput(SafeRequest $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSanitizeUrlPreservesHtmlTaint.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSanitizeUrlPreservesHtmlTaint.phpt
@@ -59,7 +59,4 @@ function flowsThroughSanitizer(): void {
 }
 ?>
 --EXPECTF--
-UnusedParam on line %d: Param url is never referenced in this method
-InvalidReturnType on line %d: Not all code paths of appSafeUrl_DualSrc end in a return statement, return type string expected
 TaintedHtml on line %d: Detected tainted HTML
-UnusedParam on line %d: Param val is never referenced in this method

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSanitizeUrlPreservesHtmlTaint.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSanitizeUrlPreservesHtmlTaint.phpt
@@ -59,4 +59,7 @@ function flowsThroughSanitizer(): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml%a: Detected tainted HTML%A
+UnusedParam on line %d: Param url is never referenced in this method
+InvalidReturnType on line %d: Not all code paths of appSafeUrl_DualSrc end in a return statement, return type string expected
+TaintedHtml on line %d: Detected tainted HTML
+UnusedParam on line %d: Param val is never referenced in this method

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionHelper.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionHelper.phpt
@@ -8,7 +8,5 @@ function renderSessionData() {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method renderSessionData does not have a return type, expecting void
-MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionHelper.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionHelper.phpt
@@ -8,5 +8,7 @@ function renderSessionData() {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MissingReturnType on line %d: Method renderSessionData does not have a return type, expecting void
+MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStore.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStore.phpt
@@ -8,5 +8,7 @@ function renderSessionData(\Illuminate\Session\Store $session) {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MissingReturnType on line %d: Method renderSessionData does not have a return type, expecting void
+MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStore.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStore.phpt
@@ -8,7 +8,5 @@ function renderSessionData(\Illuminate\Session\Store $session) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method renderSessionData does not have a return type, expecting void
-MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreAll.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreAll.phpt
@@ -10,8 +10,5 @@ function renderAllSessionData(\Illuminate\Session\Store $session) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method renderAllSessionData does not have a return type, expecting void
-MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
-PossiblyUndefinedStringArrayOffset on line %d: Possibly undefined array offset ''name'' is risky given expected type 'array-key'. Consider using isset beforehand.
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreAll.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreAll.phpt
@@ -10,5 +10,8 @@ function renderAllSessionData(\Illuminate\Session\Store $session) {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MissingReturnType on line %d: Method renderAllSessionData does not have a return type, expecting void
+MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
+PossiblyUndefinedStringArrayOffset on line %d: Possibly undefined array offset ''name'' is risky given expected type 'array-key'. Consider using isset beforehand.
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreExcept.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreExcept.phpt
@@ -10,5 +10,8 @@ function renderExceptSessionData(\Illuminate\Session\Store $session) {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MissingReturnType on line %d: Method renderExceptSessionData does not have a return type, expecting void
+MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
+PossiblyUndefinedStringArrayOffset on line %d: Possibly undefined array offset ''name'' is risky given expected type 'array-key'. Consider using isset beforehand.
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreExcept.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreExcept.phpt
@@ -10,8 +10,5 @@ function renderExceptSessionData(\Illuminate\Session\Store $session) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method renderExceptSessionData does not have a return type, expecting void
-MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
-PossiblyUndefinedStringArrayOffset on line %d: Possibly undefined array offset ''name'' is risky given expected type 'array-key'. Consider using isset beforehand.
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreOldInput.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreOldInput.phpt
@@ -8,5 +8,7 @@ function renderOldInput(\Illuminate\Session\Store $session) {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MissingReturnType on line %d: Method renderOldInput does not have a return type, expecting void
+MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreOldInput.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreOldInput.phpt
@@ -8,7 +8,5 @@ function renderOldInput(\Illuminate\Session\Store $session) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method renderOldInput does not have a return type, expecting void
-MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreOnly.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreOnly.phpt
@@ -10,8 +10,5 @@ function renderOnlySessionData(\Illuminate\Session\Store $session) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method renderOnlySessionData does not have a return type, expecting void
-MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
-PossiblyUndefinedStringArrayOffset on line %d: Possibly undefined array offset ''name'' is risky given expected type 'array-key'. Consider using isset beforehand.
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreOnly.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreOnly.phpt
@@ -10,5 +10,8 @@ function renderOnlySessionData(\Illuminate\Session\Store $session) {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MissingReturnType on line %d: Method renderOnlySessionData does not have a return type, expecting void
+MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
+PossiblyUndefinedStringArrayOffset on line %d: Possibly undefined array offset ''name'' is risky given expected type 'array-key'. Consider using isset beforehand.
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStorePreviousUrl.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStorePreviousUrl.phpt
@@ -8,6 +8,5 @@ function renderPreviousUrl(\Illuminate\Session\Store $session) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method renderPreviousUrl does not have a return type, expecting void
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStorePreviousUrl.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStorePreviousUrl.phpt
@@ -8,5 +8,6 @@ function renderPreviousUrl(\Illuminate\Session\Store $session) {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MissingReturnType on line %d: Method renderPreviousUrl does not have a return type, expecting void
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStorePull.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStorePull.phpt
@@ -8,5 +8,7 @@ function renderPulledSessionData(\Illuminate\Session\Store $session) {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MissingReturnType on line %d: Method renderPulledSessionData does not have a return type, expecting void
+MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStorePull.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStorePull.phpt
@@ -8,7 +8,5 @@ function renderPulledSessionData(\Illuminate\Session\Store $session) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method renderPulledSessionData does not have a return type, expecting void
-MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreRemember.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreRemember.phpt
@@ -8,5 +8,7 @@ function renderRememberedSessionData(\Illuminate\Session\Store $session) {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MissingReturnType on line %d: Method renderRememberedSessionData does not have a return type, expecting void
+MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreRemember.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreRemember.phpt
@@ -8,7 +8,5 @@ function renderRememberedSessionData(\Illuminate\Session\Store $session) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method renderRememberedSessionData does not have a return type, expecting void
-MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreRemove.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreRemove.phpt
@@ -8,5 +8,7 @@ function renderRemovedSessionData(\Illuminate\Session\Store $session) {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MissingReturnType on line %d: Method renderRemovedSessionData does not have a return type, expecting void
+MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreRemove.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlSessionStoreRemove.phpt
@@ -8,7 +8,5 @@ function renderRemovedSessionData(\Illuminate\Session\Store $session) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method renderRemovedSessionData does not have a return type, expecting void
-MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlStrHelper.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlStrHelper.phpt
@@ -11,5 +11,5 @@ function displayInput(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlStrOf.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlStrOf.phpt
@@ -11,5 +11,5 @@ function displayName(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlString.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlString.phpt
@@ -10,7 +10,4 @@ function renderBio(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method renderBio does not have a return type, expecting Illuminate\Support\HtmlString
-MixedAssignment on line %d: Unable to determine the type that $bio is being assigned to
-MixedArgument on line %d: Argument 1 of Illuminate\Support\HtmlString::__construct cannot be mixed, expecting string
 TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlString.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlString.phpt
@@ -10,4 +10,7 @@ function renderBio(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
+MissingReturnType on line %d: Method renderBio does not have a return type, expecting Illuminate\Support\HtmlString
+MixedAssignment on line %d: Unable to determine the type that $bio is being assigned to
+MixedArgument on line %d: Argument 1 of Illuminate\Support\HtmlString::__construct cannot be mixed, expecting string
+TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlStringableAppend.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlStringableAppend.phpt
@@ -11,5 +11,5 @@ function displayWithPrefix(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlStringablePrepend.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlStringablePrepend.phpt
@@ -11,5 +11,5 @@ function displayWithSuffix(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlStringableReplace.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlStringableReplace.phpt
@@ -11,5 +11,5 @@ function displayReplaced(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlStringableWrap.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlStringableWrap.phpt
@@ -11,5 +11,5 @@ function displayWrapped(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlTokenGuardToken.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlTokenGuardToken.phpt
@@ -10,4 +10,5 @@ function leakApiToken(\Illuminate\Auth\TokenGuard $guard): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML%A
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlUploadedFileContents.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlUploadedFileContents.phpt
@@ -12,5 +12,5 @@ function renderUploadedFileContents(\Illuminate\Http\UploadedFile $file): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlUploadedFileContentsViaRequestFile.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlUploadedFileContentsViaRequestFile.phpt
@@ -20,5 +20,5 @@ function renderUploadContents(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlUploadedFileExtension.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlUploadedFileExtension.phpt
@@ -12,5 +12,5 @@ function renderUploadedFileExtension(\Illuminate\Http\UploadedFile $file): void 
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlUploadedFileGetContent.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlUploadedFileGetContent.phpt
@@ -14,5 +14,5 @@ function renderUploadGetContent(\Illuminate\Http\UploadedFile $file): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlUploadedFileMimeType.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlUploadedFileMimeType.phpt
@@ -12,5 +12,5 @@ function renderUploadedFileMimeType(\Illuminate\Http\UploadedFile $file): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlUploadedFileName.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlUploadedFileName.phpt
@@ -12,5 +12,5 @@ function renderUploadedFileName(\Illuminate\Http\UploadedFile $file): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlUploadedFilePath.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlUploadedFilePath.phpt
@@ -12,5 +12,5 @@ function renderUploadedFilePath(\Illuminate\Http\UploadedFile $file): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlUrlEDoesNotEscape.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlUrlEDoesNotEscape.phpt
@@ -39,4 +39,4 @@ function sendActionWithEEscapedUrl(): void {
 }
 ?>
 --EXPECTF--
-%ATaintedCustom%a: Detected tainted html_url%A
+TaintedCustom on line %d: Detected tainted html_url

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlUrlMailActionWithoutSanitize.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlUrlMailActionWithoutSanitize.phpt
@@ -28,4 +28,4 @@ function sendActionWithUntrustedUrl(\Illuminate\Notifications\Messages\MailMessa
 }
 ?>
 --EXPECTF--
-%ATaintedCustom%a: Detected tainted html_url%A
+TaintedCustom on line %d: Detected tainted html_url

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlUserAgent.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlUserAgent.phpt
@@ -8,6 +8,5 @@ function logVisitor(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method logVisitor does not have a return type, expecting void
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlUserAgent.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlUserAgent.phpt
@@ -8,5 +8,6 @@ function logVisitor(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MissingReturnType on line %d: Method logVisitor does not have a return type, expecting void
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlValidatedString.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlValidatedString.phpt
@@ -21,5 +21,5 @@ function renderComment(CommentRequest $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlValidatorValidated.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlValidatorValidated.phpt
@@ -9,5 +9,7 @@ function renderFromValidator(\Illuminate\Validation\Validator $validator): void 
 }
 ?>
 --EXPECTF--
-%ATaintedHtml on line %d: Detected tainted HTML
-%ATaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
+PossiblyUndefinedStringArrayOffset on line %d: Possibly undefined array offset ''body'' is risky given expected type 'string'. Consider using isset beforehand.
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlValidatorValidated.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlValidatorValidated.phpt
@@ -9,7 +9,5 @@ function renderFromValidator(\Illuminate\Validation\Validator $validator): void 
 }
 ?>
 --EXPECTF--
-MixedArgument on line %d: Argument 1 of echo cannot be mixed, expecting string
-PossiblyUndefinedStringArrayOffset on line %d: Possibly undefined array offset ''body'' is risky given expected type 'string'. Consider using isset beforehand.
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedIncludeViewFactory.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedIncludeViewFactory.phpt
@@ -16,7 +16,6 @@ function renderCustomTemplateViaContract(\Illuminate\Http\Request $request, \Ill
 }
 ?>
 --EXPECTF--
-MixedAssignment on line %d: Unable to determine the type that $template is being assigned to
 TaintedFile on line %d: Detected tainted file handling
 TaintedInclude on line %d: Detected tainted code passed to include or similar
 TaintedFile on line %d: Detected tainted file handling

--- a/tests/Type/tests/TaintAnalysis/TaintedIncludeViewFactory.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedIncludeViewFactory.phpt
@@ -16,7 +16,8 @@ function renderCustomTemplateViaContract(\Illuminate\Http\Request $request, \Ill
 }
 ?>
 --EXPECTF--
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedInclude on line %d: Detected tainted code passed to include or similar
-%ATaintedFile on line %d: Detected tainted file handling
-%ATaintedInclude on line %d: Detected tainted code passed to include or similar
+MixedAssignment on line %d: Unable to determine the type that $template is being assigned to
+TaintedFile on line %d: Detected tainted file handling
+TaintedInclude on line %d: Detected tainted code passed to include or similar
+TaintedFile on line %d: Detected tainted file handling
+TaintedInclude on line %d: Detected tainted code passed to include or similar

--- a/tests/Type/tests/TaintAnalysis/TaintedShellArtisanCall.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedShellArtisanCall.phpt
@@ -11,4 +11,7 @@ function runArtisanCommand(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedShell on line %d: Detected tainted shell code
+MissingReturnType on line %d: Method runArtisanCommand does not have a return type, expecting void
+MixedAssignment on line %d: Unable to determine the type that $command is being assigned to
+MixedArgument on line %d: Argument 1 of Illuminate\Contracts\Console\Kernel::call cannot be mixed, expecting string
+TaintedShell on line %d: Detected tainted shell code

--- a/tests/Type/tests/TaintAnalysis/TaintedShellArtisanCall.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedShellArtisanCall.phpt
@@ -11,7 +11,4 @@ function runArtisanCommand(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method runArtisanCommand does not have a return type, expecting void
-MixedAssignment on line %d: Unable to determine the type that $command is being assigned to
-MixedArgument on line %d: Argument 1 of Illuminate\Contracts\Console\Kernel::call cannot be mixed, expecting string
 TaintedShell on line %d: Detected tainted shell code

--- a/tests/Type/tests/TaintAnalysis/TaintedShellArtisanCallFoundation.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedShellArtisanCallFoundation.phpt
@@ -11,7 +11,4 @@ function runArtisanCommandViaFoundationKernel(\Illuminate\Http\Request $request)
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method runArtisanCommandViaFoundationKernel does not have a return type, expecting void
-MixedAssignment on line %d: Unable to determine the type that $command is being assigned to
-MixedArgument on line %d: Argument 1 of Illuminate\Foundation\Console\Kernel::call cannot be mixed, expecting Symfony\Component\Console\Command\Command|string
 TaintedShell on line %d: Detected tainted shell code

--- a/tests/Type/tests/TaintAnalysis/TaintedShellArtisanCallFoundation.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedShellArtisanCallFoundation.phpt
@@ -11,4 +11,7 @@ function runArtisanCommandViaFoundationKernel(\Illuminate\Http\Request $request)
 }
 ?>
 --EXPECTF--
-%ATaintedShell on line %d: Detected tainted shell code
+MissingReturnType on line %d: Method runArtisanCommandViaFoundationKernel does not have a return type, expecting void
+MixedAssignment on line %d: Unable to determine the type that $command is being assigned to
+MixedArgument on line %d: Argument 1 of Illuminate\Foundation\Console\Kernel::call cannot be mixed, expecting Symfony\Component\Console\Command\Command|string
+TaintedShell on line %d: Detected tainted shell code

--- a/tests/Type/tests/TaintAnalysis/TaintedShellArtisanFacadeStatic.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedShellArtisanFacadeStatic.phpt
@@ -18,4 +18,4 @@ function facadeStaticCallIsTainted(Request $request): void
 }
 ?>
 --EXPECTF--
-%ATaintedShell on line %d: Detected tainted shell code
+TaintedShell on line %d: Detected tainted shell code

--- a/tests/Type/tests/TaintAnalysis/TaintedShellArtisanQueue.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedShellArtisanQueue.phpt
@@ -11,7 +11,4 @@ function queueArtisanCommand(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method queueArtisanCommand does not have a return type, expecting void
-MixedAssignment on line %d: Unable to determine the type that $command is being assigned to
-MixedArgument on line %d: Argument 1 of Illuminate\Contracts\Console\Kernel::queue cannot be mixed, expecting string
 TaintedShell on line %d: Detected tainted shell code

--- a/tests/Type/tests/TaintAnalysis/TaintedShellArtisanQueue.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedShellArtisanQueue.phpt
@@ -11,4 +11,7 @@ function queueArtisanCommand(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedShell on line %d: Detected tainted shell code
+MissingReturnType on line %d: Method queueArtisanCommand does not have a return type, expecting void
+MixedAssignment on line %d: Unable to determine the type that $command is being assigned to
+MixedArgument on line %d: Argument 1 of Illuminate\Contracts\Console\Kernel::queue cannot be mixed, expecting string
+TaintedShell on line %d: Detected tainted shell code

--- a/tests/Type/tests/TaintAnalysis/TaintedShellArtisanQueueFoundation.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedShellArtisanQueueFoundation.phpt
@@ -11,4 +11,7 @@ function queueArtisanCommandViaFoundationKernel(\Illuminate\Http\Request $reques
 }
 ?>
 --EXPECTF--
-%ATaintedShell on line %d: Detected tainted shell code
+MissingReturnType on line %d: Method queueArtisanCommandViaFoundationKernel does not have a return type, expecting void
+MixedAssignment on line %d: Unable to determine the type that $command is being assigned to
+MixedArgument on line %d: Argument 1 of Illuminate\Foundation\Console\Kernel::queue cannot be mixed, expecting string
+TaintedShell on line %d: Detected tainted shell code

--- a/tests/Type/tests/TaintAnalysis/TaintedShellArtisanQueueFoundation.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedShellArtisanQueueFoundation.phpt
@@ -11,7 +11,4 @@ function queueArtisanCommandViaFoundationKernel(\Illuminate\Http\Request $reques
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method queueArtisanCommandViaFoundationKernel does not have a return type, expecting void
-MixedAssignment on line %d: Unable to determine the type that $command is being assigned to
-MixedArgument on line %d: Argument 1 of Illuminate\Foundation\Console\Kernel::queue cannot be mixed, expecting string
 TaintedShell on line %d: Detected tainted shell code

--- a/tests/Type/tests/TaintAnalysis/TaintedShellProcess.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedShellProcess.phpt
@@ -10,4 +10,8 @@ function convertImage(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedShell on line %d: Detected tainted shell code
+MissingReturnType on line %d: Method convertImage does not have a return type, expecting void
+MixedAssignment on line %d: Unable to determine the type that $filename is being assigned to
+TooFewArguments on line %d: Too few arguments for Illuminate\Process\PendingProcess::__construct - expecting factory to be passed
+MixedArgument on line %d: Argument 1 of Illuminate\Process\PendingProcess::run cannot be mixed, expecting array<array-key, mixed>|null|string
+TaintedShell on line %d: Detected tainted shell code

--- a/tests/Type/tests/TaintAnalysis/TaintedShellProcess.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedShellProcess.phpt
@@ -10,8 +10,4 @@ function convertImage(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method convertImage does not have a return type, expecting void
-MixedAssignment on line %d: Unable to determine the type that $filename is being assigned to
-TooFewArguments on line %d: Too few arguments for Illuminate\Process\PendingProcess::__construct - expecting factory to be passed
-MixedArgument on line %d: Argument 1 of Illuminate\Process\PendingProcess::run cannot be mixed, expecting array<array-key, mixed>|null|string
 TaintedShell on line %d: Detected tainted shell code

--- a/tests/Type/tests/TaintAnalysis/TaintedShellProcessCommandStart.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedShellProcessCommandStart.phpt
@@ -20,9 +20,5 @@ function processStart(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-TooFewArguments on line %d: Too few arguments for Illuminate\Process\PendingProcess::__construct - expecting factory to be passed
-MixedArgument on line %d: Argument 1 of Illuminate\Process\PendingProcess::command cannot be mixed, expecting array<array-key, mixed>|string
 TaintedShell on line %d: Detected tainted shell code
-TooFewArguments on line %d: Too few arguments for Illuminate\Process\PendingProcess::__construct - expecting factory to be passed
-MixedArgument on line %d: Argument 1 of Illuminate\Process\PendingProcess::start cannot be mixed, expecting array<array-key, mixed>|null|string
 TaintedShell on line %d: Detected tainted shell code

--- a/tests/Type/tests/TaintAnalysis/TaintedShellProcessCommandStart.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedShellProcessCommandStart.phpt
@@ -20,5 +20,9 @@ function processStart(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedShell on line %d: Detected tainted shell code
-%ATaintedShell on line %d: Detected tainted shell code
+TooFewArguments on line %d: Too few arguments for Illuminate\Process\PendingProcess::__construct - expecting factory to be passed
+MixedArgument on line %d: Argument 1 of Illuminate\Process\PendingProcess::command cannot be mixed, expecting array<array-key, mixed>|string
+TaintedShell on line %d: Detected tainted shell code
+TooFewArguments on line %d: Too few arguments for Illuminate\Process\PendingProcess::__construct - expecting factory to be passed
+MixedArgument on line %d: Argument 1 of Illuminate\Process\PendingProcess::start cannot be mixed, expecting array<array-key, mixed>|null|string
+TaintedShell on line %d: Detected tainted shell code

--- a/tests/Type/tests/TaintAnalysis/TaintedShellProcessFacadeStatic.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedShellProcessFacadeStatic.phpt
@@ -19,4 +19,4 @@ function facadeStaticRunIsTainted(Request $request): void
 }
 ?>
 --EXPECTF--
-%ATaintedShell on line %d: Detected tainted shell code
+TaintedShell on line %d: Detected tainted shell code

--- a/tests/Type/tests/TaintAnalysis/TaintedShellWhereValueFlowPreserved.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedShellWhereValueFlowPreserved.phpt
@@ -26,4 +26,4 @@ function shellFlowsThroughWhereValue(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedShell on line %d: Detected tainted shell code
+TaintedShell on line %d: Detected tainted shell code

--- a/tests/Type/tests/TaintAnalysis/TaintedSql.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSql.phpt
@@ -11,7 +11,4 @@ function searchPosts(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method searchPosts does not have a return type, expecting void
-TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
-MixedAssignment on line %d: Unable to determine the type that $searchTerm is being assigned to
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSql.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSql.phpt
@@ -11,4 +11,7 @@ function searchPosts(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+MissingReturnType on line %d: Method searchPosts does not have a return type, expecting void
+TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
+MixedAssignment on line %d: Unable to determine the type that $searchTerm is being assigned to
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlConnectionTable.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlConnectionTable.phpt
@@ -12,6 +12,4 @@ function unsafeConnectionTable(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-MixedAssignment on line %d: Unable to determine the type that $table is being assigned to
-MixedArgument on line %d: Argument 1 of Illuminate\Database\Connection::table cannot be mixed, expecting Illuminate\Contracts\Database\Query\Expression|Illuminate\Database\Query\Builder|UnitEnum|impure-Closure|string
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlConnectionTable.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlConnectionTable.phpt
@@ -12,4 +12,6 @@ function unsafeConnectionTable(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+MixedAssignment on line %d: Unable to determine the type that $table is being assigned to
+MixedArgument on line %d: Argument 1 of Illuminate\Database\Connection::table cannot be mixed, expecting Illuminate\Contracts\Database\Query\Expression|Illuminate\Database\Query\Builder|UnitEnum|impure-Closure|string
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlConnectionTableAlias.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlConnectionTableAlias.phpt
@@ -12,6 +12,4 @@ function unsafeConnectionTableAlias(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-MixedAssignment on line %d: Unable to determine the type that $alias is being assigned to
-MixedArgument on line %d: Argument 2 of Illuminate\Database\Connection::table cannot be mixed, expecting null|string
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlConnectionTableAlias.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlConnectionTableAlias.phpt
@@ -12,4 +12,6 @@ function unsafeConnectionTableAlias(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+MixedAssignment on line %d: Unable to determine the type that $alias is being assigned to
+MixedArgument on line %d: Argument 2 of Illuminate\Database\Connection::table cannot be mixed, expecting null|string
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlDbSelect.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlDbSelect.phpt
@@ -10,4 +10,7 @@ function showPost(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL%A
+MissingReturnType on line %d: Method showPost does not have a return type, expecting void
+MixedAssignment on line %d: Unable to determine the type that $postId is being assigned to
+TaintedSql on line %d: Detected tainted SQL
+MixedOperand on line %d: Right operand cannot be mixed

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlDbSelect.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlDbSelect.phpt
@@ -10,7 +10,4 @@ function showPost(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method showPost does not have a return type, expecting void
-MixedAssignment on line %d: Unable to determine the type that $postId is being assigned to
 TaintedSql on line %d: Detected tainted SQL
-MixedOperand on line %d: Right operand cannot be mixed

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlDbTable.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlDbTable.phpt
@@ -10,4 +10,6 @@ function unsafeDbTable(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+MixedAssignment on line %d: Unable to determine the type that $table is being assigned to
+MixedArgument on line %d: Argument 1 of Illuminate\Support\Facades\DB::table cannot be mixed, expecting Illuminate\Contracts\Database\Query\Expression|Illuminate\Database\Query\Builder|UnitEnum|impure-Closure|string
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlDbTable.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlDbTable.phpt
@@ -10,6 +10,4 @@ function unsafeDbTable(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-MixedAssignment on line %d: Unable to determine the type that $table is being assigned to
-MixedArgument on line %d: Argument 1 of Illuminate\Support\Facades\DB::table cannot be mixed, expecting Illuminate\Contracts\Database\Query\Expression|Illuminate\Database\Query\Builder|UnitEnum|impure-Closure|string
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlDbTableAlias.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlDbTableAlias.phpt
@@ -10,6 +10,4 @@ function unsafeDbTableAlias(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-MixedAssignment on line %d: Unable to determine the type that $alias is being assigned to
-MixedArgument on line %d: Argument 2 of Illuminate\Support\Facades\DB::table cannot be mixed, expecting null|string
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlDbTableAlias.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlDbTableAlias.phpt
@@ -10,4 +10,6 @@ function unsafeDbTableAlias(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+MixedAssignment on line %d: Unable to determine the type that $alias is being assigned to
+MixedArgument on line %d: Argument 2 of Illuminate\Support\Facades\DB::table cannot be mixed, expecting null|string
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlDbUnprepared.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlDbUnprepared.phpt
@@ -10,7 +10,4 @@ function exportPosts(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method exportPosts does not have a return type, expecting void
-MixedAssignment on line %d: Unable to determine the type that $sql is being assigned to
-MixedArgument on line %d: Argument 1 of Illuminate\Database\Connection::unprepared cannot be mixed, expecting string
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlDbUnprepared.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlDbUnprepared.phpt
@@ -10,4 +10,7 @@ function exportPosts(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+MissingReturnType on line %d: Method exportPosts does not have a return type, expecting void
+MixedAssignment on line %d: Unable to determine the type that $sql is being assigned to
+MixedArgument on line %d: Argument 1 of Illuminate\Database\Connection::unprepared cannot be mixed, expecting string
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlEloquentWhereColumnCompareSink.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlEloquentWhereColumnCompareSink.phpt
@@ -17,4 +17,4 @@ function unsafeEloquentWhereColumn(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlEloquentWhereColumnSink.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlEloquentWhereColumnSink.phpt
@@ -12,4 +12,6 @@ function unsafeEloquentColumnWhere(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+MixedAssignment on line %d: Unable to determine the type that $column is being assigned to
+MixedArgument on line %d: Argument 1 of Illuminate\Database\Eloquent\Builder::where cannot be mixed, expecting Illuminate\Contracts\Database\Query\Expression|array<array-key, mixed>|impure-Closure(Illuminate\Database\Eloquent\Builder<EloquentColumnSinkPost&static>):mixed|string
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlEloquentWhereColumnSink.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlEloquentWhereColumnSink.phpt
@@ -12,6 +12,4 @@ function unsafeEloquentColumnWhere(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-MixedAssignment on line %d: Unable to determine the type that $column is being assigned to
-MixedArgument on line %d: Argument 1 of Illuminate\Database\Eloquent\Builder::where cannot be mixed, expecting Illuminate\Contracts\Database\Query\Expression|array<array-key, mixed>|impure-Closure(Illuminate\Database\Eloquent\Builder<EloquentColumnSinkPost&static>):mixed|string
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlFirstWhereColumnSink.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlFirstWhereColumnSink.phpt
@@ -18,6 +18,4 @@ function unsafeFirstWhereColumn(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-MixedAssignment on line %d: Unable to determine the type that $column is being assigned to
-MixedArgument on line %d: Argument 1 of Illuminate\Database\Eloquent\Builder::firstWhere cannot be mixed, expecting Illuminate\Contracts\Database\Query\Expression|array<array-key, mixed>|impure-Closure(Illuminate\Database\Eloquent\Builder<FirstWhereColumnSinkModel&static>):mixed|string
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlFirstWhereColumnSink.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlFirstWhereColumnSink.phpt
@@ -18,4 +18,6 @@ function unsafeFirstWhereColumn(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+MixedAssignment on line %d: Unable to determine the type that $column is being assigned to
+MixedArgument on line %d: Argument 1 of Illuminate\Database\Eloquent\Builder::firstWhere cannot be mixed, expecting Illuminate\Contracts\Database\Query\Expression|array<array-key, mixed>|impure-Closure(Illuminate\Database\Eloquent\Builder<FirstWhereColumnSinkModel&static>):mixed|string
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlFirstWhereUnsealedMap.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlFirstWhereUnsealedMap.phpt
@@ -29,4 +29,4 @@ function unsafeUnsealedMapFirstWhere(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlFrom.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlFrom.phpt
@@ -11,7 +11,4 @@ function unsafeFrom(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
-MixedAssignment on line %d: Unable to determine the type that $table is being assigned to
-MixedArgument on line %d: Argument 1 of Illuminate\Database\Query\Builder::from cannot be mixed, expecting Illuminate\Contracts\Database\Query\Expression|Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>|Illuminate\Database\Query\Builder|impure-Closure|string
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlFrom.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlFrom.phpt
@@ -11,4 +11,7 @@ function unsafeFrom(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
+MixedAssignment on line %d: Unable to determine the type that $table is being assigned to
+MixedArgument on line %d: Argument 1 of Illuminate\Database\Query\Builder::from cannot be mixed, expecting Illuminate\Contracts\Database\Query\Expression|Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>|Illuminate\Database\Query\Builder|impure-Closure|string
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlFromAlias.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlFromAlias.phpt
@@ -11,7 +11,4 @@ function unsafeFromAlias(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
-MixedAssignment on line %d: Unable to determine the type that $alias is being assigned to
-MixedArgument on line %d: Argument 2 of Illuminate\Database\Query\Builder::from cannot be mixed, expecting null|string
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlFromAlias.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlFromAlias.phpt
@@ -11,4 +11,7 @@ function unsafeFromAlias(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
+MixedAssignment on line %d: Unable to determine the type that $alias is being assigned to
+MixedArgument on line %d: Argument 2 of Illuminate\Database\Query\Builder::from cannot be mixed, expecting null|string
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlHavingMap.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlHavingMap.phpt
@@ -21,4 +21,4 @@ function unsafeHavingMap(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlInsertOrIgnoreUsing.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlInsertOrIgnoreUsing.phpt
@@ -11,4 +11,7 @@ function unsafeInsertOrIgnoreUsing(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
+MixedAssignment on line %d: Unable to determine the type that $query is being assigned to
+MixedArgument on line %d: Argument 2 of Illuminate\Database\Query\Builder::insertOrIgnoreUsing cannot be mixed, expecting Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>|Illuminate\Database\Query\Builder|impure-Closure|string
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlInsertOrIgnoreUsing.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlInsertOrIgnoreUsing.phpt
@@ -11,7 +11,4 @@ function unsafeInsertOrIgnoreUsing(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
-MixedAssignment on line %d: Unable to determine the type that $query is being assigned to
-MixedArgument on line %d: Argument 2 of Illuminate\Database\Query\Builder::insertOrIgnoreUsing cannot be mixed, expecting Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>|Illuminate\Database\Query\Builder|impure-Closure|string
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlInsertUsing.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlInsertUsing.phpt
@@ -11,4 +11,7 @@ function unsafeInsertUsing(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
+MixedAssignment on line %d: Unable to determine the type that $query is being assigned to
+MixedArgument on line %d: Argument 2 of Illuminate\Database\Query\Builder::insertUsing cannot be mixed, expecting Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>|Illuminate\Database\Query\Builder|impure-Closure|string
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlInsertUsing.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlInsertUsing.phpt
@@ -11,7 +11,4 @@ function unsafeInsertUsing(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
-MixedAssignment on line %d: Unable to determine the type that $query is being assigned to
-MixedArgument on line %d: Argument 2 of Illuminate\Database\Query\Builder::insertUsing cannot be mixed, expecting Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>|Illuminate\Database\Query\Builder|impure-Closure|string
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlInsertUsingColumns.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlInsertUsingColumns.phpt
@@ -12,4 +12,5 @@ function unsafeInsertUsingColumns(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlInsertUsingColumns.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlInsertUsingColumns.phpt
@@ -12,5 +12,4 @@ function unsafeInsertUsingColumns(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlJsEncodePreservesTaint.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlJsEncodePreservesTaint.phpt
@@ -16,4 +16,4 @@ function unsafeJsSql(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlMapAssignmentFlow.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlMapAssignmentFlow.phpt
@@ -14,4 +14,4 @@ function mapValueFlowsToRawSink(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlMapReturnFlow.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlMapReturnFlow.phpt
@@ -19,4 +19,4 @@ function useBuiltFilter(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlOrWhereAll.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlOrWhereAll.phpt
@@ -12,5 +12,4 @@ function unsafeOrWhereAll(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlOrWhereAll.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlOrWhereAll.phpt
@@ -12,4 +12,5 @@ function unsafeOrWhereAll(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlOrWhereAny.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlOrWhereAny.phpt
@@ -12,5 +12,4 @@ function unsafeOrWhereAny(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlOrWhereAny.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlOrWhereAny.phpt
@@ -12,4 +12,5 @@ function unsafeOrWhereAny(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlOrWhereNone.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlOrWhereNone.phpt
@@ -12,4 +12,5 @@ function unsafeOrWhereNone(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlOrWhereNone.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlOrWhereNone.phpt
@@ -12,5 +12,4 @@ function unsafeOrWhereNone(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlOrderBy.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlOrderBy.phpt
@@ -11,4 +11,7 @@ function unsafeOrderBy(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
+MixedAssignment on line %d: Unable to determine the type that $column is being assigned to
+MixedArgument on line %d: Argument 1 of Illuminate\Database\Query\Builder::orderBy cannot be mixed, expecting Illuminate\Contracts\Database\Query\Expression|Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>|Illuminate\Database\Query\Builder|impure-Closure|string
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlOrderBy.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlOrderBy.phpt
@@ -11,7 +11,4 @@ function unsafeOrderBy(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
-MixedAssignment on line %d: Unable to determine the type that $column is being assigned to
-MixedArgument on line %d: Argument 1 of Illuminate\Database\Query\Builder::orderBy cannot be mixed, expecting Illuminate\Contracts\Database\Query\Expression|Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>|Illuminate\Database\Query\Builder|impure-Closure|string
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlOrderByRaw.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlOrderByRaw.phpt
@@ -10,8 +10,4 @@ function listPosts(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method listPosts does not have a return type, expecting void
-TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
-MixedAssignment on line %d: Unable to determine the type that $sortClause is being assigned to
-MixedArgument on line %d: Argument 1 of Illuminate\Database\Query\Builder::orderByRaw cannot be mixed, expecting string
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlOrderByRaw.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlOrderByRaw.phpt
@@ -10,4 +10,8 @@ function listPosts(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+MissingReturnType on line %d: Method listPosts does not have a return type, expecting void
+TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
+MixedAssignment on line %d: Unable to determine the type that $sortClause is being assigned to
+MixedArgument on line %d: Argument 1 of Illuminate\Database\Query\Builder::orderByRaw cannot be mixed, expecting string
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlRawIndex.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlRawIndex.phpt
@@ -14,4 +14,6 @@ function unsafeRawIndex(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+MixedAssignment on line %d: Unable to determine the type that $expression is being assigned to
+MixedArgument on line %d: Argument 1 of Illuminate\Database\Schema\Blueprint::rawIndex cannot be mixed, expecting string
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlRawIndex.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlRawIndex.phpt
@@ -14,6 +14,4 @@ function unsafeRawIndex(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-MixedAssignment on line %d: Unable to determine the type that $expression is being assigned to
-MixedArgument on line %d: Argument 1 of Illuminate\Database\Schema\Blueprint::rawIndex cannot be mixed, expecting string
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlRequestMagicProperty.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlRequestMagicProperty.phpt
@@ -9,4 +9,6 @@ function filterPosts(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+MissingReturnType on line %d: Method filterPosts does not have a return type, expecting void
+TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlRequestMagicProperty.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlRequestMagicProperty.phpt
@@ -9,6 +9,4 @@ function filterPosts(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method filterPosts does not have a return type, expecting void
-TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaBuilderHasTable.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaBuilderHasTable.phpt
@@ -19,6 +19,4 @@ function unsafeSchemaBuilderHasTable(\Illuminate\Http\Request $request): bool {
 }
 ?>
 --EXPECTF--
-MixedAssignment on line %d: Unable to determine the type that $table is being assigned to
-MixedArgument on line %d: Argument 1 of Illuminate\Database\Schema\Builder::hasTable cannot be mixed, expecting Stringable|string
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaBuilderHasTable.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaBuilderHasTable.phpt
@@ -19,4 +19,6 @@ function unsafeSchemaBuilderHasTable(\Illuminate\Http\Request $request): bool {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+MixedAssignment on line %d: Unable to determine the type that $table is being assigned to
+MixedArgument on line %d: Argument 1 of Illuminate\Database\Schema\Builder::hasTable cannot be mixed, expecting Stringable|string
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaCreate.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaCreate.phpt
@@ -14,4 +14,6 @@ function unsafeSchemaCreate(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+MixedAssignment on line %d: Unable to determine the type that $table is being assigned to
+MixedArgument on line %d: Argument 1 of Illuminate\Database\Schema\Builder::create cannot be mixed, expecting string
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaCreate.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaCreate.phpt
@@ -14,6 +14,4 @@ function unsafeSchemaCreate(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-MixedAssignment on line %d: Unable to determine the type that $table is being assigned to
-MixedArgument on line %d: Argument 1 of Illuminate\Database\Schema\Builder::create cannot be mixed, expecting string
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaDrop.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaDrop.phpt
@@ -12,4 +12,6 @@ function unsafeSchemaDrop(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+MixedAssignment on line %d: Unable to determine the type that $table is being assigned to
+MixedArgument on line %d: Argument 1 of Illuminate\Database\Schema\Builder::drop cannot be mixed, expecting string
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaDrop.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaDrop.phpt
@@ -12,6 +12,4 @@ function unsafeSchemaDrop(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-MixedAssignment on line %d: Unable to determine the type that $table is being assigned to
-MixedArgument on line %d: Argument 1 of Illuminate\Database\Schema\Builder::drop cannot be mixed, expecting string
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaDropIfExists.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaDropIfExists.phpt
@@ -12,4 +12,6 @@ function unsafeSchemaDropIfExists(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+MixedAssignment on line %d: Unable to determine the type that $table is being assigned to
+MixedArgument on line %d: Argument 1 of Illuminate\Database\Schema\Builder::dropIfExists cannot be mixed, expecting string
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaDropIfExists.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaDropIfExists.phpt
@@ -12,6 +12,4 @@ function unsafeSchemaDropIfExists(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-MixedAssignment on line %d: Unable to determine the type that $table is being assigned to
-MixedArgument on line %d: Argument 1 of Illuminate\Database\Schema\Builder::dropIfExists cannot be mixed, expecting string
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaHasTable.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaHasTable.phpt
@@ -19,4 +19,6 @@ function unsafeSchemaHasTable(\Illuminate\Http\Request $request): bool {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+MixedAssignment on line %d: Unable to determine the type that $table is being assigned to
+MixedArgument on line %d: Argument 1 of Illuminate\Support\Facades\Schema::hasTable cannot be mixed, expecting Stringable|string
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaHasTable.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaHasTable.phpt
@@ -19,6 +19,4 @@ function unsafeSchemaHasTable(\Illuminate\Http\Request $request): bool {
 }
 ?>
 --EXPECTF--
-MixedAssignment on line %d: Unable to determine the type that $table is being assigned to
-MixedArgument on line %d: Argument 1 of Illuminate\Support\Facades\Schema::hasTable cannot be mixed, expecting Stringable|string
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaRename.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaRename.phpt
@@ -12,6 +12,4 @@ function unsafeSchemaRename(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-MixedAssignment on line %d: Unable to determine the type that $from is being assigned to
-MixedArgument on line %d: Argument 1 of Illuminate\Database\Schema\Builder::rename cannot be mixed, expecting string
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaRename.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaRename.phpt
@@ -12,4 +12,6 @@ function unsafeSchemaRename(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+MixedAssignment on line %d: Unable to determine the type that $from is being assigned to
+MixedArgument on line %d: Argument 1 of Illuminate\Database\Schema\Builder::rename cannot be mixed, expecting string
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaRenameTo.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaRenameTo.phpt
@@ -12,6 +12,4 @@ function unsafeSchemaRenameTo(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-MixedAssignment on line %d: Unable to determine the type that $to is being assigned to
-MixedArgument on line %d: Argument 2 of Illuminate\Database\Schema\Builder::rename cannot be mixed, expecting string
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaRenameTo.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaRenameTo.phpt
@@ -12,4 +12,6 @@ function unsafeSchemaRenameTo(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+MixedAssignment on line %d: Unable to determine the type that $to is being assigned to
+MixedArgument on line %d: Argument 2 of Illuminate\Database\Schema\Builder::rename cannot be mixed, expecting string
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaTable.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaTable.phpt
@@ -14,4 +14,6 @@ function unsafeSchemaTable(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+MixedAssignment on line %d: Unable to determine the type that $table is being assigned to
+MixedArgument on line %d: Argument 1 of Illuminate\Database\Schema\Builder::table cannot be mixed, expecting string
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaTable.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaTable.phpt
@@ -14,6 +14,4 @@ function unsafeSchemaTable(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-MixedAssignment on line %d: Unable to determine the type that $table is being assigned to
-MixedArgument on line %d: Argument 1 of Illuminate\Database\Schema\Builder::table cannot be mixed, expecting string
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlSelectRaw.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlSelectRaw.phpt
@@ -10,8 +10,4 @@ function getPostStats(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method getPostStats does not have a return type, expecting void
-TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
-MixedAssignment on line %d: Unable to determine the type that $column is being assigned to
-MixedArgument on line %d: Argument 1 of Illuminate\Database\Query\Builder::selectRaw cannot be mixed, expecting string
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlSelectRaw.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlSelectRaw.phpt
@@ -10,4 +10,8 @@ function getPostStats(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+MissingReturnType on line %d: Method getPostStats does not have a return type, expecting void
+TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
+MixedAssignment on line %d: Unable to determine the type that $column is being assigned to
+MixedArgument on line %d: Argument 1 of Illuminate\Database\Query\Builder::selectRaw cannot be mixed, expecting string
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlSessionHelper.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlSessionHelper.phpt
@@ -11,4 +11,7 @@ function unsafeSessionHelperQuery() {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+MissingReturnType on line %d: Method unsafeSessionHelperQuery does not have a return type, expecting void
+TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
+MixedAssignment on line %d: Unable to determine the type that $searchTerm is being assigned to
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlSessionHelper.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlSessionHelper.phpt
@@ -11,7 +11,4 @@ function unsafeSessionHelperQuery() {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method unsafeSessionHelperQuery does not have a return type, expecting void
-TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
-MixedAssignment on line %d: Unable to determine the type that $searchTerm is being assigned to
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlSessionStore.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlSessionStore.phpt
@@ -11,7 +11,4 @@ function unsafeSessionQuery(\Illuminate\Session\Store $session) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method unsafeSessionQuery does not have a return type, expecting void
-TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
-MixedAssignment on line %d: Unable to determine the type that $searchTerm is being assigned to
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlSessionStore.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlSessionStore.phpt
@@ -11,4 +11,7 @@ function unsafeSessionQuery(\Illuminate\Session\Store $session) {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+MissingReturnType on line %d: Method unsafeSessionQuery does not have a return type, expecting void
+TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
+MixedAssignment on line %d: Unable to determine the type that $searchTerm is being assigned to
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlStaticWhereConcreteModelOverride.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlStaticWhereConcreteModelOverride.phpt
@@ -26,4 +26,4 @@ function unsafeStaticConcreteModelOverride(\Illuminate\Http\Request $request): v
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlStaticWhereNestedConditionColumn.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlStaticWhereNestedConditionColumn.phpt
@@ -22,4 +22,4 @@ function unsafeStaticNestedConditionColumn(\Illuminate\Http\Request $request): v
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlStaticWhereNonModelReceiver.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlStaticWhereNonModelReceiver.phpt
@@ -40,5 +40,5 @@ function unsafeStaticNonModelReceiverWholeArgMap(\Illuminate\Http\Request $reque
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
-%ATaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlStaticWhereTraitReanalysisStale.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlStaticWhereTraitReanalysisStale.phpt
@@ -43,5 +43,5 @@ function unsafeTraitReanalysisStaleIds(\Illuminate\Http\Request $request): void 
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
-%ATaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereAll.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereAll.phpt
@@ -12,4 +12,5 @@ function unsafeWhereAll(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereAll.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereAll.phpt
@@ -12,5 +12,4 @@ function unsafeWhereAll(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereAllMap.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereAllMap.phpt
@@ -18,4 +18,4 @@ function whereAllKeyedMapFlags(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereAny.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereAny.phpt
@@ -12,4 +12,5 @@ function unsafeWhereAny(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereAny.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereAny.phpt
@@ -12,5 +12,4 @@ function unsafeWhereAny(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereArrayTaintedKey.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereArrayTaintedKey.phpt
@@ -20,4 +20,4 @@ function unsafeTaintedKeyMap(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereColumnCompareArraySink.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereColumnCompareArraySink.phpt
@@ -38,5 +38,5 @@ function unsafeWhereColumnKeyedMap(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
-%ATaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereColumnCompareSink.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereColumnCompareSink.phpt
@@ -73,9 +73,9 @@ function unsafeWhereColumnOperator(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
-%ATaintedSql on line %d: Detected tainted SQL
-%ATaintedSql on line %d: Detected tainted SQL
-%ATaintedSql on line %d: Detected tainted SQL
-%ATaintedSql on line %d: Detected tainted SQL
-%ATaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereColumnSink.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereColumnSink.phpt
@@ -11,4 +11,8 @@ function unsafeColumnWhere(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+MissingReturnType on line %d: Method unsafeColumnWhere does not have a return type, expecting void
+TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
+MixedAssignment on line %d: Unable to determine the type that $column is being assigned to
+MixedArgument on line %d: Argument 1 of Illuminate\Database\Query\Builder::where cannot be mixed, expecting array<array-key, mixed>|impure-Closure|string
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereColumnSink.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereColumnSink.phpt
@@ -11,8 +11,4 @@ function unsafeColumnWhere(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method unsafeColumnWhere does not have a return type, expecting void
-TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
-MixedAssignment on line %d: Unable to determine the type that $column is being assigned to
-MixedArgument on line %d: Argument 1 of Illuminate\Database\Query\Builder::where cannot be mixed, expecting array<array-key, mixed>|impure-Closure|string
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereLikeColumn.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereLikeColumn.phpt
@@ -28,5 +28,5 @@ function unsafeOrWhereNotLikeColumn(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
-%ATaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereListOfArrayVariable.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereListOfArrayVariable.phpt
@@ -22,4 +22,4 @@ function unsafeListOfArrayVariable(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereNestedConditionBoolean.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereNestedConditionBoolean.phpt
@@ -23,4 +23,4 @@ function unsafeNestedConditionBoolean(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereNestedConditionColumn.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereNestedConditionColumn.phpt
@@ -21,4 +21,4 @@ function unsafeNestedConditionColumn(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereNestedConditionKeyedElement.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereNestedConditionKeyedElement.phpt
@@ -42,5 +42,5 @@ function unsafeNestedConditionDuplicateStringKey(\Illuminate\Http\Request $reque
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
-%ATaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereNonBuilderReceiver.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereNonBuilderReceiver.phpt
@@ -24,4 +24,4 @@ function unsafeNonBuilderWhereReceiver(\Illuminate\Http\Request $request): void 
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereNone.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereNone.phpt
@@ -12,4 +12,5 @@ function unsafeWhereNone(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereNone.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereNone.phpt
@@ -12,5 +12,4 @@ function unsafeWhereNone(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereNullableNonBuilderReceiver.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereNullableNonBuilderReceiver.phpt
@@ -24,4 +24,4 @@ function unsafeNullableNonBuilderWhereReceiver(\Illuminate\Http\Request $request
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereOuterMixedValue.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereOuterMixedValue.phpt
@@ -19,4 +19,4 @@ function unsafeOuterMixedValueCouldBeArray(\Illuminate\Http\Request $request): v
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereRaw.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereRaw.phpt
@@ -10,4 +10,8 @@ function filterPosts(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+MissingReturnType on line %d: Method filterPosts does not have a return type, expecting void
+TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
+MixedAssignment on line %d: Unable to determine the type that $filter is being assigned to
+MixedArgument on line %d: Argument 1 of Illuminate\Database\Query\Builder::whereRaw cannot be mixed, expecting Illuminate\Contracts\Database\Query\Expression|string
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereRaw.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereRaw.phpt
@@ -10,8 +10,4 @@ function filterPosts(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method filterPosts does not have a return type, expecting void
-TooFewArguments on line %d: Too few arguments for Illuminate\Database\Query\Builder::__construct - expecting connection to be passed
-MixedAssignment on line %d: Unable to determine the type that $filter is being assigned to
-MixedArgument on line %d: Argument 1 of Illuminate\Database\Query\Builder::whereRaw cannot be mixed, expecting Illuminate\Contracts\Database\Query\Expression|string
 TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereSpreadElement.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereSpreadElement.phpt
@@ -21,4 +21,4 @@ function unsafeSpreadElementOrWhereNot(\Illuminate\Http\Request $request): void 
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereTemplateNonBuilderReceiver.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereTemplateNonBuilderReceiver.phpt
@@ -30,4 +30,4 @@ function unsafeTemplateNonBuilderWhereReceiver(\Illuminate\Http\Request $request
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereUnpackedArray.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereUnpackedArray.phpt
@@ -19,4 +19,4 @@ function unsafeUnpackedArrayWhere(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereWholeArgNonBuilderReceiver.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereWholeArgNonBuilderReceiver.phpt
@@ -31,4 +31,4 @@ function unsafeNonBuilderWholeArgWhere(\Illuminate\Http\Request $request): void 
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlWhereWholeArrayInput.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlWhereWholeArrayInput.phpt
@@ -22,4 +22,4 @@ function unsafeWholeArrayWhere(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSql on line %d: Detected tainted SQL
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/TaintAnalysis/TaintedSsrfHttpClient.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSsrfHttpClient.phpt
@@ -10,7 +10,4 @@ function fetchEmbed(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-MissingReturnType on line %d: Method fetchEmbed does not have a return type, expecting void
-MixedAssignment on line %d: Unable to determine the type that $embedUrl is being assigned to
-MixedArgument on line %d: Argument 1 of Illuminate\Http\Client\PendingRequest::get cannot be mixed, expecting string
 TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/TaintedSsrfHttpClient.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSsrfHttpClient.phpt
@@ -10,4 +10,7 @@ function fetchEmbed(\Illuminate\Http\Request $request) {
 }
 ?>
 --EXPECTF--
-%ATaintedSSRF on line %d: Detected tainted network request
+MissingReturnType on line %d: Method fetchEmbed does not have a return type, expecting void
+MixedAssignment on line %d: Unable to determine the type that $embedUrl is being assigned to
+MixedArgument on line %d: Argument 1 of Illuminate\Http\Client\PendingRequest::get cannot be mixed, expecting string
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/TaintedSsrfHttpClientBaseUrl.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSsrfHttpClientBaseUrl.phpt
@@ -14,4 +14,4 @@ function configureWebhook(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSSRF on line %d: Detected tainted network request
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/TaintedSsrfHttpClientSend.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSsrfHttpClientSend.phpt
@@ -14,4 +14,4 @@ function dispatchCallback(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSSRF on line %d: Detected tainted network request
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/TaintedSsrfHttpClientUrlParameters.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSsrfHttpClientUrlParameters.phpt
@@ -14,4 +14,4 @@ function routeToService(\Illuminate\Http\Request $request): void {
 }
 ?>
 --EXPECTF--
-%ATaintedSSRF on line %d: Detected tainted network request
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/TaintedSsrfHttpFacadeStatic.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSsrfHttpFacadeStatic.phpt
@@ -19,4 +19,4 @@ function facadeStaticGetIsTainted(Request $request): void
 }
 ?>
 --EXPECTF--
-%ATaintedSSRF on line %d: Detected tainted network request
+TaintedSSRF on line %d: Detected tainted network request

--- a/tests/Type/tests/TaintAnalysis/TaintedSystemSecretMd5ApiKey.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSystemSecretMd5ApiKey.phpt
@@ -18,4 +18,4 @@ function legacyMd5ApiKey(): string {
 }
 ?>
 --EXPECTF--
-%ATaintedSystemSecret on line %d: Detected tainted system secret leaking%A
+TaintedSystemSecret on line %d: Detected tainted system secret leaking

--- a/tests/Type/tests/TaintAnalysis/TaintedSystemSecretSha1ApiKey.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSystemSecretSha1ApiKey.phpt
@@ -19,4 +19,4 @@ function legacySha1ApiKey(): string {
 }
 ?>
 --EXPECTF--
-%ATaintedSystemSecret on line %d: Detected tainted system secret leaking%A
+TaintedSystemSecret on line %d: Detected tainted system secret leaking

--- a/tests/Type/tests/TaintAnalysis/TaintedUserSecretAuthPassword.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedUserSecretAuthPassword.phpt
@@ -10,4 +10,4 @@ function leakPasswordHash(\Illuminate\Foundation\Auth\User $user): void {
 }
 ?>
 --EXPECTF--
-%ATaintedUserSecret on line %d: Detected tainted user secret%A
+TaintedUserSecret on line %d: Detected tainted user secret leaking

--- a/tests/Type/tests/TaintAnalysis/TaintedUserSecretMd5BinaryMode.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedUserSecretMd5BinaryMode.phpt
@@ -14,4 +14,4 @@ function legacyMd5PasswordBinary(\Illuminate\Foundation\Auth\User $user): string
 }
 ?>
 --EXPECTF--
-%ATaintedUserSecret on line %d: Detected tainted user secret leaking%A
+TaintedUserSecret on line %d: Detected tainted user secret leaking

--- a/tests/Type/tests/TaintAnalysis/TaintedUserSecretMd5IndirectFlow.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedUserSecretMd5IndirectFlow.phpt
@@ -31,4 +31,4 @@ function hashViaHelper(\Illuminate\Foundation\Auth\User $user): string {
 }
 ?>
 --EXPECTF--
-%ATaintedUserSecret on line %d: Detected tainted user secret leaking%A
+TaintedUserSecret on line %d: Detected tainted user secret leaking

--- a/tests/Type/tests/TaintAnalysis/TaintedUserSecretMd5Password.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedUserSecretMd5Password.phpt
@@ -13,4 +13,4 @@ function legacyMd5Password(\Illuminate\Foundation\Auth\User $user): string {
 }
 ?>
 --EXPECTF--
-%ATaintedUserSecret on line %d: Detected tainted user secret leaking%A
+TaintedUserSecret on line %d: Detected tainted user secret leaking

--- a/tests/Type/tests/TaintAnalysis/TaintedUserSecretRememberToken.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedUserSecretRememberToken.phpt
@@ -10,4 +10,4 @@ function leakRememberToken(\Illuminate\Foundation\Auth\User $user): void {
 }
 ?>
 --EXPECTF--
-%ATaintedUserSecret on line %d: Detected tainted user secret%A
+TaintedUserSecret on line %d: Detected tainted user secret leaking

--- a/tests/Type/tests/TaintAnalysis/TaintedUserSecretSha1Password.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedUserSecretSha1Password.phpt
@@ -13,4 +13,4 @@ function legacySha1Password(\Illuminate\Foundation\Auth\User $user): string {
 }
 ?>
 --EXPECTF--
-%ATaintedUserSecret on line %d: Detected tainted user secret leaking%A
+TaintedUserSecret on line %d: Detected tainted user secret leaking

--- a/tests/Type/tests/TaintAnalysis/TimingUnsafeSystemSecretIdentical.phpt
+++ b/tests/Type/tests/TaintAnalysis/TimingUnsafeSystemSecretIdentical.phpt
@@ -14,4 +14,7 @@ function compareDecryptedSecretWithIdentical(\Illuminate\Encryption\Encrypter $e
 }
 ?>
 --EXPECTF--
-%ATaintedSystemSecret%A
+TaintedSystemSecret on line %d: Detected tainted system secret leaking
+TaintedSystemSecret on line %d: Detected tainted system secret leaking
+TaintedUserSecret on line %d: Detected tainted user secret leaking
+TaintedUserSecret on line %d: Detected tainted user secret leaking

--- a/tests/Type/tests/TaintAnalysis/TimingUnsafeSystemSecretStrcasecmp.phpt
+++ b/tests/Type/tests/TaintAnalysis/TimingUnsafeSystemSecretStrcasecmp.phpt
@@ -14,4 +14,7 @@ function compareDecryptedSecretWithStrcasecmp(\Illuminate\Encryption\Encrypter $
 }
 ?>
 --EXPECTF--
-%ATaintedSystemSecret%A
+TaintedSystemSecret on line %d: Detected tainted system secret leaking
+TaintedSystemSecret on line %d: Detected tainted system secret leaking
+TaintedUserSecret on line %d: Detected tainted user secret leaking
+TaintedUserSecret on line %d: Detected tainted user secret leaking

--- a/tests/Type/tests/TaintAnalysis/TimingUnsafeUserSecretIdentical.phpt
+++ b/tests/Type/tests/TaintAnalysis/TimingUnsafeUserSecretIdentical.phpt
@@ -14,4 +14,4 @@ function compareSecretWithIdentical(\Illuminate\Foundation\Auth\User $user, stri
 }
 ?>
 --EXPECTF--
-%ATaintedUserSecret%A
+TaintedUserSecret on line %d: Detected tainted user secret leaking

--- a/tests/Type/tests/TaintAnalysis/TimingUnsafeUserSecretSpaceship.phpt
+++ b/tests/Type/tests/TaintAnalysis/TimingUnsafeUserSecretSpaceship.phpt
@@ -14,4 +14,4 @@ function compareWithSpaceship(\Illuminate\Foundation\Auth\User $user, string $gi
 }
 ?>
 --EXPECTF--
-%ATaintedUserSecret%A
+TaintedUserSecret on line %d: Detected tainted user secret leaking

--- a/tests/Type/tests/TaintAnalysis/TimingUnsafeUserSecretStrcmp.phpt
+++ b/tests/Type/tests/TaintAnalysis/TimingUnsafeUserSecretStrcmp.phpt
@@ -14,4 +14,4 @@ function compareRememberTokenWithStrcmp(\Illuminate\Foundation\Auth\User $user, 
 }
 ?>
 --EXPECTF--
-%ATaintedUserSecret%A
+TaintedUserSecret on line %d: Detected tainted user secret leaking

--- a/tests/Type/tests/TaintAnalysis/TimingUnsafeUserSecretStrncasecmp.phpt
+++ b/tests/Type/tests/TaintAnalysis/TimingUnsafeUserSecretStrncasecmp.phpt
@@ -14,4 +14,4 @@ function comparePrefixCaseInsensitively(\Illuminate\Foundation\Auth\User $user, 
 }
 ?>
 --EXPECTF--
-%ATaintedUserSecret%A
+TaintedUserSecret on line %d: Detected tainted user secret leaking

--- a/tests/Type/tests/TaintAnalysis/TimingUnsafeUserSecretStrncmp.phpt
+++ b/tests/Type/tests/TaintAnalysis/TimingUnsafeUserSecretStrncmp.phpt
@@ -14,4 +14,4 @@ function comparePrefixWithStrncmp(\Illuminate\Foundation\Auth\User $user, string
 }
 ?>
 --EXPECTF--
-%ATaintedUserSecret%A
+TaintedUserSecret on line %d: Detected tainted user secret leaking

--- a/tests/Type/tests/TaintAnalysis/TimingUnsafeUserSecretSubstrCompare.phpt
+++ b/tests/Type/tests/TaintAnalysis/TimingUnsafeUserSecretSubstrCompare.phpt
@@ -14,4 +14,4 @@ function compareWithSubstrCompare(\Illuminate\Foundation\Auth\User $user, string
 }
 ?>
 --EXPECTF--
-%ATaintedUserSecret%A
+TaintedUserSecret on line %d: Detected tainted user secret leaking


### PR DESCRIPTION
## Issue to Solve

Backport of #1361 and #1362 to the Psalm 6 line. The defect predates both majors.

A leading `%A` on an `--EXPECTF--` issue line compiles to a lazy `.*` inside PHPUnit's anchored `/^…$/s`, so it absorbs **interleaved** output and the assertion degrades from an exact set to a lower bound. #1353 proved this live: three tests meant to pin the view-name sink fix passed against the pre-fix double-report output.

## Related

Backport of #1361 and #1362. Refs #1359. Follows #1360.

## Solution Description

1. **Merge `origin/master`** (`503a4c94`), bringing the sweep, CI rule 3 in `bin/ci/check-phpt-conventions.sh`, the allowlist file, and the `tests/Type/README.md` update.
2. **`test(type)`: regenerate exact-enumeration phpt expectations for Psalm 6** — 107 files. Master's enumerations were captured against Psalm 7; regenerating against Psalm 6.16.1 is deletion-only, because Psalm 6 does not raise the `MixedArgument` / `MixedAssignment` / `TooFewArguments` / `UnnecessaryVarAnnotation` / `MissingReturnType` companions Psalm 7 raises on these fixtures, and has no `file_get_contents` SSRF sink.

3. **Second merge of `origin/master`** (`83a89264`), bringing the rule-3 recall fix from #1362: the original pattern flagged only 218 of the 221 pre-sweep files, missing the `%A<Ident>%a:` shape.

Expectations were regenerated from real captured Psalm 6 output rather than hand-patched, so no expectation was fitted to make a test pass. No wildcard was reinstated to force green: that is precisely the defect being removed here.

### Conflict resolutions

- `TaintedFileFilesystem.phpt`, `TaintedFileUploadedFileClientNameViaRequestFile.phpt` — 3.x's old leading-`%A` form against master's exact enumeration. Took master's structure, then let regeneration supply the real Psalm 6 output.
- `TaintedSqlStaticWhereTraitReanalysisStaleKnownLimitation.phpt` — rename conflict against master's `…Stale.phpt`. Kept 3.x's file: it is a pre-existing, already-documented Psalm 6 trait-reanalysis known limitation (0 findings), unrelated to #1359. Master's version (2 findings) reflects Psalm 7-only behaviour.

The allowlist stays empty; no 3.x-specific shape needed an entry. Zero leading `%A` and zero bare-name `%A…%A` remain.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
- [x] Documentation is updated (inherited from #1361)
