### PR TITLE
Infer `Arr::pluck()` value and key types from model `@property` annotations

### DIFF
--- a/src/Handlers/Eloquent/Support/ModelPropertyResolver.php
+++ b/src/Handlers/Eloquent/Support/ModelPropertyResolver.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Enumerable;
 use Psalm\Codebase;
 use Psalm\Internal\Type\Comparator\UnionTypeComparator;
 // UnionTypeComparator is in Psalm\Internal\* but is the established convention for
@@ -17,7 +18,10 @@ use Psalm\Internal\Type\Comparator\UnionTypeComparator;
 use Psalm\LaravelPlugin\Handlers\Eloquent\ModelPropertyHandler;
 use Psalm\NodeTypeProvider;
 use Psalm\Type;
+use Psalm\Type\Atomic\TArray;
 use Psalm\Type\Atomic\TGenericObject;
+use Psalm\Type\Atomic\TIterable;
+use Psalm\Type\Atomic\TKeyedArray;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Union;
 
@@ -86,10 +90,14 @@ final class ModelPropertyResolver
         return $modelClass;
     }
 
-    /** @return class-string<Model>|null
+    /**
+     * Public: also shared with {@see \Psalm\LaravelPlugin\Handlers\Support\ArrPluckHandler}
+     * via {@see self::extractModelFromIterableValueType()}.
+     *
+     * @return class-string<Model>|null
      * @psalm-mutation-free
      */
-    private static function extractExactlyOneModelFromUnion(?Union $type): ?string
+    public static function extractExactlyOneModelFromUnion(?Union $type): ?string
     {
         $modelClass = null;
         foreach ($type?->getAtomicTypes() ?? [] as $atomic) {
@@ -102,6 +110,42 @@ final class ModelPropertyResolver
         }
 
         return $modelClass;
+    }
+
+    /**
+     * Extract a single Model class-string from the element type of an iterable-shaped
+     * argument (Collection<TKey, Model>, array<TKey, Model>, array{0: Model, ...},
+     * iterable<TKey, Model>). Used by `Arr::pluck()`, which has no generic receiver to
+     * read a template parameter off, unlike Builder/Collection::pluck() above.
+     *
+     * Declines (null) on a multi-atomic union, `mixed`, a bare `array`/`iterable` with
+     * no value type param, and any non-`Enumerable` object.
+     *
+     * @return class-string<Model>|null
+     * @psalm-mutation-free
+     */
+    public static function extractModelFromIterableValueType(?Union $argType): ?string
+    {
+        if (!$argType instanceof Union || !$argType->isSingle()) {
+            return null;
+        }
+
+        $atomic = $argType->getSingleAtomic();
+
+        if ($atomic instanceof TKeyedArray) {
+            return self::extractExactlyOneModelFromUnion($atomic->getGenericValueType());
+        }
+
+        if (($atomic instanceof TArray || $atomic instanceof TIterable) && \count($atomic->type_params) >= 2) {
+            return self::extractExactlyOneModelFromUnion($atomic->type_params[1]);
+        }
+
+        if ($atomic instanceof TGenericObject && \count($atomic->type_params) >= 2
+            && \is_a($atomic->value, Enumerable::class, true)) {
+            return self::extractExactlyOneModelFromUnion($atomic->type_params[1]);
+        }
+
+        return null;
     }
 
     /**
@@ -131,18 +175,6 @@ final class ModelPropertyResolver
         if ($args === []) {
             return null;
         }
-
-        // Extract column name from the first argument as a string literal. $args[0]/
-        // $args[1] below are positional (the $value, $key parameter order) — a call
-        // using PHP named arguments to reorder them (pluck(key: 'k', value: 'v'))
-        // would misindex here. Deliberate scope cut: no known real-world caller does
-        // this for pluck()'s two-parameter signature.
-        $argType = $nodeTypeProvider->getType($args[0]->value);
-        if (!$argType instanceof \Psalm\Type\Union || !$argType->isSingleStringLiteral()) {
-            return null;
-        }
-
-        $columnName = $argType->getSingleStringLiteral()->value;
 
         $modelClass = self::extractModelFromUnion($templateParams[$modelTemplateIndex] ?? null);
 
@@ -191,6 +223,51 @@ final class ModelPropertyResolver
             return null;
         }
 
+        $resolved = self::resolvePluckColumnTypes(
+            valueArg: $args[0],
+            keyArg: $args[1] ?? null,
+            modelClass: $modelClass,
+            nodeTypeProvider: $nodeTypeProvider,
+            codebase: $codebase,
+        );
+        if ($resolved === null) {
+            return null;
+        }
+
+        [$keyType, $propertyType] = $resolved;
+
+        return new Union([
+            new TGenericObject(Collection::class, [$keyType, $propertyType]),
+        ]);
+    }
+
+    /**
+     * Resolve the [TKey, TValue] pair for a pluck($value, $key)-shaped call against a
+     * known model. Shared core behind {@see self::resolvePluckReturnType()} and
+     * {@see \Psalm\LaravelPlugin\Handlers\Support\ArrPluckHandler}, which differ only in
+     * how $modelClass is resolved (template parameter vs. argument element type).
+     *
+     * $valueArg/$keyArg are positional — named-argument reordering (pluck(key: 'k', ...))
+     * would misindex here; deliberate scope cut, same as the rest of this class.
+     *
+     * @param class-string<Model> $modelClass
+     * @return array{Union, Union}|null [keyType, valueType]; null when the column isn't a
+     *         string literal, or neither axis narrowed past mixed/array-key.
+     */
+    public static function resolvePluckColumnTypes(
+        \PhpParser\Node\Arg $valueArg,
+        ?\PhpParser\Node\Arg $keyArg,
+        string $modelClass,
+        NodeTypeProvider $nodeTypeProvider,
+        Codebase $codebase,
+    ): ?array {
+        $argType = $nodeTypeProvider->getType($valueArg->value);
+        if (!$argType instanceof Union || !$argType->isSingleStringLiteral()) {
+            return null;
+        }
+
+        $columnName = $argType->getSingleStringLiteral()->value;
+
         // The value column is often not a @property: raw select aliases and computed
         // columns (`selectRaw('COUNT(*) AS cnt')`) have no model annotation to resolve.
         // Don't bail on that alone — fall back to mixed for the value and still attempt
@@ -200,7 +277,7 @@ final class ModelPropertyResolver
         // migration schema / casts, mirroring ordinary `$model->column` reads and
         // BuilderAggregateHandler's column resolution.
         $resolvedPropertyType = ModelPropertyHandler::resolveColumnType($codebase, $modelClass, $columnName);
-        $valueResolved = $resolvedPropertyType instanceof \Psalm\Type\Union;
+        $valueResolved = $resolvedPropertyType instanceof Union;
         $propertyType = $resolvedPropertyType ?? Type::getMixed();
 
         // Determine key type:
@@ -212,14 +289,11 @@ final class ModelPropertyResolver
         // We only adopt the @property type when it is a subset of int|string, because
         // Collection<TKey, TValue> requires TKey to be array-key. A property declared as
         // CarbonInterface|null (cast type) would produce an invalid TKey, so we fall back.
-        // $args[1] is positional too (see the $args[0] note above) — "has a $key
-        // argument" here means "has a second positional argument", not "named the
-        // $key parameter".
-        $keyResolved = \count($args) < 2;
+        $keyResolved = !$keyArg instanceof \PhpParser\Node\Arg;
         $keyType = Type::getInt();
-        if (\count($args) >= 2) {
+        if ($keyArg instanceof \PhpParser\Node\Arg) {
             $resolvedKeyType = self::resolveKeyType(
-                keyArg: $args[1],
+                keyArg: $keyArg,
                 modelClass: $modelClass,
                 nodeTypeProvider: $nodeTypeProvider,
                 codebase: $codebase,
@@ -228,15 +302,13 @@ final class ModelPropertyResolver
             $keyType = $resolvedKeyType ?? Type::getArrayKey();
         }
 
-        // Neither axis narrowed past the stub's default `Collection<array-key, mixed>` —
-        // defer to it instead of constructing an identical type via this handler.
+        // Neither axis narrowed past the stub's default `array-key, mixed` — defer to
+        // the caller's own default instead of constructing an identical type here.
         if (!$valueResolved && !$keyResolved) {
             return null;
         }
 
-        return new Union([
-            new TGenericObject(Collection::class, [$keyType, $propertyType]),
-        ]);
+        return [$keyType, $propertyType];
     }
 
     /**

--- a/src/Handlers/Support/ArrPluckHandler.php
+++ b/src/Handlers/Support/ArrPluckHandler.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Support;
+
+use Illuminate\Support\Arr;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Support\ModelPropertyResolver;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\Type;
+use Psalm\Type\Atomic\TArray;
+use Psalm\Type\Union;
+
+/**
+ * Narrows `Arr::pluck($array, $value, $key = null)` when $array's element type is a
+ * single known Eloquent model, using @property annotations — the static-call
+ * counterpart of {@see \Psalm\LaravelPlugin\Handlers\Eloquent\BuilderPluckHandler} and
+ * {@see \Psalm\LaravelPlugin\Handlers\Collections\CollectionPluckHandler}. `Arr::pluck()`
+ * has no generic receiver, so the model is read from the first argument's element type
+ * ({@see ModelPropertyResolver::extractModelFromIterableValueType()}) instead of a
+ * template parameter.
+ *
+ * `Arr::pluck()` is not stubbed (`stubs/common/Support/Arr.phpstub` is an empty class),
+ * so without this handler Psalm falls back to reflection's plain `@return array`.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1379
+ * @internal
+ */
+final class ArrPluckHandler implements MethodReturnTypeProviderInterface
+{
+    /**
+     * @return list<string>
+     * @psalm-pure
+     */
+    #[\Override]
+    public static function getClassLikeNames(): array
+    {
+        return [Arr::class];
+    }
+
+    #[\Override]
+    public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        if ($event->getMethodNameLowercase() !== 'pluck') {
+            return null;
+        }
+
+        $args = $event->getCallArgs();
+        if (\count($args) < 2) {
+            // Missing the required $value argument — not a valid call to narrow.
+            return null;
+        }
+
+        $nodeTypeProvider = $event->getSource()->getNodeTypeProvider();
+
+        $modelClass = ModelPropertyResolver::extractModelFromIterableValueType(
+            $nodeTypeProvider->getType($args[0]->value),
+        );
+        if ($modelClass === null) {
+            return null;
+        }
+
+        $resolved = ModelPropertyResolver::resolvePluckColumnTypes(
+            valueArg: $args[1],
+            keyArg: $args[2] ?? null,
+            modelClass: $modelClass,
+            nodeTypeProvider: $nodeTypeProvider,
+            codebase: $event->getSource()->getCodebase(),
+        );
+        if ($resolved === null) {
+            return null;
+        }
+
+        [$keyType, $valueType] = $resolved;
+
+        // No $key argument: Laravel pushes onto $results[] (sequential int keys) —
+        // a list, not a general array<int, V>. See Arr::pluck() source.
+        if (!isset($args[2])) {
+            return Type::getList($valueType);
+        }
+
+        return new Union([new TArray([$keyType, $valueType])]);
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -375,6 +375,9 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Support/TappableTapHandler.php';
         $registration->registerHooksFromClass(Handlers\Support\TappableTapHandler::class);
 
+        require_once __DIR__ . '/Handlers/Support/ArrPluckHandler.php';
+        $registration->registerHooksFromClass(Handlers\Support\ArrPluckHandler::class);
+
         require_once __DIR__ . '/Handlers/Console/CommandArgumentHandler.php';
         $registration->registerHooksFromClass(Handlers\Console\CommandArgumentHandler::class);
         require_once __DIR__ . '/Handlers/Console/ConsoleClosureScopeHandler.php';

--- a/tests/Type/tests/Support/ArrPluckTest.phpt
+++ b/tests/Type/tests/Support/ArrPluckTest.phpt
@@ -1,0 +1,120 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use App\Models\Vehicle;
+use Illuminate\Support\Arr;
+
+/**
+ * Arr::pluck() should infer value/key types from Eloquent model @property annotations,
+ * the same way Builder::pluck()/Collection::pluck() already do.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1379
+ */
+
+// --- positive: no key arg -> list<TValue> ---
+
+/** @param list<Customer> $customers */
+function test_pluck_list_no_key(array $customers): void
+{
+    $_result = Arr::pluck($customers, 'id');
+    /** @psalm-check-type-exact $_result = list<string> */
+}
+
+/** @param array<int, Vehicle> $vehicles */
+function test_pluck_array_no_key(array $vehicles): void
+{
+    $_result = Arr::pluck($vehicles, 'make');
+    /** @psalm-check-type-exact $_result = list<string> */
+}
+
+/** @param iterable<Vehicle> $vehicles */
+function test_pluck_iterable_no_key(iterable $vehicles): void
+{
+    $_result = Arr::pluck($vehicles, 'make');
+    /** @psalm-check-type-exact $_result = list<string> */
+}
+
+/** @param array{Customer, Customer} $customers */
+function test_pluck_keyed_array_no_key(array $customers): void
+{
+    $_result = Arr::pluck($customers, 'id');
+    /** @psalm-check-type-exact $_result = list<string> */
+}
+
+// --- positive: with key arg -> array<TKey, TValue> ---
+
+/** @param list<Customer> $customers */
+function test_pluck_with_key(array $customers): void
+{
+    $_result = Arr::pluck($customers, 'id', 'vehicles_count');
+    /** @psalm-check-type-exact $_result = array<int<0, max>, string> */
+}
+
+/** @param list<Customer> $customers */
+function test_pluck_with_nullable_value_and_key(array $customers): void
+{
+    $_result = Arr::pluck($customers, 'email_verified_at', 'id');
+    /** @psalm-check-type-exact $_result = array<string, \Carbon\CarbonInterface|null> */
+}
+
+/**
+ * Key column @property is not array-key compatible (CarbonInterface|null) — falls
+ * back to array-key instead of producing an invalid TKey.
+ *
+ * @param list<Customer> $customers
+ */
+function test_pluck_with_non_array_key_compatible_key(array $customers): void
+{
+    $_result = Arr::pluck($customers, 'id', 'email_verified_at');
+    /** @psalm-check-type-exact $_result = array<array-key, string> */
+}
+
+// --- negative: handler declines, Psalm's default array<array-key, mixed> survives ---
+
+/** Dynamic column name: not a string literal, handler bails entirely. */
+function test_pluck_dynamic_column(array $customers, string $column): void
+{
+    $_result = Arr::pluck($customers, $column);
+    /** @psalm-check-type-exact $_result = array<array-key, mixed> */
+}
+
+/**
+ * Mixed-model union element type: extractModelFromIterableValueType() declines a
+ * union of more than one Model atomic.
+ *
+ * @param array<int, Customer|Vehicle> $mixed
+ */
+function test_pluck_mixed_model_union(array $mixed): void
+{
+    $_result = Arr::pluck($mixed, 'id');
+    /** @psalm-check-type-exact $_result = array<array-key, mixed> */
+}
+
+/** Plain `array` with no value type param: element extraction declines. */
+function test_pluck_plain_array(array $array): void
+{
+    $_result = Arr::pluck($array, 'id');
+    /** @psalm-check-type-exact $_result = array<array-key, mixed> */
+}
+
+/** Non-model list: element type resolves but is not a Model, so decline. */
+function test_pluck_non_model_list(): void
+{
+    $_result = Arr::pluck(['a', 'b'], 'id');
+    /** @psalm-check-type-exact $_result = array<array-key, mixed> */
+}
+
+/**
+ * Neither column is a known @property — neither axis narrows, handler defers
+ * entirely to the stub's default.
+ *
+ * @param list<Customer> $customers
+ */
+function test_pluck_unknown_columns(array $customers): void
+{
+    $_result = Arr::pluck($customers, 'unknown_value', 'unknown_key');
+    /** @psalm-check-type-exact $_result = array<array-key, mixed> */
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

`Collection::pluck()` and `Builder::pluck()` already infer the value type from a model's `@property` annotations. The array-level sibling, `Arr::pluck()`, did not: the same call over the same models fell back to reflection's plain `@return array`.

```php
/** @param list<Customer> $rows */   // Customer has @property string $id
Arr::pluck($rows, 'id');        // was: array<array-key, mixed>   now: list<string>
Arr::pluck($rows, 'id', 'id');  // was: array<array-key, mixed>   now: array<string, string>
```

## Related

Closes #1379

## Solution Description

New `ArrPluckHandler` (`MethodReturnTypeProvider` on `Illuminate\Support\Arr`, gated on the method name first, registered with its paired `require_once`).

`Arr::pluck()` has no generic receiver, so the model cannot come from a template parameter the way it does for `Collection`/`Builder`. Two pieces make it work:

- `ModelPropertyResolver::extractModelFromIterableValueType()` reads the model off the *element type* of argument 0 (`Collection<TKey, Model>`, `array<TKey, Model>`, `array{Model, Model}`, `iterable<TKey, Model>`). It declines on a multi-atomic union, `mixed`, a bare `array`/`iterable` with no value type parameter, and any non-`Enumerable` object.
- The column-resolution core shared with the existing handlers is factored out as `ModelPropertyResolver::resolvePluckColumnTypes()`, which takes the `$value`/`$key` args directly. This absorbs the one-position argument shift (`Arr::pluck($array, $value, $key)` versus `$collection->pluck($value, $key)`) without duplicating the resolution logic.

Key type follows the framework: with no `$key` argument Laravel appends via `$results[] =`, so the return is a `list`; with `$key` set it writes `$results[$itemKey] =`, so the return is `array<TKey, TValue>`, and a key column whose `@property` is not array-key compatible falls back to `array-key` rather than producing an invalid `TKey`.

The handler returns `null` (never a guessed type) when the value column is not a single string literal, when the element type is not exactly one known model, or when argument 0's type is unresolvable — so Psalm's own inference stays in charge.

Known scope cut, matching the rest of `ModelPropertyResolver`: arguments are read positionally, so a call using named arguments to reorder them would not be narrowed.

New type test `tests/Type/tests/Support/ArrPluckTest.phpt` covers four positive element-type shapes, the `$key` and nullable-value cases, the non-array-key-compatible key fallback, and five negatives (dynamic column, mixed-model union, bare `array`, non-model list, unknown columns) that prove the handler declines and the default inference survives. Confirmed RED before the handler.

Verified: type suite 656 pass (3 pre-existing SKIPIF skips), unit suite 1097 pass (1 pre-existing skip), `psalm` with `--find-dead-code --find-unused-psalm-suppress` zero output, `rector --dry-run` and `php-cs-fixer` both no-op.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/tests/Support/ArrPluckTest.phpt`)
