### PR TITLE
Restore facade stub method precedence

### DIFF
--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -36,6 +36,7 @@ flowchart TD
     I["Psalm scans all project files"] -.->|afterCodebasePopulated| J["ModelRegistrationHandler"]
     I -.->|afterCodebasePopulated| K["Eloquent Builder subclass fix-ups:\nBuilderSubclassQueryMixinHandler (restores dropped Query Builder @mixin)\nBuilderNativeStaticReturnTypeHandler (native ': static' return becomes docblock 'static')"]
     I -.->|afterCodebasePopulated| FMB["FactoryModelBindingHandler (injects @extends Factory&lt;TModel&gt; on bare factory subclasses, #780)"]
+    I -.->|afterCodebasePopulated| FSP["FacadeStubPrecedenceHandler (drops conflicting facade @method pseudos when the plugin ships a real stubbed static method)"]
     I -.->|afterCodebasePopulated| FTF["FacadeTaintForwardingHandler (copies taint sinks from a facade's forwarding target onto its @method pseudo-methods)"]
     J --- models["
         Discover Model subclasses

--- a/src/Handlers/Facades/FacadeStubPrecedenceHandler.php
+++ b/src/Handlers/Facades/FacadeStubPrecedenceHandler.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Facades;
+
+use Psalm\Codebase;
+use Psalm\Plugin\EventHandler\AfterCodebasePopulatedInterface;
+use Psalm\Plugin\EventHandler\Event\AfterCodebasePopulatedEvent;
+use Psalm\Storage\ClassLikeStorage;
+use Psalm\Storage\MethodStorage;
+
+/**
+ * Lets plugin-owned real methods on first-party facade stubs outrank Laravel's generated
+ * `@method` catalogue by removing only the conflicting pseudo-static entries after Psalm's
+ * populator has finished copying them into the facade hierarchy.
+ *
+ * Scoped to `stubs/common/Support/Facades/*`: userland app facades keep their declared
+ * `@method` intent, and the fix rides Psalm's native real-method/template inference instead
+ * of adding a parallel provider path just for first-party facades.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1368
+ */
+final class FacadeStubPrecedenceHandler implements AfterCodebasePopulatedInterface
+{
+    private const FACADE_NAMESPACE = 'Illuminate\\Support\\Facades\\';
+
+    private const FACADE_BASE_LOWER = 'illuminate\\support\\facades\\facade';
+
+    private const STUB_PATH_FRAGMENT = '/stubs/common/Support/Facades/';
+
+    #[\Override]
+    public static function afterCodebasePopulated(AfterCodebasePopulatedEvent $event): void
+    {
+        $codebase = $event->getCodebase();
+        $methodsToRemove = self::collectStubbedFacadeMethods($codebase);
+
+        if ($methodsToRemove === []) {
+            return;
+        }
+
+        foreach ($codebase->classlike_storage_provider::getAll() as $storage) {
+            foreach ($methodsToRemove as $facadeLower => $methodNames) {
+                if (\strtolower($storage->name) !== $facadeLower && !isset($storage->parent_classes[$facadeLower])) {
+                    continue;
+                }
+
+                foreach (\array_keys($methodNames) as $methodName) {
+                    unset($storage->pseudo_static_methods[$methodName]);
+                }
+            }
+        }
+    }
+
+    /**
+     * @return array<lowercase-string, array<lowercase-string, true>>
+     * @psalm-external-mutation-free
+     */
+    private static function collectStubbedFacadeMethods(Codebase $codebase): array
+    {
+        $methodsToRemove = [];
+
+        foreach ($codebase->classlike_storage_provider::getAll() as $storage) {
+            if (!self::isFirstPartyFacade($storage)) {
+                continue;
+            }
+
+            foreach ($storage->methods as $methodName => $methodStorage) {
+                if (!isset($storage->pseudo_static_methods[$methodName])) {
+                    continue;
+                }
+
+                if (!self::comesFromFacadeStub($methodStorage)) {
+                    continue;
+                }
+
+                $methodsToRemove[\strtolower($storage->name)][$methodName] = true;
+            }
+        }
+
+        return $methodsToRemove;
+    }
+
+    /** @psalm-mutation-free */
+    private static function isFirstPartyFacade(ClassLikeStorage $storage): bool
+    {
+        return \str_starts_with($storage->name, self::FACADE_NAMESPACE)
+            && isset($storage->parent_classes[self::FACADE_BASE_LOWER]);
+    }
+
+    /** @psalm-mutation-free */
+    private static function comesFromFacadeStub(MethodStorage $methodStorage): bool
+    {
+        if (!$methodStorage->stubbed) {
+            return false;
+        }
+
+        $filePath = $methodStorage->location?->file_path ?? $methodStorage->stmt_location?->file_path;
+
+        if ($filePath === null) {
+            return false;
+        }
+
+        return \str_contains(\str_replace('\\', '/', $filePath), self::STUB_PATH_FRAGMENT);
+    }
+}

--- a/src/Handlers/Facades/FacadeStubPrecedenceHandler.php
+++ b/src/Handlers/Facades/FacadeStubPrecedenceHandler.php
@@ -15,9 +15,16 @@ use Psalm\Storage\MethodStorage;
  * `@method` catalogue by removing only the conflicting pseudo-static entries after Psalm's
  * populator has finished copying them into the facade hierarchy.
  *
- * Scoped to `stubs/common/Support/Facades/*`: userland app facades keep their declared
- * `@method` intent, and the fix rides Psalm's native real-method/template inference instead
- * of adding a parallel provider path just for first-party facades.
+ * Scoped to plugin-owned `stubs/<layer>/Support/Facades/` methods. Application facades outside those
+ * first-party facade hierarchies keep their declared `@method` intent. Descendants of a
+ * normalised first-party facade are normalised with their parent because Psalm has already
+ * copied the parent's pseudo-method storage into them; same-name child pseudo-method intent
+ * is not recoverable at this lifecycle point.
+ *
+ * The fix rides Psalm's native real-method/template inference instead of adding a parallel
+ * provider path just for first-party facades. A real facade stub that needs taint metadata
+ * must carry that metadata itself: once its pseudo-method is removed,
+ * {@see FacadeTaintForwardingHandler} deliberately has no pseudo target to decorate.
  *
  * @see https://github.com/psalm/psalm-plugin-laravel/issues/1368
  */
@@ -27,7 +34,7 @@ final class FacadeStubPrecedenceHandler implements AfterCodebasePopulatedInterfa
 
     private const FACADE_BASE_LOWER = 'illuminate\\support\\facades\\facade';
 
-    private const STUB_PATH_FRAGMENT = '/stubs/common/Support/Facades/';
+    private const STUB_PATH_PATTERN = '~/stubs/[^/]+/Support/Facades/~';
 
     #[\Override]
     public static function afterCodebasePopulated(AfterCodebasePopulatedEvent $event): void
@@ -101,6 +108,6 @@ final class FacadeStubPrecedenceHandler implements AfterCodebasePopulatedInterfa
             return false;
         }
 
-        return \str_contains(\str_replace('\\', '/', $filePath), self::STUB_PATH_FRAGMENT);
+        return \preg_match(self::STUB_PATH_PATTERN, \str_replace('\\', '/', $filePath)) === 1;
     }
 }

--- a/src/Handlers/Facades/FacadeStubPrecedenceHandler.php
+++ b/src/Handlers/Facades/FacadeStubPrecedenceHandler.php
@@ -27,6 +27,7 @@ use Psalm\Storage\MethodStorage;
  * {@see FacadeTaintForwardingHandler} deliberately has no pseudo target to decorate.
  *
  * @see https://github.com/psalm/psalm-plugin-laravel/issues/1368
+ * @see https://github.com/vimeo/psalm/issues/3937
  */
 final class FacadeStubPrecedenceHandler implements AfterCodebasePopulatedInterface
 {

--- a/src/Handlers/Facades/FacadeTaintForwardingHandler.php
+++ b/src/Handlers/Facades/FacadeTaintForwardingHandler.php
@@ -28,8 +28,8 @@ use Psalm\Storage\MethodStorage;
  * the facade forwards to, which that code path never consults.
  *
  * So: after population, copy each target method's parameter sinks onto the facade's
- * same-named pseudo parameter. This adds detection only — it never removes a sink,
- * and it leaves types, return types and resolution untouched.
+ * same-named surviving pseudo parameter. This adds detection only — it never removes a
+ * sink, and it leaves types, return types and resolution untouched.
  *
  * Why a hardcoded map
  * -------------------
@@ -42,15 +42,19 @@ use Psalm\Storage\MethodStorage;
  *
  * To extend: add `Facade::class => [TargetClass::class]` to {@see self::FACADE_TARGETS},
  * confirm the facade's `@method` tags mirror the target's real signatures, and add a
- * `.phpt` under `tests/Type/tests/TaintAnalysis/`.
+ * `.phpt` under `tests/Type/tests/TaintAnalysis/`. If the facade also has a plugin-owned
+ * real method under `stubs/<layer>/Support/Facades/`, put the sink on that method directly:
+ * {@see FacadeStubPrecedenceHandler} removes its shadowing pseudo-method before this
+ * handler runs, so there is intentionally no pseudo target to decorate.
  *
  * Ordering and lifecycle
  * ----------------------
- * Order among `AfterCodebasePopulated` handlers is irrelevant here: the only inputs are
- * pseudo-method and declaring-method storage, both finalised by the populator before the
- * event fires, and no other handler writes `$sinks`. The handler holds no static state,
- * so it needs no `reset()` in {@see \Psalm\LaravelPlugin\Plugin}: the map is a constant
- * and `|=` is idempotent, so a repeated invocation over the same Codebase is a no-op.
+ * Registration order matters for the available pseudo-method set:
+ * {@see FacadeStubPrecedenceHandler} runs first and removes entries shadowed by real facade
+ * stubs; this handler forwards sinks only onto the entries that remain. No other handler
+ * writes `$sinks`. This handler holds no static state, so it needs no `reset()` in
+ * {@see \Psalm\LaravelPlugin\Plugin}: the map is a constant and `|=` is idempotent, so a
+ * repeated invocation over the same Codebase is a no-op.
  */
 final class FacadeTaintForwardingHandler implements AfterCodebasePopulatedInterface
 {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -451,7 +451,9 @@ final class Plugin implements PluginEntryPointInterface
         // never sees. See https://github.com/psalm/psalm-plugin-laravel/issues/787.
         require_once __DIR__ . '/Handlers/Facades/FacadeMethodHandler.php';
         require_once __DIR__ . '/Handlers/Facades/AppFacadeRegistrationHandler.php';
+        require_once __DIR__ . '/Handlers/Facades/FacadeStubPrecedenceHandler.php';
         $registration->registerHooksFromClass(Handlers\Facades\AppFacadeRegistrationHandler::class);
+        $registration->registerHooksFromClass(Handlers\Facades\FacadeStubPrecedenceHandler::class);
 
         // `App::make()`/`makeWith()`/`get()` class-string narrowing. Its getClassLikeNames() reads
         // FacadeMapProvider (for the `\App` alias), so it relies on init() having run above.

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -466,9 +466,10 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Facades/DateFacadeHandler.php';
         $registration->registerHooksFromClass(Handlers\Facades\DateFacadeHandler::class);
 
-        // Copies taint sinks from each mapped facade's forwarding target onto the facade's
+        // Copies taint sinks from each mapped facade's forwarding target onto the surviving
         // `@method` pseudo-methods, so `Storage::get($userInput)` is a sink like the
-        // `Storage::disk()->get($userInput)` chain already is. Order-independent.
+        // `Storage::disk()->get($userInput)` chain already is. FacadeStubPrecedenceHandler
+        // intentionally runs first; real facade stubs carry their own sink metadata.
         require_once __DIR__ . '/Handlers/Facades/FacadeTaintForwardingHandler.php';
         $registration->registerHooksFromClass(Handlers\Facades\FacadeTaintForwardingHandler::class);
 

--- a/stubs/common/Support/Facades/Route.phpstub
+++ b/stubs/common/Support/Facades/Route.phpstub
@@ -9,12 +9,9 @@ namespace Illuminate\Support\Facades;
  * argument list as variadic strings — `Route::middleware('a', 'b', 'c')` is a valid
  * Laravel idiom (e.g. invoiceninja `routes/contact.php`).
  *
- * Following the Schema facade pattern, we override the narrower vendor `@method static`
- * with a variadic pseudo-method and pair it with a concrete static method. The pseudo
- * entry is what Psalm consults during `__callStatic` resolution; the concrete method
- * keeps the stub self-consistent if Psalm ever switches to native lookup.
- *
- * @method static \Illuminate\Routing\RouteRegistrar middleware(string|array<array-key, string|null>|null ...$middleware)
+ * The concrete facade method below widens the value type and marks the call as variadic.
+ * FacadeStubPrecedenceHandler removes Laravel's shadowing pseudo-method after population,
+ * so Psalm resolves this native stub signature instead of the narrower vendor annotation.
  */
 class Route extends Facade
 {

--- a/stubs/common/Support/Facades/Schema.phpstub
+++ b/stubs/common/Support/Facades/Schema.phpstub
@@ -3,21 +3,14 @@
 namespace Illuminate\Support\Facades;
 
 /**
- * Facade overrides combine two mechanisms:
+ * Laravel declares a narrower `@method static bool hasTable(string $table)` on the
+ * facade. The concrete method below both widens that parameter and carries the taint sink.
  *
- * 1. `@method static` tag (widens parameter types). Psalm resolves facade calls via
- *    `__callStatic` against the facade's pseudo-method table, populated from class-level
- *    `@method static` tags. Only a pseudo-method entry can overwrite Laravel's narrower
- *    `@method static bool hasTable(string $table)` declared in vendor source.
- * 2. Explicit static method (carries `@psalm-taint-sink`). `@method static` tags do not
- *    carry taint annotations; an explicit concrete stub method does.
- *
- * We need both: the `@method static` widens the type, the concrete method carries the sink.
+ * FacadeStubPrecedenceHandler removes the shadowing vendor pseudo-method after population,
+ * so native resolution consults this concrete stub for both type and taint metadata.
  *
  * Runtime: Builder::hasTable string-concatenates the table prefix with `$table`, which
  * coerces any stringable object via __toString.
- *
- * @method static bool hasTable(string|\Stringable $table)
  */
 class Schema extends Facade
 {

--- a/tests/Type/tests/Cache/CacheManagerNarrowingBoundariesTest.phpt
+++ b/tests/Type/tests/Cache/CacheManagerNarrowingBoundariesTest.phpt
@@ -32,13 +32,19 @@ function exact_string(string $value): string
     return $value;
 }
 
-function untargeted_facade_method_unchanged(): void
+function cache_facade_stub_methods_override_pseudo_returns(): void
 {
     $_remember = Cache::remember('k', 60, static fn (): int => exact_int(1));
     /** @psalm-check-type-exact $_remember = int */
 
     $_rememberForever = Cache::rememberForever('k', static fn (): string => exact_string('x'));
     /** @psalm-check-type-exact $_rememberForever = string */
+}
+
+function unstubbed_cache_facade_method_keeps_pseudo_return(): void
+{
+    $_get = Cache::get('k');
+    /** @psalm-check-type-exact $_get = mixed */
 }
 ?>
 --EXPECTF--

--- a/tests/Type/tests/Cache/CacheManagerNarrowingBoundariesTest.phpt
+++ b/tests/Type/tests/Cache/CacheManagerNarrowingBoundariesTest.phpt
@@ -22,10 +22,23 @@ function factory_store_stays_contract(Factory $factory): void
     /** @psalm-check-type-exact $_store = \Illuminate\Contracts\Cache\Repository */
 }
 
+function exact_int(int $value): int
+{
+    return $value;
+}
+
+function exact_string(string $value): string
+{
+    return $value;
+}
+
 function untargeted_facade_method_unchanged(): void
 {
-    $_remember = Cache::remember('k', 60, static fn (): int => 1);
-    /** @psalm-check-type-exact $_remember = mixed */
+    $_remember = Cache::remember('k', 60, static fn (): int => exact_int(1));
+    /** @psalm-check-type-exact $_remember = int */
+
+    $_rememberForever = Cache::rememberForever('k', static fn (): string => exact_string('x'));
+    /** @psalm-check-type-exact $_rememberForever = string */
 }
 ?>
 --EXPECTF--

--- a/tests/Type/tests/Database/FacadeStubPrecedenceTest.phpt
+++ b/tests/Type/tests/Database/FacadeStubPrecedenceTest.phpt
@@ -1,0 +1,32 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+
+function exact_string(string $value): string
+{
+    return $value;
+}
+
+function database_facade_stub_returns_outrank_generated_pseudo_returns(): void
+{
+    $_transaction = DB::transaction(static fn (): string => exact_string('done'));
+    /** @psalm-check-type-exact $_transaction = string */
+
+    $_one = DB::selectOne('select 1');
+    /** @psalm-check-type-exact $_one = null|stdClass */
+
+    $_scalar = DB::scalar('select 1');
+    /** @psalm-check-type-exact $_scalar = null|scalar */
+
+    $_rows = DB::select('select 1');
+    /** @psalm-check-type-exact $_rows = list<stdClass> */
+
+    $_writeRows = DB::selectFromWriteConnection('select 1');
+    /** @psalm-check-type-exact $_writeRows = list<stdClass> */
+
+    $_resultSets = DB::selectResultSets('select 1');
+    /** @psalm-check-type-exact $_resultSets = list<list<stdClass>> */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Facades/AppFacadeMethodResolutionTest.phpt
+++ b/tests/Type/tests/Facades/AppFacadeMethodResolutionTest.phpt
@@ -21,7 +21,9 @@ function test_runtime_probe_resolves_method_not_in_method_catalogue(): string
 }
 
 /**
- * `@method` takes precedence over the runtime probe. The facade declares
+ * `@method` takes precedence over the runtime probe. This is also the negative pin for
+ * FacadeStubPrecedenceHandler: an ordinary application facade outside a plugin-stubbed
+ * first-party facade hierarchy must keep its own pseudo-method declaration. The facade declares
  * `@method static bool isCritical()` but `DiagnosticService::isCritical()` returns
  * `string` at runtime — the facade's declaration wins because FacadeMethodHandler
  * explicitly short-circuits when `pseudo_static_methods` contains the method.

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaHasTable.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlSchemaHasTable.phpt
@@ -6,9 +6,9 @@
 use Illuminate\Support\Facades\Schema;
 
 /**
- * Facade path: Schema::hasTable() resolves via Facade::__callStatic. Verifies the
- * dual-mechanism stub in stubs/common/Support/Facades/Schema.phpstub (pseudo-method
- * for type widening + concrete method for the @psalm-taint-sink sql annotation).
+ * Facade path: Schema::hasTable() resolves via the concrete facade stub after
+ * FacadeStubPrecedenceHandler removes Laravel's shadowing pseudo-method. Verifies that
+ * the concrete method supplies both the widened type and @psalm-taint-sink annotation.
  *
  * Builder variant lives in TaintedSqlSchemaBuilderHasTable.phpt.
  */

--- a/tests/Unit/Handlers/Facades/FacadeStubPrecedenceHandlerTest.php
+++ b/tests/Unit/Handlers/Facades/FacadeStubPrecedenceHandlerTest.php
@@ -75,6 +75,7 @@ final class FacadeStubPrecedenceHandlerTest extends TestCase
         $location = (new \ReflectionClass(CodeLocation::class))->newInstanceWithoutConstructor();
         /** @psalm-suppress InaccessibleProperty Synthetic location for storage-provenance testing. */
         $location->file_path = $filePath;
+
         $method->location = $location;
 
         return $method;

--- a/tests/Unit/Handlers/Facades/FacadeStubPrecedenceHandlerTest.php
+++ b/tests/Unit/Handlers/Facades/FacadeStubPrecedenceHandlerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Facades;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Facade;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\Codebase;
+use Psalm\CodeLocation;
+use Psalm\Internal\Provider\ClassLikeStorageProvider;
+use Psalm\LaravelPlugin\Handlers\Facades\FacadeStubPrecedenceHandler;
+use Psalm\Plugin\EventHandler\Event\AfterCodebasePopulatedEvent;
+use Psalm\Storage\MethodStorage;
+
+#[CoversClass(FacadeStubPrecedenceHandler::class)]
+final class FacadeStubPrecedenceHandlerTest extends TestCase
+{
+    #[\Override]
+    protected function tearDown(): void
+    {
+        ClassLikeStorageProvider::deleteAll();
+    }
+
+    #[Test]
+    public function it_removes_only_plugin_stub_conflicts_from_first_party_facades_and_descendants(): void
+    {
+        $provider = new ClassLikeStorageProvider();
+
+        $cache = $provider->create(Cache::class);
+        $cache->parent_classes[\strtolower(Facade::class)] = Facade::class;
+        $cache->methods['remember'] = $this->stubbedMethod('/repo/stubs/common/Support/Facades/Cache.phpstub');
+        $cache->methods['versioned'] = $this->stubbedMethod('/repo/stubs/13.0/Support/Facades/Cache.phpstub');
+        $cache->methods['projectoverride'] = $this->stubbedMethod('/project/stubs/Cache.phpstub');
+        $cache->pseudo_static_methods = [
+            'remember' => new MethodStorage(),
+            'versioned' => new MethodStorage(),
+            'projectoverride' => new MethodStorage(),
+            'get' => new MethodStorage(),
+        ];
+
+        $child = $provider->create('App\\CacheChildFacade');
+        $child->parent_classes[\strtolower(Cache::class)] = Cache::class;
+        $child->pseudo_static_methods = $cache->pseudo_static_methods;
+
+        $applicationFacade = $provider->create('App\\DiagnosticFacade');
+        $applicationFacade->parent_classes[\strtolower(Facade::class)] = Facade::class;
+        $applicationFacade->pseudo_static_methods['remember'] = new MethodStorage();
+
+        FacadeStubPrecedenceHandler::afterCodebasePopulated($this->eventFor($provider));
+
+        $this->assertArrayNotHasKey('remember', $cache->pseudo_static_methods);
+        $this->assertArrayNotHasKey('versioned', $cache->pseudo_static_methods);
+        $this->assertArrayNotHasKey('remember', $child->pseudo_static_methods);
+        $this->assertArrayNotHasKey('versioned', $child->pseudo_static_methods);
+
+        $this->assertArrayHasKey('get', $cache->pseudo_static_methods, 'Unstubbed facade methods keep native pseudo resolution.');
+        $this->assertArrayHasKey('get', $child->pseudo_static_methods);
+        $this->assertArrayHasKey(
+            'projectoverride',
+            $cache->pseudo_static_methods,
+            'Project-owned stubs are outside the plugin precedence policy.',
+        );
+        $this->assertArrayHasKey('remember', $applicationFacade->pseudo_static_methods);
+    }
+
+    private function stubbedMethod(string $filePath): MethodStorage
+    {
+        $method = new MethodStorage();
+        $method->stubbed = true;
+
+        $location = (new \ReflectionClass(CodeLocation::class))->newInstanceWithoutConstructor();
+        /** @psalm-suppress InaccessibleProperty Synthetic location for storage-provenance testing. */
+        $location->file_path = $filePath;
+        $method->location = $location;
+
+        return $method;
+    }
+
+    private function eventFor(ClassLikeStorageProvider $provider): AfterCodebasePopulatedEvent
+    {
+        $codebase = (new \ReflectionClass(Codebase::class))->newInstanceWithoutConstructor();
+        $codebase->classlike_storage_provider = $provider;
+
+        return new AfterCodebasePopulatedEvent($codebase);
+    }
+}


### PR DESCRIPTION
## Issue to Solve

Laravel-generated facade `@method` declarations currently outrank real methods supplied by plugin stubs. As a result, templated methods such as `Cache::remember()` and `Cache::rememberForever()` resolve to `mixed` instead of the callback return type.

Scope contract: `T2 — dispatch-gated facade stub precedence; budget 300 src lines; 1 reviewer; delta: yes`.

## Related

Fixes #1368.

## Solution Description

Add an after-codebase-population handler that removes only pseudo-static entries shadowing real methods owned by the plugin's version-aware facade stubs. The same normalization is applied to already-populated descendants. Ordinary application facades outside those first-party facade hierarchies retain their own `@method` declarations.

Psalm does not retain enough provenance after population to distinguish a descendant's same-name pseudo-method from the parent's copied entry. Descendants of a normalized first-party facade therefore follow their parent's normalized storage; this matches Psalm's pre-existing population behavior and is documented explicitly.

The handler runs before `FacadeTaintForwardingHandler`. Any real facade stub whose pseudo-method is removed must carry its taint metadata directly; the ordering contract is cross-referenced in both handlers.

The same policy applies to all 20 overlapping first-party facade-stub methods: Cache (2), DB (16), Route (1), and Schema (1). Route and Schema no longer add redundant plugin pseudo-methods; their concrete stubs retain the variadic middleware contract, widened `Stringable` input, and SQL taint sink.

Coverage now pins:

- exact generic inference for `Cache::remember()` and `Cache::rememberForever()`;
- the unchanged pseudo-method path for unstubbed `Cache::get()`;
- preservation of ordinary application-facade `@method` declarations;
- plugin-stub provenance, versioned stub paths, project-owned stubs, and descendant cleanup at the storage level;
- exact real-stub return types for affected DB facade methods, including `transaction()`, `selectOne()`, `scalar()`, `select()`, `selectFromWriteConnection()`, and `selectResultSets()`.
- unchanged Route variadic middleware resolution and Schema `Stringable` plus SQL-taint behavior through their concrete stubs.

Verification:

- `composer test:type` — 652 tests, 650 assertions, 2 skipped
- `composer test:unit` — 1097 tests, 2971 assertions, 1 skipped
- Psalm self-analysis with `--no-cache` — no errors
- php-cs-fixer dry-run — clean
- Rector dry-run — clean
- PHPT conventions — clean
- Focused facade precedence type/unit tests and touched-source Psalm analysis — clean
- Current-head GitHub matrix — Psalm, code style/Rector, spelling, PHPT conventions, Laravel app, and all type/unit jobs pass
- `psalm-delta` on `b992adf1` — 8/8 apps; 300 removed and 102 newly exposed diagnostics (net −198); weighted type coverage +0.24%; no significant time change

The added delta diagnostics were spot-checked as consequences of newly reachable exact types, not a facade-resolution regression. For example, Pixelfed declares `Collection` while returning an array from a cached callback result, and Coolify now exposes concrete `Cache::remember()` / `DB::transaction()` return contracts that were previously `mixed`.

Accepted imprecision: after Psalm has populated descendants, same-name child pseudo-method provenance is unavailable, so a descendant of a normalized first-party facade is normalized with its parent.

Reviewer notes: a T2 FIX-FIRST review scored 77/100 and identified lifecycle documentation plus missing negative/provenance coverage. Those findings are addressed by `064ea076`, with the Rector follow-up in `df275e54` and the Route/Schema cross-facade audit cleanup in `b992adf1`.

## Checklist

- [x] Tests cover the change (type test in `tests/Type/` and unit test in `tests/Unit/`)
- [x] Documentation is updated
