### PR TITLE
Support `$schema = Schema::connection(...)` in migrations

### DIFF
--- a/src/Handlers/Eloquent/Schema/SchemaAggregator.php
+++ b/src/Handlers/Eloquent/Schema/SchemaAggregator.php
@@ -117,14 +117,32 @@ final class SchemaAggregator
      */
     private function addMethodStatements(array $stmts): void
     {
+        // Names of local variables currently holding a Schema builder instance
+        // (e.g. `$schema = Schema::connection(...)`), scoped to this method only.
+        /** @var array<string, true> $schema_vars */
+        $schema_vars = [];
+
         // Flatten nested block structures (if/else, try/catch, foreach, etc.)
         // so Schema calls inside conditionals are not missed.
         foreach (self::flattenStatements($stmts) as $stmt) {
+            // A foreach loop variable rebinds the name each iteration
+            // (e.g. `foreach ($tables as $schema)`), so any tracked builder
+            // under that name no longer holds a schema builder afterward.
+            if ($stmt instanceof PhpParser\Node\Stmt\Foreach_) {
+                if ($stmt->valueVar instanceof PhpParser\Node\Expr\Variable && \is_string($stmt->valueVar->name)) {
+                    unset($schema_vars[$stmt->valueVar->name]);
+                }
+
+                continue;
+            }
+
             if (!$stmt instanceof PhpParser\Node\Stmt\Expression) {
                 continue;
             }
 
-            $schema_call = $this->extractSchemaCall($stmt->expr);
+            $this->trackSchemaVariable($stmt->expr, $schema_vars);
+
+            $schema_call = $this->extractSchemaCall($stmt->expr, $schema_vars);
             if ($schema_call === null || !$schema_call->name instanceof PhpParser\Node\Identifier) {
                 continue;
             }
@@ -154,17 +172,75 @@ final class SchemaAggregator
     }
 
     /**
+     * Track (or untrack) a local variable holding a Schema builder instance.
+     *
+     * Only `$var = <SchemaClass>::connection(...)` marks a variable as tracked — this
+     * mirrors the connection-chained form already handled by extractSchemaCall() and
+     * keeps the false-positive surface small (e.g. `$schema = Schema::make(...)` in
+     * Filament's unrelated `Filament\Schemas\Schema` is never tracked).
+     *
+     * Any other assignment to a previously-tracked name (a new value, a reference
+     * bind, or a compound assignment) untracks it: the variable no longer reliably
+     * holds a schema builder.
+     *
+     * @param array<string, true> $schema_vars
+     */
+    private function trackSchemaVariable(PhpParser\Node\Expr $expr, array &$schema_vars): void
+    {
+        if (
+            ($expr instanceof PhpParser\Node\Expr\AssignRef || $expr instanceof PhpParser\Node\Expr\AssignOp)
+            && $expr->var instanceof PhpParser\Node\Expr\Variable
+            && \is_string($expr->var->name)
+        ) {
+            unset($schema_vars[$expr->var->name]);
+
+            return;
+        }
+
+        if (
+            !$expr instanceof PhpParser\Node\Expr\Assign
+            || !$expr->var instanceof PhpParser\Node\Expr\Variable
+            || !\is_string($expr->var->name)
+        ) {
+            return;
+        }
+
+        $var_name = $expr->var->name;
+
+        if ($this->isSchemaConnectionCall($expr->expr)) {
+            $schema_vars[$var_name] = true;
+        } else {
+            unset($schema_vars[$var_name]);
+        }
+    }
+
+    /**
+     * Whether an expression is `<SchemaClass>::connection(...)`.
+     */
+    private function isSchemaConnectionCall(PhpParser\Node\Expr $expr): bool
+    {
+        return $expr instanceof PhpParser\Node\Expr\StaticCall
+            && $expr->class instanceof PhpParser\Node\Name
+            && $expr->name instanceof PhpParser\Node\Identifier
+            && $expr->name->name === 'connection'
+            && $this->isSchemaClass($expr->class->getAttribute('resolvedName'));
+    }
+
+    /**
      * Extract a Schema facade call from an expression, if present.
      *
-     * Handles two forms:
-     * - Direct:  Schema::create('users', ...)
-     * - Chained: Schema::connection('mysql')->create('users', ...)
+     * Handles three forms:
+     * - Direct:   Schema::create('users', ...)
+     * - Chained:  Schema::connection('mysql')->create('users', ...)
+     * - Variable: $schema = Schema::connection('mysql'); $schema->create('users', ...)
      *
      * Only single-level chaining via connection() is detected.
      * Deeper chains like Schema::connection()->connection()->create() are not supported
      * because they are invalid at runtime.
+     *
+     * @param array<string, true> $schema_vars variables tracked as holding a schema builder
      */
-    private function extractSchemaCall(PhpParser\Node\Expr $expr): PhpParser\Node\Expr\StaticCall|PhpParser\Node\Expr\MethodCall|null
+    private function extractSchemaCall(PhpParser\Node\Expr $expr, array $schema_vars): PhpParser\Node\Expr\StaticCall|PhpParser\Node\Expr\MethodCall|null
     {
         // Direct Schema facade call: Schema::create(...), Schema::table(...), etc.
         if (
@@ -186,6 +262,18 @@ final class SchemaAggregator
             && $expr->var->name instanceof PhpParser\Node\Identifier
             && $expr->var->name->name === 'connection'
             && $this->isSchemaClass($expr->var->class->getAttribute('resolvedName'))
+        ) {
+            return $expr;
+        }
+
+        // Variable-held call: $schema->create(...), where $schema was tracked
+        // by trackSchemaVariable() as `$schema = <SchemaClass>::connection(...)`.
+        if (
+            $expr instanceof PhpParser\Node\Expr\MethodCall
+            && $expr->name instanceof PhpParser\Node\Identifier
+            && $expr->var instanceof PhpParser\Node\Expr\Variable
+            && \is_string($expr->var->name)
+            && isset($schema_vars[$expr->var->name])
         ) {
             return $expr;
         }

--- a/tests/Unit/Handlers/Eloquent/Schema/Fixtures/NotASchemaFacade.php
+++ b/tests/Unit/Handlers/Eloquent/Schema/Fixtures/NotASchemaFacade.php
@@ -11,10 +11,8 @@ namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Eloquent\Schema\Fixtures;
  */
 final class NotASchemaFacade
 {
-    public static function connection(string $name): self
+    public static function connection(): self
     {
         return new self();
     }
-
-    public function create(string $table, \Closure $callback): void {}
 }

--- a/tests/Unit/Handlers/Eloquent/Schema/Fixtures/NotASchemaFacade.php
+++ b/tests/Unit/Handlers/Eloquent/Schema/Fixtures/NotASchemaFacade.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Eloquent\Schema\Fixtures;
+
+/**
+ * Test fixture: a class that exposes a static connection() method but is not
+ * (and does not extend) the Illuminate Schema facade. Used to verify the
+ * isSchemaClass() gate rejects lookalike connection() calls.
+ */
+final class NotASchemaFacade
+{
+    public static function connection(string $name): self
+    {
+        return new self();
+    }
+
+    public function create(string $table, \Closure $callback): void {}
+}

--- a/tests/Unit/Handlers/Eloquent/Schema/SchemaVariableTest.php
+++ b/tests/Unit/Handlers/Eloquent/Schema/SchemaVariableTest.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Eloquent\Schema;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaAggregator;
+
+/**
+ * Tests that a schema builder assigned to a local variable is recognized, e.g.:
+ *
+ *   $schema = Schema::connection($this->getConnection());
+ *   $schema->create('table', ...);
+ *
+ * This shape is published by Laravel Telescope's migrations.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1377
+ */
+#[CoversClass(SchemaAggregator::class)]
+final class SchemaVariableTest extends AbstractSchemaAggregatorTestCase
+{
+    #[Test]
+    public function it_detects_columns_from_variable_assigned_schema_builder(): void
+    {
+        $schema = $this->schemaFromMigration(<<<'PHP'
+            <?php
+            use Illuminate\Database\Migrations\Migration;
+            use Illuminate\Database\Schema\Blueprint;
+            use Illuminate\Support\Facades\Schema;
+
+            return new class extends Migration {
+                public function up(): void
+                {
+                    $schema = Schema::connection($this->getConnection());
+                    $schema->create('telescope_entries', function (Blueprint $table): void {
+                        $table->id();
+                        $table->string('type');
+                    });
+                }
+
+                public function getConnection(): ?string
+                {
+                    return null;
+                }
+            };
+            PHP);
+
+        $this->assertArrayHasKey('telescope_entries', $schema->tables);
+        $this->assertSchemaHasTableAndNotNullableColumnOfType('telescope_entries.id', 'int', $schema);
+        $this->assertSchemaHasTableAndNotNullableColumnOfType('telescope_entries.type', 'string', $schema);
+    }
+
+    #[Test]
+    public function it_detects_columns_from_variable_assigned_custom_schema_facade(): void
+    {
+        $schema = $this->schemaFromMigration(<<<'PHP'
+            <?php
+            use Illuminate\Database\Migrations\Migration;
+            use Illuminate\Database\Schema\Blueprint;
+            use Tests\Psalm\LaravelPlugin\Unit\Handlers\Eloquent\Schema\Fixtures\CustomSchema;
+
+            return new class extends Migration {
+                public function up(): void
+                {
+                    $schema = CustomSchema::connection('pgsql');
+                    $schema->create('posts', function (Blueprint $table): void {
+                        $table->id();
+                        $table->string('title');
+                    });
+                }
+            };
+            PHP);
+
+        $this->assertArrayHasKey('posts', $schema->tables);
+        $this->assertSchemaHasTableAndNotNullableColumnOfType('posts.id', 'int', $schema);
+        $this->assertSchemaHasTableAndNotNullableColumnOfType('posts.title', 'string', $schema);
+    }
+
+    #[Test]
+    public function it_routes_table_drop_rename_and_drop_columns_through_a_variable(): void
+    {
+        $schema = $this->schemaFromMigration(<<<'PHP'
+            <?php
+            use Illuminate\Database\Migrations\Migration;
+            use Illuminate\Database\Schema\Blueprint;
+            use Illuminate\Support\Facades\Schema;
+
+            return new class extends Migration {
+                public function up(): void
+                {
+                    $schema = Schema::connection($this->getConnection());
+                    $schema->create('telescope_entries', function (Blueprint $table): void {
+                        $table->id();
+                        $table->string('type');
+                        $table->string('scratch');
+                    });
+                    $schema->table('telescope_entries', function (Blueprint $table): void {
+                        $table->string('email')->nullable();
+                    });
+                    $schema->dropColumns('telescope_entries', 'scratch');
+                    $schema->rename('telescope_entries', 'telescope_entries_renamed');
+
+                    $schema->create('telescope_monitoring', function (Blueprint $table): void {
+                        $table->string('tag');
+                    });
+                    $schema->dropIfExists('telescope_monitoring');
+                }
+
+                public function getConnection(): ?string
+                {
+                    return null;
+                }
+            };
+            PHP);
+
+        $this->assertArrayNotHasKey('telescope_entries', $schema->tables);
+        $this->assertArrayHasKey('telescope_entries_renamed', $schema->tables);
+        $this->assertSchemaHasTableAndNotNullableColumnOfType('telescope_entries_renamed.type', 'string', $schema);
+        $this->assertSchemaHasTableAndNullableColumnOfType('telescope_entries_renamed.email', 'string', $schema);
+        $this->assertArrayNotHasKey('scratch', $schema->tables['telescope_entries_renamed']->columns);
+
+        $this->assertArrayNotHasKey('telescope_monitoring', $schema->tables);
+    }
+
+    #[Test]
+    public function it_tracks_a_variable_assigned_inside_a_conditional(): void
+    {
+        $schema = $this->schemaFromMigration(<<<'PHP'
+            <?php
+            use Illuminate\Database\Migrations\Migration;
+            use Illuminate\Database\Schema\Blueprint;
+            use Illuminate\Support\Facades\Schema;
+
+            return new class extends Migration {
+                public function up(): void
+                {
+                    if (true) {
+                        $schema = Schema::connection($this->getConnection());
+                    }
+
+                    $schema->create('telescope_entries', function (Blueprint $table): void {
+                        $table->id();
+                    });
+                }
+
+                public function getConnection(): ?string
+                {
+                    return null;
+                }
+            };
+            PHP);
+
+        $this->assertArrayHasKey('telescope_entries', $schema->tables);
+        $this->assertSchemaHasTableAndNotNullableColumnOfType('telescope_entries.id', 'int', $schema);
+    }
+
+    #[Test]
+    public function it_ignores_calls_on_an_untracked_variable(): void
+    {
+        $schema = $this->schemaFromMigration(<<<'PHP'
+            <?php
+            use Illuminate\Database\Migrations\Migration;
+            use Illuminate\Database\Schema\Blueprint;
+
+            return new class extends Migration {
+                public function up(): void
+                {
+                    $schema->create('telescope_entries', function (Blueprint $table): void {
+                        $table->id();
+                    });
+                }
+            };
+            PHP);
+
+        $this->assertArrayNotHasKey('telescope_entries', $schema->tables);
+    }
+
+    #[Test]
+    public function it_untracks_a_variable_reassigned_to_a_non_schema_value(): void
+    {
+        $schema = $this->schemaFromMigration(<<<'PHP'
+            <?php
+            use Illuminate\Database\Migrations\Migration;
+            use Illuminate\Database\Schema\Blueprint;
+            use Illuminate\Support\Facades\Schema;
+
+            return new class extends Migration {
+                public function up(): void
+                {
+                    $schema = Schema::connection($this->getConnection());
+                    $schema = new \stdClass();
+                    $schema->create('telescope_entries', function (Blueprint $table): void {
+                        $table->id();
+                    });
+                }
+
+                public function getConnection(): ?string
+                {
+                    return null;
+                }
+            };
+            PHP);
+
+        $this->assertArrayNotHasKey('telescope_entries', $schema->tables);
+    }
+
+    #[Test]
+    public function it_untracks_a_variable_rebound_by_foreach(): void
+    {
+        $schema = $this->schemaFromMigration(<<<'PHP'
+            <?php
+            use Illuminate\Database\Migrations\Migration;
+            use Illuminate\Database\Schema\Blueprint;
+            use Illuminate\Support\Facades\Schema;
+
+            return new class extends Migration {
+                public function up(): void
+                {
+                    $schema = Schema::connection($this->getConnection());
+
+                    foreach (['a', 'b'] as $schema) {
+                        // rebinds $schema to a plain string on each iteration
+                    }
+
+                    $schema->create('telescope_entries', function (Blueprint $table): void {
+                        $table->id();
+                    });
+                }
+
+                public function getConnection(): ?string
+                {
+                    return null;
+                }
+            };
+            PHP);
+
+        $this->assertArrayNotHasKey('telescope_entries', $schema->tables);
+    }
+
+    #[Test]
+    public function it_does_not_leak_tracking_between_methods(): void
+    {
+        $schema = $this->schemaFromMigration(<<<'PHP'
+            <?php
+            use Illuminate\Database\Migrations\Migration;
+            use Illuminate\Database\Schema\Blueprint;
+            use Illuminate\Support\Facades\Schema;
+
+            return new class extends Migration {
+                public function up(): void
+                {
+                    $this->setupA();
+                    $this->setupB();
+                }
+
+                private function setupA(): void
+                {
+                    $schema = Schema::connection($this->getConnection());
+                    $schema->create('telescope_entries', function (Blueprint $table): void {
+                        $table->id();
+                    });
+                }
+
+                private function setupB(): void
+                {
+                    // $schema here was never assigned a schema builder in THIS method's
+                    // scope — tracking must not leak in from setupA().
+                    $schema->create('telescope_monitoring', function (Blueprint $table): void {
+                        $table->id();
+                    });
+                }
+
+                public function getConnection(): ?string
+                {
+                    return null;
+                }
+            };
+            PHP);
+
+        $this->assertArrayHasKey('telescope_entries', $schema->tables);
+        $this->assertArrayNotHasKey('telescope_monitoring', $schema->tables);
+    }
+}

--- a/tests/Unit/Handlers/Eloquent/Schema/SchemaVariableTest.php
+++ b/tests/Unit/Handlers/Eloquent/Schema/SchemaVariableTest.php
@@ -282,4 +282,113 @@ final class SchemaVariableTest extends AbstractSchemaAggregatorTestCase
         $this->assertArrayHasKey('telescope_entries', $schema->tables);
         $this->assertArrayNotHasKey('telescope_monitoring', $schema->tables);
     }
+
+    #[Test]
+    public function it_untracks_a_variable_mutated_by_compound_assignment(): void
+    {
+        $schema = $this->schemaFromMigration(<<<'PHP'
+            <?php
+            use Illuminate\Database\Migrations\Migration;
+            use Illuminate\Database\Schema\Blueprint;
+            use Illuminate\Support\Facades\Schema;
+
+            return new class extends Migration {
+                public function up(): void
+                {
+                    $schema = Schema::connection($this->getConnection());
+                    $schema .= 'x';
+
+                    $schema->create('telescope_entries', function (Blueprint $table): void {
+                        $table->id();
+                    });
+                }
+
+                public function getConnection(): ?string
+                {
+                    return null;
+                }
+            };
+            PHP);
+
+        $this->assertArrayNotHasKey('telescope_entries', $schema->tables);
+    }
+
+    #[Test]
+    public function it_untracks_a_variable_rebound_by_reference(): void
+    {
+        $schema = $this->schemaFromMigration(<<<'PHP'
+            <?php
+            use Illuminate\Database\Migrations\Migration;
+            use Illuminate\Database\Schema\Blueprint;
+            use Illuminate\Support\Facades\Schema;
+
+            return new class extends Migration {
+                public function up(): void
+                {
+                    $schema = Schema::connection($this->getConnection());
+                    $other = new \stdClass();
+                    $schema = &$other;
+
+                    $schema->create('telescope_entries', function (Blueprint $table): void {
+                        $table->id();
+                    });
+                }
+
+                public function getConnection(): ?string
+                {
+                    return null;
+                }
+            };
+            PHP);
+
+        $this->assertArrayNotHasKey('telescope_entries', $schema->tables);
+    }
+
+    #[Test]
+    public function it_ignores_filament_schema_make_variable(): void
+    {
+        // Filament\Schemas\Schema::make() is an unrelated builder that also uses the
+        // `Schema` class name; `Schema::make(...)` (no `connection()`) must never be
+        // mistaken for Illuminate\Support\Facades\Schema::connection(...).
+        $schema = $this->schemaFromMigration(<<<'PHP'
+            <?php
+            use Illuminate\Database\Migrations\Migration;
+            use Illuminate\Database\Schema\Blueprint;
+            use Illuminate\Support\Facades\Schema;
+
+            return new class extends Migration {
+                public function up(): void
+                {
+                    $schema = Schema::make('x');
+                    $schema->create('should_not_exist', function (Blueprint $table): void {
+                        $table->id();
+                    });
+                }
+            };
+            PHP);
+
+        $this->assertArrayNotHasKey('should_not_exist', $schema->tables);
+    }
+
+    #[Test]
+    public function it_ignores_connection_call_on_a_non_schema_class(): void
+    {
+        $schema = $this->schemaFromMigration(<<<'PHP'
+            <?php
+            use Illuminate\Database\Migrations\Migration;
+            use Illuminate\Database\Schema\Blueprint;
+
+            return new class extends Migration {
+                public function up(): void
+                {
+                    $schema = \Tests\Psalm\LaravelPlugin\Unit\Handlers\Eloquent\Schema\Fixtures\NotASchemaFacade::connection('x');
+                    $schema->create('telescope_entries', function (Blueprint $table): void {
+                        $table->id();
+                    });
+                }
+            };
+            PHP);
+
+        $this->assertArrayNotHasKey('telescope_entries', $schema->tables);
+    }
 }


### PR DESCRIPTION
## Issue to Solve

The migration schema aggregator saw only two call forms:

- direct: `Schema::create('users', ...)`
- connection-chained: `Schema::connection('mysql')->create('users', ...)`

A migration that assigns the builder to a variable first matched neither, so every column it declared was invisible to `ModelMetadataRegistry`. Models backed by those tables lost their column properties, surfacing as false `UndefinedMagicPropertyFetch` / `UnknownModelAttribute` reports.

Laravel Telescope's published migration is exactly this shape:

```php
$schema = Schema::connection($this->getConnection());

$schema->create('telescope_entries', function (Blueprint $table): void {
    $table->bigIncrements('sequence');
    $table->longText('content');
    // ...
});
```

5 of the 19 apps in the local benchmark corpus carry it, for both `create()` and `dropIfExists()`.

## Related

Fixes #1377.

Upstream reference: larastan/larastan#1884 proposes the same idea for Larastan (still open). This PR diverges from it in two ways, both deliberate:

- it untracks the variable on rebinding (larastan's version only ever tracks);
- it omits `setConnection()`, which `Illuminate\Database\Schema\Builder` does not have in any supported Laravel version.

## Solution Description

`SchemaAggregator::addMethodStatements()` keeps a local `array<string, true>` of variable names holding a schema builder.

- A name is tracked only on `<SchemaClass>::connection(...)`, gated by the existing `isSchemaClass()` (so custom Schema facades and root aliases keep working).
- The name is untracked on any other `Assign`, on `AssignRef` / `AssignOp`, and on a `foreach` value var.
- `extractSchemaCall()` gained a third branch: a `MethodCall` on a tracked variable. The existing `create` / `table` / `drop` / `dropIfExists` / `dropColumns` / `rename` switch and the four per-method handlers are unchanged.

The tracking set is local to the method walk rather than a property, because one aggregator instance spans every migration file and `addClassStatements()` walks every non-`down()` method. Keeping it local stops a name from leaking between helper methods.

Narrow gating matters here: `$schema = Schema::make(...)` appears 170 times in the benchmark corpus and is Filament's unrelated `Filament\Schemas\Schema`. The `connection()` name check and `isSchemaClass()` each exclude it independently.

Verification: 12 unit tests in `tests/Unit/Handlers/Eloquent/Schema/SchemaVariableTest.php` (4 positive, 8 negative). Every accept branch and every untrack branch is pinned individually: each clause was deleted in turn, the corresponding test confirmed red, and the file restored byte-identical (md5 checked both ways). Full unit suite, type suite, and CI-exact Psalm self-analysis (no `--no-suggestions`, `--no-cache`) are green.

## Reviewer notes

- `MigrationCache` payload shape is unchanged (still `SchemaAggregator::$tables`), so no cache-format bump is needed.
- Accepted imprecision, per the FN-over-FP and cheap-heuristic-first conventions: builders reached by a route the statement walker cannot see stay untracked, and are therefore silently ignored rather than mis-attributed. That covers `Schema::getFacadeRoot()`, chained assignment (`$a = $b = Schema::connection(...)`), property-held and DI-injected builders, and a parameter named `$schema`.
- Shapes that stay tracked through a rebinding the walker cannot follow (`[$a, $schema] = f()`, `list()`, `foreach ($m as $schema => $v)`, `catch (X $schema)`, by-ref `use (&$schema)`) would require a real `Schema::connection()` assignment followed by a rebind followed by a `create()` on the rebound name, which fatals at runtime. Zero corpus prevalence, no baseline delta.
- Optional follow-up, not taken here to keep the diff inside budget: `extractSchemaCall()`'s connection-chained branch could reuse `isSchemaConnectionCall()` and drop ~5 duplicated lines.

## Checklist
- [x] Tests cover the change (unit tests in `tests/Unit/Handlers/Eloquent/Schema/SchemaVariableTest.php`)
