### PR TITLE
Version-gate the Laravel 13 `$fetchUsing` database signatures

### DIFF
--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -88,7 +88,7 @@ composer rector # run rector refactoring
 Stubs override Laravel's type signatures. Place them in:
 
 - `stubs/common/` — shared across Laravel versions (includes both type stubs and taint annotations)
-- `stubs/<version>/` — version-specific overrides, loaded when the installed Laravel is `>=` the dir name (`version_compare`). Both major-only (`stubs/13/`) and patch-level (`stubs/13.8.0/`) names work; currently `stubs/12.42.0/`, `stubs/13.5.0/`, and `stubs/13.8.0/` exist
+- `stubs/<version>/` — version-specific overrides, loaded when the installed Laravel is `>=` the dir name (`version_compare`). Both major-only (`stubs/13/`) and patch-level (`stubs/13.8.0/`) names work; currently `stubs/12.42.0/`, `stubs/13/`, `stubs/13.5.0/`, and `stubs/13.8.0/` exist
 - `stubs/integrations/<package>/` — optional stubs for third-party packages, gated on the package being installed (currently `carbon/`, with a `pre-3.12/` subdir loaded only for older Carbon; see `src/Stubs/CarbonStubProvider.php`)
 
 Rules:

--- a/stubs/13/Database/Connection.phpstub
+++ b/stubs/13/Database/Connection.phpstub
@@ -44,7 +44,6 @@ class Connection implements ConnectionInterface
      * @param  array  $bindings
      * @param  bool  $useReadPdo
      * @param  array  $fetchUsing
-     * @return \Generator<int, \stdClass>
      *
      * @psalm-taint-sink sql $query
      * @psalm-return ($fetchUsing is array{} ? \Generator<int, \stdClass> : \Generator<int, mixed>)
@@ -58,7 +57,6 @@ class Connection implements ConnectionInterface
      * @param  array  $bindings
      * @param  bool  $useReadPdo
      * @param  array  $fetchUsing
-     * @return list<list<\stdClass>>
      *
      * @psalm-taint-sink sql $query
      * @psalm-return ($fetchUsing is array{} ? list<list<\stdClass>> : list<list<mixed>>)

--- a/stubs/13/Database/Connection.phpstub
+++ b/stubs/13/Database/Connection.phpstub
@@ -1,0 +1,57 @@
+<?php
+
+namespace Illuminate\Database;
+
+/**
+ * Laravel 13.0 added a 4th $fetchUsing param to the select family (laravel/framework#55394).
+ * The common stub keeps the Laravel 12 (3-arg) shape; this override widens the arity for
+ * Laravel 13+ only, so a Laravel 12 project passing a 4th argument still gets an arity error.
+ *
+ * The full class header is copied verbatim because re-declaring the class resets Psalm's
+ * metadata (hard rule 2). Each method restates its own @psalm-taint-sink here even though
+ * the common 3-arg declaration also carries one: each file is the sole authoritative
+ * declaration for its own Laravel line (common for 12, this override for 13+), so both need
+ * the sink. Taint annotations accumulate across stub files (hard rule 4), but this does not
+ * double-report — verified via TaintedSqlDbCursor.phpt, which asserts exactly one TaintedSql.
+ */
+class Connection implements ConnectionInterface
+{
+    /**
+     * Run a select statement against the database.
+     *
+     * @param  string  $query
+     * @param  array  $bindings
+     * @param  bool  $useReadPdo
+     * @param  array  $fetchUsing
+     * @return array
+     *
+     * @psalm-taint-sink sql $query
+     */
+    public function select($query, $bindings = [], $useReadPdo = true, array $fetchUsing = []) {}
+
+    /**
+     * Run a select statement against the database and return a generator.
+     *
+     * @param  string  $query
+     * @param  array  $bindings
+     * @param  bool  $useReadPdo
+     * @param  array  $fetchUsing
+     * @return \Generator<int, \stdClass>
+     *
+     * @psalm-taint-sink sql $query
+     */
+    public function cursor($query, $bindings = [], $useReadPdo = true, array $fetchUsing = []) {}
+
+    /**
+     * Run a select statement against the database and return all result sets.
+     *
+     * @param  string  $query
+     * @param  array  $bindings
+     * @param  bool  $useReadPdo
+     * @param  array  $fetchUsing
+     * @return list<list<\stdClass>>
+     *
+     * @psalm-taint-sink sql $query
+     */
+    public function selectResultSets($query, $bindings = [], $useReadPdo = true, array $fetchUsing = []) {}
+}

--- a/stubs/13/Database/Connection.phpstub
+++ b/stubs/13/Database/Connection.phpstub
@@ -13,6 +13,14 @@ namespace Illuminate\Database;
  * declaration for its own Laravel line (common for 12, this override for 13+), so both need
  * the sink. Taint annotations accumulate across stub files (hard rule 4), but this does not
  * double-report — verified via TaintedSqlDbCursor.phpt, which asserts exactly one TaintedSql.
+ *
+ * stdClass is only true for PDO's DEFAULT fetch mode. $fetchUsing forwards straight to
+ * PDOStatement::fetch(...$fetchUsing) (cursor()) / fetchAll(...$fetchUsing) (selectResultSets()),
+ * so a non-default mode (e.g. PDO::FETCH_ASSOC) yields arrays, not stdClass objects. Each
+ * @psalm-return keys off whether $fetchUsing is the empty-array default; a non-empty literal
+ * degrades to mixed, and a non-literal array unions both branches (Psalm can't prove emptiness
+ * statically), matching what the runtime can actually produce. select() already returns the
+ * untyped `array`, so it makes no stdClass claim and needs no conditional.
  */
 class Connection implements ConnectionInterface
 {
@@ -39,6 +47,7 @@ class Connection implements ConnectionInterface
      * @return \Generator<int, \stdClass>
      *
      * @psalm-taint-sink sql $query
+     * @psalm-return ($fetchUsing is array{} ? \Generator<int, \stdClass> : \Generator<int, mixed>)
      */
     public function cursor($query, $bindings = [], $useReadPdo = true, array $fetchUsing = []) {}
 
@@ -52,6 +61,7 @@ class Connection implements ConnectionInterface
      * @return list<list<\stdClass>>
      *
      * @psalm-taint-sink sql $query
+     * @psalm-return ($fetchUsing is array{} ? list<list<\stdClass>> : list<list<mixed>>)
      */
     public function selectResultSets($query, $bindings = [], $useReadPdo = true, array $fetchUsing = []) {}
 }

--- a/stubs/13/Support/Facades/DB.phpstub
+++ b/stubs/13/Support/Facades/DB.phpstub
@@ -13,6 +13,13 @@ namespace Illuminate\Support\Facades;
  * declaration for its own Laravel line (common for 12, this override for 13+), so both need
  * the sink. Taint annotations accumulate across stub files (hard rule 4), but this does not
  * double-report — verified via TaintedSqlDbCursor.phpt, which asserts exactly one TaintedSql.
+ *
+ * stdClass is only true for PDO's DEFAULT fetch mode. $fetchUsing forwards straight to
+ * PDOStatement::fetch(...$fetchUsing) (Connection::cursor()) / fetchAll(...$fetchUsing)
+ * (select()/selectResultSets()), so a non-default mode (e.g. PDO::FETCH_ASSOC) yields arrays,
+ * not stdClass objects. Each @psalm-return keys off whether $fetchUsing is the empty-array
+ * default; a non-empty literal degrades to mixed, and a non-literal array unions both branches
+ * (Psalm can't prove emptiness statically), matching what the runtime can actually produce.
  */
 class DB extends Facade
 {
@@ -26,6 +33,7 @@ class DB extends Facade
      * @return list<\stdClass>
      *
      * @psalm-taint-sink sql $query
+     * @psalm-return ($fetchUsing is array{} ? list<\stdClass> : list<mixed>)
      */
     public static function select($query, $bindings = [], $useReadPdo = true, array $fetchUsing = []) {}
 
@@ -39,6 +47,7 @@ class DB extends Facade
      * @return \Generator<int, \stdClass>
      *
      * @psalm-taint-sink sql $query
+     * @psalm-return ($fetchUsing is array{} ? \Generator<int, \stdClass> : \Generator<int, mixed>)
      */
     public static function cursor($query, $bindings = [], $useReadPdo = true, array $fetchUsing = []) {}
 
@@ -52,6 +61,7 @@ class DB extends Facade
      * @return list<list<\stdClass>>
      *
      * @psalm-taint-sink sql $query
+     * @psalm-return ($fetchUsing is array{} ? list<list<\stdClass>> : list<list<mixed>>)
      */
     public static function selectResultSets($query, $bindings = [], $useReadPdo = true, array $fetchUsing = []) {}
 }

--- a/stubs/13/Support/Facades/DB.phpstub
+++ b/stubs/13/Support/Facades/DB.phpstub
@@ -30,7 +30,6 @@ class DB extends Facade
      * @param  array  $bindings
      * @param  bool  $useReadPdo
      * @param  array  $fetchUsing
-     * @return list<\stdClass>
      *
      * @psalm-taint-sink sql $query
      * @psalm-return ($fetchUsing is array{} ? list<\stdClass> : list<mixed>)
@@ -44,7 +43,6 @@ class DB extends Facade
      * @param  array  $bindings
      * @param  bool  $useReadPdo
      * @param  array  $fetchUsing
-     * @return \Generator<int, \stdClass>
      *
      * @psalm-taint-sink sql $query
      * @psalm-return ($fetchUsing is array{} ? \Generator<int, \stdClass> : \Generator<int, mixed>)
@@ -58,7 +56,6 @@ class DB extends Facade
      * @param  array  $bindings
      * @param  bool  $useReadPdo
      * @param  array  $fetchUsing
-     * @return list<list<\stdClass>>
      *
      * @psalm-taint-sink sql $query
      * @psalm-return ($fetchUsing is array{} ? list<list<\stdClass>> : list<list<mixed>>)

--- a/stubs/13/Support/Facades/DB.phpstub
+++ b/stubs/13/Support/Facades/DB.phpstub
@@ -1,0 +1,57 @@
+<?php
+
+namespace Illuminate\Support\Facades;
+
+/**
+ * Laravel 13.0 added a 4th $fetchUsing param to the select family (laravel/framework#55394).
+ * The common stub keeps the Laravel 12 (3-arg) shape; this override widens the arity for
+ * Laravel 13+ only, so a Laravel 12 project passing a 4th argument still gets an arity error.
+ *
+ * The full class header is copied verbatim because re-declaring the class resets Psalm's
+ * metadata (hard rule 2). Each method restates its own @psalm-taint-sink here even though
+ * the common 3-arg declaration also carries one: each file is the sole authoritative
+ * declaration for its own Laravel line (common for 12, this override for 13+), so both need
+ * the sink. Taint annotations accumulate across stub files (hard rule 4), but this does not
+ * double-report — verified via TaintedSqlDbCursor.phpt, which asserts exactly one TaintedSql.
+ */
+class DB extends Facade
+{
+    /**
+     * Run a select statement against the database.
+     *
+     * @param  string  $query
+     * @param  array  $bindings
+     * @param  bool  $useReadPdo
+     * @param  array  $fetchUsing
+     * @return list<\stdClass>
+     *
+     * @psalm-taint-sink sql $query
+     */
+    public static function select($query, $bindings = [], $useReadPdo = true, array $fetchUsing = []) {}
+
+    /**
+     * Run a select statement against the database and return a generator.
+     *
+     * @param  string  $query
+     * @param  array  $bindings
+     * @param  bool  $useReadPdo
+     * @param  array  $fetchUsing
+     * @return \Generator<int, \stdClass>
+     *
+     * @psalm-taint-sink sql $query
+     */
+    public static function cursor($query, $bindings = [], $useReadPdo = true, array $fetchUsing = []) {}
+
+    /**
+     * Run a select statement against the database and return all result sets.
+     *
+     * @param  string  $query
+     * @param  array  $bindings
+     * @param  bool  $useReadPdo
+     * @param  array  $fetchUsing
+     * @return list<list<\stdClass>>
+     *
+     * @psalm-taint-sink sql $query
+     */
+    public static function selectResultSets($query, $bindings = [], $useReadPdo = true, array $fetchUsing = []) {}
+}

--- a/stubs/common/Database/Connection.phpstub
+++ b/stubs/common/Database/Connection.phpstub
@@ -35,11 +35,12 @@ class Connection implements ConnectionInterface
      * @param  string  $query
      * @param  array  $bindings
      * @param  bool  $useReadPdo
+     * @param  array  $fetchUsing
      * @return \Generator<int, \stdClass>
      *
      * @psalm-taint-sink sql $query
      */
-    public function cursor($query, $bindings = [], $useReadPdo = true) {}
+    public function cursor($query, $bindings = [], $useReadPdo = true, array $fetchUsing = []) {}
 
     /**
      * Run an insert statement against the database.

--- a/stubs/common/Database/Connection.phpstub
+++ b/stubs/common/Database/Connection.phpstub
@@ -10,12 +10,11 @@ class Connection implements ConnectionInterface
      * @param  string  $query
      * @param  array  $bindings
      * @param  bool  $useReadPdo
-     * @param  array  $fetchUsing
      * @return array
      *
      * @psalm-taint-sink sql $query
      */
-    public function select($query, $bindings = [], $useReadPdo = true, array $fetchUsing = []) {}
+    public function select($query, $bindings = [], $useReadPdo = true) {}
 
     /**
      * Run a select statement and return a single result.
@@ -35,12 +34,11 @@ class Connection implements ConnectionInterface
      * @param  string  $query
      * @param  array  $bindings
      * @param  bool  $useReadPdo
-     * @param  array  $fetchUsing
      * @return \Generator<int, \stdClass>
      *
      * @psalm-taint-sink sql $query
      */
-    public function cursor($query, $bindings = [], $useReadPdo = true, array $fetchUsing = []) {}
+    public function cursor($query, $bindings = [], $useReadPdo = true) {}
 
     /**
      * Run an insert statement against the database.
@@ -146,12 +144,11 @@ class Connection implements ConnectionInterface
      * @param  string  $query
      * @param  array  $bindings
      * @param  bool  $useReadPdo
-     * @param  array  $fetchUsing
      * @return list<list<\stdClass>>
      *
      * @psalm-taint-sink sql $query
      */
-    public function selectResultSets($query, $bindings = [], $useReadPdo = true, array $fetchUsing = []) {}
+    public function selectResultSets($query, $bindings = [], $useReadPdo = true) {}
 
     /**
      * Begin a fluent query against a database table.

--- a/stubs/common/Support/Facades/DB.phpstub
+++ b/stubs/common/Support/Facades/DB.phpstub
@@ -33,12 +33,11 @@ class DB extends Facade
      * @param  string  $query
      * @param  array  $bindings
      * @param  bool  $useReadPdo
-     * @param  array  $fetchUsing
      * @return list<\stdClass>
      *
      * @psalm-taint-sink sql $query
      */
-    public static function select($query, $bindings = [], $useReadPdo = true, array $fetchUsing = []) {}
+    public static function select($query, $bindings = [], $useReadPdo = true) {}
 
     /**
      * Execute an SQL statement and return the boolean result.
@@ -90,12 +89,11 @@ class DB extends Facade
      * @param  string  $query
      * @param  array  $bindings
      * @param  bool  $useReadPdo
-     * @param  array  $fetchUsing
      * @return \Generator<int, \stdClass>
      *
      * @psalm-taint-sink sql $query
      */
-    public static function cursor($query, $bindings = [], $useReadPdo = true, array $fetchUsing = []) {}
+    public static function cursor($query, $bindings = [], $useReadPdo = true) {}
 
     /**
      * Run an insert statement against the database.
@@ -159,12 +157,11 @@ class DB extends Facade
      * @param  string  $query
      * @param  array  $bindings
      * @param  bool  $useReadPdo
-     * @param  array  $fetchUsing
      * @return list<list<\stdClass>>
      *
      * @psalm-taint-sink sql $query
      */
-    public static function selectResultSets($query, $bindings = [], $useReadPdo = true, array $fetchUsing = []) {}
+    public static function selectResultSets($query, $bindings = [], $useReadPdo = true) {}
 
     /**
      * Begin a fluent query against a database table.

--- a/stubs/common/Support/Facades/DB.phpstub
+++ b/stubs/common/Support/Facades/DB.phpstub
@@ -90,11 +90,12 @@ class DB extends Facade
      * @param  string  $query
      * @param  array  $bindings
      * @param  bool  $useReadPdo
-     * @return \Generator
+     * @param  array  $fetchUsing
+     * @return \Generator<int, \stdClass>
      *
      * @psalm-taint-sink sql $query
      */
-    public static function cursor($query, $bindings = [], $useReadPdo = true) {}
+    public static function cursor($query, $bindings = [], $useReadPdo = true, array $fetchUsing = []) {}
 
     /**
      * Run an insert statement against the database.

--- a/tests/Type/tests/Database/DbCursorFetchUsingTest.phpt
+++ b/tests/Type/tests/Database/DbCursorFetchUsingTest.phpt
@@ -50,6 +50,12 @@ function db_select_family_accepts_fetch_using(): void
 
     $_connectionSelectRows = $connection->select('select * from users', [], true, [\PDO::FETCH_ASSOC]);
     /** @psalm-check-type-exact $_connectionSelectRows = array */
+
+    $_defaultConnectionResultSets = $connection->selectResultSets('select 1');
+    /** @psalm-check-type-exact $_defaultConnectionResultSets = list<list<stdClass>> */
+
+    $_connectionResultSets = $connection->selectResultSets('select 1; select 2', [], true, [\PDO::FETCH_ASSOC]);
+    /** @psalm-check-type-exact $_connectionResultSets = list<list<mixed>> */
 }
 ?>
 --EXPECTF--

--- a/tests/Type/tests/Database/DbCursorFetchUsingTest.phpt
+++ b/tests/Type/tests/Database/DbCursorFetchUsingTest.phpt
@@ -1,23 +1,41 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+\Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipBelow('13');
 --FILE--
 <?php declare(strict_types=1);
 
 use Illuminate\Support\Facades\DB;
 
 /**
- * Laravel 13 added a 4th $fetchUsing param to Connection::cursor() (laravel/framework#55394).
+ * Laravel 13.0 added a 4th $fetchUsing param to the select family (laravel/framework#55394):
+ * DB::select()/selectResultSets()/cursor() and Connection::select()/selectResultSets()/cursor().
  * The concrete DB facade stub is authoritative over the generated pseudo-method (#1370), so it
  * must accept the same arity or a valid 4-arg call is rejected as TooManyArguments (#1372).
+ * `stubs/13/` widens the arity for Laravel 13+ only (#1375); this test covers that side, the
+ * companion DbSelectFamilyArityL12Test.phpt covers the pre-13 side.
  */
-function db_cursor_accepts_fetch_using(): void
+function db_select_family_accepts_fetch_using(): void
 {
-    $_rows = DB::cursor('select * from users', [], true, [\PDO::FETCH_ASSOC]);
-    /** @psalm-check-type-exact $_rows = Generator<int, stdClass> */
+    $_cursorRows = DB::cursor('select * from users', [], true, [\PDO::FETCH_ASSOC]);
+    /** @psalm-check-type-exact $_cursorRows = Generator<int, stdClass> */
 
-    $_defaultRows = DB::cursor('select 1');
-    /** @psalm-check-type-exact $_defaultRows = Generator<int, stdClass> */
+    $_defaultCursorRows = DB::cursor('select 1');
+    /** @psalm-check-type-exact $_defaultCursorRows = Generator<int, stdClass> */
 
-    $_connectionRows = DB::connection()->cursor('select * from users', [], true, [\PDO::FETCH_ASSOC]);
-    /** @psalm-check-type-exact $_connectionRows = Generator<int, stdClass> */
+    $_selectRows = DB::select('select * from users', [], true, [\PDO::FETCH_ASSOC]);
+    /** @psalm-check-type-exact $_selectRows = list<stdClass> */
+
+    $_resultSets = DB::selectResultSets('select 1; select 2', [], true, [\PDO::FETCH_ASSOC]);
+    /** @psalm-check-type-exact $_resultSets = list<list<stdClass>> */
+
+    $connection = DB::connection();
+
+    $_connectionCursorRows = $connection->cursor('select * from users', [], true, [\PDO::FETCH_ASSOC]);
+    /** @psalm-check-type-exact $_connectionCursorRows = Generator<int, stdClass> */
+
+    $_connectionSelectRows = $connection->select('select * from users', [], true, [\PDO::FETCH_ASSOC]);
+    /** @psalm-check-type-exact $_connectionSelectRows = array */
 }
 ?>
 --EXPECTF--

--- a/tests/Type/tests/Database/DbCursorFetchUsingTest.phpt
+++ b/tests/Type/tests/Database/DbCursorFetchUsingTest.phpt
@@ -14,25 +14,39 @@ use Illuminate\Support\Facades\DB;
  * must accept the same arity or a valid 4-arg call is rejected as TooManyArguments (#1372).
  * `stubs/13/` widens the arity for Laravel 13+ only (#1375); this test covers that side, the
  * companion DbSelectFamilyArityL12Test.phpt covers the pre-13 side.
+ *
+ * stdClass is only true under PDO's DEFAULT fetch mode. A non-default $fetchUsing (e.g.
+ * PDO::FETCH_ASSOC) makes PDOStatement::fetch()/fetchAll() yield arrays, not stdClass — the
+ * stub must not claim stdClass unconditionally (#1372 acceptance criteria). Each 4-arg call
+ * below both proves the arity is accepted AND that the value type honestly degrades to mixed.
  */
 function db_select_family_accepts_fetch_using(): void
 {
-    $_cursorRows = DB::cursor('select * from users', [], true, [\PDO::FETCH_ASSOC]);
-    /** @psalm-check-type-exact $_cursorRows = Generator<int, stdClass> */
-
     $_defaultCursorRows = DB::cursor('select 1');
     /** @psalm-check-type-exact $_defaultCursorRows = Generator<int, stdClass> */
 
+    $_cursorRows = DB::cursor('select * from users', [], true, [\PDO::FETCH_ASSOC]);
+    /** @psalm-check-type-exact $_cursorRows = Generator<int, mixed> */
+
+    $_defaultSelectRows = DB::select('select 1');
+    /** @psalm-check-type-exact $_defaultSelectRows = list<stdClass> */
+
     $_selectRows = DB::select('select * from users', [], true, [\PDO::FETCH_ASSOC]);
-    /** @psalm-check-type-exact $_selectRows = list<stdClass> */
+    /** @psalm-check-type-exact $_selectRows = list<mixed> */
+
+    $_defaultResultSets = DB::selectResultSets('select 1');
+    /** @psalm-check-type-exact $_defaultResultSets = list<list<stdClass>> */
 
     $_resultSets = DB::selectResultSets('select 1; select 2', [], true, [\PDO::FETCH_ASSOC]);
-    /** @psalm-check-type-exact $_resultSets = list<list<stdClass>> */
+    /** @psalm-check-type-exact $_resultSets = list<list<mixed>> */
 
     $connection = DB::connection();
 
+    $_defaultConnectionCursorRows = $connection->cursor('select 1');
+    /** @psalm-check-type-exact $_defaultConnectionCursorRows = Generator<int, stdClass> */
+
     $_connectionCursorRows = $connection->cursor('select * from users', [], true, [\PDO::FETCH_ASSOC]);
-    /** @psalm-check-type-exact $_connectionCursorRows = Generator<int, stdClass> */
+    /** @psalm-check-type-exact $_connectionCursorRows = Generator<int, mixed> */
 
     $_connectionSelectRows = $connection->select('select * from users', [], true, [\PDO::FETCH_ASSOC]);
     /** @psalm-check-type-exact $_connectionSelectRows = array */

--- a/tests/Type/tests/Database/DbCursorFetchUsingTest.phpt
+++ b/tests/Type/tests/Database/DbCursorFetchUsingTest.phpt
@@ -1,0 +1,23 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Laravel 13 added a 4th $fetchUsing param to Connection::cursor() (laravel/framework#55394).
+ * The concrete DB facade stub is authoritative over the generated pseudo-method (#1370), so it
+ * must accept the same arity or a valid 4-arg call is rejected as TooManyArguments (#1372).
+ */
+function db_cursor_accepts_fetch_using(): void
+{
+    $_rows = DB::cursor('select * from users', [], true, [\PDO::FETCH_ASSOC]);
+    /** @psalm-check-type-exact $_rows = Generator<int, stdClass> */
+
+    $_defaultRows = DB::cursor('select 1');
+    /** @psalm-check-type-exact $_defaultRows = Generator<int, stdClass> */
+
+    $_connectionRows = DB::connection()->cursor('select * from users', [], true, [\PDO::FETCH_ASSOC]);
+    /** @psalm-check-type-exact $_connectionRows = Generator<int, stdClass> */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Database/DbSelectFamilyArityL12Test.phpt
+++ b/tests/Type/tests/Database/DbSelectFamilyArityL12Test.phpt
@@ -1,0 +1,46 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+\Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipFrom('13');
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Companion to DbCursorFetchUsingTest.phpt (#1375): on Laravel 12 the select family
+ * (DB::select()/selectResultSets()/cursor(), Connection::select()/selectResultSets()/cursor())
+ * has no $fetchUsing 4th param (`stubs/13/` does not load below Laravel 13). A 4-arg call must
+ * report TooManyArguments, matching what the Laravel 12 runtime itself raises as ArgumentCountError.
+ *
+ * Also pins that the 3-arg cursor() call's return stays Generator<int, stdClass> on Laravel 12
+ * too: the value type is not version-dependent (only the $fetchUsing param is), so it must not
+ * regress to bare Generator when the common stub's parameter list is kept at 3-arg.
+ */
+function db_select_family_rejects_fetch_using_below_13(): void
+{
+    DB::cursor('select * from users', [], true, [\PDO::FETCH_ASSOC]);
+
+    $_cursorRows = DB::cursor('select 1');
+    /** @psalm-check-type-exact $_cursorRows = Generator<int, stdClass> */
+
+    DB::select('select * from users', [], true, [\PDO::FETCH_ASSOC]);
+
+    DB::selectResultSets('select 1; select 2', [], true, [\PDO::FETCH_ASSOC]);
+
+    $connection = DB::connection();
+
+    $connection->cursor('select * from users', [], true, [\PDO::FETCH_ASSOC]);
+
+    $connection->select('select * from users', [], true, [\PDO::FETCH_ASSOC]);
+
+    $connection->selectResultSets('select 1; select 2', [], true, [\PDO::FETCH_ASSOC]);
+}
+?>
+--EXPECTF--
+TooManyArguments on line %d: Too many arguments for Illuminate\Support\Facades\DB::cursor - expecting 3 but saw 4
+TooManyArguments on line %d: Too many arguments for Illuminate\Support\Facades\DB::select - expecting 3 but saw 4
+TooManyArguments on line %d: Too many arguments for Illuminate\Support\Facades\DB::selectResultSets - expecting 3 but saw 4
+TooManyArguments on line %d: Too many arguments for method Illuminate\Database\Connection::cursor - saw 4
+TooManyArguments on line %d: Too many arguments for method Illuminate\Database\Connection::select - saw 4
+TooManyArguments on line %d: Too many arguments for method Illuminate\Database\Connection::selectresultsets - saw 4

--- a/tests/Type/tests/TaintAnalysis/TaintedSqlDbCursor.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedSqlDbCursor.phpt
@@ -1,0 +1,18 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+
+function showPosts(\Illuminate\Http\Request $request) {
+    $postId = $request->input('id');
+    foreach (DB::cursor("SELECT * FROM posts WHERE id = " . $postId) as $_post) {
+    }
+}
+?>
+--EXPECTF--
+MissingReturnType on line %d: Method showPosts does not have a return type, expecting void
+MixedAssignment on line %d: Unable to determine the type that $postId is being assigned to
+TaintedSql on line %d: Detected tainted SQL
+MixedOperand on line %d: Right operand cannot be mixed


### PR DESCRIPTION
## Issue to Solve

Laravel 13.0 added a fourth `array $fetchUsing = []` argument to the database select family (laravel/framework#55394). The plugin's stubs declared the Laravel 12 three-argument shape for `cursor()`, so after #1370 made the concrete DB facade stub authoritative over Laravel's generated `@method`, a valid Laravel 13 call was rejected:

```php
DB::cursor('select * from users', [], true, [PDO::FETCH_ASSOC]); // TooManyArguments
```

`Illuminate\Database\Connection::cursor()` had the same gap, independent of #1370.

`select()` and `selectResultSets()` had the opposite problem: they carried `$fetchUsing` unconditionally in the common stubs, so a Laravel 12 project passing a fourth argument got no error where the runtime raises `ArgumentCountError`. `docs/contributing/README.md` says newer-Laravel-only parameters belong in a version dir, so the stubs and the documented policy disagreed.

Scope contract: `T2 — version-gate the Laravel 13 $fetchUsing database signatures; budget ~80 src lines; 1 reviewer; delta: no`.

## Related

Fixes #1372.
Closes #1375.

## Solution Description

Version-gate the whole family instead of widening the common stubs:

- Common stubs keep the Laravel 12 three-argument shape for `select()`, `selectResultSets()`, and `cursor()` in both `stubs/common/Support/Facades/DB.phpstub` and `stubs/common/Database/Connection.phpstub`.
- New single-method overlays `stubs/13/Support/Facades/DB.phpstub` and `stubs/13/Database/Connection.phpstub` re-declare those six methods at four arguments, class headers copied verbatim (hard rule 2).
- Each overlay method restates its own `@return` and `@psalm-taint-sink sql $query`: each file is the sole authoritative declaration for its own Laravel line, and taint annotations accumulate across stub files (hard rule 4). Verified this does not double-report.
- Return types are conditional on the fetch mode: `@psalm-return ($fetchUsing is array{} ? <precise> : <mixed analogue>)`. `stdClass` is only true under PDO's default mode, so a call passing `PDO::FETCH_ASSOC` degrades honestly to `mixed` instead of claiming objects that never materialize. A non-literal `$fetchUsing` unions both branches.
- The common (Laravel 12, three-argument) declarations keep their unconditional precise returns: with no fetch-mode parameter there, `stdClass` is sound.

Version overlays were confirmed to override *arity*, not just docblock types, before this approach was committed: existing overlays only ever changed parameter and return types. A bare `13/` dir is matched by `StubFileFinder` the same way `13.5.0/` is (`version_compare` reads it as `13.0.0`), and single-method partials do not blank sibling methods on the same class.

`FacadeStubPrecedenceHandler` (#1370) needed no change: its `STUB_PATH_PATTERN` (`~/stubs/[^/]+/Support/Facades/~`) already matches a bare `13` dir, so the overlay still outranks the vendor pseudo-method. Confirmed from the regex and empirically.

Coverage, both majors:

- `tests/Type/tests/Database/DbCursorFetchUsingTest.phpt` (`skipBelow('13')`) — four-argument facade and `Connection` calls, plus the `Generator<int, stdClass>` return.
- `tests/Type/tests/Database/DbSelectFamilyArityL12Test.phpt` (`skipFrom('13')`) — `TooManyArguments` on all six method/receiver combos, plus the three-argument return type.
- `tests/Type/tests/TaintAnalysis/TaintedSqlDbCursor.phpt` — `TaintedSql` still reported through `DB::cursor()` from an uncast `request()->input()` source.

The CI type-test matrix runs `^12.14` and `^13.3`, so both sides execute.

Verification:

- Laravel 13.25.0 — `composer test:type` 655 tests, 652 assertions, 3 skipped
- Laravel 12.66.0 (`composer update --with="laravel/framework:^12.14"` in a throwaway copy) — `composer test:type` 655 tests, 650 assertions, 5 skipped
- `composer test:unit` — 1097 tests, 2971 assertions, 1 skipped
- Psalm self-analysis `--no-cache` — no errors, 100% type coverage
- php-cs-fixer dry-run, Rector dry-run, PHPT conventions — clean

Fetch-mode inference was probed per method across five argument shapes (omitted, `[]`, `[PDO::FETCH_ASSOC]`, non-literal `array`, non-literal `non-empty-array`); the precise type survives the first two, `stdClass` never appears for the third or fifth, and the fourth unions both branches.

Teeth were proven per side in an isolated copy: deleting the overlays turns the Laravel 13 test red on five sites; re-widening the common declarations turns the Laravel 12 test red on all six. Each test was also confirmed to actually *run* on its own major rather than pass by being skipped. Taint was checked on both majors across six call shapes: exactly one `TaintedSql` per site, no doubling from the duplicated sink and no loss on Laravel 12.

## Accepted imprecision

- `Connection::select()` returns bare `array` while the facade returns `list<\stdClass>`. Pre-existing asymmetry, untouched.
- The overlays omit the trait `use` block, matching the pre-existing common stubs. Probed as byte-identical output with and without the overlays.

## Reviewer notes (not blocking)

- Only the one-argument facade form pins non-doubling of the SQL sink; the other five forms are proven clean but unpinned.
- A future `stubs/13.x/` overlay re-declaring `DB` or `Connection` must repeat all six four-argument methods, or arity silently falls back to the three-argument common shape.
- `DbCursorFetchUsingTest.phpt` now covers the whole select family; renaming it to mirror its L12 companion would read better.

## Checklist
- [x] Tests cover the change (type tests in `tests/Type/`, both Laravel majors)
- [x] Documentation is updated (`docs/contributing/README.md` version-dir list)
