### PR TITLE
Rename `MissingSerializesModels` to `SerializedQueuedModel`

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -169,7 +169,7 @@ See [MissingView](issues/MissingView.md) for details.
 <findMissingViews value="true" />
 ```
 
-## `findMissingSerializesModels`
+## `findSerializedQueuedModels`
 
 **default**: `false`
 
@@ -177,12 +177,12 @@ When enabled, the plugin flags a class implementing `ShouldQueue` that holds an 
 
 The check is on the resulting `__serialize()`, not on the trait name, so the framework bases that already pull the trait in are silent (`Illuminate\Foundation\Queue\Queueable`, what `make:job` scaffolds since Laravel 11, and `Illuminate\Notifications\Notification`), as is a class that hand-writes its own serialization.
 
-See [MissingSerializesModels](issues/MissingSerializesModels.md) for details.
+See [SerializedQueuedModel](issues/SerializedQueuedModel.md) for details.
 
 ### Example
 
 ```xml
-<findMissingSerializesModels value="true" />
+<findSerializedQueuedModels value="true" />
 ```
 
 ## `findOctaneIncompatibleBinding`

--- a/docs/issues/SerializedQueuedModel.md
+++ b/docs/issues/SerializedQueuedModel.md
@@ -1,16 +1,16 @@
 ---
-title: MissingSerializesModels
+title: SerializedQueuedModel
 parent: Custom Issues
 nav_order: 6
 ---
 
-# MissingSerializesModels
+# SerializedQueuedModel
 
 Emitted when a class implementing `Illuminate\Contracts\Queue\ShouldQueue` holds an Eloquent model (or an `Eloquent\Collection`) in a property, and the class has no `__serialize()` or `__sleep()` of its own, inherited, or brought in by a trait.
 
 One report per class, on the class declaration, naming the offending properties (the first three of them). The fix is a single `use SerializesModels;`, so a per-property report would be several findings for one edit.
 
-Controlled by the `findMissingSerializesModels` flag (see [Configuration](../config.md)).
+Controlled by the `findSerializedQueuedModels` flag (see [Configuration](../config.md)).
 
 ## Why this is a problem
 
@@ -58,4 +58,4 @@ Known blind spots, all in the safe direction:
 
 Add `use SerializesModels;` to the queued class, or replace a hand-assembled trait list with `Illuminate\Foundation\Queue\Queueable`.
 
-If a property deliberately holds a detached model that must survive as-is, suppress the issue in the class docblock with `@psalm-suppress MissingSerializesModels` and say why in a comment. The report is class-level, so a property-level suppression does not reach it.
+If a property deliberately holds a detached model that must survive as-is, suppress the issue in the class docblock with `@psalm-suppress SerializedQueuedModel` and say why in a comment. The report is class-level, so a property-level suppression does not reach it.

--- a/docs/issues/index.md
+++ b/docs/issues/index.md
@@ -13,7 +13,7 @@ The plugin ships advanced Laravel-aware static analysis checks that extend Psalm
 - [InvalidConsoleOptionName](InvalidConsoleOptionName.md) — `option()` references undefined console command option
 - [MissingView](MissingView.md) — `view()` references a non-existent Blade template (opt-in)
 - [MissingTranslation](MissingTranslation.md) — `__()` or `trans()` references an undefined translation key (opt-in)
-- [MissingSerializesModels](MissingSerializesModels.md) — a queued class holds an Eloquent model in a property without reaching `SerializesModels`, so the whole model is written into the queue payload
+- [SerializedQueuedModel](SerializedQueuedModel.md) — a queued class holds an Eloquent model in a property without reaching `SerializesModels`, so the whole model is written into the queue payload
 - [ModelMakeDiscouraged](ModelMakeDiscouraged.md) — `Model::make()` used instead of `new Model()`
 - [OctaneIncompatibleBinding](OctaneIncompatibleBinding.md) — `singleton()` closure resolves a request-scoped service such as Request, Session, or Auth (auto-enabled when `laravel/octane` is installed)
 - [PublicModelScope](PublicModelScope.md) — `public` `#[Scope]` Eloquent query scope, whose static call is a runtime fatal (reported at error levels 1 to 4)

--- a/src/Config/PluginConfig.php
+++ b/src/Config/PluginConfig.php
@@ -29,7 +29,7 @@ final readonly class PluginConfig
         public bool $reportImplicitQueryBuilderCalls,
         public bool $findMissingTranslations,
         public bool $findMissingViews,
-        public bool $findMissingSerializesModels,
+        public bool $findSerializedQueuedModels,
         /**
          * Tri-state opt-in/out for the OctaneIncompatibleBinding rule.
          *
@@ -63,7 +63,7 @@ final readonly class PluginConfig
         $experimental = self::xmlBoolAttr($config?->experimental, 'experimental');
         $findMissingTranslations = self::xmlBoolAttr($config?->findMissingTranslations, 'findMissingTranslations');
         $findMissingViews = self::xmlBoolAttr($config?->findMissingViews, 'findMissingViews');
-        $findMissingSerializesModels = self::xmlBoolAttr($config?->findMissingSerializesModels, 'findMissingSerializesModels');
+        $findSerializedQueuedModels = self::xmlBoolAttr($config?->findSerializedQueuedModels, 'findSerializedQueuedModels');
         $reportImplicitQueryBuilderCalls = self::xmlBoolAttr($config?->reportImplicitQueryBuilderCalls, 'reportImplicitQueryBuilderCalls');
         $findOctaneIncompatibleBinding = self::xmlOptionalBoolAttr($config?->findOctaneIncompatibleBinding, 'findOctaneIncompatibleBinding');
         $resolveDynamicWhereClauses = self::xmlBoolAttr($config?->resolveDynamicWhereClauses, 'resolveDynamicWhereClauses', true);
@@ -78,7 +78,7 @@ final readonly class PluginConfig
             reportImplicitQueryBuilderCalls: $reportImplicitQueryBuilderCalls,
             findMissingTranslations: $findMissingTranslations,
             findMissingViews: $findMissingViews,
-            findMissingSerializesModels: $findMissingSerializesModels,
+            findSerializedQueuedModels: $findSerializedQueuedModels,
             findOctaneIncompatibleBinding: $findOctaneIncompatibleBinding,
             cachePath: self::resolveCachePath(),
             experimental: $experimental,

--- a/src/Handlers/Rules/SerializedQueuedModelHandler.php
+++ b/src/Handlers/Rules/SerializedQueuedModelHandler.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Psalm\Codebase;
 use Psalm\CodeLocation;
 use Psalm\IssueBuffer;
-use Psalm\LaravelPlugin\Issues\MissingSerializesModels;
+use Psalm\LaravelPlugin\Issues\SerializedQueuedModel;
 use Psalm\Plugin\EventHandler\AfterClassLikeAnalysisInterface;
 use Psalm\Plugin\EventHandler\Event\AfterClassLikeAnalysisEvent;
 use Psalm\Type\Atomic\TNamedObject;
@@ -51,7 +51,7 @@ use Psalm\Type\Union;
  * @see https://github.com/psalm/psalm-plugin-laravel/issues/1380
  * @internal
  */
-final class MissingSerializesModelsHandler implements AfterClassLikeAnalysisInterface
+final class SerializedQueuedModelHandler implements AfterClassLikeAnalysisInterface
 {
     private const SHOULD_QUEUE = 'illuminate\contracts\queue\shouldqueue';
 
@@ -110,7 +110,7 @@ final class MissingSerializesModelsHandler implements AfterClassLikeAnalysisInte
         // One report per class, anchored at the class name: the fix is a single
         // `use SerializesModels;`, so a per-property report would be N findings for one edit.
         IssueBuffer::accepts(
-            new MissingSerializesModels(
+            new SerializedQueuedModel(
                 "{$storage->name} implements ShouldQueue without "
                 . 'Illuminate\Queue\SerializesModels, so '
                 . self::listOffenders($offenders)

--- a/src/Internal/IssueUrlGenerator.php
+++ b/src/Internal/IssueUrlGenerator.php
@@ -87,7 +87,7 @@ final class IssueUrlGenerator
             '- reportImplicitQueryBuilderCalls: ' . self::formatBool($pluginConfig->reportImplicitQueryBuilderCalls),
             '- findMissingTranslations: ' . self::formatBool($pluginConfig->findMissingTranslations),
             '- findMissingViews: ' . self::formatBool($pluginConfig->findMissingViews),
-            '- findMissingSerializesModels: ' . self::formatBool($pluginConfig->findMissingSerializesModels),
+            '- findSerializedQueuedModels: ' . self::formatBool($pluginConfig->findSerializedQueuedModels),
             '- findOctaneIncompatibleBinding: ' . self::formatOctaneFlag($pluginConfig->findOctaneIncompatibleBinding),
             '- cachePath: ' . self::sanitizeCachePath($pluginConfig->cachePath),
             '- experimental: ' . self::formatBool($pluginConfig->experimental),

--- a/src/Issues/SerializedQueuedModel.php
+++ b/src/Issues/SerializedQueuedModel.php
@@ -11,7 +11,7 @@ use Psalm\Issue\PluginIssue;
  * but cannot reach Illuminate\Queue\SerializesModels, so the whole model is written into
  * the queue payload instead of a ModelIdentifier.
  */
-final class MissingSerializesModels extends PluginIssue
+final class SerializedQueuedModel extends PluginIssue
 {
-    public const DOCUMENTATION_URL = 'https://psalm.github.io/psalm-plugin-laravel/issues/MissingSerializesModels/';
+    public const DOCUMENTATION_URL = 'https://psalm.github.io/psalm-plugin-laravel/issues/SerializedQueuedModel/';
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -517,9 +517,9 @@ final class Plugin implements PluginEntryPointInterface
         }
 
         // Flag queued classes that hold an Eloquent model without reaching SerializesModels.
-        if ($pluginConfig->findMissingSerializesModels) {
-            require_once __DIR__ . '/Handlers/Rules/MissingSerializesModelsHandler.php';
-            $registration->registerHooksFromClass(Handlers\Rules\MissingSerializesModelsHandler::class);
+        if ($pluginConfig->findSerializedQueuedModels) {
+            require_once __DIR__ . '/Handlers/Rules/SerializedQueuedModelHandler.php';
+            $registration->registerHooksFromClass(Handlers\Rules\SerializedQueuedModelHandler::class);
         }
 
         // Tri-state gate for the OctaneIncompatibleBinding rule:

--- a/tests/Type/psalm-with-optin-custom-issues.xml
+++ b/tests/Type/psalm-with-optin-custom-issues.xml
@@ -19,7 +19,7 @@
             <reportImplicitQueryBuilderCalls value="true" />
             <findMissingTranslations value="true" />
             <findMissingViews value="true" />
-            <findMissingSerializesModels value="true" />
+            <findSerializedQueuedModels value="true" />
             <findOctaneIncompatibleBinding value="true" />
             <failOnInternalError value="true" />
         </pluginClass>

--- a/tests/Type/tests/SerializedQueuedModelTest.phpt
+++ b/tests/Type/tests/SerializedQueuedModelTest.phpt
@@ -17,7 +17,7 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
 
 /**
- * The MissingSerializesModels rule flags a queued class holding an Eloquent model without
+ * The SerializedQueuedModel rule flags a queued class holding an Eloquent model without
  * reaching Illuminate\Queue\SerializesModels, which would serialize the whole model into
  * the payload instead of a ModelIdentifier. Registered by the config this test runs under
  * (see --ARGS-- above).
@@ -172,7 +172,7 @@ class PruneCache implements ShouldQueue
  * The report lands on the class, so a deliberate detached model is silenced by a class-level
  * suppression — a property-level one would not be seen.
  *
- * @psalm-suppress MissingSerializesModels
+ * @psalm-suppress SerializedQueuedModel
  */
 class KeepDetachedCustomer implements ShouldQueue
 {
@@ -209,8 +209,8 @@ abstract class AbstractCustomerJob implements ShouldQueue
 class ConcreteCustomerJob extends AbstractCustomerJob {}
 ?>
 --EXPECTF--
-MissingSerializesModels on line %d: App\QueuedJobs\SendCustomerReport implements ShouldQueue without Illuminate\Queue\SerializesModels, so $customer will be serialized whole into the queue payload
-MissingSerializesModels on line %d: App\QueuedJobs\ArchiveCustomer implements ShouldQueue without Illuminate\Queue\SerializesModels, so $customer will be serialized whole into the queue payload
-MissingSerializesModels on line %d: App\QueuedJobs\NotifyCustomers implements ShouldQueue without Illuminate\Queue\SerializesModels, so $customers will be serialized whole into the queue payload
-MissingSerializesModels on line %d: App\QueuedJobs\SettleInvoice implements ShouldQueue without Illuminate\Queue\SerializesModels, so $payer, $payee, $invoice will be serialized whole into the queue payload
-MissingSerializesModels on line %d: App\QueuedJobs\ReconcileLedger implements ShouldQueue without Illuminate\Queue\SerializesModels, so $customer, $opening, $closing and 1 more will be serialized whole into the queue payload
+SerializedQueuedModel on line %d: App\QueuedJobs\SendCustomerReport implements ShouldQueue without Illuminate\Queue\SerializesModels, so $customer will be serialized whole into the queue payload
+SerializedQueuedModel on line %d: App\QueuedJobs\ArchiveCustomer implements ShouldQueue without Illuminate\Queue\SerializesModels, so $customer will be serialized whole into the queue payload
+SerializedQueuedModel on line %d: App\QueuedJobs\NotifyCustomers implements ShouldQueue without Illuminate\Queue\SerializesModels, so $customers will be serialized whole into the queue payload
+SerializedQueuedModel on line %d: App\QueuedJobs\SettleInvoice implements ShouldQueue without Illuminate\Queue\SerializesModels, so $payer, $payee, $invoice will be serialized whole into the queue payload
+SerializedQueuedModel on line %d: App\QueuedJobs\ReconcileLedger implements ShouldQueue without Illuminate\Queue\SerializesModels, so $customer, $opening, $closing and 1 more will be serialized whole into the queue payload

--- a/tests/Unit/PluginConfigTest.php
+++ b/tests/Unit/PluginConfigTest.php
@@ -44,7 +44,7 @@ final class PluginConfigTest extends TestCase
         $this->assertFalse($config->findMissingTranslations);
         $this->assertFalse($config->findMissingViews);
         $this->assertFalse($config->reportImplicitQueryBuilderCalls);
-        $this->assertFalse($config->findMissingSerializesModels);
+        $this->assertFalse($config->findSerializedQueuedModels);
         $this->assertFalse($config->experimental);
         // null = auto-detect via class_exists('Laravel\Octane\Octane') at runtime;
         // explicit true/false in XML overrides the auto-detection.
@@ -249,7 +249,7 @@ final class PluginConfigTest extends TestCase
         $config = PluginConfig::fromXml($xml);
 
         $this->assertFalse($config->reportImplicitQueryBuilderCalls);
-        $this->assertFalse($config->findMissingSerializesModels);
+        $this->assertFalse($config->findSerializedQueuedModels);
     }
 
     #[Test]


### PR DESCRIPTION
## Issue to Solve

`MissingSerializesModels` (merged in #1385, unreleased) does not fit the naming used by the other 13 custom issues, and it no longer describes what the rule requires.

- `Missing*` here means *the thing your code referenced does not exist*: `MissingView`, `MissingTranslation`. This rule has no missing referent.
- The rule gates on the class ending up with a `__serialize()` / `__sleep()` from any source, so a class that hand-writes its own serialization passes. Naming the issue after one particular fix (`use SerializesModels;`) overstates what it demands.
- 11 of the 14 issue names carry their domain (`Model` x6, `Console` x2, `QueryBuilder`, `Octane`, `View`). This one carried no queue context at all.

## Related

Follow-up to #1385. Refs #1380.

## Solution Description

Rename to `SerializedQueuedModel`, with `findMissingSerializesModels` becoming `findSerializedQueuedModels`.

- `[state][domain][offending thing]` is the house shape, the same as `UnresolvableAppendedModelAttribute` and `OctaneIncompatibleBinding`: it names the defective code rather than the fix, so the hand-written `__serialize()` exemption is consistent with the name instead of an exception to it.
- `Queued`, not `Job`: `ShouldQueue` also covers mailables, notifications, and queued listeners, so `Job` would be wrong for most of the surface.
- The flag follows the issue name mechanically, as every other flag does (`findMissingViews` <- `MissingView`).

Mechanical rename across 11 files: issue class and its `DOCUMENTATION_URL`, handler class and file, `PluginConfig` property plus XML attribute, the `psalm-laravel diagnose` flag listing, the type test and its config, `docs/issues/` page and index entry, and `docs/config.md`.

The rule is unreleased (merged after `v4.15.5`), so no baseline entry, `@psalm-suppress` line, or documentation URL in the wild points at the old name. Renaming after the flag flips to enabled-by-default would cost users all three.

Verified: type suite 659 pass, unit suite 1109 pass, `psalm` exit 0 at 100% type coverage, `rector` and `php-cs-fixer` clean. Type test asserts the new issue name, the new `@psalm-suppress SerializedQueuedModel` docblock, and the renamed flag in `tests/Type/psalm-with-optin-custom-issues.xml`; `PluginConfigTest` asserts the renamed property.

Not changed: the report message, the detection logic, and the `nav_order` of the docs page (it keeps 6, so under the title-sorted tie it now renders after `ModelMakeDiscouraged` instead of directly after `MissingTranslation`; say the word if you want it moved).

## Checklist
- [x] Tests cover the change (`tests/Type/tests/SerializedQueuedModelTest.phpt`, `tests/Unit/PluginConfigTest.php`)
- [x] Documentation is updated (`docs/issues/SerializedQueuedModel.md`, `docs/issues/index.md`, `docs/config.md`)
